### PR TITLE
fix(discover): fixed bug that caused the creation of a new `kcp-scan` directory

### DIFF
--- a/internal/cli/scan/clusters/scan_clusters.go
+++ b/internal/cli/scan/clusters/scan_clusters.go
@@ -68,7 +68,6 @@ func preRunScanClusters(cmd *cobra.Command, args []string) error {
 }
 
 func runScanClusters(cmd *cobra.Command, args []string) error {
-
 	credsFile, errs := types.NewCredentials(credentialsYaml)
 	if len(errs) > 0 {
 		errMsg := "Failed to parse credentials file:"

--- a/internal/generators/scan/clusters/clusters_scanner.go
+++ b/internal/generators/scan/clusters/clusters_scanner.go
@@ -96,11 +96,11 @@ func (cs *ClustersScanner) scanCluster(region string, clusterEntry types.Cluster
 		return fmt.Errorf("❌ failed to scan Kafka resources: %v", err)
 	}
 
-	if err := clusterInfo.WriteAsJson(); err != nil {
+	if err := clusterInfo.WriteAsJsonWithBase(cs.DiscoverDir); err != nil {
 		return fmt.Errorf("❌ Failed to write broker info to file: %v", err)
 	}
 
-	if err := clusterInfo.WriteAsMarkdown(true); err != nil {
+	if err := clusterInfo.WriteAsMarkdownWithBase(cs.DiscoverDir, true); err != nil {
 		return fmt.Errorf("❌ Failed to write broker info to markdown file: %v", err)
 	}
 

--- a/internal/types/cluster_information.go
+++ b/internal/types/cluster_information.go
@@ -120,17 +120,24 @@ func (c *ClusterInformation) GetMarkdownPath() string {
 }
 
 func (c *ClusterInformation) GetDirPath() string {
-	return filepath.Join("kcp-scan", c.Region, aws.ToString(c.Cluster.ClusterName))
+	return c.GetDirPathWithBase("kcp-scan")
+}
+
+func (c *ClusterInformation) GetDirPathWithBase(baseDir string) string {
+	return filepath.Join(baseDir, c.Region, aws.ToString(c.Cluster.ClusterName))
 }
 
 func (c *ClusterInformation) WriteAsJson() error {
+	return c.WriteAsJsonWithBase("kcp-scan")
+}
 
-	dirPath := c.GetDirPath()
+func (c *ClusterInformation) WriteAsJsonWithBase(baseDir string) error {
+	dirPath := c.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := c.GetJsonPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s.json", aws.ToString(c.Cluster.ClusterName)))
 
 	data, err := c.AsJson()
 	if err != nil {
@@ -153,12 +160,16 @@ func (c *ClusterInformation) AsJson() ([]byte, error) {
 }
 
 func (c *ClusterInformation) WriteAsMarkdown(suppressToTerminal bool) error {
-	dirPath := c.GetDirPath()
+	return c.WriteAsMarkdownWithBase("kcp-scan", suppressToTerminal)
+}
+
+func (c *ClusterInformation) WriteAsMarkdownWithBase(baseDir string, suppressToTerminal bool) error {
+	dirPath := c.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := c.GetMarkdownPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s.md", aws.ToString(c.Cluster.ClusterName)))
 
 	md := c.AsMarkdown()
 	return md.Print(markdown.PrintOptions{ToTerminal: !suppressToTerminal, ToFile: filePath})

--- a/internal/types/costs.go
+++ b/internal/types/costs.go
@@ -47,17 +47,24 @@ func (c *RegionCosts) GetCSVPath() string {
 }
 
 func (c *RegionCosts) GetDirPath() string {
-	return filepath.Join("kcp-scan", c.Region)
+	return c.GetDirPathWithBase("kcp-scan")
+}
+
+func (c *RegionCosts) GetDirPathWithBase(baseDir string) string {
+	return filepath.Join(baseDir, c.Region)
 }
 
 func (c *RegionCosts) WriteAsJson() error {
+	return c.WriteAsJsonWithBase("kcp-scan")
+}
 
-	dirPath := c.GetDirPath()
+func (c *RegionCosts) WriteAsJsonWithBase(baseDir string) error {
+	dirPath := c.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := c.GetJsonPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-cost-report.json", c.Region))
 
 	data, err := c.AsJson()
 	if err != nil {
@@ -80,12 +87,16 @@ func (c *RegionCosts) AsJson() ([]byte, error) {
 }
 
 func (c *RegionCosts) WriteAsMarkdown(suppressToTerminal bool) error {
-	dirPath := c.GetDirPath()
+	return c.WriteAsMarkdownWithBase("kcp-scan", suppressToTerminal)
+}
+
+func (c *RegionCosts) WriteAsMarkdownWithBase(baseDir string, suppressToTerminal bool) error {
+	dirPath := c.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := c.GetMarkdownPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-cost-report.md", c.Region))
 	md := c.AsMarkdown()
 	return md.Print(markdown.PrintOptions{ToTerminal: !suppressToTerminal, ToFile: filePath})
 }
@@ -290,13 +301,16 @@ func (c *RegionCosts) AsCSVRecords() [][]string {
 }
 
 func (c *RegionCosts) WriteAsCSV() error {
+	return c.WriteAsCSVWithBase("kcp-scan")
+}
 
-	dirPath := c.GetDirPath()
+func (c *RegionCosts) WriteAsCSVWithBase(baseDir string) error {
+	dirPath := c.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := c.GetCSVPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-cost-report.csv", c.Region))
 
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -315,5 +329,4 @@ func (c *RegionCosts) WriteAsCSV() error {
 		}
 	}
 	return nil
-
 }

--- a/internal/types/metrics.go
+++ b/internal/types/metrics.go
@@ -77,16 +77,24 @@ func (cm *ClusterMetrics) GetMarkdownPath() string {
 }
 
 func (cm *ClusterMetrics) GetDirPath() string {
-	return filepath.Join("kcp-scan", cm.Region, aws.ToString(&cm.ClusterName))
+	return cm.GetDirPathWithBase("kcp-scan")
+}
+
+func (cm *ClusterMetrics) GetDirPathWithBase(baseDir string) string {
+	return filepath.Join(baseDir, cm.Region, aws.ToString(&cm.ClusterName))
 }
 
 func (cm *ClusterMetrics) WriteAsJson() error {
-	dirPath := cm.GetDirPath()
+	return cm.WriteAsJsonWithBase("kcp-scan")
+}
+
+func (cm *ClusterMetrics) WriteAsJsonWithBase(baseDir string) error {
+	dirPath := cm.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := cm.GetJsonPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-metrics.json", aws.ToString(&cm.ClusterName)))
 
 	data, err := cm.AsJson()
 	if err != nil {
@@ -109,12 +117,16 @@ func (cm *ClusterMetrics) AsJson() ([]byte, error) {
 }
 
 func (cm *ClusterMetrics) WriteAsMarkdown(suppressToTerminal bool) error {
-	dirPath := cm.GetDirPath()
+	return cm.WriteAsMarkdownWithBase("kcp-scan", suppressToTerminal)
+}
+
+func (cm *ClusterMetrics) WriteAsMarkdownWithBase(baseDir string, suppressToTerminal bool) error {
+	dirPath := cm.GetDirPathWithBase(baseDir)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return fmt.Errorf("❌ Failed to create directory structure: %v", err)
 	}
 
-	filePath := cm.GetMarkdownPath()
+	filePath := filepath.Join(dirPath, fmt.Sprintf("%s-metrics.md", aws.ToString(&cm.ClusterName)))
 	md := cm.AsMarkdown()
 	return md.Print(markdown.PrintOptions{ToTerminal: !suppressToTerminal, ToFile: filePath})
 }


### PR DESCRIPTION
## Description

Proposes a fix for the `kcp scan clusters` command that accepts a `--discover-dir` flag. When passing the current directory `.`, it would create a new `kcp-scan` directory in the current working directory instead of appending the Kafka Admin gathered information to the existing scan reports.

---

## Changes Made

- [x] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [ ] New tests added/updated
- [x] Manual testing completed
- [x] All tests pass

**Test Instructions:**

<!-- How should reviewers test this? -->

---

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
