### PR TITLE
feat(kcp report): add new static time range flags to `kcp report region cost` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ migration-plan/
 cost_report/
 cluster_scan_*.md
 cluster_scan_*.json
+cost_reports/
 
 # Added by goreleaser init:
 dist/

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -164,32 +164,6 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 	var startDate, endDate time.Time
 	var err error
 
-	// Validate that exactly one time range method is provided
-	timeRangeMethods := 0
-	if start != "" && end != "" {
-		timeRangeMethods++
-	}
-
-	if lastDay {
-		timeRangeMethods++
-	}
-
-	if lastWeek {
-		timeRangeMethods++
-	}
-
-	if lastMonth {
-		timeRangeMethods++
-	}
-
-	if timeRangeMethods == 0 {
-		return nil, fmt.Errorf("must provide either start/end dates, --last-day, --last-week, or --last-month")
-	}
-	if timeRangeMethods > 1 {
-		return nil, fmt.Errorf("cannot combine start/end dates with --last-day, --last-week, or --last-month")
-	}
-
-	// Handle different time range methods
 	switch {
 	case start != "" && end != "":
 		startDate, err = time.Parse(dateFormat, start)

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -192,7 +192,7 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 
 	case lastThirtyDays:
 		now := time.Now()
-		startDate = now.AddDate(0, 0, -30).UTC().Truncate(24 * time.Hour)
+		startDate = now.AddDate(0, 0, -31).UTC().Truncate(24 * time.Hour)
 		endDate = now.UTC().Truncate(24 * time.Hour)
 	}
 

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -216,20 +216,18 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 
 	case lastDay:
 		now := time.Now()
-		startDate = now.AddDate(0, 0, -1).UTC().Truncate(24 * time.Hour).In(now.Location())
-		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
-
-		fmt.Println(startDate, endDate)
+		startDate = now.AddDate(0, 0, -1).UTC().Truncate(24 * time.Hour)
+		endDate = now.UTC().Truncate(24 * time.Hour)
 
 	case lastWeek:
 		now := time.Now()
-		startDate = now.AddDate(0, 0, -7).UTC().Truncate(24 * time.Hour).In(now.Location())
-		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
+		startDate = now.AddDate(0, 0, -7).UTC().Truncate(24 * time.Hour)
+		endDate = now.UTC().Truncate(24 * time.Hour)
 
 	case lastMonth:
 		now := time.Now()
-		startDate = now.AddDate(0, 0, -30).UTC().Truncate(24 * time.Hour).In(now.Location())
-		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
+		startDate = now.AddDate(0, 0, -30).UTC().Truncate(24 * time.Hour)
+		endDate = now.UTC().Truncate(24 * time.Hour)
 	}
 
 	opts := rrc.RegionCosterOpts{

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -18,11 +18,11 @@ import (
 var (
 	region string
 
-	start     string
-	end       string
-	lastDay   bool
-	lastWeek  bool
-	lastMonth bool
+	start          string
+	end            string
+	lastDay        bool
+	lastWeek       bool
+	lastThirtyDays bool
 
 	hourly  bool
 	daily   bool
@@ -55,9 +55,9 @@ func NewReportRegionCostsCmd() *cobra.Command {
 	timeRangeFlags.SortFlags = false
 	timeRangeFlags.StringVar(&start, "start", "", "inclusive start date for cost report (YYYY-MM-DD)")
 	timeRangeFlags.StringVar(&end, "end", "", "exclusive end date for cost report (YYYY-MM-DD)")
-	timeRangeFlags.BoolVar(&lastDay, "last-day", false, "generate cost report for the last day")
-	timeRangeFlags.BoolVar(&lastWeek, "last-week", false, "generate cost report for the last 7 days")
-	timeRangeFlags.BoolVar(&lastMonth, "last-month", false, "generate cost report for the last 30 days")
+	timeRangeFlags.BoolVar(&lastDay, "last-day", false, "generate cost report for the previous day")
+	timeRangeFlags.BoolVar(&lastWeek, "last-week", false, "generate cost report for the previous 7 days (not including today)")
+	timeRangeFlags.BoolVar(&lastThirtyDays, "last-thirty-days", false, "generate cost report for the previous 30 days (not including today)")
 	regionCmd.Flags().AddFlagSet(timeRangeFlags)
 	groups[timeRangeFlags] = "Time Range Flags"
 
@@ -97,8 +97,8 @@ func NewReportRegionCostsCmd() *cobra.Command {
 
 	regionCmd.MarkFlagRequired("region")
 
-	regionCmd.MarkFlagsMutuallyExclusive("start", "last-day", "last-week", "last-month")
-	regionCmd.MarkFlagsOneRequired("start", "last-day", "last-week", "last-month")
+	regionCmd.MarkFlagsMutuallyExclusive("start", "last-day", "last-week", "last-thirty-days")
+	regionCmd.MarkFlagsOneRequired("start", "last-day", "last-week", "last-thirty-days")
 	regionCmd.MarkFlagsRequiredTogether("start", "end")
 
 	regionCmd.MarkFlagsMutuallyExclusive("hourly", "daily", "monthly")
@@ -187,10 +187,10 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 
 	case lastWeek:
 		now := time.Now()
-		startDate = now.AddDate(0, 0, -7).UTC().Truncate(24 * time.Hour)
+		startDate = now.AddDate(0, 0, -8).UTC().Truncate(24 * time.Hour)
 		endDate = now.UTC().Truncate(24 * time.Hour)
 
-	case lastMonth:
+	case lastThirtyDays:
 		now := time.Now()
 		startDate = now.AddDate(0, 0, -30).UTC().Truncate(24 * time.Hour)
 		endDate = now.UTC().Truncate(24 * time.Hour)

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -97,17 +97,9 @@ func NewReportRegionCostsCmd() *cobra.Command {
 
 	regionCmd.MarkFlagRequired("region")
 
-	// Make start/end pair mutually exclusive with last-X flags.
-	regionCmd.MarkFlagsMutuallyExclusive("start", "last-day")
-	regionCmd.MarkFlagsMutuallyExclusive("start", "last-week")
-	regionCmd.MarkFlagsMutuallyExclusive("start", "last-month")
-	regionCmd.MarkFlagsMutuallyExclusive("end", "last-day")
-	regionCmd.MarkFlagsMutuallyExclusive("end", "last-week")
-	regionCmd.MarkFlagsMutuallyExclusive("end", "last-month")
-	regionCmd.MarkFlagsMutuallyExclusive("last-day", "last-week")
-	regionCmd.MarkFlagsMutuallyExclusive("last-day", "last-month")
-	regionCmd.MarkFlagsMutuallyExclusive("last-week", "last-month")
-	regionCmd.MarkFlagsOneRequired("start", "end", "last-day", "last-week", "last-month")
+	regionCmd.MarkFlagsMutuallyExclusive("start", "last-day", "last-week", "last-month")
+	regionCmd.MarkFlagsOneRequired("start", "last-day", "last-week", "last-month")
+	regionCmd.MarkFlagsRequiredTogether("start", "end")
 
 	regionCmd.MarkFlagsMutuallyExclusive("hourly", "daily", "monthly")
 	regionCmd.MarkFlagsOneRequired("hourly", "daily", "monthly")

--- a/internal/cli/report/region/costs/report_region_costs.go
+++ b/internal/cli/report/region/costs/report_region_costs.go
@@ -16,19 +16,19 @@ import (
 )
 
 var (
-	region  string
+	region string
 
-	start   string
-	end     string
-	lastDay bool
+	start     string
+	end       string
+	lastDay   bool
 	lastWeek  bool
 	lastMonth bool
-	
+
 	hourly  bool
 	daily   bool
 	monthly bool
-	
-	tag     []string
+
+	tag []string
 )
 
 func NewReportRegionCostsCmd() *cobra.Command {
@@ -90,7 +90,7 @@ func NewReportRegionCostsCmd() *cobra.Command {
 			}
 		}
 
-		fmt.Println("\nAll flags can be provided via environment variables (uppercase, with underscores).")
+		fmt.Println("All flags can be provided via environment variables (uppercase, with underscores).")
 
 		return nil
 	})
@@ -177,18 +177,24 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 	if start != "" && end != "" {
 		timeRangeMethods++
 	}
+
+	if lastDay {
+		timeRangeMethods++
+	}
+
 	if lastWeek {
 		timeRangeMethods++
 	}
+
 	if lastMonth {
 		timeRangeMethods++
 	}
 
 	if timeRangeMethods == 0 {
-		return nil, fmt.Errorf("must provide either start/end dates, --last-week, or --last-month")
+		return nil, fmt.Errorf("must provide either start/end dates, --last-day, --last-week, or --last-month")
 	}
 	if timeRangeMethods > 1 {
-		return nil, fmt.Errorf("cannot combine start/end dates with --last-week or --last-month")
+		return nil, fmt.Errorf("cannot combine start/end dates with --last-day, --last-week, or --last-month")
 	}
 
 	// Handle different time range methods
@@ -208,17 +214,22 @@ func parseReportRegionCostsOpts() (*rrc.RegionCosterOpts, error) {
 			return nil, fmt.Errorf("start date '%s' cannot be after end date '%s'", start, end)
 		}
 
+	case lastDay:
+		now := time.Now()
+		startDate = now.AddDate(0, 0, -1).UTC().Truncate(24 * time.Hour).In(now.Location())
+		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
+
+		fmt.Println(startDate, endDate)
+
 	case lastWeek:
 		now := time.Now()
-		// Calculate start of last week (7 days ago)
-		startDate = now.AddDate(0, 0, -7).Truncate(24 * time.Hour)
-		endDate = now.Truncate(24 * time.Hour)
+		startDate = now.AddDate(0, 0, -7).UTC().Truncate(24 * time.Hour).In(now.Location())
+		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
 
 	case lastMonth:
 		now := time.Now()
-		// Calculate start of last month (30 days ago)
-		startDate = now.AddDate(0, 0, -30).Truncate(24 * time.Hour)
-		endDate = now.Truncate(24 * time.Hour)
+		startDate = now.AddDate(0, 0, -30).UTC().Truncate(24 * time.Hour).In(now.Location())
+		endDate = now.UTC().Truncate(24 * time.Hour).In(now.Location())
 	}
 
 	opts := rrc.RegionCosterOpts{


### PR DESCRIPTION
- Updating the `kcp report region costs` command usage to group flags.
```shell
❯ kcp report region costs --help
Generate a costs report on an AWS region.

Generate costs report on an AWS region

Required Flags:
      --region string   AWS region the cost report is generated for

Time Range Flags:
      --start string       inclusive start date for cost report (YYYY-MM-DD)
      --end string         exclusive end date for cost report (YYYY-MM-DD)
      --last-day           generate cost report for the previous day
      --last-week          generate cost report for the previous 7 days (not including today)
      --last-thirty-days   generate cost report for the previous 30 days (not including today)

Granularity Flags (choose one):
      --hourly    generate hourly cost report
      --daily     generate daily cost report
      --monthly   generate monthly cost report

Optional Flags:
      --tag strings   generate cost report for a specific tag(key=value)

All flags can be provided via environment variables (uppercase, with underscores).
```

- Adding new static time range flags `--last-day`, `--last-week` and `--last-thirty-days`.