### PR TITLE
fix: remove IAM as default execute auth + error out when no source auth is provided

### DIFF
--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -126,6 +126,10 @@ func preRunMigrationExecute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !useSaslIam && !useSaslScram && !useTls && !useUnauthenticatedTLS && !useUnauthenticatedPlaintext {
+		return fmt.Errorf("at least one source cluster authentication flag is required (--use-sasl-iam, --use-sasl-scram, --use-tls, --use-unauthenticated-tls, --use-unauthenticated-plaintext)")
+	}
+
 	if useSaslIam {
 		_ = cmd.MarkFlagRequired("aws-region")
 	}

--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -181,7 +181,7 @@ func resolveAuthType() types.AuthType {
 	case useUnauthenticatedPlaintext:
 		return types.AuthTypeUnauthenticatedPlaintext
 	default:
-		return types.AuthTypeIAM
+		panic("unreachable: MarkFlagsOneRequired guarantees an auth flag is set")
 	}
 }
 

--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -117,6 +117,7 @@ interrupted, re-running this command will resume from the last completed step.`,
 	_ = migrationExecuteCmd.MarkFlagRequired("cluster-api-key")
 	_ = migrationExecuteCmd.MarkFlagRequired("cluster-api-secret")
 	migrationExecuteCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationExecuteCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
 
 	return migrationExecuteCmd
 }
@@ -124,10 +125,6 @@ interrupted, re-running this command will resume from the last completed step.`,
 func preRunMigrationExecute(cmd *cobra.Command, args []string) error {
 	if err := utils.BindEnvToFlags(cmd); err != nil {
 		return err
-	}
-
-	if !useSaslIam && !useSaslScram && !useTls && !useUnauthenticatedTLS && !useUnauthenticatedPlaintext {
-		return fmt.Errorf("at least one source cluster authentication flag is required (--use-sasl-iam, --use-sasl-scram, --use-tls, --use-unauthenticated-tls, --use-unauthenticated-plaintext)")
 	}
 
 	if useSaslIam {

--- a/cmd/migration/execute/cmd_migration_execute_test.go
+++ b/cmd/migration/execute/cmd_migration_execute_test.go
@@ -18,7 +18,7 @@ func TestMigrationExecute_NoAuthFlag_ReturnsError(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one source cluster authentication flag is required")
+	assert.Contains(t, err.Error(), "at least one of the flags")
 }
 
 func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
@@ -41,6 +41,6 @@ func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
 	err := cmd.Execute()
 	// Should fail later (missing state file), NOT on auth validation.
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "at least one source cluster authentication flag is required")
+	assert.NotContains(t, err.Error(), "at least one of the flags")
 	assert.Contains(t, err.Error(), "migration state file")
 }

--- a/cmd/migration/execute/cmd_migration_execute_test.go
+++ b/cmd/migration/execute/cmd_migration_execute_test.go
@@ -7,7 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func resetAuthFlags() {
+	useSaslIam = false
+	useSaslScram = false
+	useTls = false
+	useUnauthenticatedTLS = false
+	useUnauthenticatedPlaintext = false
+}
+
 func TestMigrationExecute_NoAuthFlag_ReturnsError(t *testing.T) {
+	resetAuthFlags()
+
 	cmd := NewMigrationExecuteCmd()
 	cmd.SetArgs([]string{
 		"--migration-id", "test-migration",
@@ -22,12 +32,7 @@ func TestMigrationExecute_NoAuthFlag_ReturnsError(t *testing.T) {
 }
 
 func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
-	// Reset package-level vars to avoid cross-test pollution.
-	useSaslIam = false
-	useSaslScram = false
-	useTls = false
-	useUnauthenticatedTLS = false
-	useUnauthenticatedPlaintext = false
+	resetAuthFlags()
 
 	cmd := NewMigrationExecuteCmd()
 	cmd.SetArgs([]string{
@@ -43,4 +48,22 @@ func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "at least one of the flags")
 	assert.Contains(t, err.Error(), "migration state file")
+}
+
+func TestMigrationExecute_MultipleAuthFlags_ReturnsError(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationExecuteCmd()
+	cmd.SetArgs([]string{
+		"--migration-id", "test-migration",
+		"--lag-threshold", "1",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--use-unauthenticated-tls",
+		"--use-unauthenticated-plaintext",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "if any flags in the group")
 }

--- a/cmd/migration/execute/cmd_migration_execute_test.go
+++ b/cmd/migration/execute/cmd_migration_execute_test.go
@@ -1,0 +1,46 @@
+package execute
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationExecute_NoAuthFlag_ReturnsError(t *testing.T) {
+	cmd := NewMigrationExecuteCmd()
+	cmd.SetArgs([]string{
+		"--migration-id", "test-migration",
+		"--lag-threshold", "1",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one source cluster authentication flag is required")
+}
+
+func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
+	// Reset package-level vars to avoid cross-test pollution.
+	useSaslIam = false
+	useSaslScram = false
+	useTls = false
+	useUnauthenticatedTLS = false
+	useUnauthenticatedPlaintext = false
+
+	cmd := NewMigrationExecuteCmd()
+	cmd.SetArgs([]string{
+		"--migration-id", "test-migration",
+		"--lag-threshold", "1",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--use-unauthenticated-plaintext",
+	})
+
+	err := cmd.Execute()
+	// Should fail later (missing state file), NOT on auth validation.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one source cluster authentication flag is required")
+	assert.Contains(t, err.Error(), "migration state file")
+}

--- a/cmd/migration/init/cmd_migration_init.go
+++ b/cmd/migration/init/cmd_migration_init.go
@@ -151,6 +151,7 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	_ = migrationInitCmd.MarkFlagRequired("switchover-cr-yaml")
 
 	migrationInitCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationInitCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
 
 	return migrationInitCmd
 }

--- a/cmd/migration/init/cmd_migration_init_test.go
+++ b/cmd/migration/init/cmd_migration_init_test.go
@@ -1,0 +1,64 @@
+package init
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetAuthFlags() {
+	useSaslIam = false
+	useSaslScram = false
+	useTls = false
+	useUnauthenticatedTLS = false
+	useUnauthenticatedPlaintext = false
+}
+
+func TestMigrationInit_NoAuthFlag_ReturnsError(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationInitCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--cluster-bootstrap", "pkc-abc.confluent.cloud:9092",
+		"--k8s-namespace", "test-ns",
+		"--initial-cr-name", "test-cr",
+		"--cluster-id", "lkc-123",
+		"--cluster-rest-endpoint", "https://pkc-abc.confluent.cloud:443",
+		"--cluster-link-name", "test-link",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--fenced-cr-yaml", "fenced.yaml",
+		"--switchover-cr-yaml", "switchover.yaml",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of the flags")
+}
+
+func TestMigrationInit_WithAuthFlag_PassesValidation(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationInitCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--cluster-bootstrap", "pkc-abc.confluent.cloud:9092",
+		"--k8s-namespace", "test-ns",
+		"--initial-cr-name", "test-cr",
+		"--cluster-id", "lkc-123",
+		"--cluster-rest-endpoint", "https://pkc-abc.confluent.cloud:443",
+		"--cluster-link-name", "test-link",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--fenced-cr-yaml", "fenced.yaml",
+		"--switchover-cr-yaml", "switchover.yaml",
+		"--use-unauthenticated-plaintext",
+	})
+
+	err := cmd.Execute()
+	// Should fail later (missing YAML files), NOT on auth validation.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one of the flags")
+}


### PR DESCRIPTION
Fix for running the `kcp migration execute ...` command when providing no source cluster authentication method causing kcp to default to IAM. If the source cluster is not IAM-compatible, it returns the following error:

```shell
2026/04/06 22:20:11 ERROR failed to connect to source cluster: failed to create Kafka client: authType=SASL/IAM brokerAddresses=[18.220.31.188:11111] error=kafka: client has run out of available brokers to talk to: EOF
Error: failed to connect to source cluster: failed to create Kafka client: authType=SASL/IAM brokerAddresses=[18.220.31.188:11111] error=kafka: client has run out of available brokers to talk to: EOF
```