### PR TITLE
docs: minor adjustments to some pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Before committing or pushing any changes, always:
 
 ## Project Overview
 
-KCP (Kafka Copy) is a CLI tool for planning and executing Kafka migrations from **AWS MSK and Open Source Kafka (OSK)** to Confluent Cloud. It provides commands for discovering resources, generating reports, creating migration assets (Terraform), and managing the migration workflow.
+KCP (Kafka Copy Paste) is a CLI tool for planning and executing Kafka migrations from **AWS MSK and Open Source Kafka (OSK)** to Confluent Cloud. It provides commands for discovering resources, generating reports, creating migration assets (Terraform), and managing the migration workflow.
 
 ## Source Types
 

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -22,6 +22,47 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
+// commandOrder pins the sidebar order of subcommands under a given parent in
+// the generated `.pages` files. Keys are full command paths; values are child
+// command names in display order. Children of an ordered parent that are not
+// listed here fall in at the end alphabetically (via awesome-pages' `...`
+// token), so a newly added subcommand still surfaces in the sidebar without
+// touching this map. Parents not present here keep the awesome-pages default
+// (alphabetical).
+var commandOrder = map[string][]string{
+	"kcp": {
+		"discover",
+		"scan",
+		"report",
+		"create-asset",
+		"migration",
+		"ui",
+		"docs",
+		"update",
+		"version",
+	},
+	"kcp create-asset": {
+		"bastion-host",
+		"target-infra",
+		"migration-infra",
+		"migrate-topics",
+		"migrate-schemas",
+		"migrate-acls",
+		"migrate-connectors",
+	},
+	"kcp migration": {
+		"init",
+		"execute",
+		"lag-check",
+		"list",
+	},
+	"kcp scan": {
+		"clusters",
+		"client-inventory",
+		"schema-registry",
+	},
+}
+
 func main() {
 	outDir := flag.String("out", "docs/assets/command-reference", "output directory for generated markdown")
 	flag.Parse()
@@ -46,6 +87,46 @@ func main() {
 	}
 
 	fmt.Printf("gen-docs: wrote command reference to %s\n", *outDir)
+}
+
+// buildPagesContent renders a .pages file for a parent command. If
+// commandOrder pins the parent's children, emit an explicit nav: block (with
+// awesome-pages' `...` rest-token at the end so unlisted children — e.g. a
+// newly added subcommand — still surface). Otherwise emit just the title and
+// let awesome-pages fall back to alphabetical.
+func buildPagesContent(c *cobra.Command, title string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "title: %s\n", title)
+
+	order, ok := commandOrder[c.CommandPath()]
+	if !ok {
+		return b.String()
+	}
+
+	childByName := map[string]*cobra.Command{}
+	for _, sub := range c.Commands() {
+		if !sub.IsAvailableCommand() || sub.IsAdditionalHelpTopicCommand() {
+			continue
+		}
+		childByName[sub.Name()] = sub
+	}
+
+	b.WriteString("nav:\n")
+	for _, name := range order {
+		sub, ok := childByName[name]
+		if !ok {
+			continue
+		}
+		// Parents render as <name>/index.md (a directory in the nav); leaves
+		// render as <name>.md.
+		if sub.HasAvailableSubCommands() {
+			fmt.Fprintf(&b, "  - %s\n", name)
+		} else {
+			fmt.Fprintf(&b, "  - %s.md\n", name)
+		}
+	}
+	b.WriteString("  - ...\n")
+	return b.String()
 }
 
 // outputPath returns the markdown file path for a command within outDir.
@@ -118,7 +199,7 @@ func emit(c *cobra.Command, outDir string, linkMap map[string]string) error {
 			title = "Command Reference"
 		}
 		pagesPath := filepath.Join(filepath.Dir(path), ".pages")
-		pagesContent := fmt.Sprintf("title: %s\n", title)
+		pagesContent := buildPagesContent(c, title)
 		if err := os.WriteFile(pagesPath, []byte(pagesContent), 0o644); err != nil {
 			return err
 		}

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -22,7 +22,7 @@ If you're unsure whether to download the `amd64` or `arm64` build:
 
 - **macOS**: run `uname -m` — `arm64` means Apple Silicon (M1/M2/M3/M4); `x86_64` means Intel (use `amd64`).
 - **Linux**: run `uname -m` — `aarch64` maps to `arm64`; `x86_64` maps to `amd64`.
-- **Windows**: open *System Information* and check *System type*, or run `echo %PROCESSOR_ARCHITECTURE%` in cmd — `ARM64` maps to `arm64`; `AMD64` maps to `amd64`. Only `amd64` is currently published for Windows.
+- **Windows**: open _System Information_ and check _System type_, or run `echo %PROCESSOR_ARCHITECTURE%` in cmd — `ARM64` maps to `arm64`; `AMD64` maps to `amd64`. Only `amd64` is currently published for Windows.
 
 ## Authentication
 
@@ -50,11 +50,11 @@ Each command's per-command AWS IAM permission requirements are documented on its
 The typical migration flow:
 
 1. **Discover / scan** — `kcp discover` (MSK) or `kcp scan clusters` (MSK or OSK) to build `kcp-state.json`.
-2. **Report** — `kcp report costs` and `kcp report metrics` for cost and utilization analysis.
-3. **Generate migration assets** — `kcp create-asset target-infra`, `migration-infra`, `migrate-topics`, `migrate-schemas`, `migrate-acls`, `migrate-connectors`.
-4. **Initialize and execute** — `kcp migration init` followed by `kcp migration execute`.
+2. **Report** — `kcp report costs` and `kcp report metrics` for cost and utilization analysis. Alternatively, use the `kcp ui` for fine-grained analysis.
+3. **Generate migration assets for data migration** — `kcp create-asset target-infra`, `migration-infra`, `migrate-topics`, `migrate-schemas`, `migrate-acls`, `migrate-connectors`.
+4. **Initialize and execute client switchover** — `kcp migration init` followed by `kcp migration execute`.
 
-The [Getting Started with Zero-Cut Migrations](getting-started-with-zero-cut-migrations.md) guide walks through the end-to-end migration reference, including how KCP fits with the Confluent Cloud Gateway.
+The [Getting Started with Zero-Cut Migrations](getting-started-with-zero-cut-migrations.md) guide walks through the end-to-end migration reference, including how KCP fits with the [Confluent Cloud Gateway](https://docs.confluent.io/cloud/current/cp-component/gateway/overview.html).
 
 ## Key infrastructure decisions
 
@@ -70,8 +70,8 @@ Only certain migration topologies are possible for a given combination — see [
 
 - **Public endpoints** — you can run `kcp` commands directly from your local machine.
 - **Private endpoints** — `kcp` must run from inside the source VPC. Either:
-    1. Provision a new bastion with [`kcp create-asset bastion-host`](command-reference/create-asset/bastion-host.md), or
-    2. Use an existing jump server and copy the `kcp` binary onto it.
+  1. Provision a new bastion with [`kcp create-asset bastion-host`](command-reference/create-asset/bastion-host.md), or
+  2. Use an existing jump server and copy the `kcp` binary onto it.
 
 > [!NOTE]
 > For private MSK, transfer the `kcp` binary to a host inside the same VPC before continuing.

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,6 +1,6 @@
 # KCP CLI
 
-KCP (Kafka Copy) is a CLI tool for planning and executing Kafka migrations to Confluent Cloud.
+KCP (Kafka Copy Paste) is a CLI tool for planning and executing Kafka migrations to Confluent Cloud.
 
 > [!NOTE]
 > KCP supports migrations from two source types:

--- a/docs/assets/getting-started-with-zero-cut-migrations.md
+++ b/docs/assets/getting-started-with-zero-cut-migrations.md
@@ -1,6 +1,6 @@
 # Confluent Cloud Migration: KCP + Gateway Reference Guide
 
-**Scope**: This document is a reference for the KCP + Gateway migration approach. It focuses specifically on the three KCP migration commands (`kcp migration init`, `kcp migration lag-check`, `kcp migration execute`) that orchestrate the client cutover. KCP's discovery and provisioning commands (`kcp scan`, `kcp create-asset`, etc.) are covered in the [KCP repository documentation](https://github.com/confluentinc/kcp/tree/main/docs) and are treated here as prerequisites. Covers component overview, licensing, infrastructure requirements, authentication support matrix, and operational guidance.
+**Scope**: This document is a reference for the KCP + Gateway migration approach. It focuses specifically on the three KCP migration commands (`kcp migration init`, `kcp migration lag-check`, `kcp migration execute`) that orchestrate the client cutover. KCP's discovery and provisioning commands (`kcp scan`, `kcp create-asset`, etc.) are covered in the [KCP documentation](https://confluentinc.github.io/kcp/) and are treated here as prerequisites. Covers component overview, licensing, infrastructure requirements, authentication support matrix, and operational guidance.
 
 ---
 
@@ -32,7 +32,7 @@ There are three active components in the migration:
 
 ## 3. Licensing
 
-**KCP CLI** is Apache 2.0 and free to use. Binaries are available for Linux, macOS (amd64/arm64), and Windows via GitHub Releases at [github.com/confluentinc/kcp](https://github.com/confluentinc/kcp). It can also be installed as a Confluent CLI plugin (`confluent plugin install kcp`), which lets it inherit existing Confluent CLI authentication and eliminates the need for separate API key flags.
+**KCP CLI** is Apache 2.0 and free to use. Binaries are available for Linux, macOS (amd64/arm64), and Windows via GitHub Releases at [github.com/confluentinc/kcp](https://github.com/confluentinc/kcp/releases). It can also be installed as a Confluent CLI plugin (`confluent plugin install kcp`), which lets it inherit existing Confluent CLI authentication and eliminates the need for separate API key flags.
 
 **CC Gateway** requires a Confluent Cloud Gateway Add-On license. This is delivered as a Confluent license key (JWT) configured on the Gateway container via `GATEWAY_LICENSES`. The license is org-scoped: one license covers all Confluent Cloud clusters in a customer's org, with no per-node or per-cluster fees.
 
@@ -93,7 +93,7 @@ IAM clients cannot connect to the gateway and must migrate to SCRAM or mTLS befo
 2. Update each client's auth config from `sasl.mechanism=AWS_MSK_IAM` to `sasl.mechanism=SCRAM-SHA-512` with the new SCRAM credentials. The bootstrap URL continues to point at the source cluster (or gateway, if they onboard directly).
 3. Once all clients are confirmed on SCRAM, they can onboard to the gateway.
 
-For MSK clusters, KCP provides tooling to accelerate this: `kcp scan clusters` discovers IAM principals from Kafka ACLs, and `kcp create-asset migrate-acls iam` generates Terraform for corresponding CC service accounts. These are out of scope for this document but are covered in the [KCP repository](https://github.com/confluentinc/kcp/tree/main/docs).
+For MSK clusters, KCP provides tooling to accelerate this: `kcp scan clusters` discovers IAM principals from Kafka ACLs, and `kcp create-asset migrate-acls iam` generates Terraform for corresponding CC service accounts. These are out of scope for this document but are covered in the [KCP repository](https://confluentinc.github.io/kcp/).
 
 ### 5.3 SASL/SCRAM: How the Gateway Handles It
 
@@ -132,7 +132,7 @@ KCP's `kcp migration init` validates that Cluster Linking is correctly configure
 
 ## 7. KCP Permissions Required
 
-The following permissions are required specifically for the three migration commands (`kcp migration init`, `kcp migration lag-check`, `kcp migration execute`). Permissions for discovery and provisioning commands are documented in the [KCP repository](https://github.com/confluentinc/kcp/tree/main/docs).
+The following permissions are required specifically for the three migration commands (`kcp migration init`, `kcp migration lag-check`, `kcp migration execute`). Permissions for discovery and provisioning commands are documented in the [KCP repository](https://confluentinc.github.io/kcp/latest/command-reference/) under each command that interacts with AWS/MSK.
 
 **Confluent Cloud:**
 - `CloudClusterAdmin` on the destination cluster: for cluster link operations (describe, list mirror topics, promote)
@@ -200,7 +200,7 @@ Before running any `kcp migration` command, confirm the following are in place:
 
 Before init, you need three gateway CR files ready on disk. The **initial CR** is your currently deployed gateway config — you reference it by name, KCP reads it from Kubernetes. The **fenced CR** is a modified version that blocks all traffic on the route and returns `BROKER_NOT_AVAILABLE` to clients. The **switchover CR** is another version that points the route at Confluent Cloud instead of the source cluster.
 
-KCP does not generate these files. You author the fenced and switchover variants from your initial CR before running init, and pass their file paths to `kcp migration init`. Working examples for every supported auth combination are in the KCP repo at [`docs/switchover-*`](https://github.com/confluentinc/kcp/tree/main/docs).
+KCP does not generate these files. You author the fenced and switchover variants from your initial CR before running init, and pass their file paths to `kcp migration init`. Working examples for every supported auth combination are in the KCP repo at under [Gateway Switchover](https://confluentinc.github.io/kcp/latest/gateway-switchover/).
 
 ![Description](images/image-20260112-174757.png)
 
@@ -212,7 +212,7 @@ Run once per migration group. Init validates the entire setup before anything is
 
 On success, KCP writes a `migration-state.json` file and prints a `migration-id`. That ID ties together all state for this group — you pass it to `lag-check` and `execute`. If KCP is installed as a Confluent CLI plugin, it inherits authentication from `confluent login` and the CC credential flags are not required.
 
-Full flag reference: [`kcp migration init --help`](https://github.com/confluentinc/kcp/tree/main/docs#kcp-migration)
+Full flag reference: [`kcp migration init --help`](https://confluentinc.github.io/kcp/latest/command-reference/migration/init/)
 
 ---
 
@@ -229,7 +229,7 @@ demo-topic3   ACTIVE     9,503     ███████
 
 Run it until lag is consistently near zero across all topics, then Ctrl+C and proceed.
 
-Full flag reference: [`kcp migration lag-check --help`](https://github.com/confluentinc/kcp/tree/main/docs#kcp-migration)
+Full flag reference: [`kcp migration lag-check --help`](https://confluentinc.github.io/kcp/latest/command-reference/migration/lag-check/)
 
 ---
 
@@ -254,4 +254,4 @@ Steps:
 ![Description](images/image-20260112-175233.png)
 ![Description](images/image-20260112-175246.png)
 
-Full flag reference: [`kcp migration execute --help`](https://github.com/confluentinc/kcp/tree/main/docs#kcp-migration)
+Full flag reference: [`kcp migration execute --help`](https://confluentinc.github.io/kcp/latest/command-reference/migration/execute/)

--- a/docs/assets/getting-started-with-zero-cut-migrations.md
+++ b/docs/assets/getting-started-with-zero-cut-migrations.md
@@ -32,7 +32,7 @@ There are three active components in the migration:
 
 ## 3. Licensing
 
-**KCP CLI** is Apache 2.0 and free to use. Binaries are available for Linux, macOS (amd64/arm64), and Windows via GitHub Releases at [github.com/confluentinc/kcp](https://github.com/confluentinc/kcp/releases). It can also be installed as a Confluent CLI plugin (`confluent plugin install kcp`), which lets it inherit existing Confluent CLI authentication and eliminates the need for separate API key flags.
+**KCP CLI** is Apache 2.0 and free to use. Binaries are available for Linux, macOS (amd64/arm64), and Windows via GitHub Releases at [github.com/confluentinc/kcp](https://github.com/confluentinc/kcp/releases).
 
 **CC Gateway** requires a Confluent Cloud Gateway Add-On license. This is delivered as a Confluent license key (JWT) configured on the Gateway container via `GATEWAY_LICENSES`. The license is org-scoped: one license covers all Confluent Cloud clusters in a customer's org, with no per-node or per-cluster fees.
 
@@ -69,17 +69,18 @@ This is the most operationally complex part of the migration. There are three di
 3. **Gateway → CC**: how the gateway authenticates to Confluent Cloud after cutover.
 
 The `--auth-mode` parameter in `kcp migration init` determines which direction uses passthrough vs. swap:
+
 - `dest_swap` (default): clients present their **source credentials** to the gateway. Gateway passes these through to the source; gateway swaps them for CC credentials when routing to CC.
 - `source_swap`: clients present their **CC credentials** to the gateway. Gateway passes these through to CC; gateway swaps them for source credentials when routing to the source.
 
 ### 5.1 Auth Combination Matrix
 
-| Source auth | CC SASL/PLAIN | CC mTLS | CC OAuth |
-|---|---|---|---|
-| **IAM** | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported |
-| **mTLS** | 🟢 Supported, see §5.4 | 🟢 Supported, see §5.4 | 🟢 Supported, see §5.4 |
-| **SASL/SCRAM** | 🟢 Supported, see §5.3 | 🔴 Not supported | 🟢 Supported, see §5.3 |
-| **Unauthenticated** | 🟢 Supported | 🟢 Supported | 🟢 Supported |
+| Source auth         | CC SASL/PLAIN          | CC mTLS                | CC OAuth               |
+| ------------------- | ---------------------- | ---------------------- | ---------------------- |
+| **IAM**             | 🔴 Not supported       | 🔴 Not supported       | 🔴 Not supported       |
+| **mTLS**            | 🟢 Supported, see §5.4 | 🟢 Supported, see §5.4 | 🟢 Supported, see §5.4 |
+| **SASL/SCRAM**      | 🟢 Supported, see §5.3 | 🔴 Not supported       | 🟢 Supported, see §5.3 |
+| **Unauthenticated** | 🟢 Supported           | 🟢 Supported           | 🟢 Supported           |
 
 Note: Confluent Cloud does not support SASL/SCRAM as a target protocol. When the source uses SCRAM, the gateway's auth swap translates client credentials to CC SASL/PLAIN (API key) or OAuth. This is handled transparently and requires no client changes.
 
@@ -127,7 +128,6 @@ Cluster Linking must be configured before running any KCP migration commands. Th
 
 KCP's `kcp migration init` validates that Cluster Linking is correctly configured and will surface any issues before the cutover begins.
 
-
 ---
 
 ## 7. KCP Permissions Required
@@ -135,10 +135,12 @@ KCP's `kcp migration init` validates that Cluster Linking is correctly configure
 The following permissions are required specifically for the three migration commands (`kcp migration init`, `kcp migration lag-check`, `kcp migration execute`). Permissions for discovery and provisioning commands are documented in the [KCP repository](https://confluentinc.github.io/kcp/latest/command-reference/) under each command that interacts with AWS/MSK.
 
 **Confluent Cloud:**
+
 - `CloudClusterAdmin` on the destination cluster: for cluster link operations (describe, list mirror topics, promote)
 - `MetricsViewer`: for lag monitoring via the Confluent metrics API
 
 **Kubernetes (for gateway CRD patching during cutover):**
+
 - `get`, `patch`, `update` on `Gateway` resources in the gateway namespace
 - Validate with: `kubectl auth can-i patch gateways -n confluent`
 
@@ -172,6 +174,7 @@ Clients should expect a brief partial downtime window of approximately 60 second
 **Cost during migration window**: Source cluster and CC run simultaneously during replication. Factor in the double-cost window for your migration timeline. `kcp report costs` gives you the source cluster baseline; `kcp create-asset target-infra` with appropriate sizing gives you the CC estimate.
 
 **Rollback states**:
+
 - Rollback after block but before any promotion: fully supported, safe. KCP unblocks and reverts the gateway CRD.
 - Rollback after promotion: possible (no data loss) but the cluster link is broken. Requires recreating the cluster link and mirror topics from scratch. This is not automated.
 - Rollback after unblock (traffic flowing to CC): not supported. Manual intervention required.
@@ -237,12 +240,12 @@ Full flag reference: [`kcp migration lag-check --help`](https://confluentinc.git
 
 Performs the cutover in four automatic phases. The operation is resumable: if interrupted at any point, re-running the same command picks up from the last completed phase.
 
-| Phase | What KCP does | What clients see |
-|---|---|---|
-| **Pre-flight** | Re-checks lag against `--lag-threshold`; aborts if any topic exceeds it | Normal traffic |
-| **Block** | Applies the fenced CR to the gateway; the route stops accepting produce/consume requests | `BROKER_NOT_AVAILABLE`; standard clients buffer and retry automatically |
-| **Promote** | Promotes mirror topics one by one (lowest lag first), waiting for lag=0 per topic before each promotion | Still retrying; records buffered locally |
-| **Switch + unblock** | Applies the switchover CR; gateway route now targets CC, traffic is unblocked | First retry succeeds; clients now on CC |
+| Phase                | What KCP does                                                                                           | What clients see                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Pre-flight**       | Re-checks lag against `--lag-threshold`; aborts if any topic exceeds it                                 | Normal traffic                                                          |
+| **Block**            | Applies the fenced CR to the gateway; the route stops accepting produce/consume requests                | `BROKER_NOT_AVAILABLE`; standard clients buffer and retry automatically |
+| **Promote**          | Promotes mirror topics one by one (lowest lag first), waiting for lag=0 per topic before each promotion | Still retrying; records buffered locally                                |
+| **Switch + unblock** | Applies the switchover CR; gateway route now targets CC, traffic is unblocked                           | First retry succeeds; clients now on CC                                 |
 
 The total window from block to unblock is typically 30–90 seconds, dominated by lag drain on the highest-lag topic. If the Cluster Link is fully caught up before the block fires, the window is closer to the gateway rolling restart time (~60 seconds).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: KCP — Kafka Copy
+site_name: KCP — Kafka Copy Paste
 site_description: CLI tool for planning and executing Kafka migrations from AWS MSK and Open Source Kafka to Confluent Cloud.
 site_url: https://confluentinc.github.io/kcp/
 repo_url: https://github.com/confluentinc/kcp


### PR DESCRIPTION
- Updating naming
- Updating reference URLs on pages from `https://github.com/confluentinc/kcp/docs/` to the GitHub pages docs
- Removed paragraph on Confluent CLI auth inheritance when installing as a plugin
- Reordered the `command-references` section to flow like a 'typical' workflow