### PR TITLE
chore(state): preserving state between each run of discover

### DIFF
--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -25,9 +25,9 @@ type State struct {
 	Timestamp    time.Time          `json:"timestamp"`
 }
 
-func NewState(discoveredRegions []DiscoveredRegion) State {
-	return State{
-		Regions: discoveredRegions,
+func NewState(fromState *State) *State {
+	// Always create with fresh metadata for the current discovery run
+	workingState := &State{
 		KcpBuildInfo: KcpBuildInfo{
 			Version: build_info.Version,
 			Commit:  build_info.Commit,
@@ -35,6 +35,16 @@ func NewState(discoveredRegions []DiscoveredRegion) State {
 		},
 		Timestamp: time.Now(),
 	}
+
+	if fromState == nil {
+		workingState.Regions = []DiscoveredRegion{}
+	} else {
+		// Copy existing regions to preserve untouched regions
+		workingState.Regions = make([]DiscoveredRegion, len(fromState.Regions))
+		copy(workingState.Regions, fromState.Regions)
+	}
+
+	return workingState
 }
 
 func (s *State) WriteToJsonFile(filePath string) error {
@@ -66,6 +76,22 @@ func (s *State) PersistStateFile(stateFile string) error {
 	return s.WriteToJsonFile(stateFile)
 }
 
+// UpsertRegion inserts a new region or updates an existing one by name
+// Automatically preserves KafkaAdminClientInformation from existing clusters
+func (s *State) UpsertRegion(newRegion DiscoveredRegion) {
+	for i, existingRegion := range s.Regions {
+		if existingRegion.Name == newRegion.Name {
+			discoveredClusters := newRegion.Clusters
+			newRegion.Clusters = existingRegion.Clusters
+			// set discovered clusters and refresh into state (preserves KafkaAdminClientInformation)
+			newRegion.RefreshClusters(discoveredClusters)
+			s.Regions[i] = newRegion
+			return
+		}
+	}
+	s.Regions = append(s.Regions, newRegion)
+}
+
 type DiscoveredRegion struct {
 	Name           string                                      `json:"name"`
 	Configurations []kafka.DescribeConfigurationRevisionOutput `json:"configurations"`
@@ -73,6 +99,25 @@ type DiscoveredRegion struct {
 	Clusters       []DiscoveredCluster                         `json:"clusters"`
 	// internal only - exclude from JSON output
 	ClusterArns []string `json:"-"`
+}
+
+// RefreshClusters replaces the cluster list but preserves KafkaAdminClientInformation from existing clusters
+func (dr *DiscoveredRegion) RefreshClusters(newClusters []DiscoveredCluster) {
+	// build map of ARN -> KafkaAdminClientInformation from existing clusters
+	adminInfoByArn := make(map[string]KafkaAdminClientInformation)
+	for _, existingCluster := range dr.Clusters {
+		adminInfoByArn[existingCluster.Arn] = existingCluster.KafkaAdminClientInformation
+	}
+
+	// replace cluster list with new discoveries
+	dr.Clusters = newClusters
+
+	// restore admin info for clusters that still exist
+	for i := range dr.Clusters {
+		if adminInfo, exists := adminInfoByArn[dr.Clusters[i].Arn]; exists {
+			dr.Clusters[i].KafkaAdminClientInformation = adminInfo
+		}
+	}
 }
 
 type DiscoveredCluster struct {

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1,0 +1,243 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestNewState(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromState   *State
+		wantNil     bool
+		wantEmpty   bool
+		wantRegions []string
+	}{
+		{
+			name:        "nil fromState creates empty state",
+			fromState:   nil,
+			wantNil:     false,
+			wantEmpty:   true,
+			wantRegions: []string{},
+		},
+		{
+			name: "non-nil fromState copies regions",
+			fromState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1"},
+				},
+			},
+			wantNil:     false,
+			wantEmpty:   false,
+			wantRegions: []string{"us-east-1", "eu-west-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewState(tt.fromState)
+
+			// Check if result is nil when we expect it to be
+			if (result == nil) != tt.wantNil {
+				t.Errorf("NewState() returned nil = %v, want nil = %v", result == nil, tt.wantNil)
+			}
+
+			if result != nil {
+				// Check if regions slice is empty when expected
+				isEmpty := len(result.Regions) == 0
+				if isEmpty != tt.wantEmpty {
+					t.Errorf("NewState() regions empty = %v, want empty = %v", isEmpty, tt.wantEmpty)
+				}
+
+				// Check that regions match expected
+				if len(result.Regions) != len(tt.wantRegions) {
+					t.Errorf("NewState() got %d regions, want %d", len(result.Regions), len(tt.wantRegions))
+				}
+
+				for i, expectedName := range tt.wantRegions {
+					if i >= len(result.Regions) {
+						t.Errorf("NewState() missing region at index %d", i)
+						continue
+					}
+					if result.Regions[i].Name != expectedName {
+						t.Errorf("NewState() region[%d] = %q, want %q", i, result.Regions[i].Name, expectedName)
+					}
+				}
+			}
+		})
+	}
+}
+func TestUpsertRegion(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState *State
+		upsertRegion DiscoveredRegion
+		wantRegions  []DiscoveredRegion
+	}{
+		{
+			name: "add new region to empty state",
+			initialState: &State{
+				Regions: []DiscoveredRegion{},
+			},
+			upsertRegion: DiscoveredRegion{Name: "us-west-2"},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-west-2"},
+			},
+		},
+		{
+			name: "add new region to existing regions",
+			initialState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1"},
+				},
+			},
+			upsertRegion: DiscoveredRegion{Name: "ap-south-1"},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-east-1"},
+				{Name: "eu-west-1"},
+				{Name: "ap-south-1"},
+			},
+		},
+		{
+			name: "replace existing region with new content",
+			initialState: &State{
+				Regions: []DiscoveredRegion{
+					{Name: "us-east-1"},
+					{Name: "eu-west-1", ClusterArns: []string{"old-cluster-1", "old-cluster-2"}},
+					{Name: "ap-south-1"},
+				},
+			},
+			upsertRegion: DiscoveredRegion{Name: "eu-west-1", ClusterArns: []string{"new-cluster-1", "new-cluster-2", "new-cluster-3"}},
+			wantRegions: []DiscoveredRegion{
+				{Name: "us-east-1"},
+				{Name: "eu-west-1", ClusterArns: []string{"new-cluster-1", "new-cluster-2", "new-cluster-3"}},
+				{Name: "ap-south-1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initialState.UpsertRegion(tt.upsertRegion)
+
+			// Check that final state matches expected exactly
+			if len(tt.initialState.Regions) != len(tt.wantRegions) {
+				t.Errorf("UpsertRegion() got %d regions, want %d", len(tt.initialState.Regions), len(tt.wantRegions))
+			}
+
+			for i, wantRegion := range tt.wantRegions {
+				if i >= len(tt.initialState.Regions) {
+					t.Errorf("UpsertRegion() missing region at index %d", i)
+					continue
+				}
+
+				actualRegion := tt.initialState.Regions[i]
+
+				// Check name
+				if actualRegion.Name != wantRegion.Name {
+					t.Errorf("UpsertRegion() region[%d].Name = %q, want %q", i, actualRegion.Name, wantRegion.Name)
+				}
+
+				// Check ClusterArns
+				if len(actualRegion.ClusterArns) != len(wantRegion.ClusterArns) {
+					t.Errorf("UpsertRegion() region[%d] got %d cluster ARNs, want %d", i, len(actualRegion.ClusterArns), len(wantRegion.ClusterArns))
+				}
+
+				for j, wantArn := range wantRegion.ClusterArns {
+					if j >= len(actualRegion.ClusterArns) {
+						t.Errorf("UpsertRegion() region[%d] missing cluster ARN at index %d", i, j)
+						continue
+					}
+					if actualRegion.ClusterArns[j] != wantArn {
+						t.Errorf("UpsertRegion() region[%d].ClusterArns[%d] = %q, want %q", i, j, actualRegion.ClusterArns[j], wantArn)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRefreshClusters(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialClusters []DiscoveredCluster
+		newClusters     []DiscoveredCluster
+		wantClusters    []DiscoveredCluster
+	}{
+		{
+			name:            "add clusters to empty region",
+			initialClusters: []DiscoveredCluster{},
+			newClusters: []DiscoveredCluster{
+				{Name: "cluster-1", Arn: "arn:cluster-1"},
+				{Name: "cluster-2", Arn: "arn:cluster-2"},
+			},
+			wantClusters: []DiscoveredCluster{
+				{Name: "cluster-1", Arn: "arn:cluster-1"},
+				{Name: "cluster-2", Arn: "arn:cluster-2"},
+			},
+		},
+		{
+			name: "preserve admin info for existing clusters",
+			initialClusters: []DiscoveredCluster{
+				{
+					Name:                        "cluster-1",
+					Arn:                         "arn:cluster-1",
+					KafkaAdminClientInformation: KafkaAdminClientInformation{ClusterID: "old-cluster-1-id"},
+				},
+				{
+					Name:                        "cluster-2",
+					Arn:                         "arn:cluster-2",
+					KafkaAdminClientInformation: KafkaAdminClientInformation{ClusterID: "old-cluster-2-id"},
+				},
+			},
+			newClusters: []DiscoveredCluster{
+				{Name: "cluster-1", Arn: "arn:cluster-1"}, // fresh discovery data
+				{Name: "cluster-3", Arn: "arn:cluster-3"}, // new cluster
+			},
+			wantClusters: []DiscoveredCluster{
+				{
+					Name:                        "cluster-1",
+					Arn:                         "arn:cluster-1",
+					KafkaAdminClientInformation: KafkaAdminClientInformation{ClusterID: "old-cluster-1-id"}, // preserved
+				},
+				{Name: "cluster-3", Arn: "arn:cluster-3"}, // no admin info to preserve
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			region := &DiscoveredRegion{
+				Name:     "test-region",
+				Clusters: tt.initialClusters,
+			}
+
+			region.RefreshClusters(tt.newClusters)
+
+			// Check that final clusters match expected
+			if len(region.Clusters) != len(tt.wantClusters) {
+				t.Errorf("RefreshClusters() got %d clusters, want %d", len(region.Clusters), len(tt.wantClusters))
+			}
+
+			for i, wantCluster := range tt.wantClusters {
+				if i >= len(region.Clusters) {
+					t.Errorf("RefreshClusters() missing cluster at index %d", i)
+					continue
+				}
+
+				actualCluster := region.Clusters[i]
+				if actualCluster.Name != wantCluster.Name {
+					t.Errorf("RefreshClusters() cluster[%d].Name = %q, want %q", i, actualCluster.Name, wantCluster.Name)
+				}
+				if actualCluster.Arn != wantCluster.Arn {
+					t.Errorf("RefreshClusters() cluster[%d].Arn = %q, want %q", i, actualCluster.Arn, wantCluster.Arn)
+				}
+				if actualCluster.KafkaAdminClientInformation.ClusterID != wantCluster.KafkaAdminClientInformation.ClusterID {
+					t.Errorf("RefreshClusters() cluster[%d].KafkaAdminClientInformation.ClusterID = %q, want %q",
+						i, actualCluster.KafkaAdminClientInformation.ClusterID, wantCluster.KafkaAdminClientInformation.ClusterID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add State Preservation for Discovery Operations

Implements incremental discovery functionality that preserves existing state data while refreshing discovery information. This allows users to run discovery on specific regions without losing data from previous runs or other commands.

Key Features
🔄 State Preservation Between Discovery Runs
* Discovery command now loads existing kcp-state.json if present
* Regions not included in current discovery are preserved unchanged
* Enables incremental discovery workflows

🔒 Cluster Admin Information Preservation
* KafkaAdminClientInformation is preserved for clusters that still exist after discovery
* Fresh discovery data replaces all other cluster information (metrics, costs, etc.)
---

## Changes Made

- [x] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [ ] New tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass

**Test Instructions:**

kcp discover --region us-east-1

once completed and in same directory
kcp discover --region eu-west-1

the state file should have two entries under regions, the existing us-east-1 and the new eu-west-1

also

once discovered copy one of the cluster entries and update name and arn (effectively faking that there were two clusters under a region) then discover that region again. The state file should be updated and the cluster we added manually should be removed. Effectively showing the behaviour should an actual cluster be removed from a region.

also

once discovered, use scan clusters for that cluster to get the admin info - see thats its populated.

then discover that region again, everything other than this admin info will be refreshed but the topic, acls and clusterid will remain in tact

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
