### PR TITLE
feat: add --use-sasl-plain flag to migration commands

### DIFF
--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -18,12 +18,16 @@ var (
 	awsRegion                   string
 	useSaslIam                  bool
 	useSaslScram                bool
+	useSaslPlain                bool
 	useTls                      bool
 	useUnauthenticatedTLS       bool
 	useUnauthenticatedPlaintext bool
 
 	saslScramUsername string
 	saslScramPassword string
+
+	saslPlainUsername string
+	saslPlainPassword string
 
 	tlsCaCert             string
 	tlsClientCert         string
@@ -71,6 +75,7 @@ interrupted, re-running this command will resume from the last completed step.`,
 	authFlags.SortFlags = false
 	authFlags.BoolVar(&useSaslIam, "use-sasl-iam", false, "Use IAM authentication for the source MSK cluster.")
 	authFlags.BoolVar(&useSaslScram, "use-sasl-scram", false, "Use SASL/SCRAM authentication for the source MSK cluster.")
+	authFlags.BoolVar(&useSaslPlain, "use-sasl-plain", false, "Use SASL/PLAIN authentication for the source cluster.")
 	authFlags.BoolVar(&useTls, "use-tls", false, "Use TLS authentication for the source MSK cluster.")
 	authFlags.BoolVar(&useUnauthenticatedTLS, "use-unauthenticated-tls", false, "Use unauthenticated (TLS encryption) for the source MSK cluster.")
 	authFlags.BoolVar(&useUnauthenticatedPlaintext, "use-unauthenticated-plaintext", false, "Use unauthenticated (plaintext) for the source MSK cluster.")
@@ -84,6 +89,14 @@ interrupted, re-running this command will resume from the last completed step.`,
 	saslScramFlags.StringVar(&saslScramPassword, "sasl-scram-password", "", "SASL/SCRAM password for the source MSK cluster.")
 	migrationExecuteCmd.Flags().AddFlagSet(saslScramFlags)
 	groups[saslScramFlags] = "SASL/SCRAM Flags"
+
+	// SASL/PLAIN credential flags.
+	saslPlainFlags := pflag.NewFlagSet("sasl-plain", pflag.ExitOnError)
+	saslPlainFlags.SortFlags = false
+	saslPlainFlags.StringVar(&saslPlainUsername, "sasl-plain-username", "", "SASL/PLAIN username for the source cluster.")
+	saslPlainFlags.StringVar(&saslPlainPassword, "sasl-plain-password", "", "SASL/PLAIN password for the source cluster.")
+	migrationExecuteCmd.Flags().AddFlagSet(saslPlainFlags)
+	groups[saslPlainFlags] = "SASL/PLAIN Flags"
 
 	// IAM credential flags.
 	iamFlags := pflag.NewFlagSet("iam", pflag.ExitOnError)
@@ -104,8 +117,8 @@ interrupted, re-running this command will resume from the last completed step.`,
 	migrationExecuteCmd.SetUsageFunc(func(c *cobra.Command) error {
 		fmt.Printf("%s\n\n", c.Short)
 
-		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authFlags, iamFlags, saslScramFlags, tlsFlags}
-		groupNames := []string{"Required Flags", "Optional Flags", "Source Cluster Authentication Flags", "IAM Flags", "SASL/SCRAM Flags", "TLS Flags"}
+		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authFlags, iamFlags, saslScramFlags, saslPlainFlags, tlsFlags}
+		groupNames := []string{"Required Flags", "Optional Flags", "Source Cluster Authentication Flags", "IAM Flags", "SASL/SCRAM Flags", "SASL/PLAIN Flags", "TLS Flags"}
 
 		for i, fs := range flagOrder {
 			usage := fs.FlagUsages()
@@ -123,8 +136,8 @@ interrupted, re-running this command will resume from the last completed step.`,
 	_ = migrationExecuteCmd.MarkFlagRequired("lag-threshold")
 	_ = migrationExecuteCmd.MarkFlagRequired("cluster-api-key")
 	_ = migrationExecuteCmd.MarkFlagRequired("cluster-api-secret")
-	migrationExecuteCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
-	migrationExecuteCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationExecuteCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-sasl-plain", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationExecuteCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-sasl-plain", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
 
 	return migrationExecuteCmd
 }
@@ -141,6 +154,11 @@ func preRunMigrationExecute(cmd *cobra.Command, args []string) error {
 	if useSaslScram {
 		_ = cmd.MarkFlagRequired("sasl-scram-username")
 		_ = cmd.MarkFlagRequired("sasl-scram-password")
+	}
+
+	if useSaslPlain {
+		_ = cmd.MarkFlagRequired("sasl-plain-username")
+		_ = cmd.MarkFlagRequired("sasl-plain-password")
 	}
 
 	if useTls {
@@ -181,6 +199,8 @@ func resolveAuthType() types.AuthType {
 		return types.AuthTypeIAM
 	case useSaslScram:
 		return types.AuthTypeSASLSCRAM
+	case useSaslPlain:
+		return types.AuthTypeSASLPlain
 	case useTls:
 		return types.AuthTypeTLS
 	case useUnauthenticatedTLS:
@@ -206,6 +226,8 @@ func parseMigrationExecutorOpts(migrationState types.MigrationState, config type
 		AuthType:              resolveAuthType(),
 		SaslScramUsername:     saslScramUsername,
 		SaslScramPassword:     saslScramPassword,
+		SaslPlainUsername:     saslPlainUsername,
+		SaslPlainPassword:     saslPlainPassword,
 		TlsCaCert:             tlsCaCert,
 		TlsClientCert:         tlsClientCert,
 		TlsClientKey:          tlsClientKey,

--- a/cmd/migration/execute/cmd_migration_execute_test.go
+++ b/cmd/migration/execute/cmd_migration_execute_test.go
@@ -10,6 +10,7 @@ import (
 func resetAuthFlags() {
 	useSaslIam = false
 	useSaslScram = false
+	useSaslPlain = false
 	useTls = false
 	useUnauthenticatedTLS = false
 	useUnauthenticatedPlaintext = false
@@ -45,6 +46,43 @@ func TestMigrationExecute_WithAuthFlag_PassesValidation(t *testing.T) {
 
 	err := cmd.Execute()
 	// Should fail later (missing state file), NOT on auth validation.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one of the flags")
+	assert.Contains(t, err.Error(), "migration state file")
+}
+
+func TestMigrationExecute_WithSaslPlainFlag_RequiresCredentials(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationExecuteCmd()
+	cmd.SetArgs([]string{
+		"--migration-id", "test-migration",
+		"--lag-threshold", "1",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--use-sasl-plain",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sasl-plain-username")
+}
+
+func TestMigrationExecute_WithSaslPlainFlagAndCredentials_PassesValidation(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationExecuteCmd()
+	cmd.SetArgs([]string{
+		"--migration-id", "test-migration",
+		"--lag-threshold", "1",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--use-sasl-plain",
+		"--sasl-plain-username", "user",
+		"--sasl-plain-password", "pass",
+	})
+
+	err := cmd.Execute()
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "at least one of the flags")
 	assert.Contains(t, err.Error(), "migration state file")

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -29,6 +29,8 @@ type MigrationExecutorOpts struct {
 	AuthType              types.AuthType
 	SaslScramUsername     string
 	SaslScramPassword     string
+	SaslPlainUsername     string
+	SaslPlainPassword     string
 	TlsCaCert             string
 	TlsClientCert         string
 	TlsClientKey          string
@@ -112,6 +114,12 @@ func (m *MigrationExecutor) createSourceOffset(_ context.Context) (*offset.Servi
 			CACert:     m.opts.TlsCaCert,
 			ClientCert: m.opts.TlsClientCert,
 			ClientKey:  m.opts.TlsClientKey,
+		}
+	case types.AuthTypeSASLPlain:
+		clusterAuth.AuthMethod.SASLPlain = &types.SASLPlainConfig{
+			Use:      true,
+			Username: m.opts.SaslPlainUsername,
+			Password: m.opts.SaslPlainPassword,
 		}
 	case types.AuthTypeIAM:
 		clusterAuth.AuthMethod.IAM = &types.IAMConfig{Use: true}

--- a/cmd/migration/init/cmd_migration_init.go
+++ b/cmd/migration/init/cmd_migration_init.go
@@ -98,7 +98,9 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	migrationInitCmd.Flags().AddFlagSet(optionalFlags)
 	groups[optionalFlags] = "Optional Flags"
 
-	// Authentication flags.
+	// Authentication flags. These are validated at init time so the user declares their source auth
+	// strategy up front (fail-fast), but credentials are not passed to the initializer — source cluster
+	// connections only happen during 'migration execute'.
 	authFlags := pflag.NewFlagSet("auth", pflag.ExitOnError)
 	authFlags.SortFlags = false
 	authFlags.BoolVar(&useSaslIam, "use-sasl-iam", false, "Use IAM authentication for the source MSK cluster.")

--- a/cmd/migration/init/cmd_migration_init.go
+++ b/cmd/migration/init/cmd_migration_init.go
@@ -36,12 +36,16 @@ var (
 
 	useSaslIam                  bool
 	useSaslScram                bool
+	useSaslPlain                bool
 	useTls                      bool
 	useUnauthenticatedTLS       bool
 	useUnauthenticatedPlaintext bool
 
 	saslScramUsername string
 	saslScramPassword string
+
+	saslPlainUsername string
+	saslPlainPassword string
 
 	tlsCaCert     string
 	tlsClientCert string
@@ -99,6 +103,7 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	authFlags.SortFlags = false
 	authFlags.BoolVar(&useSaslIam, "use-sasl-iam", false, "Use IAM authentication for the source MSK cluster.")
 	authFlags.BoolVar(&useSaslScram, "use-sasl-scram", false, "Use SASL/SCRAM authentication for the source MSK cluster.")
+	authFlags.BoolVar(&useSaslPlain, "use-sasl-plain", false, "Use SASL/PLAIN authentication for the source cluster.")
 	authFlags.BoolVar(&useTls, "use-tls", false, "Use TLS authentication for the source MSK cluster.")
 	authFlags.BoolVar(&useUnauthenticatedTLS, "use-unauthenticated-tls", false, "Use unauthenticated (TLS encryption) for the source MSK cluster.")
 	authFlags.BoolVar(&useUnauthenticatedPlaintext, "use-unauthenticated-plaintext", false, "Use unauthenticated (plaintext) for the source MSK cluster.")
@@ -113,6 +118,14 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	migrationInitCmd.Flags().AddFlagSet(saslScramFlags)
 	groups[saslScramFlags] = "SASL/SCRAM Flags"
 
+	// SASL/PLAIN credential flags.
+	saslPlainFlags := pflag.NewFlagSet("sasl-plain", pflag.ExitOnError)
+	saslPlainFlags.SortFlags = false
+	saslPlainFlags.StringVar(&saslPlainUsername, "sasl-plain-username", "", "SASL/PLAIN username for the source cluster.")
+	saslPlainFlags.StringVar(&saslPlainPassword, "sasl-plain-password", "", "SASL/PLAIN password for the source cluster.")
+	migrationInitCmd.Flags().AddFlagSet(saslPlainFlags)
+	groups[saslPlainFlags] = "SASL/PLAIN Flags"
+
 	// TLS credential flags.
 	tlsFlags := pflag.NewFlagSet("tls", pflag.ExitOnError)
 	tlsFlags.SortFlags = false
@@ -125,8 +138,8 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	migrationInitCmd.SetUsageFunc(func(c *cobra.Command) error {
 		fmt.Printf("%s\n\n", c.Short)
 
-		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authFlags, saslScramFlags, tlsFlags}
-		groupNames := []string{"Required Flags", "Optional Flags", "Source Cluster Authentication Flags", "SASL/SCRAM Flags", "TLS Flags"}
+		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authFlags, saslScramFlags, saslPlainFlags, tlsFlags}
+		groupNames := []string{"Required Flags", "Optional Flags", "Source Cluster Authentication Flags", "SASL/SCRAM Flags", "SASL/PLAIN Flags", "TLS Flags"}
 
 		for i, fs := range flagOrder {
 			usage := fs.FlagUsages()
@@ -152,8 +165,8 @@ The state file can then be used by 'kcp migration execute' to run the migration.
 	_ = migrationInitCmd.MarkFlagRequired("fenced-cr-yaml")
 	_ = migrationInitCmd.MarkFlagRequired("switchover-cr-yaml")
 
-	migrationInitCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
-	migrationInitCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationInitCmd.MarkFlagsMutuallyExclusive("use-sasl-iam", "use-sasl-scram", "use-sasl-plain", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
+	migrationInitCmd.MarkFlagsOneRequired("use-sasl-iam", "use-sasl-scram", "use-sasl-plain", "use-tls", "use-unauthenticated-tls", "use-unauthenticated-plaintext")
 
 	return migrationInitCmd
 }
@@ -166,6 +179,11 @@ func preRunMigrationInit(cmd *cobra.Command, args []string) error {
 	if useSaslScram {
 		_ = cmd.MarkFlagRequired("sasl-scram-username")
 		_ = cmd.MarkFlagRequired("sasl-scram-password")
+	}
+
+	if useSaslPlain {
+		_ = cmd.MarkFlagRequired("sasl-plain-username")
+		_ = cmd.MarkFlagRequired("sasl-plain-password")
 	}
 
 	if useTls {

--- a/cmd/migration/init/cmd_migration_init_test.go
+++ b/cmd/migration/init/cmd_migration_init_test.go
@@ -10,6 +10,7 @@ import (
 func resetAuthFlags() {
 	useSaslIam = false
 	useSaslScram = false
+	useSaslPlain = false
 	useTls = false
 	useUnauthenticatedTLS = false
 	useUnauthenticatedPlaintext = false

--- a/cmd/migration/init/cmd_migration_init_test.go
+++ b/cmd/migration/init/cmd_migration_init_test.go
@@ -39,6 +39,57 @@ func TestMigrationInit_NoAuthFlag_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one of the flags")
 }
 
+func TestMigrationInit_WithSaslPlainFlag_RequiresCredentials(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationInitCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--cluster-bootstrap", "pkc-abc.confluent.cloud:9092",
+		"--k8s-namespace", "test-ns",
+		"--initial-cr-name", "test-cr",
+		"--cluster-id", "lkc-123",
+		"--cluster-rest-endpoint", "https://pkc-abc.confluent.cloud:443",
+		"--cluster-link-name", "test-link",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--fenced-cr-yaml", "fenced.yaml",
+		"--switchover-cr-yaml", "switchover.yaml",
+		"--use-sasl-plain",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sasl-plain-username")
+}
+
+func TestMigrationInit_WithSaslPlainFlagAndCredentials_PassesValidation(t *testing.T) {
+	resetAuthFlags()
+
+	cmd := NewMigrationInitCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--cluster-bootstrap", "pkc-abc.confluent.cloud:9092",
+		"--k8s-namespace", "test-ns",
+		"--initial-cr-name", "test-cr",
+		"--cluster-id", "lkc-123",
+		"--cluster-rest-endpoint", "https://pkc-abc.confluent.cloud:443",
+		"--cluster-link-name", "test-link",
+		"--cluster-api-key", "key",
+		"--cluster-api-secret", "secret",
+		"--fenced-cr-yaml", "fenced.yaml",
+		"--switchover-cr-yaml", "switchover.yaml",
+		"--use-sasl-plain",
+		"--sasl-plain-username", "user",
+		"--sasl-plain-password", "pass",
+	})
+
+	err := cmd.Execute()
+	// Should fail later (missing YAML files), NOT on auth validation.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one of the flags")
+}
+
 func TestMigrationInit_WithAuthFlag_PassesValidation(t *testing.T) {
 	resetAuthFlags()
 

--- a/internal/client/kafka_admin.go
+++ b/internal/client/kafka_admin.go
@@ -140,8 +140,13 @@ func configureSASLTypeSCRAMAuthentication(config *sarama.Config, username string
 
 func configureSASLTypePlainAuthentication(config *sarama.Config, username string, password string, withTLSEncryption bool, insecureSkipVerify bool) {
 	slog.Info("configuring SASL/PLAIN authentication", "enableTlsEncryption", withTLSEncryption)
+	if !withTLSEncryption {
+		slog.Warn("SASL/PLAIN without TLS: credentials will be transmitted in cleartext over the network")
+	}
 	config.Net.TLS.Enable = withTLSEncryption
-	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // user-controlled flag
+	if withTLSEncryption {
+		config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // user-controlled flag
+	}
 	config.Net.SASL.Enable = true
 	config.Net.SASL.User = username
 	config.Net.SASL.Password = password

--- a/internal/client/kafka_admin.go
+++ b/internal/client/kafka_admin.go
@@ -26,6 +26,7 @@ type AdminConfig struct {
 	clientCertFile     string
 	clientKeyFile      string
 	insecureSkipVerify bool
+	disableTLS         bool
 }
 
 // AdminOption is a function type for configuring the Kafka admin client
@@ -77,6 +78,17 @@ func WithSASLPlainAuth(username, password string) AdminOption {
 	}
 }
 
+// WithSASLPlainAuthNoTLS configures SASL/PLAIN authentication without TLS encryption.
+// Used for source clusters using SASL_PLAINTEXT listeners.
+func WithSASLPlainAuthNoTLS(username, password string) AdminOption {
+	return func(config *AdminConfig) {
+		config.authType = types.AuthTypeSASLPlain
+		config.username = username
+		config.password = password
+		config.disableTLS = true
+	}
+}
+
 // WithInsecureSkipVerify disables TLS certificate verification.
 func WithInsecureSkipVerify() AdminOption {
 	return func(config *AdminConfig) {
@@ -97,6 +109,8 @@ func AdminOptionForAuth(authType types.AuthType, clusterAuth types.ClusterAuth) 
 		return WithUnauthenticatedPlaintextAuth()
 	case types.AuthTypeTLS:
 		return WithTLSAuth(clusterAuth.AuthMethod.TLS.CACert, clusterAuth.AuthMethod.TLS.ClientCert, clusterAuth.AuthMethod.TLS.ClientKey)
+	case types.AuthTypeSASLPlain:
+		return WithSASLPlainAuthNoTLS(clusterAuth.AuthMethod.SASLPlain.Username, clusterAuth.AuthMethod.SASLPlain.Password)
 	default:
 		slog.Warn("unknown auth type, defaulting to IAM", "authType", authType)
 		return WithIAMAuth()
@@ -124,9 +138,9 @@ func configureSASLTypeSCRAMAuthentication(config *sarama.Config, username string
 	config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 }
 
-func configureSASLTypePlainAuthentication(config *sarama.Config, username string, password string, insecureSkipVerify bool) {
-	slog.Info("configuring SASL/PLAIN authentication")
-	config.Net.TLS.Enable = true
+func configureSASLTypePlainAuthentication(config *sarama.Config, username string, password string, withTLSEncryption bool, insecureSkipVerify bool) {
+	slog.Info("configuring SASL/PLAIN authentication", "enableTlsEncryption", withTLSEncryption)
+	config.Net.TLS.Enable = withTLSEncryption
 	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // user-controlled flag
 	config.Net.SASL.Enable = true
 	config.Net.SASL.User = username
@@ -552,7 +566,7 @@ func NewKafkaClient(brokerAddresses []string, region string, opts ...AdminOption
 	case types.AuthTypeSASLSCRAM:
 		configureSASLTypeSCRAMAuthentication(saramaConfig, config.username, config.password, config.insecureSkipVerify)
 	case types.AuthTypeSASLPlain:
-		configureSASLTypePlainAuthentication(saramaConfig, config.username, config.password, config.insecureSkipVerify)
+		configureSASLTypePlainAuthentication(saramaConfig, config.username, config.password, !config.disableTLS, config.insecureSkipVerify)
 	case types.AuthTypeUnauthenticatedTLS:
 		configureUnauthenticatedAuthentication(saramaConfig, true, config.insecureSkipVerify)
 	case types.AuthTypeUnauthenticatedPlaintext:
@@ -598,6 +612,8 @@ func NewKafkaAdmin(brokerAddresses []string, clientBrokerEncryptionInTransit kaf
 		configureSASLTypeOAuthAuthentication(saramaConfig, region, config.insecureSkipVerify)
 	case types.AuthTypeSASLSCRAM:
 		configureSASLTypeSCRAMAuthentication(saramaConfig, config.username, config.password, config.insecureSkipVerify)
+	case types.AuthTypeSASLPlain:
+		configureSASLTypePlainAuthentication(saramaConfig, config.username, config.password, !config.disableTLS, config.insecureSkipVerify)
 	case types.AuthTypeUnauthenticatedTLS:
 		configureUnauthenticatedAuthentication(saramaConfig, true, config.insecureSkipVerify)
 	case types.AuthTypeUnauthenticatedPlaintext:

--- a/internal/client/kafka_admin_test.go
+++ b/internal/client/kafka_admin_test.go
@@ -274,6 +274,25 @@ func TestAdminOptionFunctions(t *testing.T) {
 				clientKeyFile:  "client.key",
 			},
 		},
+		{
+			name:   "WithSASLPlainAuth sets SASL/PLAIN auth with TLS",
+			option: WithSASLPlainAuth("test-user", "test-pass"),
+			expectedConfig: AdminConfig{
+				authType: types.AuthTypeSASLPlain,
+				username: "test-user",
+				password: "test-pass",
+			},
+		},
+		{
+			name:   "WithSASLPlainAuthNoTLS sets SASL/PLAIN auth without TLS",
+			option: WithSASLPlainAuthNoTLS("test-user", "test-pass"),
+			expectedConfig: AdminConfig{
+				authType:   types.AuthTypeSASLPlain,
+				username:   "test-user",
+				password:   "test-pass",
+				disableTLS: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +308,7 @@ func TestAdminOptionFunctions(t *testing.T) {
 			assert.Equal(t, tt.expectedConfig.caCertFile, config.caCertFile)
 			assert.Equal(t, tt.expectedConfig.clientCertFile, config.clientCertFile)
 			assert.Equal(t, tt.expectedConfig.clientKeyFile, config.clientKeyFile)
+			assert.Equal(t, tt.expectedConfig.disableTLS, config.disableTLS)
 		})
 	}
 }
@@ -349,6 +369,58 @@ func TestConfigureSASLTypeSCRAMAuthentication(t *testing.T) {
 	// Verify SCRAM client generator function
 	scramClient := config.Net.SASL.SCRAMClientGeneratorFunc()
 	assert.NotNil(t, scramClient)
+}
+
+func TestConfigureSASLTypePlainAuthentication(t *testing.T) {
+	tests := []struct {
+		name               string
+		withTLSEncryption  bool
+		expectedTLSEnabled bool
+	}{
+		{
+			name:               "with TLS encryption (SASL_SSL)",
+			withTLSEncryption:  true,
+			expectedTLSEnabled: true,
+		},
+		{
+			name:               "without TLS encryption (SASL_PLAINTEXT)",
+			withTLSEncryption:  false,
+			expectedTLSEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sarama.NewConfig()
+			configureSASLTypePlainAuthentication(config, "user", "pass", tt.withTLSEncryption, false)
+
+			assert.Equal(t, tt.expectedTLSEnabled, config.Net.TLS.Enable)
+			assert.True(t, config.Net.SASL.Enable)
+			assert.Equal(t, "user", config.Net.SASL.User)
+			assert.Equal(t, "pass", config.Net.SASL.Password)
+			assert.Equal(t, string(sarama.SASLTypePlaintext), string(config.Net.SASL.Mechanism))
+		})
+	}
+}
+
+func TestAdminOptionForAuth_SASLPlain(t *testing.T) {
+	clusterAuth := types.ClusterAuth{
+		AuthMethod: types.AuthMethodConfig{
+			SASLPlain: &types.SASLPlainConfig{
+				Use:      true,
+				Username: "test-user",
+				Password: "test-pass",
+			},
+		},
+	}
+	opt := AdminOptionForAuth(types.AuthTypeSASLPlain, clusterAuth)
+	config := AdminConfig{}
+	opt(&config)
+
+	assert.Equal(t, types.AuthTypeSASLPlain, config.authType)
+	assert.Equal(t, "test-user", config.username)
+	assert.Equal(t, "test-pass", config.password)
+	assert.True(t, config.disableTLS)
 }
 
 func TestConfigureUnauthenticatedAuthentication(t *testing.T) {

--- a/internal/types/credentials.go
+++ b/internal/types/credentials.go
@@ -158,6 +158,9 @@ func (ce ClusterAuth) GetAuthMethods() []AuthType {
 	if ce.AuthMethod.SASLScram != nil && ce.AuthMethod.SASLScram.Use {
 		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
 	}
+	if ce.AuthMethod.SASLPlain != nil && ce.AuthMethod.SASLPlain.Use {
+		enabledMethods = append(enabledMethods, AuthTypeSASLPlain)
+	}
 	if ce.AuthMethod.TLS != nil && ce.AuthMethod.TLS.Use {
 		enabledMethods = append(enabledMethods, AuthTypeTLS)
 	}
@@ -168,6 +171,7 @@ func (ce ClusterAuth) GetAuthMethods() []AuthType {
 type AuthMethodConfig struct {
 	IAM                      *IAMConfig                      `yaml:"iam,omitempty"`
 	SASLScram                *SASLScramConfig                `yaml:"sasl_scram,omitempty"`
+	SASLPlain                *SASLPlainConfig                `yaml:"sasl_plain,omitempty"`
 	TLS                      *TLSConfig                      `yaml:"tls,omitempty"`
 	UnauthenticatedTLS       *UnauthenticatedTLSConfig       `yaml:"unauthenticated_tls,omitempty"`
 	UnauthenticatedPlaintext *UnauthenticatedPlaintextConfig `yaml:"unauthenticated_plaintext,omitempty"`
@@ -200,6 +204,12 @@ func (amc *AuthMethodConfig) MergeWith(existing AuthMethodConfig) {
 		amc.SASLScram.Username = existing.SASLScram.Username
 		amc.SASLScram.Password = existing.SASLScram.Password
 	}
+
+	if amc.SASLPlain != nil && existing.SASLPlain != nil {
+		amc.SASLPlain.Use = existing.SASLPlain.Use
+		amc.SASLPlain.Username = existing.SASLPlain.Username
+		amc.SASLPlain.Password = existing.SASLPlain.Password
+	}
 }
 
 type UnauthenticatedPlaintextConfig struct {
@@ -222,6 +232,12 @@ type TLSConfig struct {
 }
 
 type SASLScramConfig struct {
+	Use      bool   `yaml:"use"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+type SASLPlainConfig struct {
 	Use      bool   `yaml:"use"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`


### PR DESCRIPTION
## Summary
- Adds `--use-sasl-plain`, `--sasl-plain-username`, `--sasl-plain-password` flags to `migration init` and `migration execute` commands
- Enables migrations from source clusters using `SASL_PLAINTEXT` listeners (e.g. Confluent Platform, self-managed Kafka with SASL/PLAIN mechanism)
- Fixes `AdminOptionForAuth` silently falling through to IAM when given `AuthTypeSASLPlain`
- Adds `WithSASLPlainAuthNoTLS` AdminOption and TLS toggle to `configureSASLTypePlainAuthentication` — CC destination path (which needs TLS) is unaffected

## Context
A user migrating from Confluent Platform to Confluent Cloud had a source cluster configured with `SASL_PLAINTEXT` + `PLAIN` mechanism. No existing auth flag combination supported this — IAM/SCRAM both hardcode TLS, unauthenticated options skip SASL, and mTLS is a different mechanism entirely.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 28 packages)
- [x] New unit tests: `WithSASLPlainAuthNoTLS` config, `configureSASLTypePlainAuthentication` with TLS on/off, `AdminOptionForAuth` SASL/PLAIN mapping
- [x] New command tests: `--use-sasl-plain` requires credentials, passes validation with credentials
- [x] E2E: `make e2e-setup && make ci-e2e-tests` (existing `--use-unauthenticated-plaintext` path still works)
- [x] Manual: test against a SASL_PLAINTEXT source cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)