### PR TITLE
chore(creds): convert yaml file to lists instead of maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,7 @@ fmt:
 test:
 	@echo "🧪 Running tests..."
 	@echo "=================="
-	@go test -v ./... || (echo ""; echo "❌ TESTS FAILED - See failures above"; echo "=========================================="; exit 1)
-	@echo ""
-	@echo "✅ All tests passed!"
+	@bash -c 'go test -v ./...; exit_code=$$?; echo ""; if [ $$exit_code -ne 0 ]; then echo "❌ Tests failed with exit code $$exit_code"; else echo "✅ All tests passed!"; fi; exit $$exit_code'
 
 # Run tests with coverage - beautiful terminal output
 test-cov:

--- a/internal/cli/scan/clusters/scan_clusters.go
+++ b/internal/cli/scan/clusters/scan_clusters.go
@@ -53,6 +53,9 @@ func NewScanClustersCmd() *cobra.Command {
 		return nil
 	})
 
+	clustersCmd.MarkFlagRequired("discover-dir")
+	clustersCmd.MarkFlagRequired("credentials-yaml")
+
 	return clustersCmd
 }
 

--- a/internal/generators/discover/discoverer_test.go
+++ b/internal/generators/discover/discoverer_test.go
@@ -19,7 +19,7 @@ func TestDiscoverer_getClusterEntry(t *testing.T) {
 		expected types.ClusterEntry
 	}{
 		{
-			name: "Provisioned cluster with all authentication methods enabled",
+			name: "Provisioned cluster with all authentication methods enabled - unauthentication selected",
 			cluster: kafkatypes.Cluster{
 				ClusterName: aws.String("test-cluster-all-auth"),
 				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-all-auth/12345678-1234-1234-1234-123456789012-1"),
@@ -140,7 +140,7 @@ func TestDiscoverer_getClusterEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "Provisioned cluster with IAM and SCRAM (IAM priority)",
+			name: "Provisioned cluster with IAM and SCRAM - IAM selected",
 			cluster: kafkatypes.Cluster{
 				ClusterName: aws.String("test-cluster-iam-scram"),
 				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-iam-scram/12345678-1234-1234-1234-123456789012-6"),
@@ -168,7 +168,7 @@ func TestDiscoverer_getClusterEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "Provisioned cluster with SCRAM and TLS (SCRAM priority)",
+			name: "Provisioned cluster with SASL_SCRAM and TLS - SASL_SCRAM selected",
 			cluster: kafkatypes.Cluster{
 				ClusterName: aws.String("test-cluster-scram-tls"),
 				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-scram-tls/12345678-1234-1234-1234-123456789012-7"),

--- a/internal/generators/discover/discoverer_test.go
+++ b/internal/generators/discover/discoverer_test.go
@@ -1,0 +1,274 @@
+package discover
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverer_getClusterEntry(t *testing.T) {
+	discoverer := &Discoverer{}
+
+	tests := []struct {
+		name     string
+		cluster  kafkatypes.Cluster
+		expected types.ClusterEntry
+	}{
+		{
+			name: "Provisioned cluster with all authentication methods enabled",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-all-auth"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-all-auth/12345678-1234-1234-1234-123456789012-1"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Iam: &kafkatypes.Iam{
+								Enabled: aws.Bool(true),
+							},
+							Scram: &kafkatypes.Scram{
+								Enabled: aws.Bool(true),
+							},
+						},
+						Tls: &kafkatypes.Tls{
+							Enabled: aws.Bool(true),
+						},
+						Unauthenticated: &kafkatypes.Unauthenticated{
+							Enabled: aws.Bool(true),
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-all-auth",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-all-auth/12345678-1234-1234-1234-123456789012-1",
+				AuthMethod: types.AuthMethodConfig{
+					Unauthenticated: &types.UnauthenticatedConfig{Use: true},                                 // highest priority, selected
+					IAM:             &types.IAMConfig{Use: false},                                            // not selected due to priority
+					SASLScram:       &types.SASLScramConfig{Use: false, Username: "", Password: ""},          // not selected due to priority
+					TLS:             &types.TLSConfig{Use: false, CACert: "", ClientCert: "", ClientKey: ""}, // not selected due to priority
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with only IAM enabled",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-iam-only"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-iam-only/12345678-1234-1234-1234-123456789012-2"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Iam: &kafkatypes.Iam{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-iam-only",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-iam-only/12345678-1234-1234-1234-123456789012-2",
+				AuthMethod: types.AuthMethodConfig{
+					IAM: &types.IAMConfig{Use: true}, // only auth method available, selected
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with only SASL/SCRAM enabled",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-scram-only"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-scram-only/12345678-1234-1234-1234-123456789012-3"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Scram: &kafkatypes.Scram{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-scram-only",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-scram-only/12345678-1234-1234-1234-123456789012-3",
+				AuthMethod: types.AuthMethodConfig{
+					SASLScram: &types.SASLScramConfig{Use: true, Username: "", Password: ""}, // only auth method available, selected
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with only TLS enabled",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-tls-only"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-tls-only/12345678-1234-1234-1234-123456789012-4"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Tls: &kafkatypes.Tls{
+							Enabled: aws.Bool(true),
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-tls-only",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-tls-only/12345678-1234-1234-1234-123456789012-4",
+				AuthMethod: types.AuthMethodConfig{
+					TLS: &types.TLSConfig{Use: true, CACert: "", ClientCert: "", ClientKey: ""}, // only auth method available, selected
+				},
+			},
+		},
+		{
+			name: "Serverless cluster",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-serverless"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-serverless/12345678-1234-1234-1234-123456789012-5"),
+				ClusterType: kafkatypes.ClusterTypeServerless,
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-serverless",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-serverless/12345678-1234-1234-1234-123456789012-5",
+				AuthMethod: types.AuthMethodConfig{
+					IAM: &types.IAMConfig{Use: true}, // serverless defaults to IAM
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with IAM and SCRAM (IAM priority)",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-iam-scram"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-iam-scram/12345678-1234-1234-1234-123456789012-6"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Iam: &kafkatypes.Iam{
+								Enabled: aws.Bool(true),
+							},
+							Scram: &kafkatypes.Scram{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-iam-scram",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-iam-scram/12345678-1234-1234-1234-123456789012-6",
+				AuthMethod: types.AuthMethodConfig{
+					IAM:       &types.IAMConfig{Use: true},                                    // higher priority than SCRAM
+					SASLScram: &types.SASLScramConfig{Use: false, Username: "", Password: ""}, // lower priority
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with SCRAM and TLS (SCRAM priority)",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-scram-tls"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-scram-tls/12345678-1234-1234-1234-123456789012-7"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Scram: &kafkatypes.Scram{
+								Enabled: aws.Bool(true),
+							},
+						},
+						Tls: &kafkatypes.Tls{
+							Enabled: aws.Bool(true),
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name: "test-cluster-scram-tls",
+				Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-scram-tls/12345678-1234-1234-1234-123456789012-7",
+				AuthMethod: types.AuthMethodConfig{
+					SASLScram: &types.SASLScramConfig{Use: true, Username: "", Password: ""},           // higher priority than TLS
+					TLS:       &types.TLSConfig{Use: false, CACert: "", ClientCert: "", ClientKey: ""}, // lower priority
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with disabled authentication methods",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-disabled"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-disabled/12345678-1234-1234-1234-123456789012-8"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: &kafkatypes.ClientAuthentication{
+						Sasl: &kafkatypes.Sasl{
+							Iam: &kafkatypes.Iam{
+								Enabled: aws.Bool(false),
+							},
+							Scram: &kafkatypes.Scram{
+								Enabled: aws.Bool(false),
+							},
+						},
+						Tls: &kafkatypes.Tls{
+							Enabled: aws.Bool(false),
+						},
+						Unauthenticated: &kafkatypes.Unauthenticated{
+							Enabled: aws.Bool(false),
+						},
+					},
+				},
+			},
+			expected: types.ClusterEntry{
+				Name:       "test-cluster-disabled",
+				Arn:        "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-disabled/12345678-1234-1234-1234-123456789012-8",
+				AuthMethod: types.AuthMethodConfig{
+					// no auth methods should be configured since all are disabled
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with nil client authentication",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-nil-auth"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-nil-auth/12345678-1234-1234-1234-123456789012-9"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					ClientAuthentication: nil,
+				},
+			},
+			expected: types.ClusterEntry{
+				Name:       "test-cluster-nil-auth",
+				Arn:        "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-nil-auth/12345678-1234-1234-1234-123456789012-9",
+				AuthMethod: types.AuthMethodConfig{
+					// no auth methods should be configured
+				},
+			},
+		},
+		{
+			name: "Provisioned cluster with nil provisioned section",
+			cluster: kafkatypes.Cluster{
+				ClusterName: aws.String("test-cluster-nil-provisioned"),
+				ClusterArn:  aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-nil-provisioned/12345678-1234-1234-1234-123456789012-10"),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: nil,
+			},
+			expected: types.ClusterEntry{
+				Name:       "test-cluster-nil-provisioned",
+				Arn:        "arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster-nil-provisioned/12345678-1234-1234-1234-123456789012-10",
+				AuthMethod: types.AuthMethodConfig{
+					// no auth methods should be configured
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := discoverer.getClusterEntry(tt.cluster)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/generators/scan/clusters/clusters_scanner.go
+++ b/internal/generators/scan/clusters/clusters_scanner.go
@@ -29,9 +29,9 @@ func NewClustersScanner(discoverDir string, credentials types.Credentials) *Clus
 
 func (cs *ClustersScanner) Run() error {
 	for _, regionEntry := range cs.Credentials.Regions {
-		for arn, clusterEntry := range regionEntry.Clusters {
+		for _, clusterEntry := range regionEntry.Clusters {
 			if err := cs.scanCluster(regionEntry.Name, clusterEntry); err != nil {
-				slog.Error("failed to scan cluster", "cluster", arn, "error", err)
+				slog.Error("failed to scan cluster", "cluster", clusterEntry.Arn, "error", err)
 				continue
 			}
 		}

--- a/internal/generators/scan/clusters/clusters_scanner_test.go
+++ b/internal/generators/scan/clusters/clusters_scanner_test.go
@@ -17,10 +17,12 @@ import (
 func newTestClustersScanner() *ClustersScanner {
 	// Create test credentials
 	testCredentials := types.Credentials{
-		Regions: map[string]types.RegionEntry{
-			"us-west-2": {
-				Clusters: map[string]types.ClusterEntry{
-					"arn:aws:kafka:us-west-2:123456789012:cluster/test-cluster": {
+		Regions: []types.RegionEntry{
+			{
+				Name: "us-west-2",
+				Clusters: []types.ClusterEntry{
+					{
+						Arn: "arn:aws:kafka:us-west-2:123456789012:cluster/test-cluster",
 						AuthMethod: types.AuthMethodConfig{
 							IAM: &types.IAMConfig{Use: true},
 						},

--- a/internal/types/credentials.go
+++ b/internal/types/credentials.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Credentials struct {
-	Regions map[string]RegionEntry `yaml:"regions"`
+	Regions []RegionEntry `yaml:"regions"`
 }
 
 func NewCredentials(credentialsYamlPath string) (*Credentials, []error) {
@@ -52,10 +52,10 @@ func (c Credentials) Validate() (bool, []error) {
 	errs := []error{}
 
 	for _, clusters := range c.Regions {
-		for arn, cluster := range clusters.Clusters {
+		for _, cluster := range clusters.Clusters {
 			enabledMethods := cluster.GetAuthMethods()
 			if len(enabledMethods) > 1 {
-				errs = append(errs, fmt.Errorf("More than one authentication method enabled for %s", arn))
+				errs = append(errs, fmt.Errorf("More than one authentication method enabled for %s", cluster.Arn))
 				continue
 			}
 		}
@@ -64,10 +64,13 @@ func (c Credentials) Validate() (bool, []error) {
 }
 
 type RegionEntry struct {
-	Clusters map[string]ClusterEntry `yaml:"clusters"`
+	Name     string         `yaml:"name"`
+	Clusters []ClusterEntry `yaml:"clusters"`
 }
 
 type ClusterEntry struct {
+	Name       string           `yaml:"name"`
+	Arn        string           `yaml:"arn"`
 	AuthMethod AuthMethodConfig `yaml:"auth_method"`
 }
 


### PR DESCRIPTION
## Description

## 🔄 **Refactor: Convert YAML credentials structure from maps to lists**

This PR refactors the credentials YAML structure to use lists instead of maps for regions and clusters, improving maintainability and making the configuration more intuitive.

---

### **📋 Changes Made**

#### **Core Structure Changes**
- **Regions**: Changed from `map[string]RegionEntry` to `[]RegionEntry`
- **Clusters**: Changed from `map[string]ClusterEntry` to `[]ClusterEntry`
- Added explicit `Name` and `Arn` fields to `ClusterEntry` struct
- Added explicit `Name` field to `RegionEntry` struct

#### **YAML Format Transformation**
**Before:**
```yaml
regions:
  us-east-1:
    clusters:
      arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster/12345678-1234-1234-1234-123456789012-1:
        auth_method:
          iam:
            use: true
```

**After:**
```yaml
regions:
- name: us-east-1
  clusters:
  - name: test-cluster
    arn: arn:aws:kafka:us-east-1:123456789012:cluster/test-cluster/12345678-1234-1234-1234-123456789012-1
    auth_method:
      iam:
        use: true
```

#### **Code Updates**
- **Discoverer**: Refactored cluster discovery logic to build lists instead of maps
- **Scanner**: Updated cluster scanning to iterate over list structures
- **Validation**: Modified validation logic to work with new list-based structure
- **Tests**: Added comprehensive test coverage for the new `getClusterEntry` method
- **CLI**: Added required flag validation for `discover-dir` and `credentials-yaml`

#### **Test Improvements**
- Fixed test execution in Makefile to properly handle exit codes
- Added extensive test cases covering various cluster authentication scenarios
- Improved error handling and validation test coverage

---

### **✅ Benefits**

1. **Better Readability**: YAML structure is more intuitive and easier to read
2. **Explicit Structure**: Clear separation of cluster names and ARNs
3. **Maintainability**: Easier to add/remove clusters without complex key management
4. **Consistency**: Uniform list-based approach throughout the configuration
5. **Validation**: Improved error messages with explicit cluster identification

---


### **🔄 Migration Impact**

This is a **breaking change** for existing `creds.yaml` files. Users will need to:
1. Regenerate their credentials files using the `discover` command
2. Update any manual YAML configurations to use the new list format

---

### **📝 Files Modified**

- `internal/types/credentials.go` - Core structure changes
- `internal/generators/discover/discoverer.go` - Discovery logic refactor
- `internal/generators/scan/clusters/clusters_scanner.go` - Scanner updates
- `internal/cli/scan/clusters/scan_clusters.go` - CLI validation
- `Makefile` - Test execution improvements
- Comprehensive test updates across multiple files

This refactor sets the foundation for more maintainable credential management and clearer YAML configuration structure.

---

## Changes Made

- [x] Feature/bug fix/improvement description
- [x] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [x] New tests added/updated
- [x] Manual testing completed
- [x] All tests pass


---

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<img width="1494" height="262" alt="Screenshot 2025-09-03 at 15 37 15" src="https://github.com/user-attachments/assets/84217693-110e-4678-8466-32f654105280" />
