### PR TITLE
fix: migration lag check cluster link validation

### DIFF
--- a/cmd/migration/lagcheck/cmd_migration_lagcheck.go
+++ b/cmd/migration/lagcheck/cmd_migration_lagcheck.go
@@ -1,7 +1,9 @@
 package lagcheck
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/confluentinc/kcp/internal/services/clusterlink"
 	"github.com/confluentinc/kcp/internal/utils"
@@ -80,10 +82,16 @@ func runMigrationLagCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	svc := clusterlink.NewConfluentCloudService(nil)
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+	defer cancel()
+	if _, err := svc.GetClusterLink(ctx, config); err != nil {
+		return fmt.Errorf("failed to verify cluster link: %w", err)
+	}
+
 	model := newModel(svc, config, interval)
 	p := newProgram(model)
-	_, err := p.Run()
-	if err != nil {
+	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("TUI: %w", err)
 	}
 	return nil

--- a/cmd/migration/lagcheck/cmd_migration_lagcheck.go
+++ b/cmd/migration/lagcheck/cmd_migration_lagcheck.go
@@ -2,6 +2,7 @@ package lagcheck
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// clusterLinkVerifyTimeout bounds the pre-TUI GetClusterLink probe so the
+// command fails fast with a clear error instead of hanging on a bad endpoint.
+const clusterLinkVerifyTimeout = 15 * time.Second
 
 var (
 	restEndpoint string
@@ -83,9 +88,12 @@ func runMigrationLagCheck(cmd *cobra.Command, args []string) error {
 
 	svc := clusterlink.NewConfluentCloudService(nil)
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), clusterLinkVerifyTimeout)
 	defer cancel()
 	if _, err := svc.GetClusterLink(ctx, config); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("timed out verifying cluster link after %s — check network connectivity to %s", clusterLinkVerifyTimeout, restEndpoint)
+		}
 		return fmt.Errorf("failed to verify cluster link: %w", err)
 	}
 

--- a/internal/services/clusterlink/clusterlink.go
+++ b/internal/services/clusterlink/clusterlink.go
@@ -12,6 +12,17 @@ import (
 	"slices"
 )
 
+// ClusterLink describes a Confluent Cloud cluster link as returned by
+// GET /kafka/v3/clusters/{cluster_id}/links/{link_name}.
+type ClusterLink struct {
+	LinkName        string `json:"link_name"`
+	LinkID          string `json:"link_id"`
+	ClusterID       string `json:"cluster_id"`
+	SourceClusterID string `json:"source_cluster_id"`
+	LinkState       string `json:"link_state"`
+	LinkError       string `json:"link_error,omitempty"`
+}
+
 type MirrorLag struct {
 	Partition             int `json:"partition"`
 	Lag                   int `json:"lag"`
@@ -50,6 +61,7 @@ type PromoteMirrorTopicsResponse struct {
 
 // Service defines cluster link operations
 type Service interface {
+	GetClusterLink(ctx context.Context, config Config) (*ClusterLink, error)
 	ListMirrorTopics(ctx context.Context, config Config) ([]MirrorTopic, error)
 	ListConfigs(ctx context.Context, config Config) (map[string]string, error)
 	ValidateTopics(topics []string, clusterLinkTopics []string) error
@@ -74,6 +86,47 @@ func NewConfluentCloudService(httpClient HTTPClient) *ConfluentCloudService {
 	return &ConfluentCloudService{
 		httpClient: httpClient,
 	}
+}
+
+// GetClusterLink fetches the cluster link resource. Returns a descriptive
+// error when the Confluent Cloud REST API responds with HTTP 404 so callers
+// can surface the missing link to the user.
+func (s *ConfluentCloudService) GetClusterLink(ctx context.Context, config Config) (*ClusterLink, error) {
+	path := fmt.Sprintf("/kafka/v3/clusters/%s/links/%s", config.ClusterID, config.LinkName)
+	url := config.RestEndpoint + path
+	auth := base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", config.APIKey, config.APISecret))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Add("Authorization", "Basic "+auth)
+
+	res, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("cluster link %q not found on cluster %s", config.LinkName, config.ClusterID)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("unexpected status code %d: %s", res.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var link ClusterLink
+	if err := json.Unmarshal(body, &link); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &link, nil
 }
 
 func (s *ConfluentCloudService) ListMirrorTopics(ctx context.Context, config Config) ([]MirrorTopic, error) {

--- a/internal/services/clusterlink/clusterlink.go
+++ b/internal/services/clusterlink/clusterlink.go
@@ -5,12 +5,39 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"slices"
 )
+
+// httpStatusError is returned by doRequest/doPostRequest when the server
+// responds with a non-success status code. Callers can use errors.As to
+// branch on StatusCode (e.g. to distinguish 404 from 401).
+type httpStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %s", e.StatusCode, e.Body)
+}
+
+// basicAuthHeader returns the full "Basic <base64>" header value built from
+// the config's API key and secret.
+func basicAuthHeader(config Config) string {
+	return "Basic " + base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", config.APIKey, config.APISecret))
+}
+
+// linkPath returns the escaped base path for the cluster link resource.
+func linkPath(config Config) string {
+	return fmt.Sprintf("/kafka/v3/clusters/%s/links/%s",
+		url.PathEscape(config.ClusterID),
+		url.PathEscape(config.LinkName))
+}
 
 // ClusterLink describes a Confluent Cloud cluster link as returned by
 // GET /kafka/v3/clusters/{cluster_id}/links/{link_name}.
@@ -88,49 +115,28 @@ func NewConfluentCloudService(httpClient HTTPClient) *ConfluentCloudService {
 	}
 }
 
-// GetClusterLink fetches the cluster link resource. Returns a descriptive
-// error when the Confluent Cloud REST API responds with HTTP 404 so callers
-// can surface the missing link to the user.
+// GetClusterLink fetches the cluster link resource. Translates common
+// failure statuses (404, 401/403) into user-facing messages so callers can
+// surface actionable errors to the CLI.
 func (s *ConfluentCloudService) GetClusterLink(ctx context.Context, config Config) (*ClusterLink, error) {
-	path := fmt.Sprintf("/kafka/v3/clusters/%s/links/%s", config.ClusterID, config.LinkName)
-	url := config.RestEndpoint + path
-	auth := base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", config.APIKey, config.APISecret))
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Add("Authorization", "Basic "+auth)
-
-	res, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer func() { _ = res.Body.Close() }()
-
-	if res.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("cluster link %q not found on cluster %s", config.LinkName, config.ClusterID)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("unexpected status code %d: %s", res.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
 	var link ClusterLink
-	if err := json.Unmarshal(body, &link); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	if err := s.doRequest(ctx, config, linkPath(config), &link); err != nil {
+		var statusErr *httpStatusError
+		if errors.As(err, &statusErr) {
+			switch statusErr.StatusCode {
+			case http.StatusNotFound:
+				return nil, fmt.Errorf("cluster link %q not found on cluster %s", config.LinkName, config.ClusterID)
+			case http.StatusUnauthorized, http.StatusForbidden:
+				return nil, fmt.Errorf("authentication failed (status %d) — verify --cluster-api-key and --cluster-api-secret", statusErr.StatusCode)
+			}
+		}
+		return nil, fmt.Errorf("failed to get cluster link: %w", err)
 	}
 	return &link, nil
 }
 
 func (s *ConfluentCloudService) ListMirrorTopics(ctx context.Context, config Config) ([]MirrorTopic, error) {
-	path := fmt.Sprintf("/kafka/v3/clusters/%s/links/%s/mirrors", config.ClusterID, config.LinkName)
+	path := linkPath(config) + "/mirrors"
 
 	var response struct {
 		Data []MirrorTopic `json:"data"`
@@ -158,7 +164,7 @@ func (s *ConfluentCloudService) ListMirrorTopics(ctx context.Context, config Con
 
 // ListConfigs retrieves cluster link configurations
 func (s *ConfluentCloudService) ListConfigs(ctx context.Context, config Config) (map[string]string, error) {
-	path := fmt.Sprintf("/kafka/v3/clusters/%s/links/%s/configs", config.ClusterID, config.LinkName)
+	path := linkPath(config) + "/configs"
 
 	var response struct {
 		Data []struct {
@@ -195,7 +201,7 @@ func (s *ConfluentCloudService) PromoteMirrorTopics(ctx context.Context, config 
 		return &PromoteMirrorTopicsResponse{}, nil
 	}
 
-	path := fmt.Sprintf("/kafka/v3/clusters/%s/links/%s/mirrors:promote", config.ClusterID, config.LinkName)
+	path := linkPath(config) + "/mirrors:promote"
 
 	requestBody := struct {
 		MirrorTopicNames []string `json:"mirror_topic_names"`
@@ -211,17 +217,15 @@ func (s *ConfluentCloudService) PromoteMirrorTopics(ctx context.Context, config 
 	return &response, nil
 }
 
-// doRequest performs an authenticated HTTP GET request to Confluent Cloud API
+// doRequest performs an authenticated HTTP GET request to Confluent Cloud API.
+// Non-2xx responses are returned as *httpStatusError so callers can branch on
+// the status code.
 func (s *ConfluentCloudService) doRequest(ctx context.Context, config Config, path string, result interface{}) error {
-	url := config.RestEndpoint + path
-	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", config.APIKey, config.APISecret)))
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, config.RestEndpoint+path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-
-	req.Header.Add("Authorization", "Basic "+auth)
+	req.Header.Set("Authorization", basicAuthHeader(config))
 
 	res, err := s.httpClient.Do(req)
 	if err != nil {
@@ -231,7 +235,7 @@ func (s *ConfluentCloudService) doRequest(ctx context.Context, config Config, pa
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		return fmt.Errorf("unexpected status code %d: %s", res.StatusCode, string(body))
+		return &httpStatusError{StatusCode: res.StatusCode, Body: string(body)}
 	}
 
 	body, err := io.ReadAll(res.Body)
@@ -248,21 +252,17 @@ func (s *ConfluentCloudService) doRequest(ctx context.Context, config Config, pa
 
 // doPostRequest performs an authenticated HTTP POST request to Confluent Cloud API
 func (s *ConfluentCloudService) doPostRequest(ctx context.Context, config Config, path string, requestBody interface{}, result interface{}) error {
-	url := config.RestEndpoint + path
-	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", config.APIKey, config.APISecret)))
-
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.RestEndpoint+path, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-
-	req.Header.Add("Authorization", "Basic "+auth)
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("Authorization", basicAuthHeader(config))
+	req.Header.Set("Content-Type", "application/json")
 
 	res, err := s.httpClient.Do(req)
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *ConfluentCloudService) doPostRequest(ctx context.Context, config Config
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(res.Body)
-		return fmt.Errorf("unexpected status code %d: %s", res.StatusCode, string(body))
+		return &httpStatusError{StatusCode: res.StatusCode, Body: string(body)}
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/internal/services/clusterlink/clusterlink_test.go
+++ b/internal/services/clusterlink/clusterlink_test.go
@@ -347,6 +347,92 @@ func TestPromoteMirrorTopics_HTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
+func TestGetClusterLink_Success(t *testing.T) {
+	clusterID := "lkc-abc123"
+	linkName := "my-cluster-link"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/kafka/v3/clusters/" + clusterID + "/links/" + linkName
+		assert.Equal(t, expectedPath, r.URL.Path, "request path")
+		assert.Equal(t, http.MethodGet, r.Method, "HTTP method")
+
+		resp := map[string]interface{}{
+			"link_name":         linkName,
+			"link_id":           "link-id-42",
+			"cluster_id":        clusterID,
+			"source_cluster_id": "lkc-source",
+			"link_state":        "ACTIVE",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    clusterID,
+		LinkName:     linkName,
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	link, err := svc.GetClusterLink(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, link)
+	assert.Equal(t, linkName, link.LinkName)
+	assert.Equal(t, "link-id-42", link.LinkID)
+	assert.Equal(t, clusterID, link.ClusterID)
+	assert.Equal(t, "lkc-source", link.SourceClusterID)
+	assert.Equal(t, "ACTIVE", link.LinkState)
+}
+
+func TestGetClusterLink_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error_code":404,"message":"link not found"}`))
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    "lkc-missing",
+		LinkName:     "missing-link",
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	link, err := svc.GetClusterLink(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Nil(t, link)
+	assert.Contains(t, err.Error(), "missing-link")
+	assert.Contains(t, err.Error(), "lkc-missing")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetClusterLink_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unauthorized"))
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    "lkc-err",
+		LinkName:     "link-err",
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	link, err := svc.GetClusterLink(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Nil(t, link)
+	assert.Contains(t, err.Error(), "401")
+}
+
 func TestListConfigs_Success(t *testing.T) {
 	clusterID := "lkc-cfg"
 	linkName := "config-link"

--- a/internal/services/clusterlink/clusterlink_test.go
+++ b/internal/services/clusterlink/clusterlink_test.go
@@ -2,6 +2,7 @@ package clusterlink
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -350,11 +351,13 @@ func TestPromoteMirrorTopics_HTTPError(t *testing.T) {
 func TestGetClusterLink_Success(t *testing.T) {
 	clusterID := "lkc-abc123"
 	linkName := "my-cluster-link"
+	expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("key:secret"))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		expectedPath := "/kafka/v3/clusters/" + clusterID + "/links/" + linkName
 		assert.Equal(t, expectedPath, r.URL.Path, "request path")
 		assert.Equal(t, http.MethodGet, r.Method, "HTTP method")
+		assert.Equal(t, expectedAuth, r.Header.Get("Authorization"), "Authorization header")
 
 		resp := map[string]interface{}{
 			"link_name":         linkName,
@@ -387,6 +390,39 @@ func TestGetClusterLink_Success(t *testing.T) {
 	assert.Equal(t, "ACTIVE", link.LinkState)
 }
 
+func TestGetClusterLink_PathIsEscaped(t *testing.T) {
+	clusterID := "lkc abc"       // whitespace
+	linkName := "link/with?bits" // characters that would otherwise alter the path
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// r.URL.Path is already URL-decoded by net/http; asserting on it confirms
+		// the server received exactly the values we sent (i.e. nothing escaped
+		// past the intended path segment).
+		assert.Equal(t, "/kafka/v3/clusters/"+clusterID+"/links/"+linkName, r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery, "query string must not leak from link name")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"link_name":  linkName,
+			"cluster_id": clusterID,
+			"link_state": "ACTIVE",
+		})
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    clusterID,
+		LinkName:     linkName,
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	_, err := svc.GetClusterLink(context.Background(), cfg)
+	require.NoError(t, err)
+}
+
 func TestGetClusterLink_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -411,7 +447,7 @@ func TestGetClusterLink_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-func TestGetClusterLink_HTTPError(t *testing.T) {
+func TestGetClusterLink_Unauthorized(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte("unauthorized"))
@@ -431,6 +467,52 @@ func TestGetClusterLink_HTTPError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, link)
 	assert.Contains(t, err.Error(), "401")
+	assert.Contains(t, err.Error(), "authentication failed")
+	assert.Contains(t, err.Error(), "--cluster-api-key")
+}
+
+func TestGetClusterLink_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    "lkc-err",
+		LinkName:     "link-err",
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	_, err := svc.GetClusterLink(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func TestGetClusterLink_UnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("oops"))
+	}))
+	defer server.Close()
+
+	svc := NewConfluentCloudService(server.Client())
+	cfg := Config{
+		RestEndpoint: server.URL,
+		ClusterID:    "lkc-err",
+		LinkName:     "link-err",
+		APIKey:       "key",
+		APISecret:    "secret",
+	}
+
+	link, err := svc.GetClusterLink(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Nil(t, link)
+	assert.Contains(t, err.Error(), "failed to get cluster link")
+	assert.Contains(t, err.Error(), "500")
 }
 
 func TestListConfigs_Success(t *testing.T) {

--- a/internal/services/migration/mock_test.go
+++ b/internal/services/migration/mock_test.go
@@ -64,10 +64,18 @@ func (m *mockGatewayService) WaitForGatewayPods(ctx context.Context, namespace, 
 
 // mockClusterLinkService implements clusterlink.Service using function fields for test control.
 type mockClusterLinkService struct {
+	getClusterLinkFn      func(ctx context.Context, config clusterlink.Config) (*clusterlink.ClusterLink, error)
 	listMirrorTopicsFn    func(ctx context.Context, config clusterlink.Config) ([]clusterlink.MirrorTopic, error)
 	listConfigsFn         func(ctx context.Context, config clusterlink.Config) (map[string]string, error)
 	validateTopicsFn      func(topics []string, clusterLinkTopics []string) error
 	promoteMirrorTopicsFn func(ctx context.Context, config clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error)
+}
+
+func (m *mockClusterLinkService) GetClusterLink(ctx context.Context, config clusterlink.Config) (*clusterlink.ClusterLink, error) {
+	if m.getClusterLinkFn != nil {
+		return m.getClusterLinkFn(ctx, config)
+	}
+	return nil, fmt.Errorf("mockClusterLinkService.GetClusterLink not configured")
 }
 
 func (m *mockClusterLinkService) ListMirrorTopics(ctx context.Context, config clusterlink.Config) ([]clusterlink.MirrorTopic, error) {


### PR DESCRIPTION
Adds some pre-flight checking on the `kcp migration lag-check` command so that it doesn't start up the TUI w/ a non-existent cluster link. New error message now indicates the following

```shell
$ kcp migration lag-check ... --cluster-link-name msk-to-cc-link-FAKE ...

Executing kcp with build version=0.0.0-localdev commit=5bfbc9719706357dbd63305384addbf0ed7f9d8f date=2026-04-17T10:56:10Z

...

2026/04/17 11:00:34 ERROR failed to verify cluster link: cluster link "msk-to-cc-link-FAKE" not found on cluster lkc-XXX
Error: failed to verify cluster link: cluster link "msk-to-cc-link-FAKE" not found on cluster lkc-XXX
```

Moreover, returning any error status codes + possible causes - lack of network connectivity, invalid API key/secret, invalid REST URL, etc.