### PR TITLE
chore: [scan client-inventory] make region and s3-uri required flags

### DIFF
--- a/internal/cli/scan/client_inventory/scan_client_inventory.go
+++ b/internal/cli/scan/client_inventory/scan_client_inventory.go
@@ -56,6 +56,9 @@ func NewScanClientInventoryCmd() *cobra.Command {
 		return nil
 	})
 
+	clientInventoryCmd.MarkFlagRequired("region")
+	clientInventoryCmd.MarkFlagRequired("s3-uri")
+
 	return clientInventoryCmd
 }
 


### PR DESCRIPTION
## Description

Fix issue where flags region and s3-uri are not set as required but the scan command will not work without them

---

## Changes Made

- [x] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [ ] New tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass

**Test Instructions:**

<!-- How should reviewers test this? -->

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
