### PR TITLE
replaced unauthenticated auth with 2 variants, tls and plaintext

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -81,7 +81,7 @@ func (h *PrettyHandler) Handle(ctx context.Context, r slog.Record) error {
 		return true
 	})
 
-	h.l.Printf("%s %s %s %s", time, level, message, strings.Join(values, " "))	
+	h.l.Printf("%s %s %s %s", time, level, message, strings.Join(values, " "))
 
 	return nil
 }

--- a/internal/client/kafka_admin.go
+++ b/internal/client/kafka_admin.go
@@ -46,9 +46,15 @@ func WithSASLSCRAMAuth(username, password string) AdminOption {
 	}
 }
 
-func WithUnauthenticatedAuth() AdminOption {
+func WithUnauthenticatedTlsAuth() AdminOption {
 	return func(config *AdminConfig) {
-		config.authType = types.AuthTypeUnauthenticated
+		config.authType = types.AuthTypeUnauthenticatedTLS
+	}
+}
+
+func WithUnauthenticatedPlaintextAuth() AdminOption {
+	return func(config *AdminConfig) {
+		config.authType = types.AuthTypeUnauthenticatedPlaintext
 	}
 }
 
@@ -82,11 +88,10 @@ func configureSASLTypeSCRAMAuthentication(config *sarama.Config, username string
 	config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 }
 
-func configureUnauthenticatedAuthentication(config *sarama.Config, clientBrokerEncryptionInTransit kafkatypes.ClientBroker) {
-	slog.Info("🔍 configuring client broker encryption in transit", "clientBrokerEncryptionInTransit", clientBrokerEncryptionInTransit)
-	enableTlsEncryption := clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTls || clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTlsPlaintext
-	config.Net.TLS.Enable = enableTlsEncryption
-	slog.Info("🔍 enabling TLS encryption", "enableTlsEncryption", enableTlsEncryption)
+func configureUnauthenticatedAuthentication(config *sarama.Config, withTLSEncryption bool) {
+	slog.Info("🔍 enabling TLS encryption", "enableTlsEncryption", withTLSEncryption)
+	// enableTlsEncryption := clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTls || clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTlsPlaintext
+	config.Net.TLS.Enable = withTLSEncryption
 	config.Net.TLS.Config = &tls.Config{}
 }
 
@@ -161,18 +166,18 @@ func (m *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
 
 // KafkaAdminClient wraps sarama.ClusterAdmin to implement our KafkaAdmin interface
 type KafkaAdminClient struct {
-	admin        sarama.ClusterAdmin
-	region       string
-	config       AdminConfig
-	saramaConfig *sarama.Config
-	resourceAcls map[string]sarama.ResourceAcls
+	admin           sarama.ClusterAdmin
+	region          string
+	config          AdminConfig
+	saramaConfig    *sarama.Config
+	resourceAcls    map[string]sarama.ResourceAcls
 	brokerAddresses []string
 }
 
 /*
-	A custom implementation of the ListTopics() function in Sarama that returns all topic configs
-	instead of just overridden configs. This was done to reduce the number of requests to the broker.
-	https://github.com/IBM/sarama/blob/main/admin.go#L349
+A custom implementation of the ListTopics() function in Sarama that returns all topic configs
+instead of just overridden configs. This was done to reduce the number of requests to the broker.
+https://github.com/IBM/sarama/blob/main/admin.go#L349
 */
 func (k *KafkaAdminClient) ListTopicsWithConfigs() (map[string]sarama.TopicDetail, error) {
 
@@ -180,7 +185,7 @@ func (k *KafkaAdminClient) ListTopicsWithConfigs() (map[string]sarama.TopicDetai
 	controller, err := k.admin.Controller()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get controller: %w", err)
-	}	
+	}
 
 	// Send the all-topic MetadataRequest
 	metadataReq := sarama.NewMetadataRequest(k.saramaConfig.Version, nil)
@@ -350,8 +355,10 @@ func NewKafkaAdmin(brokerAddresses []string, clientBrokerEncryptionInTransit kaf
 		configureSASLTypeOAuthAuthentication(saramaConfig, region)
 	case types.AuthTypeSASLSCRAM:
 		configureSASLTypeSCRAMAuthentication(saramaConfig, config.username, config.password)
-	case types.AuthTypeUnauthenticated:
-		configureUnauthenticatedAuthentication(saramaConfig, clientBrokerEncryptionInTransit)
+	case types.AuthTypeUnauthenticatedTLS:
+		configureUnauthenticatedAuthentication(saramaConfig, true)
+	case types.AuthTypeUnauthenticatedPlaintext:
+		configureUnauthenticatedAuthentication(saramaConfig, false)
 	case types.AuthTypeTLS:
 		err := configureTLSAuth(saramaConfig, config.caCertFile, config.clientCertFile, config.clientKeyFile)
 		if err != nil {
@@ -367,11 +374,11 @@ func NewKafkaAdmin(brokerAddresses []string, clientBrokerEncryptionInTransit kaf
 	}
 
 	return &KafkaAdminClient{
-		admin:        admin,
-		region:       region,
-		config:       config,
-		saramaConfig: saramaConfig,
-		resourceAcls: make(map[string]sarama.ResourceAcls),
+		admin:           admin,
+		region:          region,
+		config:          config,
+		saramaConfig:    saramaConfig,
+		resourceAcls:    make(map[string]sarama.ResourceAcls),
 		brokerAddresses: brokerAddresses,
 	}, nil
 }

--- a/internal/client/kafka_admin_test.go
+++ b/internal/client/kafka_admin_test.go
@@ -258,10 +258,17 @@ func TestAdminOptionFunctions(t *testing.T) {
 			},
 		},
 		{
-			name:   "WithUnauthenticatedAuth sets unauthenticated auth",
-			option: WithUnauthenticatedAuth(),
+			name:   "WithUnauthenticatedTlsAuth sets unauthenticated TLS auth",
+			option: WithUnauthenticatedTlsAuth(),
 			expectedConfig: AdminConfig{
-				authType: types.AuthTypeUnauthenticated,
+				authType: types.AuthTypeUnauthenticatedTLS,
+			},
+		},
+		{
+			name:   "WithUnauthenticatedPlaintextAuth sets unauthenticated plaintext auth",
+			option: WithUnauthenticatedPlaintextAuth(),
+			expectedConfig: AdminConfig{
+				authType: types.AuthTypeUnauthenticatedPlaintext,
 			},
 		},
 		{
@@ -378,7 +385,10 @@ func TestConfigureUnauthenticatedAuthentication(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := sarama.NewConfig()
 
-			configureUnauthenticatedAuthentication(config, tt.clientBrokerEncryptionInTransit)
+			// Convert ClientBroker to boolean for the function call
+			withTLSEncryption := tt.clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTls ||
+				tt.clientBrokerEncryptionInTransit == kafkatypes.ClientBrokerTlsPlaintext
+			configureUnauthenticatedAuthentication(config, withTLSEncryption)
 
 			assert.Equal(t, tt.expectedTLSEnabled, config.Net.TLS.Enable)
 			if tt.expectedTLSEnabled {
@@ -512,11 +522,19 @@ func TestNewKafkaAdmin(t *testing.T) {
 			expectError:                     false,
 		},
 		{
-			name:                            "successful unauthenticated auth creation",
+			name:                            "successful unauthenticated TLS auth creation",
 			brokerAddresses:                 []string{"broker1:9092"},
 			clientBrokerEncryptionInTransit: kafkatypes.ClientBrokerTls,
 			region:                          "us-west-2",
-			opts:                            []AdminOption{WithUnauthenticatedAuth()},
+			opts:                            []AdminOption{WithUnauthenticatedTlsAuth()},
+			expectError:                     false,
+		},
+		{
+			name:                            "successful unauthenticated plaintext auth creation",
+			brokerAddresses:                 []string{"broker1:9092"},
+			clientBrokerEncryptionInTransit: kafkatypes.ClientBrokerPlaintext,
+			region:                          "us-west-2",
+			opts:                            []AdminOption{WithUnauthenticatedPlaintextAuth()},
 			expectError:                     false,
 		},
 		{

--- a/internal/generators/scan/cluster/cluster_scanner_test.go
+++ b/internal/generators/scan/cluster/cluster_scanner_test.go
@@ -464,7 +464,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 		{
 			name: "handles large number of topics",
 			mockTopics: map[string]sarama.TopicDetail{
-				"topic1":  {
+				"topic1": {
 					NumPartitions:     1,
 					ReplicationFactor: 1,
 					ConfigEntries: map[string]*string{
@@ -474,7 +474,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("1"),
 					},
 				},
-				"topic2":  {
+				"topic2": {
 					NumPartitions:     2,
 					ReplicationFactor: 2,
 					ConfigEntries: map[string]*string{
@@ -484,7 +484,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("2"),
 					},
 				},
-				"topic3":  {
+				"topic3": {
 					NumPartitions:     3,
 					ReplicationFactor: 3,
 					ConfigEntries: map[string]*string{
@@ -494,7 +494,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("3"),
 					},
 				},
-				"topic4":  {
+				"topic4": {
 					NumPartitions:     4,
 					ReplicationFactor: 4,
 					ConfigEntries: map[string]*string{
@@ -504,7 +504,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("4"),
 					},
 				},
-				"topic5":  {
+				"topic5": {
 					NumPartitions:     5,
 					ReplicationFactor: 5,
 					ConfigEntries: map[string]*string{
@@ -514,7 +514,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("5"),
 					},
 				},
-				"topic6":  {
+				"topic6": {
 					NumPartitions:     6,
 					ReplicationFactor: 6,
 					ConfigEntries: map[string]*string{
@@ -524,7 +524,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("6"),
 					},
 				},
-				"topic7":  {
+				"topic7": {
 					NumPartitions:     7,
 					ReplicationFactor: 7,
 					ConfigEntries: map[string]*string{
@@ -534,7 +534,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("7"),
 					},
 				},
-				"topic8":  {
+				"topic8": {
 					NumPartitions:     8,
 					ReplicationFactor: 8,
 					ConfigEntries: map[string]*string{
@@ -544,7 +544,7 @@ func TestClusterScanner_ScanKafkaResources(t *testing.T) {
 						"min.insync.replicas": aws.String("8"),
 					},
 				},
-				"topic9":  {
+				"topic9": {
 					NumPartitions:     9,
 					ReplicationFactor: 9,
 					ConfigEntries: map[string]*string{

--- a/internal/generators/scan/clusters/clusters_scanner.go
+++ b/internal/generators/scan/clusters/clusters_scanner.go
@@ -83,8 +83,10 @@ func (cs *ClustersScanner) scanCluster(region string, clusterEntry types.Cluster
 			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithIAMAuth())
 		case types.AuthTypeSASLSCRAM:
 			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithSASLSCRAMAuth(clusterEntry.AuthMethod.SASLScram.Username, clusterEntry.AuthMethod.SASLScram.Password))
-		case types.AuthTypeUnauthenticated:
-			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithUnauthenticatedAuth())
+		case types.AuthTypeUnauthenticatedTLS:
+			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithUnauthenticatedTlsAuth())
+		case types.AuthTypeUnauthenticatedPlaintext:
+			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithUnauthenticatedPlaintextAuth())
 		case types.AuthTypeTLS:
 			return client.NewKafkaAdmin(brokerAddresses, clientBrokerEncryptionInTransit, region, kafkaVersion, client.WithTLSAuth(clusterEntry.AuthMethod.TLS.CACert, clusterEntry.AuthMethod.TLS.ClientCert, clusterEntry.AuthMethod.TLS.ClientKey))
 		default:

--- a/internal/generators/scan/region/region_scanner_test.go
+++ b/internal/generators/scan/region/region_scanner_test.go
@@ -1007,7 +1007,7 @@ func TestScanner_SummariseAuthentication(t *testing.T) {
 					},
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "provisioned cluster with only SASL/SCRAM enabled",
@@ -1161,7 +1161,7 @@ func TestScanner_SummariseAuthentication(t *testing.T) {
 					},
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 	}
 
@@ -1276,7 +1276,7 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 					// ClientAuthentication is nil
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "serverless cluster with nil serverless config",
@@ -1284,7 +1284,7 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 				ClusterType: kafkatypes.ClusterTypeServerless,
 				// Serverless is nil
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "provisioned cluster with nil provisioned config",
@@ -1292,7 +1292,7 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 				ClusterType: kafkatypes.ClusterTypeProvisioned,
 				// Provisioned is nil
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "provisioned cluster with nil client authentication",
@@ -1302,7 +1302,7 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 					// ClientAuthentication is nil
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "provisioned cluster with only unauthenticated enabled",
@@ -1319,9 +1319,14 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 							Enabled: aws.Bool(true),
 						},
 					},
+					EncryptionInfo: &kafkatypes.EncryptionInfo{
+						EncryptionInTransit: &kafkatypes.EncryptionInTransit{
+							ClientBroker: kafkatypes.ClientBrokerTls,
+						},
+					},
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "Unauthenticated (TLS Encryption)",
 		},
 		{
 			name: "provisioned cluster with mixed authentication including unauthenticated",
@@ -1338,16 +1343,21 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 							Enabled: aws.Bool(true),
 						},
 					},
+					EncryptionInfo: &kafkatypes.EncryptionInfo{
+						EncryptionInTransit: &kafkatypes.EncryptionInTransit{
+							ClientBroker: kafkatypes.ClientBrokerTls,
+						},
+					},
 				},
 			},
-			expected: "SASL/SCRAM,Unauthenticated",
+			expected: "SASL/SCRAM,Unauthenticated (TLS Encryption)",
 		},
 		{
 			name: "unknown cluster type",
 			cluster: kafkatypes.Cluster{
 				ClusterType: "UNKNOWN_TYPE", // Invalid cluster type
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 		{
 			name: "provisioned cluster with nil enabled fields",
@@ -1372,7 +1382,7 @@ func TestScanner_SummariseAuthentication_EdgeCases(t *testing.T) {
 					},
 				},
 			},
-			expected: "Unauthenticated",
+			expected: "",
 		},
 	}
 

--- a/internal/types/cluster_information.go
+++ b/internal/types/cluster_information.go
@@ -88,14 +88,17 @@ func (c *ClusterInformation) GetBootstrapBrokersForAuthType(authType AuthType) (
 		if brokerList == "" {
 			return nil, fmt.Errorf("❌ No SASL/SCRAM brokers found in the cluster")
 		}
-	case AuthTypeUnauthenticated:
+	case AuthTypeUnauthenticatedTLS:
 		brokerList = aws.ToString(c.BootstrapBrokers.BootstrapBrokerStringTls)
 		visibility = "PRIVATE"
 		if brokerList == "" {
-			brokerList = aws.ToString(c.BootstrapBrokers.BootstrapBrokerString)
+			return nil, fmt.Errorf("❌ No Unauthenticated (TLS Encryption) brokers found in the cluster")
 		}
+	case AuthTypeUnauthenticatedPlaintext:
+		brokerList = aws.ToString(c.BootstrapBrokers.BootstrapBrokerString)
+		visibility = "PRIVATE"
 		if brokerList == "" {
-			return nil, fmt.Errorf("❌ No Unauthenticated brokers found in the cluster")
+			return nil, fmt.Errorf("❌ No Unauthenticated (Plaintext) brokers found in the cluster")
 		}
 	case AuthTypeTLS:
 		brokerList = aws.ToString(c.BootstrapBrokers.BootstrapBrokerStringPublicTls)

--- a/internal/types/cluster_information_test.go
+++ b/internal/types/cluster_information_test.go
@@ -605,32 +605,40 @@ func TestClusterInformation_GetBootstrapBrokersForAuthType(t *testing.T) {
 			expectedError: "❌ No TLS brokers found in the cluster",
 		},
 		{
-			name: "AuthTypeUnauthenticated with TLS brokers",
+			name: "AuthTypeUnauthenticatedTLS with TLS brokers",
 			clusterInfo: &ClusterInformation{
 				BootstrapBrokers: kafka.GetBootstrapBrokersOutput{
 					BootstrapBrokerStringTls: aws.String("b-1.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9094,b-2.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9094"),
 				},
 			},
-			authType:        AuthTypeUnauthenticated,
+			authType:        AuthTypeUnauthenticatedTLS,
 			expectedBrokers: []string{"b-1.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9094", "b-2.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9094"},
 		},
 		{
-			name: "AuthTypeUnauthenticated with plaintext brokers only",
+			name: "AuthTypeUnauthenticatedPlaintext with plaintext brokers only",
 			clusterInfo: &ClusterInformation{
 				BootstrapBrokers: kafka.GetBootstrapBrokersOutput{
 					BootstrapBrokerString: aws.String("b-1.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9092,b-2.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9092"),
 				},
 			},
-			authType:        AuthTypeUnauthenticated,
+			authType:        AuthTypeUnauthenticatedPlaintext,
 			expectedBrokers: []string{"b-1.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9092", "b-2.test-cluster.abc123.c2.kafka.us-east-1.amazonaws.com:9092"},
 		},
 		{
-			name: "AuthTypeUnauthenticated with no brokers",
+			name: "AuthTypeUnauthenticatedTLS with no brokers",
 			clusterInfo: &ClusterInformation{
 				BootstrapBrokers: kafka.GetBootstrapBrokersOutput{},
 			},
-			authType:      AuthTypeUnauthenticated,
-			expectedError: "❌ No Unauthenticated brokers found in the cluster",
+			authType:      AuthTypeUnauthenticatedTLS,
+			expectedError: "❌ No Unauthenticated (TLS Encryption) brokers found in the cluster",
+		},
+		{
+			name: "AuthTypeUnauthenticatedPlaintext with no brokers",
+			clusterInfo: &ClusterInformation{
+				BootstrapBrokers: kafka.GetBootstrapBrokersOutput{},
+			},
+			authType:      AuthTypeUnauthenticatedPlaintext,
+			expectedError: "❌ No Unauthenticated (Plaintext) brokers found in the cluster",
 		},
 		{
 			name: "Invalid auth type",

--- a/internal/types/credentials.go
+++ b/internal/types/credentials.go
@@ -80,49 +80,45 @@ func (ce ClusterEntry) GetSelectedAuthType() (AuthType, error) {
 		return "", fmt.Errorf("no authentication method enabled for cluster")
 	}
 
-	authMethod := enabledMethods[0]
-	switch authMethod {
-	case "unauthenticated":
-		return AuthTypeUnauthenticated, nil
-	case "iam":
-		return AuthTypeIAM, nil
-	case "sasl_scram":
-		return AuthTypeSASLSCRAM, nil
-	case "tls":
-		return AuthTypeTLS, nil
-	default:
-		return "", fmt.Errorf("unsupported authentication method: %s", authMethod)
-	}
+	return enabledMethods[0], nil
 }
 
 // Gets a list of the authentication method(s) selected in the `creds.yaml` file generated during discovery.
-func (ce ClusterEntry) GetAuthMethods() []string {
-	enabledMethods := []string{}
+func (ce ClusterEntry) GetAuthMethods() []AuthType {
+	enabledMethods := []AuthType{}
 
-	if ce.AuthMethod.Unauthenticated != nil && ce.AuthMethod.Unauthenticated.Use {
-		enabledMethods = append(enabledMethods, "unauthenticated")
+	if ce.AuthMethod.UnauthenticatedPlaintext != nil && ce.AuthMethod.UnauthenticatedPlaintext.Use {
+		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedPlaintext)
+	}
+	if ce.AuthMethod.UnauthenticatedTLS != nil && ce.AuthMethod.UnauthenticatedTLS.Use {
+		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedTLS)
 	}
 	if ce.AuthMethod.IAM != nil && ce.AuthMethod.IAM.Use {
-		enabledMethods = append(enabledMethods, "iam")
+		enabledMethods = append(enabledMethods, AuthTypeIAM)
 	}
 	if ce.AuthMethod.SASLScram != nil && ce.AuthMethod.SASLScram.Use {
-		enabledMethods = append(enabledMethods, "sasl_scram")
+		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
 	}
 	if ce.AuthMethod.TLS != nil && ce.AuthMethod.TLS.Use {
-		enabledMethods = append(enabledMethods, "tls")
+		enabledMethods = append(enabledMethods, AuthTypeTLS)
 	}
 
 	return enabledMethods
 }
 
 type AuthMethodConfig struct {
-	Unauthenticated *UnauthenticatedConfig `yaml:"unauthenticated,omitempty"`
-	IAM             *IAMConfig             `yaml:"iam,omitempty"`
-	TLS             *TLSConfig             `yaml:"tls,omitempty"`
-	SASLScram       *SASLScramConfig       `yaml:"sasl_scram,omitempty"`
+	UnauthenticatedTLS       *UnauthenticatedTLSConfig       `yaml:"unauthenticated_tls,omitempty"`
+	UnauthenticatedPlaintext *UnauthenticatedPlaintextConfig `yaml:"unauthenticated_plaintext,omitempty"`
+	IAM                      *IAMConfig                      `yaml:"iam,omitempty"`
+	TLS                      *TLSConfig                      `yaml:"tls,omitempty"`
+	SASLScram                *SASLScramConfig                `yaml:"sasl_scram,omitempty"`
 }
 
-type UnauthenticatedConfig struct {
+type UnauthenticatedPlaintextConfig struct {
+	Use bool `yaml:"use"`
+}
+
+type UnauthenticatedTLSConfig struct {
 	Use bool `yaml:"use"`
 }
 

--- a/internal/types/credentials_test.go
+++ b/internal/types/credentials_test.go
@@ -208,23 +208,32 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 	tests := []struct {
 		name            string
 		clusterEntry    ClusterEntry
-		expectedMethods []string
+		expectedMethods []AuthType
 	}{
 		{
 			name: "no auth methods enabled",
 			clusterEntry: ClusterEntry{
 				AuthMethod: AuthMethodConfig{},
 			},
-			expectedMethods: []string{},
+			expectedMethods: []AuthType{},
 		},
 		{
-			name: "unauthenticated enabled",
+			name: "unauthenticated TLS enabled",
 			clusterEntry: ClusterEntry{
 				AuthMethod: AuthMethodConfig{
-					Unauthenticated: &UnauthenticatedConfig{Use: true},
+					UnauthenticatedTLS: &UnauthenticatedTLSConfig{Use: true},
 				},
 			},
-			expectedMethods: []string{"unauthenticated"},
+			expectedMethods: []AuthType{AuthTypeUnauthenticatedTLS},
+		},
+		{
+			name: "unauthenticated plaintext enabled",
+			clusterEntry: ClusterEntry{
+				AuthMethod: AuthMethodConfig{
+					UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				},
+			},
+			expectedMethods: []AuthType{AuthTypeUnauthenticatedPlaintext},
 		},
 		{
 			name: "IAM enabled",
@@ -233,7 +242,7 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 					IAM: &IAMConfig{Use: true},
 				},
 			},
-			expectedMethods: []string{"iam"},
+			expectedMethods: []AuthType{AuthTypeIAM},
 		},
 		{
 			name: "SASL/SCRAM enabled",
@@ -242,7 +251,7 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 					SASLScram: &SASLScramConfig{Use: true},
 				},
 			},
-			expectedMethods: []string{"sasl_scram"},
+			expectedMethods: []AuthType{AuthTypeSASLSCRAM},
 		},
 		{
 			name: "TLS enabled",
@@ -251,7 +260,7 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 					TLS: &TLSConfig{Use: true},
 				},
 			},
-			expectedMethods: []string{"tls"},
+			expectedMethods: []AuthType{AuthTypeTLS},
 		},
 		{
 			name: "multiple methods enabled",
@@ -261,7 +270,7 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 					TLS: &TLSConfig{Use: true},
 				},
 			},
-			expectedMethods: []string{"iam", "tls"},
+			expectedMethods: []AuthType{AuthTypeIAM, AuthTypeTLS},
 		},
 		{
 			name: "auth method configured but not enabled",
@@ -270,7 +279,7 @@ func TestClusterEntry_GetAuthMethods(t *testing.T) {
 					IAM: &IAMConfig{Use: false},
 				},
 			},
-			expectedMethods: []string{},
+			expectedMethods: []AuthType{},
 		},
 	}
 
@@ -290,13 +299,23 @@ func TestClusterEntry_GetSelectedAuthType(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "unauthenticated auth type",
+			name: "unauthenticated TLS auth type",
 			clusterEntry: ClusterEntry{
 				AuthMethod: AuthMethodConfig{
-					Unauthenticated: &UnauthenticatedConfig{Use: true},
+					UnauthenticatedTLS: &UnauthenticatedTLSConfig{Use: true},
 				},
 			},
-			expectedType:  AuthTypeUnauthenticated,
+			expectedType:  AuthTypeUnauthenticatedTLS,
+			expectedError: false,
+		},
+		{
+			name: "unauthenticated plaintext auth type",
+			clusterEntry: ClusterEntry{
+				AuthMethod: AuthMethodConfig{
+					UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				},
+			},
+			expectedType:  AuthTypeUnauthenticatedPlaintext,
 			expectedError: false,
 		},
 		{
@@ -441,8 +460,13 @@ func TestCredentials_WriteToFile_InvalidPath(t *testing.T) {
 }
 
 func TestAuthMethodConfigs(t *testing.T) {
-	t.Run("UnauthenticatedConfig", func(t *testing.T) {
-		config := &UnauthenticatedConfig{Use: true}
+	t.Run("UnauthenticatedTLSConfig", func(t *testing.T) {
+		config := &UnauthenticatedTLSConfig{Use: true}
+		assert.True(t, config.Use)
+	})
+
+	t.Run("UnauthenticatedPlaintextConfig", func(t *testing.T) {
+		config := &UnauthenticatedPlaintextConfig{Use: true}
 		assert.True(t, config.Use)
 	})
 

--- a/internal/types/kafka.go
+++ b/internal/types/kafka.go
@@ -12,9 +12,9 @@ type TopicSummary struct {
 }
 
 type TopicDetails struct {
-	Name              string            `json:"name"`
-	Partitions        int               `json:"partitions"`
-	ReplicationFactor int               `json:"replication_factor"`
+	Name              string             `json:"name"`
+	Partitions        int                `json:"partitions"`
+	ReplicationFactor int                `json:"replication_factor"`
 	Configurations    map[string]*string `json:"configurations"`
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -57,15 +57,16 @@ type TerraformOutputValue struct {
 type AuthType string
 
 const (
-	AuthTypeSASLSCRAM       AuthType = "SASL/SCRAM"
-	AuthTypeIAM             AuthType = "SASL/IAM"
-	AuthTypeTLS             AuthType = "TLS"
-	AuthTypeUnauthenticated AuthType = "Unauthenticated"
+	AuthTypeSASLSCRAM                AuthType = "SASL/SCRAM"
+	AuthTypeIAM                      AuthType = "SASL/IAM"
+	AuthTypeTLS                      AuthType = "TLS"
+	AuthTypeUnauthenticatedPlaintext AuthType = "Unauthenticated (Plaintext)"
+	AuthTypeUnauthenticatedTLS       AuthType = "Unauthenticated (TLS Encryption)"
 )
 
 func (a AuthType) IsValid() bool {
 	switch a {
-	case AuthTypeSASLSCRAM, AuthTypeIAM, AuthTypeTLS, AuthTypeUnauthenticated:
+	case AuthTypeSASLSCRAM, AuthTypeIAM, AuthTypeTLS, AuthTypeUnauthenticatedPlaintext, AuthTypeUnauthenticatedTLS:
 		return true
 	default:
 		return false
@@ -84,7 +85,8 @@ func AllAuthTypes() []string {
 		string(AuthTypeSASLSCRAM),
 		string(AuthTypeIAM),
 		string(AuthTypeTLS),
-		string(AuthTypeUnauthenticated),
+		string(AuthTypeUnauthenticatedPlaintext),
+		string(AuthTypeUnauthenticatedTLS),
 	}
 }
 


### PR DESCRIPTION
## Description

This PR refactors the unauthenticated authentication type to distinguish between TLS-encrypted and plaintext unauthenticated access.  The tool now allows users to explicitly choose between TLS and plaintext unauthenticated access when both are available, rather than automatically preferring TLS and only falling back to plaintext when TLS is unavailable.

---

## Changes Made

- Split `AuthTypeUnauthenticated` into two distinct types:
-- `AuthTypeUnauthenticatedTLS` = "Unauthenticated (TLS Encryption)"
-- `AuthTypeUnauthenticatedPlaintext` = "Unauthenticated (Plaintext)"
- Updated `AuthMethodConfig` to use separate config structs:
-- `UnauthenticatedTLSConfig` for TLS-encrypted unauthenticated access
-- `UnauthenticatedPlaintextConfig` for plaintext unauthenticated access

Authentication Logic Updates

- Discovery Engine: Enhanced cluster discovery to determine unauthenticated encryption type based on `EncryptionInfo.ClientBroker` setting
- Region Scanner: Updated authentication summarizer to properly categorize unauthenticated access by encryption type
- Kafka Admin Client: Split `WithUnauthenticatedAuth() `into:
-- `WithUnauthenticatedTlsAuth()` for TLS-encrypted connections
-- `WithUnauthenticatedPlaintextAuth()` for plaintext connections

Command Usage changes

- `kcp scan cluster ` has flags `--use-unathenticated-tls` and `--use-unathenticate-plaintext` flags 
- `--use-unathenticate-tls` flag is removed
- the creds file now includes the new unathenticated-tls and unathenticated-plaintext auth types


Broker Address Resolution

- Cluster Information: Updated broker address parsing to handle both unauthenticated variants
- MSK Service: Enhanced broker selection logic to choose appropriate endpoints based on encryption requirements

---

## Testing

- [x] New tests added/updated
- [x] Manual testing completed
- [x] All tests pass

**Test Instructions:**

1. Run `kcp discover` to scan a region with a cluster with unathenticated enabled -> observe that the new auth types are in the cred.yml file
2. Set the creds file for both tls and plaintext -> Run `kcp scan clusters` -> observe that the correct brokers are being use for the auth type and the connections are successful
3. run `kcp scan cluster ` with the new `--use-unathenticate-tls` and `--use-unathenticate-plaintext`


---

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
