### PR TITLE
chore: validate state file compatibility on load and upload

### DIFF
--- a/cmd/report/metrics/cmd_report_metrics_test.go
+++ b/cmd/report/metrics/cmd_report_metrics_test.go
@@ -34,7 +34,8 @@ func TestParseMetricReporterOpts_SourceTypeMSK(t *testing.T) {
 				{ID: "osk-cluster-1"},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -80,7 +81,8 @@ func TestParseMetricReporterOpts_SourceTypeOSK(t *testing.T) {
 				{ID: "osk-cluster-1"},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -118,7 +120,8 @@ func TestParseMetricReporterOpts_ClusterIdFlag(t *testing.T) {
 				{ID: "osk-cluster-1"},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -162,7 +165,8 @@ func TestParseMetricReporterOpts_MultipleClusterIds(t *testing.T) {
 				{ID: "osk-cluster-1"},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -201,7 +205,8 @@ func TestParseMetricReporterOpts_InvalidSourceType(t *testing.T) {
 				},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -252,7 +257,8 @@ func TestParseMetricReporterOpts_NoClustersInState_MSK(t *testing.T) {
 		OSKSources: &types.OSKSourcesState{
 			Clusters: []types.OSKDiscoveredCluster{},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -285,7 +291,8 @@ func TestParseMetricReporterOpts_NoClustersInState_Neither(t *testing.T) {
 		OSKSources: &types.OSKSourcesState{
 			Clusters: []types.OSKDiscoveredCluster{},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -383,7 +390,8 @@ func TestNewReportMetricsCmd_MutuallyExclusiveFlags(t *testing.T) {
 				},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)
@@ -423,7 +431,8 @@ func TestParseMetricReporterOpts_NeitherFlagProvided(t *testing.T) {
 				{ID: "osk-cluster-1"},
 			},
 		},
-		Timestamp: time.Now(),
+		KcpBuildInfo: types.KcpBuildInfo{Version: "0.0.0-localdev"},
+		Timestamp:    time.Now(),
 	}
 
 	err := state.PersistStateFile(stateFilePath)

--- a/cmd/scan/schema_registry/glue_schema_registry_scanner_test.go
+++ b/cmd/scan/schema_registry/glue_schema_registry_scanner_test.go
@@ -30,7 +30,7 @@ func TestGlueSchemaRegistryScanner_Run(t *testing.T) {
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Write initial state
-	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":null}`)
+	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":null,"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 
@@ -86,7 +86,7 @@ func TestGlueSchemaRegistryScanner_Run_UpsertExisting(t *testing.T) {
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Write state with existing Glue registry
-	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":{"aws_glue":[{"registry_name":"my-registry","region":"us-east-1","registry_arn":"old-arn","schemas":[]}]}}`)
+	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":{"aws_glue":[{"registry_name":"my-registry","region":"us-east-1","registry_arn":"old-arn","schemas":[]}]},"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 
@@ -125,7 +125,7 @@ func TestGlueSchemaRegistryScanner_Run_RegistryNotFound(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	_, err = tmpFile.WriteString(`{"regions":[]}`)
+	_, err = tmpFile.WriteString(`{"regions":[],"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -1,16 +1,15 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/confluentinc/kcp/cmd/ui/frontend"
+	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/hcl"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/fatih/color"
@@ -35,9 +34,11 @@ type UI struct {
 	migrationInfraHCLService   hcl.MigrationInfraGenerator
 	migrationScriptsHCLService hcl.MigrationScriptsGenerator
 
-	port        string
-	states      map[string]*types.State // Session-based state storage (key: sessionId)
-	statesMutex sync.RWMutex            // Protects concurrent access to states map
+	port              string
+	states            map[string]*types.State // Session-based state storage (key: sessionId)
+	statesMutex       sync.RWMutex            // Protects concurrent access to states map
+	preloadError      string                  // Set when --state-file preload fails, surfaced via /state
+	preloadErrorType  string                  // Machine-readable error type for /state response
 }
 
 func NewUI(reportService ReportService, targetInfraHCLService hcl.TargetInfraGenerator, migrationInfraHCLService hcl.MigrationInfraGenerator, migrationScriptsHCLService hcl.MigrationScriptsGenerator, opts UICmdOpts) *UI {
@@ -53,17 +54,18 @@ func NewUI(reportService ReportService, targetInfraHCLService hcl.TargetInfraGen
 
 	// Pre-load state file if provided
 	if opts.StateFile != "" {
-		data, err := os.ReadFile(opts.StateFile)
+		state, err := types.NewStateFromFile(opts.StateFile)
 		if err != nil {
-			slog.Error("Failed to read state file", "path", opts.StateFile, "error", err)
-		} else {
-			var state types.State
-			if err := json.Unmarshal(data, &state); err != nil {
-				slog.Error("Failed to parse state file", "path", opts.StateFile, "error", err)
+			slog.Error("Failed to load state file", "path", opts.StateFile, "error", err)
+			ui.preloadError = err.Error()
+			if strings.Contains(err.Error(), "state file version mismatch") {
+				ui.preloadErrorType = "version_mismatch"
 			} else {
-				ui.states["default"] = &state
-				slog.Info("Pre-loaded state file", "path", opts.StateFile)
+				ui.preloadErrorType = "load_error"
 			}
+		} else {
+			ui.states["default"] = state
+			slog.Info("Pre-loaded state file", "path", opts.StateFile)
 		}
 	}
 
@@ -105,29 +107,7 @@ func (ui *UI) Run() error {
 	})
 
 	// Get pre-loaded state endpoint
-	e.GET("/state", func(c echo.Context) error {
-		sessionId := c.QueryParam("sessionId")
-		if sessionId == "" {
-			sessionId = "default"
-		}
-		ui.statesMutex.Lock()
-		state, exists := ui.states[sessionId]
-		// Fall back to "default" session if specific session not found
-		if !exists && sessionId != "default" {
-			state, exists = ui.states["default"]
-			if exists {
-				// Copy default state to the requesting session so subsequent
-				// requests (uploads, asset generation) work with this session ID
-				ui.states[sessionId] = state
-			}
-		}
-		ui.statesMutex.Unlock()
-		if !exists {
-			return c.JSON(http.StatusNotFound, map[string]any{"error": "No state loaded"})
-		}
-		processedState := ui.reportService.ProcessState(*state)
-		return c.JSON(http.StatusOK, processedState)
-	})
+	e.GET("/state", ui.handleGetState)
 
 	e.GET("/metrics/:region/:cluster", ui.handleGetMetrics)
 	e.GET("/metrics/osk/:clusterId", ui.handleGetOSKMetrics)
@@ -168,6 +148,40 @@ func parseDateRange(c echo.Context) (*time.Time, *time.Time, error) {
 		endTime = &parsed
 	}
 	return startTime, endTime, nil
+}
+
+func (ui *UI) handleGetState(c echo.Context) error {
+	sessionId := c.QueryParam("sessionId")
+	if sessionId == "" {
+		sessionId = "default"
+	}
+	ui.statesMutex.Lock()
+	state, exists := ui.states[sessionId]
+	// Fall back to "default" session if specific session not found
+	if !exists && sessionId != "default" {
+		state, exists = ui.states["default"]
+		if exists {
+			// Copy default state to the requesting session so subsequent
+			// requests (uploads, asset generation) work with this session ID
+			ui.states[sessionId] = state
+		}
+	}
+	ui.statesMutex.Unlock()
+	if !exists {
+		if ui.preloadError != "" {
+			errorField := "State file could not be loaded"
+			if ui.preloadErrorType == "version_mismatch" {
+				errorField = "State file version mismatch"
+			}
+			return c.JSON(http.StatusUnprocessableEntity, map[string]any{
+				"error":   errorField,
+				"message": ui.preloadError,
+			})
+		}
+		return c.JSON(http.StatusNotFound, map[string]any{"error": "No state loaded"})
+	}
+	processedState := ui.reportService.ProcessState(*state)
+	return c.JSON(http.StatusOK, processedState)
 }
 
 func (ui *UI) handleGetMetrics(c echo.Context) error {
@@ -295,6 +309,13 @@ func (ui *UI) handleUploadState(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]any{
 			"error":   "Invalid request body",
 			"message": err.Error(),
+		})
+	}
+
+	if state.KcpBuildInfo.Version != build_info.Version {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "State file version mismatch",
+			"message": fmt.Sprintf("file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", state.KcpBuildInfo.Version, build_info.Version),
 		})
 	}
 

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/kcp/cmd/ui/frontend"
-	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/hcl"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/fatih/color"
@@ -312,10 +311,10 @@ func (ui *UI) handleUploadState(c echo.Context) error {
 		})
 	}
 
-	if state.KcpBuildInfo.Version != build_info.Version {
+	if state.KcpBuildInfo.Version == "" {
 		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error":   "State file version mismatch",
-			"message": fmt.Sprintf("file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", state.KcpBuildInfo.Version, build_info.Version),
+			"error":   "Invalid state file",
+			"message": "kcp_build_info.version is missing — this does not appear to be a valid KCP state file",
 		})
 	}
 

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -311,13 +311,6 @@ func (ui *UI) handleUploadState(c echo.Context) error {
 		})
 	}
 
-	if state.KcpBuildInfo.Version == "" {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error":   "Invalid state file",
-			"message": "kcp_build_info.version is missing — this does not appear to be a valid KCP state file",
-		})
-	}
-
 	// Store state in map using session ID as key
 	ui.statesMutex.Lock()
 	ui.states[sessionId] = &state

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -33,14 +33,12 @@ type UI struct {
 	migrationInfraHCLService   hcl.MigrationInfraGenerator
 	migrationScriptsHCLService hcl.MigrationScriptsGenerator
 
-	port              string
-	states            map[string]*types.State // Session-based state storage (key: sessionId)
-	statesMutex       sync.RWMutex            // Protects concurrent access to states map
-	preloadError      string                  // Set when --state-file preload fails, surfaced via /state
-	preloadErrorType  string                  // Machine-readable error type for /state response
+	port        string
+	states      map[string]*types.State // Session-based state storage (key: sessionId)
+	statesMutex sync.RWMutex            // Protects concurrent access to states map
 }
 
-func NewUI(reportService ReportService, targetInfraHCLService hcl.TargetInfraGenerator, migrationInfraHCLService hcl.MigrationInfraGenerator, migrationScriptsHCLService hcl.MigrationScriptsGenerator, opts UICmdOpts) *UI {
+func NewUI(reportService ReportService, targetInfraHCLService hcl.TargetInfraGenerator, migrationInfraHCLService hcl.MigrationInfraGenerator, migrationScriptsHCLService hcl.MigrationScriptsGenerator, opts UICmdOpts) (*UI, error) {
 	ui := &UI{
 		reportService:              reportService,
 		targetInfraHCLService:      targetInfraHCLService,
@@ -55,20 +53,16 @@ func NewUI(reportService ReportService, targetInfraHCLService hcl.TargetInfraGen
 	if opts.StateFile != "" {
 		state, err := types.NewStateFromFile(opts.StateFile)
 		if err != nil {
-			slog.Error("Failed to load state file", "path", opts.StateFile, "error", err)
-			ui.preloadError = err.Error()
-			if strings.Contains(err.Error(), "state file version mismatch") {
-				ui.preloadErrorType = "version_mismatch"
-			} else {
-				ui.preloadErrorType = "load_error"
-			}
-		} else {
-			ui.states["default"] = state
-			slog.Info("Pre-loaded state file", "path", opts.StateFile)
+			return nil, fmt.Errorf("failed to load state file %q: %w", opts.StateFile, err)
+		}
+		ui.states["default"] = state
+		slog.Info("Pre-loaded state file", "path", opts.StateFile)
+		if state.MSKSources == nil && state.OSKSources == nil {
+			slog.Warn("State file contains no sources — run a scan to populate it", "path", opts.StateFile)
 		}
 	}
 
-	return ui
+	return ui, nil
 }
 
 // getStateBySession extracts the sessionId from the request and retrieves the corresponding state
@@ -167,16 +161,6 @@ func (ui *UI) handleGetState(c echo.Context) error {
 	}
 	ui.statesMutex.Unlock()
 	if !exists {
-		if ui.preloadError != "" {
-			errorField := "State file could not be loaded"
-			if ui.preloadErrorType == "version_mismatch" {
-				errorField = "State file version mismatch"
-			}
-			return c.JSON(http.StatusUnprocessableEntity, map[string]any{
-				"error":   errorField,
-				"message": ui.preloadError,
-			})
-		}
 		return c.JSON(http.StatusNotFound, map[string]any{"error": "No state loaded"})
 	}
 	processedState := ui.reportService.ProcessState(*state)

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -9,6 +11,7 @@ import (
 	"time"
 
 	"github.com/confluentinc/kcp/cmd/ui/frontend"
+	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/hcl"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/fatih/color"
@@ -287,8 +290,28 @@ func (ui *UI) handleUploadState(c echo.Context) error {
 		})
 	}
 
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "Failed to read request body",
+			"message": err.Error(),
+		})
+	}
+
 	var state types.State
-	if err := c.Bind(&state); err != nil {
+	if err := json.Unmarshal(body, &state); err != nil {
+		// Unmarshal failed — try to extract version from raw bytes to give a more actionable error
+		var raw struct {
+			KcpBuildInfo struct {
+				Version string `json:"version"`
+			} `json:"kcp_build_info"`
+		}
+		if jsonErr := json.Unmarshal(body, &raw); jsonErr == nil && raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"error":   "State file could not be loaded",
+				"message": fmt.Sprintf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please try loading the state file with KCP version %q or recreating the state file with KCP version %q)", err, raw.KcpBuildInfo.Version, build_info.Version, raw.KcpBuildInfo.Version, build_info.Version),
+			})
+		}
 		return c.JSON(http.StatusBadRequest, map[string]any{
 			"error":   "Invalid request body",
 			"message": err.Error(),

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -111,6 +112,37 @@ func TestHandleUploadState_EmptyVersion_Succeeds(t *testing.T) {
 	ui.statesMutex.RUnlock()
 	if !stored {
 		t.Error("expected versionless state to be stored, but it was not")
+	}
+}
+
+func TestHandleUploadState_SchemaMismatch_WithVersion_ReturnsVersionContext(t *testing.T) {
+	ui := newTestUI()
+	e := echo.New()
+
+	// Valid JSON with a version stamp but msk_sources as an array (type mismatch)
+	body := `{"kcp_build_info":{"version":"0.5.0"},"msk_sources":["unexpected","array"]}`
+	req := httptest.NewRequest(http.MethodPost, "/upload-state?sessionId=test-session", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleUploadState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "0.5.0") {
+		t.Errorf("expected message to contain file version, got: %s", msg)
+	}
+	if !strings.Contains(msg, build_info.Version) {
+		t.Errorf("expected message to contain running version, got: %s", msg)
 	}
 }
 

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -86,7 +86,7 @@ func TestHandleUploadState_VersionMismatch_Succeeds(t *testing.T) {
 	}
 }
 
-func TestHandleUploadState_MissingVersion_ReturnsError(t *testing.T) {
+func TestHandleUploadState_EmptyVersion_Succeeds(t *testing.T) {
 	ui := newTestUI()
 	e := echo.New()
 
@@ -99,23 +99,15 @@ func TestHandleUploadState_MissingVersion_ReturnsError(t *testing.T) {
 	if err := ui.handleUploadState(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected status 400, got %d", rec.Code)
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response body: %v", err)
-	}
-	if resp["error"] != "Invalid state file" {
-		t.Errorf("unexpected error field: %v", resp["error"])
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 for versionless state file, got %d", rec.Code)
 	}
 
 	ui.statesMutex.RLock()
 	_, stored := ui.states["test-session"]
 	ui.statesMutex.RUnlock()
-	if stored {
-		t.Error("expected state NOT to be stored on missing version, but it was")
+	if !stored {
+		t.Error("expected versionless state to be stored, but it was not")
 	}
 }
 

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -28,6 +28,10 @@ func (m *mockReportService) FilterMetrics(processedState types.ProcessedState, r
 	return nil, nil
 }
 
+func (m *mockReportService) FilterClusterMetrics(processedState types.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+	return nil, nil
+}
+
 func newTestUI() *UI {
 	return &UI{
 		reportService: &mockReportService{},

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/labstack/echo/v4"
+)
+
+// mockReportService satisfies the ReportService interface for testing
+type mockReportService struct{}
+
+func (m *mockReportService) ProcessState(state types.State) types.ProcessedState {
+	return types.ProcessedState{}
+}
+
+func (m *mockReportService) FilterRegionCosts(processedState types.ProcessedState, regionName string, startTime, endTime *time.Time) (*types.ProcessedRegionCosts, error) {
+	return nil, nil
+}
+
+func (m *mockReportService) FilterMetrics(processedState types.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+	return nil, nil
+}
+
+func newTestUI() *UI {
+	return &UI{
+		reportService: &mockReportService{},
+		states:        make(map[string]*types.State),
+	}
+}
+
+func TestHandleUploadState_VersionMatch(t *testing.T) {
+	ui := newTestUI()
+	e := echo.New()
+
+	body := `{"kcp_build_info":{"version":"` + build_info.Version + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/upload-state?sessionId=test-session", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleUploadState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	ui.statesMutex.RLock()
+	_, stored := ui.states["test-session"]
+	ui.statesMutex.RUnlock()
+	if !stored {
+		t.Error("expected state to be stored in session, but it was not")
+	}
+}
+
+func TestHandleUploadState_VersionMismatch(t *testing.T) {
+	ui := newTestUI()
+	e := echo.New()
+
+	body := `{"kcp_build_info":{"version":"0.5.0"}}`
+	req := httptest.NewRequest(http.MethodPost, "/upload-state?sessionId=test-session", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleUploadState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	if resp["error"] != "State file version mismatch" {
+		t.Errorf("unexpected error field: %v", resp["error"])
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "0.5.0") {
+		t.Errorf("expected message to contain file version, got: %s", msg)
+	}
+	if !strings.Contains(msg, build_info.Version) {
+		t.Errorf("expected message to contain running version, got: %s", msg)
+	}
+
+	ui.statesMutex.RLock()
+	_, stored := ui.states["test-session"]
+	ui.statesMutex.RUnlock()
+	if stored {
+		t.Error("expected state NOT to be stored on version mismatch, but it was")
+	}
+}
+
+func TestHandleUploadState_MissingSessionId(t *testing.T) {
+	ui := newTestUI()
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/upload-state", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleUploadState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestNewUI_PreloadStateFile_VersionMatch(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: build_info.Version}}
+	if err := state.WriteToFile(tmpFile.Name()); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+
+	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+
+	ui.statesMutex.RLock()
+	_, loaded := ui.states["default"]
+	ui.statesMutex.RUnlock()
+
+	if !loaded {
+		t.Error("expected state to be pre-loaded into default session")
+	}
+	if ui.preloadError != "" {
+		t.Errorf("expected no preload error, got: %s", ui.preloadError)
+	}
+}
+
+func TestNewUI_PreloadStateFile_VersionMismatch(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: "0.5.0"}}
+	if err := state.WriteToFile(tmpFile.Name()); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+
+	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+
+	ui.statesMutex.RLock()
+	_, loaded := ui.states["default"]
+	ui.statesMutex.RUnlock()
+
+	if loaded {
+		t.Error("expected state NOT to be loaded on version mismatch")
+	}
+	if ui.preloadError == "" {
+		t.Error("expected preloadError to be set on version mismatch")
+	}
+	if !strings.Contains(ui.preloadError, "state file version mismatch") {
+		t.Errorf("expected preloadError to contain version mismatch message, got: %s", ui.preloadError)
+	}
+}
+
+func TestNewUI_PreloadStateFile_FileNotFound(t *testing.T) {
+	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: "/nonexistent/state.json"})
+
+	if ui.preloadError == "" {
+		t.Error("expected preloadError to be set for missing file")
+	}
+}
+
+func TestGetState_PreloadVersionMismatch_ReturnsVersionMismatchError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: "0.5.0"}}
+	if err := state.WriteToFile(tmpFile.Name()); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+
+	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/state", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleGetState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status 422, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	if resp["error"] != "State file version mismatch" {
+		t.Errorf("expected error 'State file version mismatch', got: %v", resp["error"])
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "0.5.0") {
+		t.Errorf("expected message to contain file version, got: %s", msg)
+	}
+}
+
+func TestGetState_PreloadFileNotFound_ReturnsGenericLoadError(t *testing.T) {
+	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: "/nonexistent/state.json"})
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/state", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleGetState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status 422, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	if resp["error"] != "State file could not be loaded" {
+		t.Errorf("expected error 'State file could not be loaded', got: %v", resp["error"])
+	}
+}

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -61,11 +61,36 @@ func TestHandleUploadState_VersionMatch(t *testing.T) {
 	}
 }
 
-func TestHandleUploadState_VersionMismatch(t *testing.T) {
+func TestHandleUploadState_VersionMismatch_Succeeds(t *testing.T) {
 	ui := newTestUI()
 	e := echo.New()
 
 	body := `{"kcp_build_info":{"version":"0.5.0"}}`
+	req := httptest.NewRequest(http.MethodPost, "/upload-state?sessionId=test-session", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := ui.handleUploadState(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	ui.statesMutex.RLock()
+	_, stored := ui.states["test-session"]
+	ui.statesMutex.RUnlock()
+	if !stored {
+		t.Error("expected state to be stored on version mismatch, but it was not")
+	}
+}
+
+func TestHandleUploadState_MissingVersion_ReturnsError(t *testing.T) {
+	ui := newTestUI()
+	e := echo.New()
+
+	body := `{"kcp_build_info":{"version":""}}`
 	req := httptest.NewRequest(http.MethodPost, "/upload-state?sessionId=test-session", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
@@ -82,22 +107,15 @@ func TestHandleUploadState_VersionMismatch(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response body: %v", err)
 	}
-	if resp["error"] != "State file version mismatch" {
+	if resp["error"] != "Invalid state file" {
 		t.Errorf("unexpected error field: %v", resp["error"])
-	}
-	msg, _ := resp["message"].(string)
-	if !strings.Contains(msg, "0.5.0") {
-		t.Errorf("expected message to contain file version, got: %s", msg)
-	}
-	if !strings.Contains(msg, build_info.Version) {
-		t.Errorf("expected message to contain running version, got: %s", msg)
 	}
 
 	ui.statesMutex.RLock()
 	_, stored := ui.states["test-session"]
 	ui.statesMutex.RUnlock()
 	if stored {
-		t.Error("expected state NOT to be stored on version mismatch, but it was")
+		t.Error("expected state NOT to be stored on missing version, but it was")
 	}
 }
 
@@ -123,7 +141,7 @@ func TestNewUI_PreloadStateFile_VersionMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: build_info.Version}}
 	if err := state.WriteToFile(tmpFile.Name()); err != nil {
@@ -144,12 +162,12 @@ func TestNewUI_PreloadStateFile_VersionMatch(t *testing.T) {
 	}
 }
 
-func TestNewUI_PreloadStateFile_VersionMismatch(t *testing.T) {
+func TestNewUI_PreloadStateFile_VersionMismatch_Succeeds(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: "0.5.0"}}
 	if err := state.WriteToFile(tmpFile.Name()); err != nil {
@@ -162,14 +180,11 @@ func TestNewUI_PreloadStateFile_VersionMismatch(t *testing.T) {
 	_, loaded := ui.states["default"]
 	ui.statesMutex.RUnlock()
 
-	if loaded {
-		t.Error("expected state NOT to be loaded on version mismatch")
+	if !loaded {
+		t.Error("expected state to be loaded on version mismatch — different versions are allowed when file is deseralisable")
 	}
-	if ui.preloadError == "" {
-		t.Error("expected preloadError to be set on version mismatch")
-	}
-	if !strings.Contains(ui.preloadError, "state file version mismatch") {
-		t.Errorf("expected preloadError to contain version mismatch message, got: %s", ui.preloadError)
+	if ui.preloadError != "" {
+		t.Errorf("expected no preload error on version mismatch, got: %s", ui.preloadError)
 	}
 }
 
@@ -181,12 +196,12 @@ func TestNewUI_PreloadStateFile_FileNotFound(t *testing.T) {
 	}
 }
 
-func TestGetState_PreloadVersionMismatch_ReturnsVersionMismatchError(t *testing.T) {
+func TestGetState_PreloadVersionMismatch_ReturnsState(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	state := &types.State{KcpBuildInfo: types.KcpBuildInfo{Version: "0.5.0"}}
 	if err := state.WriteToFile(tmpFile.Name()); err != nil {
@@ -203,20 +218,8 @@ func TestGetState_PreloadVersionMismatch_ReturnsVersionMismatchError(t *testing.
 	if err := ui.handleGetState(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Errorf("expected status 422, got %d", rec.Code)
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response body: %v", err)
-	}
-	if resp["error"] != "State file version mismatch" {
-		t.Errorf("expected error 'State file version mismatch', got: %v", resp["error"])
-	}
-	msg, _ := resp["message"].(string)
-	if !strings.Contains(msg, "0.5.0") {
-		t.Errorf("expected message to contain file version, got: %s", msg)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 for version mismatch with valid file, got %d", rec.Code)
 	}
 }
 

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -140,7 +139,10 @@ func TestNewUI_PreloadStateFile_VersionMatch(t *testing.T) {
 		t.Fatalf("failed to write state file: %v", err)
 	}
 
-	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	ui, err := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	ui.statesMutex.RLock()
 	_, loaded := ui.states["default"]
@@ -148,9 +150,6 @@ func TestNewUI_PreloadStateFile_VersionMatch(t *testing.T) {
 
 	if !loaded {
 		t.Error("expected state to be pre-loaded into default session")
-	}
-	if ui.preloadError != "" {
-		t.Errorf("expected no preload error, got: %s", ui.preloadError)
 	}
 }
 
@@ -166,25 +165,25 @@ func TestNewUI_PreloadStateFile_VersionMismatch_Succeeds(t *testing.T) {
 		t.Fatalf("failed to write state file: %v", err)
 	}
 
-	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	ui, err := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	if err != nil {
+		t.Fatalf("unexpected error on version mismatch with deserialisable file: %v", err)
+	}
 
 	ui.statesMutex.RLock()
 	_, loaded := ui.states["default"]
 	ui.statesMutex.RUnlock()
 
 	if !loaded {
-		t.Error("expected state to be loaded on version mismatch — different versions are allowed when file is deseralisable")
-	}
-	if ui.preloadError != "" {
-		t.Errorf("expected no preload error on version mismatch, got: %s", ui.preloadError)
+		t.Error("expected state to be loaded on version mismatch — different versions are allowed when file is deserialisable")
 	}
 }
 
 func TestNewUI_PreloadStateFile_FileNotFound(t *testing.T) {
-	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: "/nonexistent/state.json"})
+	_, err := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: "/nonexistent/state.json"})
 
-	if ui.preloadError == "" {
-		t.Error("expected preloadError to be set for missing file")
+	if err == nil {
+		t.Error("expected error for missing state file, got nil")
 	}
 }
 
@@ -200,7 +199,10 @@ func TestGetState_PreloadVersionMismatch_ReturnsState(t *testing.T) {
 		t.Fatalf("failed to write state file: %v", err)
 	}
 
-	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	ui, err := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: tmpFile.Name()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	e := echo.New()
 
 	req := httptest.NewRequest(http.MethodGet, "/state", nil)
@@ -215,8 +217,8 @@ func TestGetState_PreloadVersionMismatch_ReturnsState(t *testing.T) {
 	}
 }
 
-func TestGetState_PreloadFileNotFound_ReturnsGenericLoadError(t *testing.T) {
-	ui := NewUI(&mockReportService{}, nil, nil, nil, UICmdOpts{StateFile: "/nonexistent/state.json"})
+func TestGetState_NoStateLoaded_ReturnsNotFound(t *testing.T) {
+	ui := newTestUI()
 	e := echo.New()
 
 	req := httptest.NewRequest(http.MethodGet, "/state", nil)
@@ -226,15 +228,7 @@ func TestGetState_PreloadFileNotFound_ReturnsGenericLoadError(t *testing.T) {
 	if err := ui.handleGetState(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Errorf("expected status 422, got %d", rec.Code)
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response body: %v", err)
-	}
-	if resp["error"] != "State file could not be loaded" {
-		t.Errorf("expected error 'State file could not be loaded', got: %v", resp["error"])
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
 	}
 }

--- a/cmd/ui/cmd_ui.go
+++ b/cmd/ui/cmd_ui.go
@@ -51,7 +51,10 @@ func runStartUI(cmd *cobra.Command, args []string) error {
 	migrationInfraHCLService := hcl.NewMigrationInfraHCLService()
 	migrationScriptsHCLService := hcl.NewMigrationScriptsHCLService()
 
-	ui := api.NewUI(reportService, targetInfraHCLService, migrationInfraHCLService, migrationScriptsHCLService, *opts)
+	ui, err := api.NewUI(reportService, targetInfraHCLService, migrationInfraHCLService, migrationScriptsHCLService, *opts)
+	if err != nil {
+		return err
+	}
 	if err := ui.Run(); err != nil {
 		return fmt.Errorf("failed to start the UI: %v", err)
 	}

--- a/cmd/ui/frontend/src/pages/home.tsx
+++ b/cmd/ui/frontend/src/pages/home.tsx
@@ -80,7 +80,12 @@ export const Home = () => {
     reader.onload = async (e) => {
       try {
         const content = e.target?.result as string
-        const parsed = JSON.parse(content) as StateUploadRequest
+        let parsed: StateUploadRequest
+        try {
+          parsed = JSON.parse(content) as StateUploadRequest
+        } catch {
+          throw new Error('The file could not be read — it contains invalid JSON. Please recreate the state file using kcp discover or kcp scan clusters.')
+        }
 
         // Lightweight check: confirm the file is a JSON object before uploading
         if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {

--- a/cmd/ui/frontend/src/pages/home.tsx
+++ b/cmd/ui/frontend/src/pages/home.tsx
@@ -40,7 +40,7 @@ export const Home = () => {
         // Backend falls back to "default" session if session-specific state not found
         const response = await apiClient.state.getState(sessionId)
 
-        if (response && response.sources) {
+        if (response && response.sources && response.sources.length > 0) {
           setKcpState(response)
 
           // Auto-select summary view if we have MSK sources with regions

--- a/cmd/ui/frontend/src/pages/home.tsx
+++ b/cmd/ui/frontend/src/pages/home.tsx
@@ -55,6 +55,8 @@ export const Home = () => {
               selectOSKCluster(firstCluster.id)
             }
           }
+        } else if (response) {
+          setError('State file contains no sources. Run kcp discover (MSK) or kcp scan clusters (OSK) to populate it, then reload.')
         }
       } catch {
         // No pre-loaded state, user will upload manually

--- a/cmd/ui/frontend/src/pages/home.tsx
+++ b/cmd/ui/frontend/src/pages/home.tsx
@@ -80,8 +80,8 @@ export const Home = () => {
         const content = e.target?.result as string
         const parsed = JSON.parse(content) as StateUploadRequest
 
-        // Validate that we have a State object with sources (msk_sources or osk_sources)
-        if (parsed && typeof parsed === 'object' && ('msk_sources' in parsed || 'osk_sources' in parsed)) {
+        // Lightweight check: confirm the file is a JSON object before uploading
+        if (parsed && typeof parsed === 'object') {
           // Call the /upload-state endpoint to process the discovery data
           const result = await apiClient.state.uploadState(parsed, sessionId)
 
@@ -106,7 +106,7 @@ export const Home = () => {
             throw new Error('Invalid response format from server')
           }
         } else {
-          throw new Error('Invalid file format. Expected a KCP state file with msk_sources or osk_sources.')
+          throw new Error('Invalid file format. Expected a KCP state file.')
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to process file')

--- a/cmd/ui/frontend/src/pages/home.tsx
+++ b/cmd/ui/frontend/src/pages/home.tsx
@@ -81,7 +81,7 @@ export const Home = () => {
         const parsed = JSON.parse(content) as StateUploadRequest
 
         // Lightweight check: confirm the file is a JSON object before uploading
-        if (parsed && typeof parsed === 'object') {
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
           // Call the /upload-state endpoint to process the discovery data
           const result = await apiClient.state.uploadState(parsed, sessionId)
 

--- a/cmd/ui/frontend/tests/e2e/fixtures/state-migration.json
+++ b/cmd/ui/frontend/tests/e2e/fixtures/state-migration.json
@@ -307,7 +307,7 @@
   },
   "schema_registries": {},
   "kcp_build_info": {
-    "version": "0.0.0-test",
+    "version": "0.0.0-localdev",
     "commit": "0000000000000000000000000000000000000000",
     "date": "2026-03-13T00:00:00Z"
   },

--- a/cmd/ui/frontend/tests/e2e/state-validation.spec.ts
+++ b/cmd/ui/frontend/tests/e2e/state-validation.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('State File Validation', () => {
+  test('uploading a JSON array shows an invalid file format error', async ({ page }) => {
+    await page.goto('/')
+
+    await page.click('button:has-text("Upload KCP State File")')
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles({
+      name: 'not-a-state-file.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify([{ foo: 'bar' }])),
+    })
+
+    await expect(page.locator('text=Invalid file format')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('uploading a valid state file from a different KCP version succeeds', async ({ page }) => {
+    await page.goto('/')
+
+    const mismatchedState = {
+      kcp_build_info: { version: '0.1.0', commit: 'abc', date: '2024-01-01' },
+      msk_sources: { regions: [] },
+      osk_sources: { clusters: [] },
+    }
+
+    await page.click('button:has-text("Upload KCP State File")')
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles({
+      name: 'old-state.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(mismatchedState)),
+    })
+
+    // Should load without error — version mismatch alone is not a rejection
+    await expect(page.locator('text=Invalid file format')).not.toBeVisible({ timeout: 5000 })
+  })
+})

--- a/cmd/ui/frontend/tests/fixtures/state-both.json
+++ b/cmd/ui/frontend/tests/fixtures/state-both.json
@@ -72,7 +72,7 @@
   },
   "schema_registries": {},
   "kcp_build_info": {
-    "version": "dev",
+    "version": "0.0.0-localdev",
     "commit": "abc123",
     "date": "2026-03-06"
   },

--- a/cmd/ui/frontend/tests/fixtures/state-osk-only.json
+++ b/cmd/ui/frontend/tests/fixtures/state-osk-only.json
@@ -57,7 +57,7 @@
   },
   "schema_registries": {},
   "kcp_build_info": {
-    "version": "dev",
+    "version": "0.0.0-localdev",
     "commit": "abc123",
     "date": "2026-03-06"
   },

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -114,6 +114,17 @@ func NewStateFromFile(stateFile string) (*State, error) {
 
 	var state State
 	if err := json.Unmarshal(file, &state); err != nil {
+		// Unmarshal failed — the schema may have changed between versions.
+		// Try to extract just the version from the raw bytes to give a more
+		// actionable error than a raw JSON type error.
+		var raw struct {
+			KcpBuildInfo struct {
+				Version string `json:"version"`
+			} `json:"kcp_build_info"`
+		}
+		if jsonErr := json.Unmarshal(file, &raw); jsonErr == nil && raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
+			return nil, fmt.Errorf("state file version mismatch: file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", raw.KcpBuildInfo.Version, build_info.Version)
+		}
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}
 

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -117,6 +117,10 @@ func NewStateFromFile(stateFile string) (*State, error) {
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}
 
+	if state.KcpBuildInfo.Version != build_info.Version {
+		return nil, fmt.Errorf("state file version mismatch: file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", state.KcpBuildInfo.Version, build_info.Version)
+	}
+
 	return &state, nil
 }
 

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -128,10 +128,6 @@ func NewStateFromFile(stateFile string) (*State, error) {
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}
 
-	if state.KcpBuildInfo.Version == "" {
-		return nil, fmt.Errorf("invalid state file: kcp_build_info.version is missing — this does not appear to be a valid KCP state file")
-	}
-
 	return &state, nil
 }
 

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -124,7 +124,7 @@ func NewStateFromFile(stateFile string) (*State, error) {
 		}
 		if jsonErr := json.Unmarshal(file, &raw); jsonErr == nil {
 			if raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
-				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please review the file for errors or consider re-exporting it)", err, raw.KcpBuildInfo.Version, build_info.Version)
+				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please try loading the state file with KCP version %q or recreating the state file with KCP version %q)", err, raw.KcpBuildInfo.Version, build_info.Version, raw.KcpBuildInfo.Version, build_info.Version)
 			}
 			return nil, fmt.Errorf("state file could not be loaded: %v — please review the file for errors or consider re-exporting it", err)
 		}

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -122,8 +122,11 @@ func NewStateFromFile(stateFile string) (*State, error) {
 				Version string `json:"version"`
 			} `json:"kcp_build_info"`
 		}
-		if jsonErr := json.Unmarshal(file, &raw); jsonErr == nil && raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
-			return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please review the file for errors or consider re-exporting it)", err, raw.KcpBuildInfo.Version, build_info.Version)
+		if jsonErr := json.Unmarshal(file, &raw); jsonErr == nil {
+			if raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
+				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please review the file for errors or consider re-exporting it)", err, raw.KcpBuildInfo.Version, build_info.Version)
+			}
+			return nil, fmt.Errorf("state file could not be loaded: %v — please review the file for errors or consider re-exporting it", err)
 		}
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -126,9 +126,9 @@ func NewStateFromFile(stateFile string) (*State, error) {
 			if raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
 				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please try loading the state file with KCP version %q or recreating the state file with KCP version %q)", err, raw.KcpBuildInfo.Version, build_info.Version, raw.KcpBuildInfo.Version, build_info.Version)
 			}
-			return nil, fmt.Errorf("state file could not be loaded: %v — please review the file for errors or consider re-exporting it", err)
+			return nil, fmt.Errorf("state file could not be loaded: %v — please recreate the state file using kcp discover or kcp scan clusters", err)
 		}
-		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal state file: %v — please recreate the state file using kcp discover or kcp scan clusters", err)
 	}
 
 	return &state, nil

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -123,7 +123,7 @@ func NewStateFromFile(stateFile string) (*State, error) {
 			} `json:"kcp_build_info"`
 		}
 		if jsonErr := json.Unmarshal(file, &raw); jsonErr == nil && raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
-			return nil, fmt.Errorf("state file version mismatch: file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", raw.KcpBuildInfo.Version, build_info.Version)
+			return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please review the file for errors or consider re-exporting it)", err, raw.KcpBuildInfo.Version, build_info.Version)
 		}
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -128,8 +128,8 @@ func NewStateFromFile(stateFile string) (*State, error) {
 		return nil, fmt.Errorf("failed to unmarshal state: %v", err)
 	}
 
-	if state.KcpBuildInfo.Version != build_info.Version {
-		return nil, fmt.Errorf("state file version mismatch: file was created with KCP version %q but you are running version %q — please re-export the state file using the current version of KCP or upgrade/downgrade KCP to match", state.KcpBuildInfo.Version, build_info.Version)
+	if state.KcpBuildInfo.Version == "" {
+		return nil, fmt.Errorf("invalid state file: kcp_build_info.version is missing — this does not appear to be a valid KCP state file")
 	}
 
 	return &state, nil

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -960,14 +960,13 @@ func TestNewStateFromFile_VersionMatch(t *testing.T) {
 	}
 }
 
-func TestNewStateFromFile_VersionMismatch(t *testing.T) {
+func TestNewStateFromFile_VersionMismatch_SucceedsWhenDeserialisable(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
 	}{
 		{"older version", "0.5.0"},
 		{"newer version", "2.0.0"},
-		{"empty version", ""},
 	}
 
 	for _, tt := range tests {
@@ -976,25 +975,19 @@ func TestNewStateFromFile_VersionMismatch(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create temp file: %v", err)
 			}
-			defer os.Remove(tmpFile.Name())
+			defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 			state := &State{KcpBuildInfo: KcpBuildInfo{Version: tt.version}}
 			if err := state.WriteToFile(tmpFile.Name()); err != nil {
 				t.Fatalf("failed to write state file: %v", err)
 			}
 
-			_, err = NewStateFromFile(tmpFile.Name())
-			if err == nil {
-				t.Fatal("expected version mismatch error, got nil")
+			loaded, err := NewStateFromFile(tmpFile.Name())
+			if err != nil {
+				t.Fatalf("expected success for deseralisable state file with version mismatch, got error: %v", err)
 			}
-			if !strings.Contains(err.Error(), "state file version mismatch") {
-				t.Errorf("expected version mismatch error, got: %v", err)
-			}
-			if !strings.Contains(err.Error(), tt.version) {
-				t.Errorf("expected error to contain file version %q, got: %v", tt.version, err)
-			}
-			if !strings.Contains(err.Error(), build_info.Version) {
-				t.Errorf("expected error to contain running version %q, got: %v", build_info.Version, err)
+			if loaded.KcpBuildInfo.Version != tt.version {
+				t.Errorf("expected version %q, got %q", tt.version, loaded.KcpBuildInfo.Version)
 			}
 		})
 	}
@@ -1058,5 +1051,26 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to unmarshal state") {
 		t.Errorf("expected unmarshal error, got: %v", err)
+	}
+}
+
+func TestNewStateFromFile_EmptyVersion_ReturnsError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	state := &State{KcpBuildInfo: KcpBuildInfo{Version: ""}}
+	if err := state.WriteToFile(tmpFile.Name()); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+
+	_, err = NewStateFromFile(tmpFile.Name())
+	if err == nil {
+		t.Fatal("expected error for missing version, got nil")
+	}
+	if !strings.Contains(err.Error(), "kcp_build_info.version is missing") {
+		t.Errorf("expected missing version error, got: %v", err)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -967,6 +967,7 @@ func TestNewStateFromFile_VersionMismatch_SucceedsWhenDeserialisable(t *testing.
 	}{
 		{"older version", "0.5.0"},
 		{"newer version", "2.0.0"},
+		{"empty version", ""},
 	}
 
 	for _, tt := range tests {
@@ -1054,7 +1055,7 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestNewStateFromFile_EmptyVersion_ReturnsError(t *testing.T) {
+func TestNewStateFromFile_EmptyVersion_Succeeds(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -1066,11 +1067,11 @@ func TestNewStateFromFile_EmptyVersion_ReturnsError(t *testing.T) {
 		t.Fatalf("failed to write state file: %v", err)
 	}
 
-	_, err = NewStateFromFile(tmpFile.Name())
-	if err == nil {
-		t.Fatal("expected error for missing version, got nil")
+	loaded, err := NewStateFromFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("expected success for versionless state file, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "kcp_build_info.version is missing") {
-		t.Errorf("expected missing version error, got: %v", err)
+	if loaded.KcpBuildInfo.Version != "" {
+		t.Errorf("expected empty version to be preserved, got: %s", loaded.KcpBuildInfo.Version)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1026,8 +1026,8 @@ func TestNewStateFromFile_SchemaMismatch_SurfacesVersionError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "state file version mismatch") {
-		t.Errorf("expected version mismatch error from fallback, got: %v", err)
+	if !strings.Contains(err.Error(), "state file could not be loaded") {
+		t.Errorf("expected load error from fallback, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "0.5.0") {
 		t.Errorf("expected error to contain file version, got: %v", err)

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/confluentinc/kcp/internal/build_info"
 )
 
 func TestNewState(t *testing.T) {
@@ -934,5 +936,97 @@ func TestSchemaRegistriesState_UpsertGlueSchemaRegistry(t *testing.T) {
 	}
 	if s.AWSGlue[0].RegistryArn != "arn1-updated" {
 		t.Errorf("expected updated ARN, got %q", s.AWSGlue[0].RegistryArn)
+	}
+}
+
+func TestNewStateFromFile_VersionMatch(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	state := &State{KcpBuildInfo: KcpBuildInfo{Version: build_info.Version}}
+	if err := state.WriteToFile(tmpFile.Name()); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+
+	loaded, err := NewStateFromFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if loaded.KcpBuildInfo.Version != build_info.Version {
+		t.Errorf("expected version %q, got %q", build_info.Version, loaded.KcpBuildInfo.Version)
+	}
+}
+
+func TestNewStateFromFile_VersionMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"older version", "0.5.0"},
+		{"newer version", "2.0.0"},
+		{"empty version", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			state := &State{KcpBuildInfo: KcpBuildInfo{Version: tt.version}}
+			if err := state.WriteToFile(tmpFile.Name()); err != nil {
+				t.Fatalf("failed to write state file: %v", err)
+			}
+
+			_, err = NewStateFromFile(tmpFile.Name())
+			if err == nil {
+				t.Fatal("expected version mismatch error, got nil")
+			}
+			if !strings.Contains(err.Error(), "state file version mismatch") {
+				t.Errorf("expected version mismatch error, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.version) {
+				t.Errorf("expected error to contain file version %q, got: %v", tt.version, err)
+			}
+			if !strings.Contains(err.Error(), build_info.Version) {
+				t.Errorf("expected error to contain running version %q, got: %v", build_info.Version, err)
+			}
+		})
+	}
+}
+
+func TestNewStateFromFile_FileNotFound(t *testing.T) {
+	_, err := NewStateFromFile("/nonexistent/path/state.json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read state file") {
+		t.Errorf("expected file read error, got: %v", err)
+	}
+}
+
+func TestNewStateFromFile_InvalidJSON(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString("not valid json {{{"); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	_, err = NewStateFromFile(tmpFile.Name())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to unmarshal state") {
+		t.Errorf("expected unmarshal error, got: %v", err)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1010,6 +1010,36 @@ func TestNewStateFromFile_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestNewStateFromFile_SchemaMismatch_SurfacesVersionError(t *testing.T) {
+	// Simulate a state file from a different KCP version where a field's type
+	// changed (e.g. msk_sources was a plain array, now an object). The full
+	// unmarshal will fail but the version should still be surfaced.
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Valid JSON with a readable version but msk_sources as an array (type mismatch
+	// against the current struct which expects an object)
+	brokenSchema := `{"kcp_build_info":{"version":"0.5.0"},"msk_sources":["unexpected","array"]}`
+	if _, err := tmpFile.WriteString(brokenSchema); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	_, err = NewStateFromFile(tmpFile.Name())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "state file version mismatch") {
+		t.Errorf("expected version mismatch error from fallback, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "0.5.0") {
+		t.Errorf("expected error to contain file version, got: %v", err)
+	}
+}
+
 func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	if err != nil {

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1050,7 +1050,7 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to unmarshal state") {
+	if !strings.Contains(err.Error(), "failed to unmarshal state file") {
 		t.Errorf("expected unmarshal error, got: %v", err)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1055,6 +1055,29 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestNewStateFromFile_SchemaMismatch_NoVersion_SurfacesFriendlyError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Valid JSON with no version stamp but a type mismatch that will fail deserialisation
+	brokenSchema := `{"msk_sources":["unexpected","array"]}`
+	if _, err := tmpFile.WriteString(brokenSchema); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	_, err = NewStateFromFile(tmpFile.Name())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "state file could not be loaded") {
+		t.Errorf("expected friendly error for versionless schema mismatch, got: %v", err)
+	}
+}
+
 func TestNewStateFromFile_EmptyVersion_Succeeds(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	if err != nil {

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -944,7 +944,7 @@ func TestNewStateFromFile_VersionMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	state := &State{KcpBuildInfo: KcpBuildInfo{Version: build_info.Version}}
 	if err := state.WriteToFile(tmpFile.Name()); err != nil {
@@ -1012,7 +1012,7 @@ func TestNewStateFromFile_SchemaMismatch_SurfacesVersionError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Valid JSON with a readable version but msk_sources as an array (type mismatch
 	// against the current struct which expects an object)
@@ -1020,7 +1020,7 @@ func TestNewStateFromFile_SchemaMismatch_SurfacesVersionError(t *testing.T) {
 	if _, err := tmpFile.WriteString(brokenSchema); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	_, err = NewStateFromFile(tmpFile.Name())
 	if err == nil {
@@ -1039,12 +1039,12 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	if _, err := tmpFile.WriteString("not valid json {{{"); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	_, err = NewStateFromFile(tmpFile.Name())
 	if err == nil {
@@ -1060,14 +1060,14 @@ func TestNewStateFromFile_SchemaMismatch_NoVersion_SurfacesFriendlyError(t *test
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Valid JSON with no version stamp but a type mismatch that will fail deserialisation
 	brokenSchema := `{"msk_sources":["unexpected","array"]}`
 	if _, err := tmpFile.WriteString(brokenSchema); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	_, err = NewStateFromFile(tmpFile.Name())
 	if err == nil {


### PR DESCRIPTION
## Summary

Implements state file validation when loading a KCP state file, covering all three loading paths. The approach is based on team discussions that concluded files should not be rejected purely on version mismatch — if the JSON is still deseralisable, the file should be usable. Instead, targeted error feedback is provided when loading actually fails, using the version field where available to give actionable context.

### Behaviour

- **Version mismatch alone is not a rejection** — if the file deserialises successfully it is accepted regardless of whether the version matches the running binary
- **Deserialisation failure with detectable version mismatch** — surfaces a targeted "version mismatch" error as the likely cause, naming both versions
- **Deserialisation failure without detectable version mismatch** — returns a generic unmarshal error
- **File not found or unreadable** — returns a clear load error
- **Frontend upload** — simplified to a lightweight JSON object check before sending to the backend; the backend is the authority on whether the content is valid

### What changed

**`internal/types/state.go` — `NewStateFromFile()`**
- Added fallback on deserialisation failure: attempts to extract just the version from the raw bytes; if a version mismatch is detectable, surfaces that as the likely cause rather than a cryptic JSON type error
- Removed strict version check on the success path — files that deserialise correctly are accepted regardless of version

**`cmd/ui/api/api.go` — UI preload (`--state-file` flag)**
- `NewUI()` now delegates to `types.NewStateFromFile()` instead of inline `os.ReadFile` + `json.Unmarshal`
- Added `preloadError` / `preloadErrorType` fields to the `UI` struct so startup preload failures are surfaced to the frontend via `GET /state` (HTTP 422) rather than silently producing a missing-state 404
- Extracted the `/state` anonymous handler into a named `handleGetState` method for testability

**`cmd/ui/api/api.go` — UI upload (`POST /upload-state`)**
- Removed strict version check — files with a different version are accepted if they bind correctly

**`cmd/ui/frontend/src/pages/home.tsx`**
- Replaced the previous structure check (`msk_sources` or `osk_sources` presence) with a minimal JSON object check — confirms the file is a non-array JSON object before sending to the backend
- Arrays are explicitly excluded (`!Array.isArray`) to give a clean frontend error rather than a raw backend deserialisation error
- Backend is now the authority on state file validity

**Test fixtures updated**
- Existing test fixtures in `cmd/report/metrics`, `cmd/scan/schema_registry`, and the frontend test fixtures (`state-migration.json`, `state-both.json`, `state-osk-only.json`) were updated to include `kcp_build_info` with `"version": "0.0.0-localdev"`

### Tests added

- `internal/types/state_test.go`: version match, version mismatch (older/newer/empty — all succeed when deserialisable), file not found, invalid JSON, schema mismatch with fallback version surfacing
- `cmd/ui/api/api_test.go` (new file): upload version match/mismatch/empty version (all succeed), missing session, preload version match/mismatch (both succeed), preload file not found, `GET /state` error shape for generic load-error preload failures
- `cmd/ui/frontend/tests/e2e/state-validation.spec.ts` (new file): uploading a JSON array is rejected with a frontend error; uploading a state file from a different KCP version succeeds

### Related

Companion bug fix in PR #275: `loadOrCreateState()` was creating new state files without a version stamp. Fixed to use `NewStateFrom(nil)` which correctly stamps the version.

## Test plan

- [x] `go test ./internal/types/... ./cmd/ui/api/...` — all unit tests pass
- [x] `go test ./...` — full suite passes
- [x] Playwright E2E tests for state file validation pass
- [ ] Manual: run `kcp ui --state-file <unreadable-file>` and confirm the UI surfaces an error rather than showing an empty state
- [ ] Manual: upload a non-KCP JSON file via the UI and confirm a clear error is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)