### PR TITLE
bug: stamp build version when creating new state file

### DIFF
--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -214,13 +214,9 @@ func runScanClusters(cmd *cobra.Command, args []string) error {
 func loadOrCreateState(stateFilePath string) (*types.State, error) {
 	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
 		slog.Info("creating new state file", "file", stateFilePath)
-		return &types.State{
-			MSKSources:       &types.MSKSourcesState{Regions: []types.DiscoveredRegion{}},
-			OSKSources:       &types.OSKSourcesState{Clusters: []types.OSKDiscoveredCluster{}},
-			SchemaRegistries: &types.SchemaRegistriesState{},
-			KcpBuildInfo:     types.KcpBuildInfo{},
-			Timestamp:        time.Now(),
-		}, nil
+		state := types.NewStateFrom(nil)
+		state.SchemaRegistries = &types.SchemaRegistriesState{}
+		return state, nil
 	}
 
 	state, err := types.NewStateFromFile(stateFilePath)

--- a/cmd/scan/clusters/load_or_create_state_test.go
+++ b/cmd/scan/clusters/load_or_create_state_test.go
@@ -1,0 +1,67 @@
+package clusters
+
+import (
+	"os"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOrCreateState_NewFile_StampsVersion(t *testing.T) {
+	// Use a path that does not exist to trigger new state creation
+	path := t.TempDir() + "/kcp-state.json"
+
+	state, err := loadOrCreateState(path)
+
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, build_info.Version, state.KcpBuildInfo.Version, "version should be stamped from running binary")
+	assert.Equal(t, build_info.Commit, state.KcpBuildInfo.Commit, "commit should be stamped from running binary")
+	assert.Equal(t, build_info.Date, state.KcpBuildInfo.Date, "date should be stamped from running binary")
+}
+
+func TestLoadOrCreateState_NewFile_InitialisesRequiredFields(t *testing.T) {
+	path := t.TempDir() + "/kcp-state.json"
+
+	state, err := loadOrCreateState(path)
+
+	require.NoError(t, err)
+	require.NotNil(t, state.MSKSources, "MSKSources should be initialised")
+	require.NotNil(t, state.OSKSources, "OSKSources should be initialised")
+	require.NotNil(t, state.SchemaRegistries, "SchemaRegistries should be initialised")
+	assert.Empty(t, state.MSKSources.Regions)
+	assert.Empty(t, state.OSKSources.Clusters)
+}
+
+func TestLoadOrCreateState_ExistingFile_LoadsState(t *testing.T) {
+	// Write a valid state file and confirm it is loaded correctly
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(`{"kcp_build_info":{"version":"` + build_info.Version + `","commit":"abc","date":"2024-01-01"}}`)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	state, err := loadOrCreateState(tmpFile.Name())
+
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, build_info.Version, state.KcpBuildInfo.Version)
+}
+
+func TestLoadOrCreateState_CorruptFile_ReturnsError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("not valid json {{{")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	_, err = loadOrCreateState(tmpFile.Name())
+
+	assert.Error(t, err, "corrupt state file should return error")
+}

--- a/cmd/scan/clusters/load_or_create_state_test.go
+++ b/cmd/scan/clusters/load_or_create_state_test.go
@@ -39,11 +39,11 @@ func TestLoadOrCreateState_ExistingFile_LoadsState(t *testing.T) {
 	// Write a valid state file and confirm it is loaded correctly
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	_, err = tmpFile.WriteString(`{"kcp_build_info":{"version":"` + build_info.Version + `","commit":"abc","date":"2024-01-01"}}`)
 	require.NoError(t, err)
-	tmpFile.Close()
+	require.NoError(t, tmpFile.Close())
 
 	state, err := loadOrCreateState(tmpFile.Name())
 
@@ -55,11 +55,11 @@ func TestLoadOrCreateState_ExistingFile_LoadsState(t *testing.T) {
 func TestLoadOrCreateState_CorruptFile_ReturnsError(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "kcp-state-*.json")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	_, err = tmpFile.WriteString("not valid json {{{")
 	require.NoError(t, err)
-	tmpFile.Close()
+	require.NoError(t, tmpFile.Close())
 
 	_, err = loadOrCreateState(tmpFile.Name())
 


### PR DESCRIPTION
## Summary

`loadOrCreateState()` in `cmd/scan/clusters` was constructing a new `State` struct directly with an empty `KcpBuildInfo{}` when no existing state file was found. This meant a first-time scan (particularly OSK) would write a state file to disk with no version stamped — inconsistent with `NewStateFrom()` which always stamps the current binary version via `build_info.Version`.

## What changed

- Replaced the direct struct construction in `loadOrCreateState()` with `NewStateFrom(nil)`, which correctly stamps `Version`, `Commit` and `Date` from the running binary
- Explicitly initialised `SchemaRegistries` after the call to preserve the existing behaviour — `NewStateFrom(nil)` does not initialise `SchemaRegistries` so this was carried over from the original code

## How it was found

Discovered while investigating state file version validation as part of [chore/reject-statefile-version-mismatch](#271). A first-time OSK scan produces a state file with an empty version field, which would silently fail any version-based or `kcp_build_info`-based validation on upload to the UI.

## Tests added

Unit tests added in `cmd/scan/clusters/load_or_create_state_test.go` covering the four key cases for `loadOrCreateState()`:

- **New file — version stamping**: confirms `Version`, `Commit`, and `Date` are all stamped from the running binary when creating a new state file
- **New file — field initialisation**: confirms `MSKSources`, `OSKSources`, and `SchemaRegistries` are initialised as non-nil with empty slices (guards against nil pointer panics in downstream code)
- **Existing valid file**: confirms an existing state file is loaded correctly
- **Corrupt file**: confirms an error is returned rather than silently producing empty state

## Test plan

- [x] `go test ./cmd/scan/clusters/...` — all tests pass including new ones
- [x] `go test ./...` — full suite passes
- [ ] Manual: run `kcp scan clusters --source-type osk` against a fresh directory with no existing state file and confirm the resulting `kcp-state.json` has `kcp_build_info.version` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)