### PR TITLE
feat: versioned docs site (MkDocs Material + mike)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ scratch/
 docs/plans/
 docs/brainstorms/
 docs/ideation/
+
+# MkDocs build output
+site/

--- a/Makefile
+++ b/Makefile
@@ -119,13 +119,28 @@ test-schema-registry: build ## Run Schema Registry scan tests (unauthenticated, 
 	@bash integration-tests/schema-registry/teardown.sh
 
 # ==============================================================================
+# Documentation (MkDocs Material + mike)
+# ==============================================================================
+
+.PHONY: docs-install docs-serve docs-build
+
+docs-install: ## Install MkDocs and plugins (pip)
+	pip install -r requirements-docs.txt
+
+docs-serve: ## Serve docs locally with live reload on http://localhost:8000
+	mkdocs serve
+
+docs-build: ## Build the docs site into ./site
+	mkdocs build --strict
+
+# ==============================================================================
 # Utilities
 # ==============================================================================
 
 .PHONY: clean help
 
 clean: ## Clean build artifacts
-	rm -f $(BINARY_NAME) coverage.out
+	rm -rf $(BINARY_NAME) coverage.out site/
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*## ' $(MAKEFILE_LIST) | \

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -62,7 +62,7 @@ var RootCmd = &cobra.Command{
 
 		// --- End logging setup ---
 
-		if build_info.Version == "dev" {
+		if build_info.IsDev() {
 			fmt.Printf("\n%s\n%s\n%s\n%s\n\n",
 				color.RedString("┌─────────────────────────────────────────────────────────────────────────┐"),
 				color.RedString("│ ⚠️  WARNING: This is a development build                                │"),

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/confluentinc/kcp/cmd/create_asset"
 	"github.com/confluentinc/kcp/cmd/discover"
+	"github.com/confluentinc/kcp/cmd/docs"
 	"github.com/confluentinc/kcp/cmd/migration"
 	"github.com/confluentinc/kcp/cmd/report"
 	"github.com/confluentinc/kcp/cmd/scan"
@@ -28,7 +29,7 @@ var verbose bool
 var RootCmd = &cobra.Command{
 	Use:   "kcp",
 	Short: "A CLI tool for kafka cluster planning and migration",
-	Long:  "A comprehensive CLI tool for planning and executing kafka cluster migrations to confluent cloud. Docs: " + getDocURL(),
+	Long:  "A comprehensive CLI tool for planning and executing kafka cluster migrations to confluent cloud. Docs: " + build_info.DocsURL(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// --- Logging setup (must be here so --verbose flag is parsed) ---
 		lumberjackLogger := &lumberjack.Logger{
@@ -96,6 +97,7 @@ func init() {
 		migration.NewMigrationCmd(),
 		version.NewVersionCmd(),
 		update.NewUpdateCmd(),
+		docs.NewDocsCmd(),
 	)
 }
 
@@ -106,14 +108,6 @@ type PrettyHandlerOptions struct {
 type PrettyHandler struct {
 	slog.Handler
 	l *log.Logger
-}
-
-func getDocURL() string {
-	if build_info.Version == "dev" {
-		return "https://github.com/confluentinc/kcp/tree/latest/docs"
-	}
-	return "https://github.com/confluentinc/kcp/tree/v" + build_info.Version + "/docs"
-
 }
 
 func (h *PrettyHandler) Handle(ctx context.Context, r slog.Record) error {

--- a/cmd/docs/cmd_docs.go
+++ b/cmd/docs/cmd_docs.go
@@ -11,10 +11,11 @@ func NewDocsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "docs",
 		Short: "Show the documentation URL for this build",
-		Long: "Print the documentation site URL matching the running kcp binary's version.\n" +
-			"Development builds resolve to the 'dev' alias; released builds resolve to their vX.Y.Z subdirectory.",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(build_info.DocsURL())
+		Long: `Print the documentation site URL matching the running kcp binary's version.
+Development builds resolve to the 'dev' alias; released builds resolve to their vX.Y.Z subdirectory.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), build_info.DocsURL())
+			return err
 		},
 	}
 }

--- a/cmd/docs/cmd_docs.go
+++ b/cmd/docs/cmd_docs.go
@@ -1,0 +1,49 @@
+package docs
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/spf13/cobra"
+)
+
+func NewDocsCmd() *cobra.Command {
+	var open bool
+
+	cmd := &cobra.Command{
+		Use:   "docs",
+		Short: "Show the documentation URL for this build",
+		Long: "Print (or open) the documentation site URL matching the running kcp binary's version.\n" +
+			"Development builds resolve to the 'dev' alias; released builds resolve to their vX.Y.Z subdirectory.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url := build_info.DocsURL()
+			if !open {
+				fmt.Println(url)
+				return nil
+			}
+			fmt.Println(url)
+			return openInBrowser(url)
+		},
+	}
+
+	cmd.Flags().BoolVar(&open, "open", false, "Open the docs URL in the default browser")
+	return cmd
+}
+
+func openInBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to open browser for %s: %w", url, err)
+	}
+	return nil
+}

--- a/cmd/docs/cmd_docs.go
+++ b/cmd/docs/cmd_docs.go
@@ -2,48 +2,19 @@ package docs
 
 import (
 	"fmt"
-	"os/exec"
-	"runtime"
 
 	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/spf13/cobra"
 )
 
 func NewDocsCmd() *cobra.Command {
-	var open bool
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "docs",
 		Short: "Show the documentation URL for this build",
-		Long: "Print (or open) the documentation site URL matching the running kcp binary's version.\n" +
+		Long: "Print the documentation site URL matching the running kcp binary's version.\n" +
 			"Development builds resolve to the 'dev' alias; released builds resolve to their vX.Y.Z subdirectory.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			url := build_info.DocsURL()
-			if !open {
-				fmt.Println(url)
-				return nil
-			}
-			fmt.Println(url)
-			return openInBrowser(url)
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(build_info.DocsURL())
 		},
 	}
-
-	cmd.Flags().BoolVar(&open, "open", false, "Open the docs URL in the default browser")
-	return cmd
-}
-
-func openInBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
-		cmd = exec.Command("xdg-open", url)
-	}
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to open browser for %s: %w", url, err)
-	}
-	return nil
 }

--- a/cmd/docs/cmd_docs_test.go
+++ b/cmd/docs/cmd_docs_test.go
@@ -1,0 +1,26 @@
+package docs
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+)
+
+func TestDocsCmdPrintsDocsURL(t *testing.T) {
+	cmd := NewDocsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != build_info.DocsURL() {
+		t.Errorf("cmd output = %q, want %q", got, build_info.DocsURL())
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@
 
 > [!NOTE]
 > KCP supports migrations from two source types:
+>
 > - **AWS MSK (Managed Streaming for Kafka)** - Full discovery via AWS APIs + Kafka Admin API
 > - **Open Source Kafka (OSK)** - Direct scanning via Kafka Admin API
 >
@@ -56,7 +57,7 @@ LATEST_TAG=$(curl -s https://api.github.com/repos/confluentinc/kcp/releases/late
 
 Set a variable for your platform (comment and uncomment as appropriate):
 
-```
+```shell
 PLATFORM=darwin_amd64
 # PLATFORM=darwin_arm64
 # PLATFORM=linux_amd64
@@ -465,15 +466,15 @@ A 30-minute scan with a 10-second interval produces 180 data points per metric â
 
 **Metrics Collected**
 
-| Metric | Description | Type |
-|--------|-------------|------|
-| `BytesInPerSec` | Bytes received by brokers per second | Rate (from counter) |
-| `BytesOutPerSec` | Bytes sent to consumers per second | Rate (from counter) |
-| `MessagesInPerSec` | Messages received per second | Rate (from counter) |
-| `PartitionCount` | Total partitions across queried brokers | Gauge |
-| `GlobalPartitionCount` | Same as PartitionCount (summed across brokers) | Gauge |
-| `ClientConnectionCount` | Active client connections across all listeners | Gauge (aggregated) |
-| `TotalLocalStorageUsage` | Total log storage in GB | Gauge (aggregated, bytes to GB) |
+| Metric                   | Description                                    | Type                            |
+| ------------------------ | ---------------------------------------------- | ------------------------------- |
+| `BytesInPerSec`          | Bytes received by brokers per second           | Rate (from counter)             |
+| `BytesOutPerSec`         | Bytes sent to consumers per second             | Rate (from counter)             |
+| `MessagesInPerSec`       | Messages received per second                   | Rate (from counter)             |
+| `PartitionCount`         | Total partitions across queried brokers        | Gauge                           |
+| `GlobalPartitionCount`   | Same as PartitionCount (summed across brokers) | Gauge                           |
+| `ClientConnectionCount`  | Active client connections across all listeners | Gauge (aggregated)              |
+| `TotalLocalStorageUsage` | Total log storage in GB                        | Gauge (aggregated, bytes to GB) |
 
 **Jolokia Authentication**
 

--- a/docs/gateway-switchover-examples.md
+++ b/docs/gateway-switchover-examples.md
@@ -16,7 +16,7 @@ KCP uses a three-state switchover pattern to migrate clients without reconfigura
 | mTLS | mTLS | [switchover-mtls-to-mtls](switchover-mtls-to-mtls/README.md) |
 | mTLS | OAuth | [switchover-mtls-to-oauth](switchover-mtls-to-oauth/README.md) |
 | mTLS | SASL/PLAIN | [switchover-mtls-to-sasl-plain](switchover-mtls-to-sasl-plain/README.md) |
-| SASL/SCRAM | SASL/PLAIN | [switchover-sasl-scram-to-saslplain](switchover-sasl-scram-to-saslplain/README.md) |
+| SASL/SCRAM | SASL/PLAIN | [switchover-sasl-scram-to-sasl-plain](switchover-sasl-scram-to-sasl-plain/README.md) |
 | SASL/SCRAM | OAuth | [switchover-sasl-scram-to-oauth](switchover-sasl-scram-to-oauth/README.md) |
 
 ## Auth Class Considerations

--- a/internal/build_info/build_info.go
+++ b/internal/build_info/build_info.go
@@ -1,3 +1,5 @@
+// Package build_info exposes ldflag-injected build metadata (Version, Commit,
+// Date) and small derived helpers (IsDev, DocsURL) that depend on it.
 package build_info
 
 import "strings"
@@ -15,13 +17,33 @@ var (
 	Date    = "unknown"
 )
 
+// IsDev reports whether the binary is a development (non-released) build.
+// Treats the Makefile default (DefaultDevVersion), the historical "dev"
+// sentinel, and an unset Version all as development.
+func IsDev() bool {
+	return isDev(Version)
+}
+
+// isDev is the testable core used by both IsDev and DocsURL.
+func isDev(v string) bool {
+	v = strings.TrimPrefix(v, "v")
+	return v == "" || v == "dev" || v == DefaultDevVersion
+}
+
 // DocsURL returns the versioned documentation URL matching the running binary.
 // Development builds resolve to the "dev" alias (tip of main); released builds
 // resolve to the matching vX.Y.Z subdirectory.
 func DocsURL() string {
-	v := strings.TrimPrefix(Version, "v")
-	if v == "" || v == "dev" || v == DefaultDevVersion {
+	return docsURLForVersion(Version)
+}
+
+// docsURLForVersion is the pure, testable core of DocsURL.
+// It expects a version string as injected via ldflags; an optional leading
+// "v" is stripped. Release workflows must publish mike aliases using the
+// stripped (no-"v") form — e.g. `mike deploy 1.2.3`, not `v1.2.3`.
+func docsURLForVersion(v string) string {
+	if isDev(v) {
 		return docsSiteBase + "/dev/"
 	}
-	return docsSiteBase + "/" + v + "/"
+	return docsSiteBase + "/" + strings.TrimPrefix(v, "v") + "/"
 }

--- a/internal/build_info/build_info.go
+++ b/internal/build_info/build_info.go
@@ -1,7 +1,11 @@
 package build_info
 
+import "strings"
+
 const (
 	DefaultDevVersion = "0.0.0-localdev"
+
+	docsSiteBase = "https://confluentinc.github.io/kcp"
 )
 
 // Build information variables - set via ldflags during build
@@ -10,3 +14,14 @@ var (
 	Commit  = "unknown"
 	Date    = "unknown"
 )
+
+// DocsURL returns the versioned documentation URL matching the running binary.
+// Development builds resolve to the "dev" alias (tip of main); released builds
+// resolve to the matching vX.Y.Z subdirectory.
+func DocsURL() string {
+	v := strings.TrimPrefix(Version, "v")
+	if v == "" || v == "dev" || v == DefaultDevVersion {
+		return docsSiteBase + "/dev/"
+	}
+	return docsSiteBase + "/" + v + "/"
+}

--- a/internal/build_info/build_info_test.go
+++ b/internal/build_info/build_info_test.go
@@ -1,0 +1,48 @@
+package build_info
+
+import "testing"
+
+func TestDocsURLForVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"empty version resolves to dev", "", "https://confluentinc.github.io/kcp/dev/"},
+		{"literal 'dev' sentinel", "dev", "https://confluentinc.github.io/kcp/dev/"},
+		{"Makefile default (DefaultDevVersion)", DefaultDevVersion, "https://confluentinc.github.io/kcp/dev/"},
+		{"'v'-prefixed DefaultDevVersion", "v" + DefaultDevVersion, "https://confluentinc.github.io/kcp/dev/"},
+		{"plain semver", "1.2.3", "https://confluentinc.github.io/kcp/1.2.3/"},
+		{"'v'-prefixed semver", "v1.2.3", "https://confluentinc.github.io/kcp/1.2.3/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := docsURLForVersion(tc.version); got != tc.want {
+				t.Errorf("docsURLForVersion(%q) = %q, want %q", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDev(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"", true},
+		{"dev", true},
+		{DefaultDevVersion, true},
+		{"v" + DefaultDevVersion, true},
+		{"1.2.3", false},
+		{"v1.2.3", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			if got := isDev(tc.version); got != tc.want {
+				t.Errorf("isDev(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: KCP — Kafka Copy
+site_description: CLI tool for planning and executing Kafka migrations from AWS MSK and Open Source Kafka to Confluent Cloud.
+site_url: https://confluentinc.github.io/kcp/
+repo_url: https://github.com/confluentinc/kcp
+repo_name: confluentinc/kcp
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+exclude_docs: |
+  brainstorms/
+  ideation/
+  plans/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra:
+  version:
+    provider: mike
+    default: latest
+
+nav:
+  - Home: README.md
+  - Getting Started (Zero-Cut): getting-started-with-zero-cut-migrations.md
+  - Gateway Switchover:
+      - Examples: gateway-switchover-examples.md
+      - none → mTLS: switchover-none-to-mtls/README.md
+      - none → OAuth: switchover-none-to-oauth/README.md
+      - none → SASL/PLAIN: switchover-none-to-saslplain/README.md
+      - mTLS → mTLS: switchover-mtls-to-mtls/README.md
+      - mTLS → OAuth: switchover-mtls-to-oauth/README.md
+      - mTLS → SASL/PLAIN: switchover-mtls-to-sasl-plain/README.md
+      - SASL/SCRAM → OAuth: switchover-sasl-scram-to-oauth/README.md
+      - SASL/SCRAM → SASL/PLAIN: switchover-sasl-scram-to-sasl-plain/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ theme:
 
 plugins:
   - search
+  - callouts
 
 markdown_extensions:
   - admonition

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.44
 mike==2.1.3
-pymdown-extensions==10.12
+pymdown-extensions==10.21.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.44
+mike==2.1.3
+pymdown-extensions==10.12

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,5 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.44
 mike==2.1.3
+mkdocs-callouts==1.16.0
 pymdown-extensions==10.21.2


### PR DESCRIPTION
## Summary

Scaffolds a versioned documentation site so docs can be tied to the running `kcp` binary's release version instead of drifting against main's `docs/README.md`.

Today there's no way for a user on `kcp v0.5.0` to read the docs that shipped with their binary — GitHub always renders main's `docs/README.md`. This change lays the groundwork for `https://confluentinc.github.io/kcp/<version>/` with a version selector.

## What's in this PR

- **`mkdocs.yml`** — MkDocs Material config with `mike` version provider; nav covering `README.md`, getting-started, and all 8 switchover examples.
- **`requirements-docs.txt`** — pinned `mkdocs`, `mkdocs-material`, `mike`, `pymdown-extensions`.
- **`cmd/docs/cmd_docs.go`** — new `kcp docs` subcommand. Prints the version-matched Pages URL; modern terminals make it clickable.
- **`internal/build_info.DocsURL()`** — shared helper. Dev builds → `/dev/`; released builds → `/<version>/`. Reused by the root command's `--help` text and the new subcommand.
- **`Makefile`** — `docs-install`, `docs-serve`, `docs-build` targets. Local authors get live-reload via `make docs-serve`.
- **`.gitignore`** — ignores the `site/` build output.
- **Typo fix** in `docs/gateway-switchover-examples.md` (a broken link pointing at a nonexistent directory).

## What's *not* in this PR

- The deploy pipeline. It lands separately in [confluentinc/kcp-release#51](https://github.com/confluentinc/kcp-release/pull/51) because the public repo's Semaphore project intentionally lacks push credentials to `confluentinc/kcp`.
- Splitting the monolithic `docs/README.md` into structured pages. Deferred to a follow-up PR once the pipeline is proven.
- DevProd ticket to enable GitHub Pages (source: `gh-pages` branch, `/` folder). Has to happen *after* the first release post-merge creates the `gh-pages` branch — `mike` creates it on first deploy.

## Test plan

- [x] `make build` — frontend + Go binary build cleanly.
- [x] `./kcp docs` on a dev build → `https://confluentinc.github.io/kcp/dev/`.
- [x] `VERSION=0.7.0 go build …` → `./kcp-v070 docs` → `https://confluentinc.github.io/kcp/0.7.0/`.
- [x] `./kcp --help` long description now shows `Docs: https://confluentinc.github.io/kcp/dev/`.
- [x] `go test ./cmd/... ./internal/build_info/...` all pass.
- [x] `go vet ./...` clean.
- [x] `mkdocs build --strict` (against public PyPI in a venv) builds successfully. Output includes `index.html` (from `README.md`), all 8 switchover subdirs, search index.
- [ ] After merge + kcp-release deploy block + first release: confirm `https://confluentinc.github.io/kcp/<version>/` renders, version dropdown works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
