### PR TITLE
migration_infra folder name update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1321,7 +1321,7 @@ This command generates migration scripts that mirror topics from MSK to Confluen
 ```shell
 kcp create-asset migration-scripts \
   --cluster-file cluster_scan_kcp-msk-cluster.json \
-  --migration-infra-folder migration-infra
+  --migration-infra-folder migration_infra
 ```
 
 > [!NOTE]
@@ -1356,7 +1356,7 @@ Create reverse proxy infrastructure assets to allow observability into migrated 
 kcp create-asset reverse-proxy \
   --region us-east-1 \
   --vpc-id vpc-xxxxxxxxx \
-  --migration-infra-folder migration-infra \
+  --migration-infra-folder migration_infra \
   --reverse-proxy-cidr 10.0.XXX.0/24
 ```
 


### PR DESCRIPTION
## Description

kcp create-asset requires migration-infra-folder flag and folder name should be passed, currently kcp is creating folder named migration_infra, and that is not updated in readme examples.

---

## Changes Made

- [ ] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [x] Documentation updates

---

## Testing

- [ ] New tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass

**Test Instructions:**

<!-- How should reviewers test this? -->

---

## Checklist

- [X] Code follows project style guidelines
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

Line 68 https://github.com/confluentinc/kcp/blob/main/internal/generators/create_asset/migration_infra/migration_infra.go