### PR TITLE
chore(command usage): updating output from command usage help text and grouping flags

### DIFF
--- a/internal/cli/create_asset/bastion_host/create_asset_bastion_host.go
+++ b/internal/cli/create_asset/bastion_host/create_asset_bastion_host.go
@@ -32,7 +32,7 @@ func NewBastionHostCmd() *cobra.Command {
 	// Required flags.
 	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
 	requiredFlags.SortFlags = false
-	requiredFlags.StringVar(&region, "region", "", "The AWS region to target")
+	requiredFlags.StringVar(&region, "region", "", "AWS region the cost report is generated for")
 	requiredFlags.StringVar(&vpcId, "vpc-id", "", "The VPC ID to target")
 	requiredFlags.IPNetVar(&bastionHostCidr, "bastion-host-cidr", net.IPNet{}, "The bastion host CIDR (e.g. 10.0.255.0/24)")
 	bastionHostCmd.Flags().AddFlagSet(requiredFlags)

--- a/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
+++ b/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/confluentinc/kcp/internal/generators/create_asset/migration_infra"
 	"github.com/confluentinc/kcp/internal/types"
@@ -55,9 +56,9 @@ func NewMigrationInfraCmd() *cobra.Command {
 	// Private Networking Migration flags.
 	privNetworkMigrationFlags := pflag.NewFlagSet("private-network-migration", pflag.ExitOnError)
 	privNetworkMigrationFlags.SortFlags = false
-	privNetworkMigrationFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type")
-	privNetworkMigrationFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR")
-	privNetworkMigrationFlags.IPNetVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", net.IPNet{}, "Jump cluster broker subnet config")
+	privNetworkMigrationFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type - 'Dedicated' or 'Enterprise'")
+	privNetworkMigrationFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR (e.g. 10.0.255.0/24)")
+	privNetworkMigrationFlags.IPNetVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", net.IPNet{}, "Jump cluster broker subnet config (e.g. us-east-1a:10.0.150.0/24,us-east-1b:10.0.160.0/24,us-east-1c:10.0.170.0/24)")
 	migrationInfraCmd.Flags().AddFlagSet(privNetworkMigrationFlags)
 	groups[privNetworkMigrationFlags] = "Private Network Migration Flags"
 
@@ -72,7 +73,7 @@ func NewMigrationInfraCmd() *cobra.Command {
 		fmt.Printf("%s\n\n", c.Short)
 
 		flagOrder := []*pflag.FlagSet{requiredFlags, privNetworkMigrationFlags, typeOneFlags}
-		groupNames := []string{"Required Flags", "Private Network Migration Flags", "Type 1 Required Flags"}
+		groupNames := []string{"Required Flags", "Private Network Migration Flags", "'Type 1' Required Flags"}
 
 		for i, fs := range flagOrder {
 			usage := fs.FlagUsages()
@@ -158,7 +159,7 @@ func parseMigrationInfraOpts() (*migration_infra.MigrationInfraOpts, error) {
 		JumpClusterBrokerSubnetConfig: jumpClusterBrokerSubnetConfig.String(),
 		CCEnvName:                     ccEnvName,
 		CCClusterName:                 ccClusterName,
-		CCClusterType:                 ccClusterType,
+		CCClusterType:                 strings.ToLower(ccClusterType),
 		AnsibleControlNodeSubnetCIDR:  ansibleControlNodeSubnetCIDR.String(),
 		JumpClusterBrokerIAMRoleName:  jumpClusterBrokerIAMRoleName,
 		ClusterInfo:                   clusterInfo,

--- a/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
+++ b/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
@@ -23,7 +23,7 @@ var (
 	migrationInfraType string
 
 	ccClusterType                 string
-	jumpClusterBrokerSubnetConfig net.IPNet
+	jumpClusterBrokerSubnetConfig string
 	ansibleControlNodeSubnetCIDR  net.IPNet
 
 	jumpClusterBrokerIAMRoleName string
@@ -53,27 +53,29 @@ func NewMigrationInfraCmd() *cobra.Command {
 	migrationInfraCmd.Flags().AddFlagSet(requiredFlags)
 	groups[requiredFlags] = "Required Flags"
 
-	// Private Networking Migration flags.
-	privNetworkMigrationFlags := pflag.NewFlagSet("private-network-migration", pflag.ExitOnError)
-	privNetworkMigrationFlags.SortFlags = false
-	privNetworkMigrationFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type - 'Dedicated' or 'Enterprise'")
-	privNetworkMigrationFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR (e.g. 10.0.255.0/24)")
-	privNetworkMigrationFlags.IPNetVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", net.IPNet{}, "Jump cluster broker subnet config (e.g. us-east-1a:10.0.150.0/24,us-east-1b:10.0.160.0/24,us-east-1c:10.0.170.0/24)")
-	migrationInfraCmd.Flags().AddFlagSet(privNetworkMigrationFlags)
-	groups[privNetworkMigrationFlags] = "Private Network Migration Flags"
-
 	// Type 1 flags.
 	typeOneFlags := pflag.NewFlagSet("type-1", pflag.ExitOnError)
 	typeOneFlags.SortFlags = false
+	typeOneFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type - 'Dedicated' or 'Enterprise'")
+	typeOneFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR (e.g. 10.0.255.0/24)")
+	typeOneFlags.StringVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", "", "Jump cluster broker subnet config (e.g. us-east-1a:10.0.150.0/24,us-east-1b:10.0.160.0/24,us-east-1c:10.0.170.0/24)")
 	typeOneFlags.StringVar(&jumpClusterBrokerIAMRoleName, "jump-cluster-broker-iam-role-name", "", "The Jump cluster broker IAM role name")
 	migrationInfraCmd.Flags().AddFlagSet(typeOneFlags)
 	groups[typeOneFlags] = "Type 1 Flags"
 
+	typeTwoFlags := pflag.NewFlagSet("type-2", pflag.ExitOnError)
+	typeTwoFlags.SortFlags = false
+	typeTwoFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type - 'Dedicated' or 'Enterprise'")
+	typeTwoFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR (e.g. 10.0.255.0/24)")
+	typeTwoFlags.StringVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", "", "Jump cluster broker subnet config (e.g. us-east-1a:10.0.150.0/24,us-east-1b:10.0.160.0/24,us-east-1c:10.0.170.0/24)")
+	migrationInfraCmd.Flags().AddFlagSet(typeTwoFlags)
+	groups[typeTwoFlags] = "Type 2 Flags"
+
 	migrationInfraCmd.SetUsageFunc(func(c *cobra.Command) error {
 		fmt.Printf("%s\n\n", c.Short)
 
-		flagOrder := []*pflag.FlagSet{requiredFlags, privNetworkMigrationFlags, typeOneFlags}
-		groupNames := []string{"Required Flags", "Private Network Migration Flags", "'Type 1' Required Flags"}
+		flagOrder := []*pflag.FlagSet{requiredFlags, typeOneFlags, typeTwoFlags}
+		groupNames := []string{"Required Flags", "Type 1 Flags", "Type 2 Flags"}
 
 		for i, fs := range flagOrder {
 			usage := fs.FlagUsages()
@@ -156,7 +158,7 @@ func parseMigrationInfraOpts() (*migration_infra.MigrationInfraOpts, error) {
 	opts := migration_infra.MigrationInfraOpts{
 		Region:                        region,
 		VPCId:                         vpcId,
-		JumpClusterBrokerSubnetConfig: jumpClusterBrokerSubnetConfig.String(),
+		JumpClusterBrokerSubnetConfig: jumpClusterBrokerSubnetConfig,
 		CCEnvName:                     ccEnvName,
 		CCClusterName:                 ccClusterName,
 		CCClusterType:                 strings.ToLower(ccClusterType),

--- a/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
+++ b/internal/cli/create_asset/migration_infra/create_asset_migration_infra.go
@@ -3,74 +3,88 @@ package migration_infra
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/confluentinc/kcp/internal/generators/create_asset/migration_infra"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
-	region                        string
-	vpcId                         string
-	ccEnvName                     string
-	ccClusterName                 string
+	region             string
+	vpcId              string
+	ccEnvName          string
+	ccClusterName      string
+	clusterFile        string
+	migrationInfraType string
+
 	ccClusterType                 string
-	clusterFile                   string
-	migrationInfraType            string
-	jumpClusterBrokerSubnetConfig string
-	ansibleControlNodeSubnetCIDR  string
-	jumpClusterBrokerIAMRoleName  string
+	jumpClusterBrokerSubnetConfig net.IPNet
+	ansibleControlNodeSubnetCIDR  net.IPNet
+
+	jumpClusterBrokerIAMRoleName string
 )
 
 func NewMigrationInfraCmd() *cobra.Command {
 	migrationInfraCmd := &cobra.Command{
-		Use:   "migration-infra",
-		Short: "Create assets for the migration infrastructure",
-		Long: `Create assets for the migration infrastructure
-
-All flags can be provided via environment variables (uppercase, with underscores):
-
-FLAG                                            | ENV_VAR
-------------------------------------------------|--------------------------------------------------
-Required flags:
---region                                        | REGION=us-east-1
---vpc-id                                        | VPC_ID=vpc-1234567890
---cc-env-name                                   | CC_ENV_NAME=prod-env
---cc-cluster-name                               | CC_CLUSTER_NAME=my-cluster
---cluster-file                                  | CLUSTER_FILE=path/to/cluster.json
---type                                          | TYPE=1
-
-Optional flags:
-Provide with --type 1
---ansible-control-node-subnet-cidr              | ANSIBLE_CONTROL_NODE_SUBNET_CIDR=10.0.24.0/24
---jump-cluster-broker-subnet-config            	| JUMP_CLUSTER_BROKER_SUBNET_CONFIG="us-east-1a:10.0.34.0/24,us-east-1b:10.0.35.0/24,us-east-1c:10.0.36.0/24"
---jump-cluster-broker-iam-role-name             | JUMP_CLUSTER_BROKER_IAM_ROLE_NAME=msk-broker-role
---cc-cluster-type                               | CC_CLUSTER_TYPE=enterprise
-
-Provide with --type 2
---jump-cluster-broker-subnet-config            	| JUMP_CLUSTER_BROKER_SUBNET_CONFIG="us-east-1a:10.0.34.0/24,us-east-1b:10.0.35.0/24,us-east-1c:10.0.36.0/24"
---ansible-control-node-subnet-cidr              | ANSIBLE_CONTROL_NODE_SUBNET_CIDR=10.0.24.0/24
---cc-cluster-type                               | CC_CLUSTER_TYPE=enterprise
-`,
+		Use:           "migration-infra",
+		Short:         "Create assets for the migration infrastructure",
+		Long:          "Create Terraform assets that provision the migration infrastructure - Confluent Cloud, cluster linking, etc.",
 		SilenceErrors: true,
 		PreRunE:       preRunCreateMigrationInfra,
 		RunE:          runCreateMigrationInfra,
 	}
 
-	migrationInfraCmd.Flags().StringVar(&region, "region", "", "The AWS region")
-	migrationInfraCmd.Flags().StringVar(&vpcId, "vpc-id", "", "The VPC ID")
-	migrationInfraCmd.Flags().StringVar(&ccEnvName, "cc-env-name", "", "The Confluent Cloud environment name")
-	migrationInfraCmd.Flags().StringVar(&ccClusterName, "cc-cluster-name", "", "The Confluent Cloud cluster name")
-	migrationInfraCmd.Flags().StringVar(&ccClusterType, "cc-cluster-type", "", "The Confluent Cloud cluster type")
-	migrationInfraCmd.Flags().StringVar(&clusterFile, "cluster-file", "", "The cluster json file produced from 'scan cluster' command")
-	migrationInfraCmd.Flags().StringVar(&migrationInfraType, "type", "", "The migration infra type")
+	groups := map[*pflag.FlagSet]string{}
 
-	//optional depending on type
-	migrationInfraCmd.Flags().StringVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", "", "The Jump cluster broker subnet config")
-	migrationInfraCmd.Flags().StringVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", "", "The Ansible control node subnet CIDR")
-	migrationInfraCmd.Flags().StringVar(&jumpClusterBrokerIAMRoleName, "jump-cluster-broker-iam-role-name", "", "The Jump cluster broker IAM role name")
+	// Required flags.
+	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
+	requiredFlags.SortFlags = false
+	requiredFlags.StringVar(&region, "region", "", "AWS region the cost report is generated for")
+	requiredFlags.StringVar(&vpcId, "vpc-id", "", "Existing MSK VPC ID")
+	requiredFlags.StringVar(&ccEnvName, "cc-env-name", "", "Confluent Cloud environment name")
+	requiredFlags.StringVar(&ccClusterName, "cc-cluster-name", "", "Confluent Cloud cluster name")
+	requiredFlags.StringVar(&clusterFile, "cluster-file", "", "Cluster scan JSON file produced from 'kcp scan cluster' command")
+	requiredFlags.StringVar(&migrationInfraType, "type", "", "The migration-infra type. See README for available options")
+	migrationInfraCmd.Flags().AddFlagSet(requiredFlags)
+	groups[requiredFlags] = "Required Flags"
+
+	// Private Networking Migration flags.
+	privNetworkMigrationFlags := pflag.NewFlagSet("private-network-migration", pflag.ExitOnError)
+	privNetworkMigrationFlags.SortFlags = false
+	privNetworkMigrationFlags.StringVar(&ccClusterType, "cc-cluster-type", "", "Confluent Cloud cluster type")
+	privNetworkMigrationFlags.IPNetVar(&ansibleControlNodeSubnetCIDR, "ansible-control-node-subnet-cidr", net.IPNet{}, "Ansible control node subnet CIDR")
+	privNetworkMigrationFlags.IPNetVar(&jumpClusterBrokerSubnetConfig, "jump-cluster-broker-subnet-config", net.IPNet{}, "Jump cluster broker subnet config")
+	migrationInfraCmd.Flags().AddFlagSet(privNetworkMigrationFlags)
+	groups[privNetworkMigrationFlags] = "Private Network Migration Flags"
+
+	// Type 1 flags.
+	typeOneFlags := pflag.NewFlagSet("type-1", pflag.ExitOnError)
+	typeOneFlags.SortFlags = false
+	typeOneFlags.StringVar(&jumpClusterBrokerIAMRoleName, "jump-cluster-broker-iam-role-name", "", "The Jump cluster broker IAM role name")
+	migrationInfraCmd.Flags().AddFlagSet(typeOneFlags)
+	groups[typeOneFlags] = "Type 1 Flags"
+
+	migrationInfraCmd.SetUsageFunc(func(c *cobra.Command) error {
+		fmt.Printf("%s\n\n", c.Short)
+
+		flagOrder := []*pflag.FlagSet{requiredFlags, privNetworkMigrationFlags, typeOneFlags}
+		groupNames := []string{"Required Flags", "Private Network Migration Flags", "Type 1 Required Flags"}
+
+		for i, fs := range flagOrder {
+			usage := fs.FlagUsages()
+			if usage != "" {
+				fmt.Printf("%s:\n%s\n", groupNames[i], usage)
+			}
+		}
+
+		fmt.Println("All flags can be provided via environment variables (uppercase, with underscores).")
+
+		return nil
+	})
 
 	migrationInfraCmd.MarkFlagRequired("region")
 	migrationInfraCmd.MarkFlagRequired("vpc-id")
@@ -141,11 +155,11 @@ func parseMigrationInfraOpts() (*migration_infra.MigrationInfraOpts, error) {
 	opts := migration_infra.MigrationInfraOpts{
 		Region:                        region,
 		VPCId:                         vpcId,
-		JumpClusterBrokerSubnetConfig: jumpClusterBrokerSubnetConfig,
+		JumpClusterBrokerSubnetConfig: jumpClusterBrokerSubnetConfig.String(),
 		CCEnvName:                     ccEnvName,
 		CCClusterName:                 ccClusterName,
 		CCClusterType:                 ccClusterType,
-		AnsibleControlNodeSubnetCIDR:  ansibleControlNodeSubnetCIDR,
+		AnsibleControlNodeSubnetCIDR:  ansibleControlNodeSubnetCIDR.String(),
 		JumpClusterBrokerIAMRoleName:  jumpClusterBrokerIAMRoleName,
 		ClusterInfo:                   clusterInfo,
 		MigrationInfraType:            migrationInfraType,

--- a/internal/cli/init/init.go
+++ b/internal/cli/init/init.go
@@ -10,12 +10,14 @@ import (
 func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Generate a set of env vars to export",
-		Long: `Generate a comprehensive set of environment variables to export.
+		Short: "Generate a README.md and set of env vars to export",
+		Long: `Generates a README.md to guide usage of kcp and a script to export environment variables for various kcp commands.
 eg.
 export VPC_ID=vpc-1234567890
 export REGION=us-east-1
 
+export SASL_SCRAM_USERNAME=<msk-username>
+export SASL_SCRAM_PASSWORD=<msk-password>
 etc
 		`,
 		Example: `


### PR DESCRIPTION
`kcp scan cluster`:
```shell
❯ kcp scan cluster --help
Scan a given cluster for information that will help with migration

Scan a given cluster

Required Flags:
      --cluster-arn string   The MSK cluster ARN

Authentication Flags:
      --use-sasl-iam          Use IAM authentication
      --use-sasl-scram        Use SASL/SCRAM authentication
      --use-tls               Use TLS authentication
      --use-unauthenticated   Use unauthenticated authentication
      --skip-kafka            Skip kafka level cluster scan, use when brokers are not reachable

SASL/SCRAM Flags:
      --sasl-scram-username string   The SASL SCRAM username
      --sasl-scram-password string   The SASL SCRAM password

TLS Flags:
      --tls-ca-cert string       The TLS CA certificate
      --tls-client-cert string   The TLS client certificate
      --tls-client-key string    The TLS client key

All flags can be provided via environment variables (uppercase, with underscores).
```

---

`kcp scan region`:
```shell
❯ kcp scan region --help
Scan an AWS region for MSK clusters and gather information about them

Scan an AWS region for MSK clusters

Required Flags:
      --region string   AWS region

All flags can be provided via environment variables (uppercase, with underscores).
```

---

`kcp create-asset bastion-host`:
```shell
❯ kcp create-asset bastion-host --help
Create Terraform assets for the deploying a bastion host in AWS within you an existing VPC.

Create assets for the bastion host

Required Flags:
      --region string             AWS region the cost report is generated for
      --vpc-id string             The VPC ID to target
      --bastion-host-cidr ipNet   The bastion host CIDR (e.g. 10.0.255.0/24)

Optional Flags:
      --create-igw   When set, Terraform will create a new internet gateway in the VPC.

All flags can be provided via environment variables (uppercase, with underscores).
```

---

`kcp create-asset migration-infra`:
```shell
❯ kcp create-asset migration-infra --help
Create Terraform assets that provision the migration infrastructure - Confluent Cloud, cluster linking, etc.

Create assets for the migration infrastructure

Required Flags:
      --region string            AWS region the cost report is generated for
      --vpc-id string            Existing MSK VPC ID
      --cc-env-name string       Confluent Cloud environment name
      --cc-cluster-name string   Confluent Cloud cluster name
      --cluster-file string      Cluster scan JSON file produced from 'kcp scan cluster' command
      --type string              The migration-infra type. See README for available options

Private Network Migration Flags:
      --cc-cluster-type string                    Confluent Cloud cluster type - 'Dedicated' or 'Enterprise'
      --ansible-control-node-subnet-cidr ipNet    Ansible control node subnet CIDR (e.g. 10.0.255.0/24)
      --jump-cluster-broker-subnet-config ipNet   Jump cluster broker subnet config (e.g. us-east-1a:10.0.150.0/24,us-east-1b:10.0.160.0/24,us-east-1c:10.0.170.0/24)

'Type 1' Required Flags:
      --jump-cluster-broker-iam-role-name string   The Jump cluster broker IAM role name

All flags can be provided via environment variables (uppercase, with underscores).
```

---

`kcp create-asset migration-scripts`:
```shell
❯ kcp create-asset migration-scripts --help
Create shell scripts for setting up mirror topics used by the cluster links to migrate data to the target cluster in Confluent Cloud

Create assets for the migration scripts

Required Flags:
      --cluster-file string             The cluster scan JSON file produced from 'kcp scan cluster' command
      --migration-infra-folder string   The migration-infra folder produced from 'kcp create-asset migration-infra' command after applying the Terraform

All flags can be provided via environment variables (uppercase, with underscores).
```

---

`kcp create-asset reverse-proxy`:
```shell
❯ kcp create-asset reverse-proxy --help
Create Terraform assets for deploying a reverse proxy to access the privately networked Confluent Cloud cluster

Create assets for the reverse proxy

Required Flags:
      --region string                   AWS region
      --vpc-id string                   Existing MSK VPC ID
      --reverse-proxy-cidr ipNet        Revese proxy subnet CIDR (e.g. 10.0.255.0/24)
      --migration-infra-folder string   The migration-infra folder produced from 'kcp create-asset migration-infra' command after applying the Terraform

All flags can be provided via environment variables (uppercase, with underscores).
```

---

Other minor updates:
- Updated the type for CIDR inputs from `string` to `ipNet` which handles validating that the user's IP range is in valid IP format.