### PR TITLE
Chore discover preserve state

### DIFF
--- a/cmd/discover/discoverer.go
+++ b/cmd/discover/discoverer.go
@@ -46,7 +46,7 @@ func (d *Discoverer) Run() error {
 func (d *Discoverer) discoverRegions() error {
 	regionEntries := []types.RegionEntry{}
 	regionsWithoutClusters := []string{}
-	// initialize working state from existing state if present(preserves untouched regions)
+	// initialize working state from existing state if present
 	currentState := types.NewState(d.state)
 
 	for _, region := range d.regions {
@@ -105,8 +105,8 @@ func (d *Discoverer) discoverRegions() error {
 			discoveredClusters = append(discoveredClusters, *discoveredCluster)
 		}
 
-		// set discovered clusters and upsert into state (preserves KafkaAdminClientInformation)
 		discoveredRegion.Clusters = discoveredClusters
+		// upsert region into state (preserves untouched regions)
 		currentState.UpsertRegion(*discoveredRegion)
 
 		// generate credential configurations for connecting to clusters

--- a/cmd/discover/discoverer.go
+++ b/cmd/discover/discoverer.go
@@ -46,6 +46,8 @@ func (d *Discoverer) Run() error {
 func (d *Discoverer) discoverRegions() error {
 	regionEntries := []types.RegionEntry{}
 	regionsWithoutClusters := []string{}
+
+	// Initialize working state from existing state (preserves untouched regions)
 	currentState := types.NewState(d.state)
 
 	for _, region := range d.regions {
@@ -104,6 +106,7 @@ func (d *Discoverer) discoverRegions() error {
 			discoveredClusters = append(discoveredClusters, *discoveredCluster)
 		}
 
+		// Set discovered clusters and upsert into state (preserves KafkaAdminClientInformation)
 		discoveredRegion.Clusters = discoveredClusters
 		currentState.UpsertRegion(*discoveredRegion)
 

--- a/cmd/discover/discoverer.go
+++ b/cmd/discover/discoverer.go
@@ -103,8 +103,8 @@ func (d *Discoverer) discoverRegions() error {
 			}
 			discoveredClusters = append(discoveredClusters, *discoveredCluster)
 		}
-		discoveredRegion.Clusters = discoveredClusters
 
+		discoveredRegion.Clusters = discoveredClusters
 		currentState.UpsertRegion(*discoveredRegion)
 
 		// Generate credential configurations for connecting to clusters

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -83,6 +83,7 @@ func (s *State) UpsertRegion(newRegion DiscoveredRegion) {
 		if existingRegion.Name == newRegion.Name {
 			discoveredClusters := newRegion.Clusters
 			newRegion.Clusters = existingRegion.Clusters
+			// set discovered clusters and refresh into state (preserves KafkaAdminClientInformation)
 			newRegion.RefreshClusters(discoveredClusters)
 			s.Regions[i] = newRegion
 			return

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -79,32 +79,16 @@ func (s *State) PersistStateFile(stateFile string) error {
 // UpsertRegion inserts a new region or updates an existing one by name
 // Automatically preserves KafkaAdminClientInformation from existing clusters
 func (s *State) UpsertRegion(newRegion DiscoveredRegion) {
-	// Find existing region by name and replace it
 	for i, existingRegion := range s.Regions {
 		if existingRegion.Name == newRegion.Name {
-			// Preserve cluster admin info before replacing
-			if len(existingRegion.Clusters) > 0 {
-				// Temporarily set existing clusters so UpsertClusters can build admin info map
-				discoveredClusters := newRegion.Clusters
-				newRegion.Clusters = existingRegion.Clusters
-				newRegion.UpsertClusters(discoveredClusters)
-			}
+			discoveredClusters := newRegion.Clusters
+			newRegion.Clusters = existingRegion.Clusters
+			newRegion.UpsertClusters(discoveredClusters)
 			s.Regions[i] = newRegion
 			return
 		}
 	}
-
-	// Region not found, add as new (no preservation needed)
 	s.Regions = append(s.Regions, newRegion)
-}
-
-func (s *State) GetRegionByName(regionName string) *DiscoveredRegion {
-	for i := range s.Regions {
-		if s.Regions[i].Name == regionName {
-			return &s.Regions[i]
-		}
-	}
-	return nil
 }
 
 type DiscoveredRegion struct {
@@ -121,9 +105,7 @@ func (dr *DiscoveredRegion) UpsertClusters(newClusters []DiscoveredCluster) {
 	// Build map of ARN -> KafkaAdminClientInformation from existing clusters
 	adminInfoByArn := make(map[string]KafkaAdminClientInformation)
 	for _, existingCluster := range dr.Clusters {
-		if existingCluster.KafkaAdminClientInformation.ClusterID != "" {
-			adminInfoByArn[existingCluster.Arn] = existingCluster.KafkaAdminClientInformation
-		}
+		adminInfoByArn[existingCluster.Arn] = existingCluster.KafkaAdminClientInformation
 	}
 
 	// Replace cluster list with new discoveries

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -25,9 +25,9 @@ type State struct {
 	Timestamp    time.Time          `json:"timestamp"`
 }
 
-func NewState(discoveredRegions []DiscoveredRegion) State {
-	return State{
-		Regions: discoveredRegions,
+func NewState(fromState *State) *State {
+	// Always create with fresh metadata for the current discovery run
+	workingState := &State{
 		KcpBuildInfo: KcpBuildInfo{
 			Version: build_info.Version,
 			Commit:  build_info.Commit,
@@ -35,6 +35,16 @@ func NewState(discoveredRegions []DiscoveredRegion) State {
 		},
 		Timestamp: time.Now(),
 	}
+
+	if fromState == nil {
+		workingState.Regions = []DiscoveredRegion{}
+	} else {
+		// Copy existing regions to preserve untouched regions
+		workingState.Regions = make([]DiscoveredRegion, len(fromState.Regions))
+		copy(workingState.Regions, fromState.Regions)
+	}
+
+	return workingState
 }
 
 func (s *State) WriteToJsonFile(filePath string) error {
@@ -64,6 +74,20 @@ func (s *State) PersistStateFile(stateFile string) error {
 	}
 
 	return s.WriteToJsonFile(stateFile)
+}
+
+// UpsertRegion inserts a new region or updates an existing one by name
+func (s *State) UpsertRegion(newRegion DiscoveredRegion) {
+	// Find existing region by name and replace it
+	for i, existingRegion := range s.Regions {
+		if existingRegion.Name == newRegion.Name {
+			s.Regions[i] = newRegion // Replace existing
+			return
+		}
+	}
+
+	// Region not found, add as new
+	s.Regions = append(s.Regions, newRegion)
 }
 
 type DiscoveredRegion struct {

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -83,7 +83,7 @@ func (s *State) UpsertRegion(newRegion DiscoveredRegion) {
 		if existingRegion.Name == newRegion.Name {
 			discoveredClusters := newRegion.Clusters
 			newRegion.Clusters = existingRegion.Clusters
-			newRegion.UpsertClusters(discoveredClusters)
+			newRegion.RefreshClusters(discoveredClusters)
 			s.Regions[i] = newRegion
 			return
 		}
@@ -100,18 +100,18 @@ type DiscoveredRegion struct {
 	ClusterArns []string `json:"-"`
 }
 
-// UpsertClusters replaces the cluster list but preserves KafkaAdminClientInformation from existing clusters
-func (dr *DiscoveredRegion) UpsertClusters(newClusters []DiscoveredCluster) {
-	// Build map of ARN -> KafkaAdminClientInformation from existing clusters
+// RefreshClusters replaces the cluster list but preserves KafkaAdminClientInformation from existing clusters
+func (dr *DiscoveredRegion) RefreshClusters(newClusters []DiscoveredCluster) {
+	// build map of ARN -> KafkaAdminClientInformation from existing clusters
 	adminInfoByArn := make(map[string]KafkaAdminClientInformation)
 	for _, existingCluster := range dr.Clusters {
 		adminInfoByArn[existingCluster.Arn] = existingCluster.KafkaAdminClientInformation
 	}
 
-	// Replace cluster list with new discoveries
+	// replace cluster list with new discoveries
 	dr.Clusters = newClusters
 
-	// Restore admin info for clusters that still exist
+	// restore admin info for clusters that still exist
 	for i := range dr.Clusters {
 		if adminInfo, exists := adminInfoByArn[dr.Clusters[i].Arn]; exists {
 			dr.Clusters[i].KafkaAdminClientInformation = adminInfo

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1,0 +1,160 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestNewState(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromState   *State
+		wantNil     bool
+		wantEmpty   bool
+		wantRegions []string
+	}{
+		{
+			name:        "nil fromState creates empty state",
+			fromState:   nil,
+			wantNil:     false,
+			wantEmpty:   true,
+			wantRegions: []string{},
+		},
+		{
+			name: "non-nil fromState copies regions",
+			fromState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1"},
+				},
+			},
+			wantNil:     false,
+			wantEmpty:   false,
+			wantRegions: []string{"us-east-1", "eu-west-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewState(tt.fromState)
+
+			// Check if result is nil when we expect it to be
+			if (result == nil) != tt.wantNil {
+				t.Errorf("NewState() returned nil = %v, want nil = %v", result == nil, tt.wantNil)
+			}
+
+			if result != nil {
+				// Check if regions slice is empty when expected
+				isEmpty := len(result.Regions) == 0
+				if isEmpty != tt.wantEmpty {
+					t.Errorf("NewState() regions empty = %v, want empty = %v", isEmpty, tt.wantEmpty)
+				}
+
+				// Check that regions match expected
+				if len(result.Regions) != len(tt.wantRegions) {
+					t.Errorf("NewState() got %d regions, want %d", len(result.Regions), len(tt.wantRegions))
+				}
+
+				for i, expectedName := range tt.wantRegions {
+					if i >= len(result.Regions) {
+						t.Errorf("NewState() missing region at index %d", i)
+						continue
+					}
+					if result.Regions[i].Name != expectedName {
+						t.Errorf("NewState() region[%d] = %q, want %q", i, result.Regions[i].Name, expectedName)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUpsertRegion(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *State
+		upsertRegion DiscoveredRegion
+		wantRegions  []DiscoveredRegion
+	}{
+		{
+			name: "add new region to empty state",
+			initialState: &State{
+				Regions: []DiscoveredRegion{},
+			},
+			upsertRegion: DiscoveredRegion{Name: "us-west-2"},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-west-2"},
+			},
+		},
+		{
+			name: "add new region to existing regions",
+			initialState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1"},
+				},
+			},
+			upsertRegion: DiscoveredRegion{Name: "ap-south-1"},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-east-1"},
+				{Name: "eu-west-1"},
+				{Name: "ap-south-1"},
+			},
+		},
+		{
+			name: "replace existing region with new content",
+			initialState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1", ClusterArns: []string{"old-cluster-1", "old-cluster-2"}},
+					{Name: "ap-south-1"},
+				},
+			},
+			upsertRegion: DiscoveredRegion{Name: "eu-west-1", ClusterArns: []string{"new-cluster-1", "new-cluster-2", "new-cluster-3"}},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-east-1"},
+				{Name: "eu-west-1", ClusterArns: []string{"new-cluster-1", "new-cluster-2", "new-cluster-3"}},
+				{Name: "ap-south-1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initialState.UpsertRegion(tt.upsertRegion)
+
+			// Check that final state matches expected exactly
+			if len(tt.initialState.Regions) != len(tt.wantRegions) {
+				t.Errorf("UpsertRegion() got %d regions, want %d", len(tt.initialState.Regions), len(tt.wantRegions))
+			}
+
+			for i, wantRegion := range tt.wantRegions {
+				if i >= len(tt.initialState.Regions) {
+					t.Errorf("UpsertRegion() missing region at index %d", i)
+					continue
+				}
+
+				actualRegion := tt.initialState.Regions[i]
+
+				// Check name
+				if actualRegion.Name != wantRegion.Name {
+					t.Errorf("UpsertRegion() region[%d].Name = %q, want %q", i, actualRegion.Name, wantRegion.Name)
+				}
+
+				// Check ClusterArns
+				if len(actualRegion.ClusterArns) != len(wantRegion.ClusterArns) {
+					t.Errorf("UpsertRegion() region[%d] got %d cluster ARNs, want %d", i, len(actualRegion.ClusterArns), len(wantRegion.ClusterArns))
+				}
+
+				for j, wantArn := range wantRegion.ClusterArns {
+					if j >= len(actualRegion.ClusterArns) {
+						t.Errorf("UpsertRegion() region[%d] missing cluster ARN at index %d", i, j)
+						continue
+					}
+					if actualRegion.ClusterArns[j] != wantArn {
+						t.Errorf("UpsertRegion() region[%d].ClusterArns[%d] = %q, want %q", i, j, actualRegion.ClusterArns[j], wantArn)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add State Preservation for Discovery Operations

Implements incremental discovery functionality that preserves existing state data while refreshing discovery information. This allows users to run discovery on specific regions without losing data from previous runs or other commands.

Key Features
🔄 State Preservation Between Discovery Runs
* Discovery command now loads existing kcp-state.json if present
* Regions not included in current discovery are preserved unchanged
* Enables incremental discovery workflows

🔒 Cluster Admin Information Preservation
* KafkaAdminClientInformation is preserved for clusters that still exist after discovery
* Fresh discovery data replaces all other cluster information (metrics, costs, etc.)

---

## Changes Made

- [x] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [x] New tests added/updated
- [x] Manual testing completed
- [x] All tests pass

**Test Instructions:**

`kcp discover --region us-east-1`

once completed and in same directory 
`kcp discover --region eu-west-1`


the state file should have two entries under regions, the existing us-east-1 and the new eu-west-1

also

once discovered copy one of the cluster entries and update name and arn (effectively faking that there were two clusters under a region) then discover that region again. The state file should be updated and the cluster we added manually should be removed. Effectively showing the behaviour should an actual cluster be removed from a region.

also

once discovered, use scan clusters for that cluster to get the admin info - see thats its populated.

then discover that region again, everything other than this admin info will be refreshed but the topic, acls and clusterid will remain in tact

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
