### PR TITLE
feat(outputs): refactor output structure for files generated by the scan/report commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,7 @@ migration-plan/
 .DS_Store
 
 # Ignore kcp generated files
-*-metrics.md
-*-metrics.json
-cost_report/
-cluster_scan_*.md
-cluster_scan_*.json
-cost_reports/
+kcp-scan/
 
 # Added by goreleaser init:
 dist/

--- a/internal/generators/report/cluster/metrics/cluster_metrics_collector_test.go
+++ b/internal/generators/report/cluster/metrics/cluster_metrics_collector_test.go
@@ -284,8 +284,7 @@ func TestClusterMetricsCollector_Run_Success(t *testing.T) {
 	mockAdmin.AssertExpectations(t)
 
 	// Clean up generated files
-	os.Remove("test-cluster-metrics.json")
-	os.Remove("test-cluster-metrics.md")
+	os.RemoveAll("kcp-scan")
 }
 
 func TestClusterMetricsCollector_Run_DescribeClusterError(t *testing.T) {
@@ -751,12 +750,12 @@ func TestClusterMetricsCollector_writeOutput(t *testing.T) {
 		},
 	}
 
-	err := collector.writeOutput(metrics)
+	err := collector.writeOutput(metrics, "us-west-2")
 
 	assert.NoError(t, err)
 
 	// Verify JSON file was created
-	jsonData, err := os.ReadFile("test-cluster-metrics.json")
+	jsonData, err := os.ReadFile("kcp-scan/us-west-2/test-cluster/test-cluster-metrics.json")
 	assert.NoError(t, err)
 
 	var result types.ClusterMetrics
@@ -766,12 +765,11 @@ func TestClusterMetricsCollector_writeOutput(t *testing.T) {
 	assert.Equal(t, "PROVISIONED", result.ClusterType)
 
 	// Verify Markdown file was created
-	_, err = os.Stat("test-cluster-metrics.md")
+	_, err = os.Stat("kcp-scan/us-west-2/test-cluster/test-cluster-metrics.md")
 	assert.NoError(t, err)
 
 	// Clean up
-	os.Remove("test-cluster-metrics.json")
-	os.Remove("test-cluster-metrics.md")
+	os.RemoveAll("kcp-scan")
 }
 
 func TestStructToMap(t *testing.T) {

--- a/internal/generators/report/region/costs/region_coster.go
+++ b/internal/generators/report/region/costs/region_coster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -77,7 +78,7 @@ func (rc *RegionCoster) Run() error {
 		CostData: costData,
 	}
 
-	outputFolder := fmt.Sprintf("cost_reports/%s", rc.region)
+	outputFolder := filepath.Join("kcp-scan", rc.region)
 	if err := os.MkdirAll(outputFolder, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create output folder: %v", err)
 	}
@@ -104,7 +105,7 @@ func (rc *RegionCoster) writeCostReportJSON(metrics types.RegionCosts, outputFol
 		return fmt.Errorf("failed to marshal cluster information: %v", err)
 	}
 
-	filePath := fmt.Sprintf("%s/cost_report-%s.json", outputFolder, rc.region)
+	filePath := filepath.Join(outputFolder, fmt.Sprintf("%s-cost-report.json", rc.region))
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}
@@ -113,7 +114,7 @@ func (rc *RegionCoster) writeCostReportJSON(metrics types.RegionCosts, outputFol
 }
 
 func (rc *RegionCoster) writeCostReportCSV(metrics types.RegionCosts, outputFolder string) error {
-	filePath := fmt.Sprintf("%s/cost_report-%s.csv", outputFolder, rc.region)
+	filePath := filepath.Join(outputFolder, fmt.Sprintf("%s-cost-report.csv", rc.region))
 
 	file, err := os.Create(filePath)
 	if err != nil {

--- a/internal/generators/report/region/costs/region_costs_markdown.go
+++ b/internal/generators/report/region/costs/region_costs_markdown.go
@@ -2,6 +2,7 @@ package costs
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/markdown"
@@ -112,7 +113,7 @@ func (rc *RegionCoster) writeCostReportMarkdown(metrics types.RegionCosts, outpu
 	md.AddTable(headers, data, 0, 1, 2)
 
 	// Print to terminal and save to file
-	filePath := fmt.Sprintf("%s/cost_report-%s.md", outputFolder, rc.region)
+	filePath := filepath.Join(outputFolder, fmt.Sprintf("%s-cost-report.md", rc.region))
 	err := md.Print(markdown.PrintOptions{ToTerminal: true, ToFile: filePath})
 	if err != nil {
 		return fmt.Errorf("❌ Failed to write markdown output: %v", err)

--- a/internal/generators/scan/cluster/cluster_scanner.go
+++ b/internal/generators/scan/cluster/cluster_scanner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -80,13 +81,18 @@ func (cs *ClusterScanner) Run() error {
 		return fmt.Errorf("❌ Failed to marshal cluster information: %v", err)
 	}
 
-	filePath := fmt.Sprintf("cluster_scan_%s.json", aws.ToString(clusterInfo.Cluster.ClusterName))
+	dirPath := filepath.Join("kcp-scan", clusterInfo.Region, aws.ToString(clusterInfo.Cluster.ClusterName))
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
+	}
+
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s.json", aws.ToString(clusterInfo.Cluster.ClusterName)))
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("❌ Failed to write file: %v", err)
 	}
 
 	// Generate markdown report
-	mdFilePath := fmt.Sprintf("cluster_scan_%s.md", aws.ToString(clusterInfo.Cluster.ClusterName))
+	mdFilePath := filepath.Join(dirPath, fmt.Sprintf("%s.md", aws.ToString(clusterInfo.Cluster.ClusterName)))
 	if err := cs.generateMarkdownReport(clusterInfo, mdFilePath); err != nil {
 		return fmt.Errorf("❌ Failed to generate markdown report: %v", err)
 	}

--- a/internal/generators/scan/cluster/cluster_scanner_test.go
+++ b/internal/generators/scan/cluster/cluster_scanner_test.go
@@ -921,7 +921,7 @@ func TestClusterScanner_Run(t *testing.T) {
 	readOnlyDir := filepath.Join(os.TempDir(), "readonly_test_dir")
 	err := os.MkdirAll(readOnlyDir, 0400)
 	require.NoError(t, err)
-	defer os.RemoveAll(readOnlyDir)
+	defer os.RemoveAll("kcp-scan")
 
 	tests := []struct {
 		name            string
@@ -1152,7 +1152,7 @@ func TestClusterScanner_Run(t *testing.T) {
 			require.NoError(t, err)
 			// Verify file contents for successful case
 			if tt.wantError == "" {
-				jsonFilePath := fmt.Sprintf("cluster_scan_%s.json", aws.ToString(tt.mockMSKOutput.ClusterInfoList[0].ClusterName))
+				jsonFilePath := filepath.Join("kcp-scan", defaultRegion, aws.ToString(tt.mockMSKOutput.ClusterInfoList[0].ClusterName), fmt.Sprintf("%s.json", aws.ToString(tt.mockMSKOutput.ClusterInfoList[0].ClusterName)))
 				fileContent, err := os.ReadFile(jsonFilePath)
 				require.NoError(t, err)
 
@@ -1163,10 +1163,9 @@ func TestClusterScanner_Run(t *testing.T) {
 				assert.Equal(t, aws.ToString(tt.mockMSKOutput.ClusterInfoList[0].ClusterName), aws.ToString(clusterInfo.Cluster.ClusterName))
 				assert.ElementsMatch(t, []string{"topic1", "topic2"}, clusterInfo.Topics)
 				assert.Equal(t, defaultRegion, clusterInfo.Region)
-				// Cleanup test files
-				markDownFilePath := fmt.Sprintf("cluster_scan_%s.md", aws.ToString(tt.mockMSKOutput.ClusterInfoList[0].ClusterName))
-				os.Remove(jsonFilePath)
-				os.Remove(markDownFilePath)
+
+				// Cleanup test directories
+				os.RemoveAll("kcp-scan")
 			}
 		})
 	}

--- a/internal/generators/scan/region/region_scanner.go
+++ b/internal/generators/scan/region/region_scanner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -142,13 +143,18 @@ func (rs *RegionScanner) Run() error {
 		return fmt.Errorf("❌ Failed to marshal scan results: %v", err)
 	}
 
-	filePath := fmt.Sprintf("region_scan_%s.json", rs.region)
+	dirPath := filepath.Join("kcp-scan", rs.region)
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
+	}
+
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-region-scan.json", rs.region))
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("❌ Failed to write file: %v", err)
 	}
 
 	// Generate markdown report
-	mdFilePath := fmt.Sprintf("region_scan_%s.md", rs.region)
+	mdFilePath := filepath.Join(dirPath, fmt.Sprintf("%s-region-scan.md", rs.region))
 	if err := rs.generateMarkdownReport(scanResult, mdFilePath); err != nil {
 		return fmt.Errorf("❌ Failed to generate markdown report: %v", err)
 	}

--- a/internal/generators/scan/region/region_scanner_test.go
+++ b/internal/generators/scan/region/region_scanner_test.go
@@ -217,7 +217,7 @@ func TestScanner_Run(t *testing.T) {
 	readOnlyDir := filepath.Join(os.TempDir(), "readonly_test_dir")
 	err := os.MkdirAll(readOnlyDir, 0400)
 	require.NoError(t, err)
-	defer os.RemoveAll(readOnlyDir)
+	defer os.RemoveAll("kcp-scan")
 
 	tests := []struct {
 		name       string
@@ -326,7 +326,7 @@ func TestScanner_Run(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify the output file exists and contains valid JSON
-			jsonFilePath := fmt.Sprintf("region_scan_%s.json", tt.region)
+			jsonFilePath := filepath.Join("kcp-scan", tt.region, fmt.Sprintf("%s-region-scan.json", tt.region))
 			data, err := os.ReadFile(jsonFilePath)
 			require.NoError(t, err)
 
@@ -339,9 +339,7 @@ func TestScanner_Run(t *testing.T) {
 			assert.Equal(t, len(tt.mockOutput.ClusterInfoList), len(result.Clusters))
 
 			// Cleanup test file
-			markDownFilePath := fmt.Sprintf("region_scan_%s.md", tt.region)
-			os.Remove(jsonFilePath)
-			os.Remove(markDownFilePath)
+			os.RemoveAll("kcp-scan")
 		})
 	}
 }


### PR DESCRIPTION
Any of the `kcp scan ...` and `kcp report ...` commands will now generate a `kcp-scan` directory in the current working directory.

This `kcp-scan` directory will be the new location for all generated reports. The structure will follow a region then cluster child-directory structure:
```shell
kcp-scan
├── eu-west-1
│   ├── eu-west-1-region-scan.json
│   ├── eu-west-1-region-scan.md
│   └── kcp-pub-cluster
│       ├── kcp-pub-cluster.json
│       └── kcp-pub-cluster.md
├── eu-west-3
│   ├── eu-west-3-cost-report.csv
│   ├── eu-west-3-cost-report.json
│   ├── eu-west-3-cost-report.md
│   ├── eu-west-3-region-scan.json
│   ├── eu-west-3-region-scan.md
│   └── public-retention-env-cluster
│       ├── public-retention-env-cluster-metrics.json
│       ├── public-retention-env-cluster-metrics.md
│       ├── public-retention-env-cluster.json
│       └── public-retention-env-cluster.md
└── us-east-1
    ├── us-east-1-region-scan.json
    └── us-east-1-region-scan.md

6 directories, 15 files
```