### PR TITLE
feat: command to scaffold initial credentials file for OSK `kcp scan clusters` workflow

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confluentinc/kcp/cmd/create_asset"
 	"github.com/confluentinc/kcp/cmd/discover"
 	"github.com/confluentinc/kcp/cmd/docs"
+	initcmd "github.com/confluentinc/kcp/cmd/init"
 	"github.com/confluentinc/kcp/cmd/migration"
 	"github.com/confluentinc/kcp/cmd/report"
 	"github.com/confluentinc/kcp/cmd/scan"
@@ -94,6 +95,7 @@ func init() {
 		report.NewReportCmd(),
 		ui.NewUICmd(),
 		discover.NewDiscoverCmd(),
+		initcmd.NewInitCmd(),
 		migration.NewMigrationCmd(),
 		version.NewVersionCmd(),
 		update.NewUpdateCmd(),

--- a/cmd/init/cmd_init.go
+++ b/cmd/init/cmd_init.go
@@ -23,8 +23,8 @@ var (
 func NewInitCmd() *cobra.Command {
 	initCmd := &cobra.Command{
 		Use:   "init",
-		Short: "Scaffold an osk-credentials.yaml template for Open Source Kafka",
-		Long: `Scaffold an osk-credentials.yaml template for Open Source Kafka (OSK) clusters.
+		Short: "Scaffold a credentials file template for Open Source Kafka",
+		Long: `Scaffold a credentials file template for Open Source Kafka (OSK) clusters.
 
 This command writes a commented template that covers all five supported auth methods
 (SASL/SCRAM, SASL/PLAIN, mTLS, unauthenticated TLS, unauthenticated plaintext) and the

--- a/cmd/init/cmd_init.go
+++ b/cmd/init/cmd_init.go
@@ -1,0 +1,98 @@
+package initcmd
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/confluentinc/kcp/internal/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+//go:embed osk_credentials_template.yaml
+var oskTemplate []byte
+
+const defaultOutputPath = "osk-credentials.yaml"
+
+var (
+	outputPath string
+)
+
+func NewInitCmd() *cobra.Command {
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Scaffold an osk-credentials.yaml template for Open Source Kafka",
+		Long: `Scaffold an osk-credentials.yaml template for Open Source Kafka (OSK) clusters.
+
+This command writes a commented template that covers all five supported auth methods
+(SASL/SCRAM, SASL/PLAIN, mTLS, unauthenticated TLS, unauthenticated plaintext) and the
+optional Jolokia and Prometheus metrics sections. SASL/SCRAM-SHA-256 is the active
+default; the other methods are present but commented out.
+
+Edit the generated file before running 'kcp scan clusters' — at minimum, replace the
+placeholder bootstrap servers and the REPLACE_ME SASL/SCRAM password.
+
+This command is OSK only. For AWS MSK clusters, use 'kcp discover' instead — it scans
+the AWS account and writes msk-credentials.yaml automatically based on the discovered
+footprint.`,
+		Example: `  # Write osk-credentials.yaml in the current directory
+  kcp init
+
+  # Write to a custom path + file name
+  kcp init --output ./my-cluster/osk-dev-credentials.yaml`,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		PreRunE:       preRunInit,
+		RunE:          runInit,
+	}
+
+	optionalFlags := pflag.NewFlagSet("optional", pflag.ExitOnError)
+	optionalFlags.SortFlags = false
+	optionalFlags.StringVar(&outputPath, "output", defaultOutputPath, "Path to write the osk-credentials.yaml template")
+	initCmd.Flags().AddFlagSet(optionalFlags)
+
+	initCmd.SetUsageFunc(func(c *cobra.Command) error {
+		fmt.Printf("%s\n\n", c.Short)
+
+		if usage := optionalFlags.FlagUsages(); usage != "" {
+			fmt.Printf("Optional Flags:\n%s\n", usage)
+		}
+
+		fmt.Println("All flags can be provided via environment variables (uppercase, with underscores).")
+
+		return nil
+	})
+
+	return initCmd
+}
+
+func preRunInit(cmd *cobra.Command, args []string) error {
+	return utils.BindEnvToFlags(cmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	f, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("file %q already exists; remove it first if you want to regenerate", outputPath)
+		}
+		return fmt.Errorf("failed to open output file %q: %w", outputPath, err)
+	}
+
+	if _, err := f.Write(oskTemplate); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("failed to write template to %q: %w", outputPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close %q: %w", outputPath, err)
+	}
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "✅ Wrote osk-credentials template to %s\n", outputPath)
+	_, _ = fmt.Fprintln(out, "⚠️  Edit the file before scanning: replace the placeholder bootstrap servers and the REPLACE_ME SASL/SCRAM password.")
+	_, _ = fmt.Fprintf(out, "Next step:\n  kcp scan clusters --source-type osk --credentials-file %s\n", outputPath)
+
+	return nil
+}

--- a/cmd/init/cmd_init_test.go
+++ b/cmd/init/cmd_init_test.go
@@ -1,0 +1,177 @@
+package initcmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags clears package-level flag vars so test ordering does not leak state.
+func resetFlags() {
+	outputPath = defaultOutputPath
+}
+
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetFlags()
+	cmd := NewInitCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// Drift guard: the embedded template and the OSK credentials parser must stay in
+// sync. A failure here means the template no longer parses cleanly under
+// types.NewOSKCredentialsFromFile and the asset needs updating.
+func TestEmbeddedTemplate_RoundTripParse(t *testing.T) {
+	require.NotEmpty(t, oskTemplate, "embedded template bytes must be non-empty")
+
+	path := filepath.Join(t.TempDir(), "osk-credentials.yaml")
+	require.NoError(t, os.WriteFile(path, oskTemplate, 0600))
+
+	creds, errs := types.NewOSKCredentialsFromFile(path)
+	require.Empty(t, errs, "embedded template must parse and validate cleanly")
+	require.NotNil(t, creds)
+
+	require.Len(t, creds.Clusters, 1, "template must declare exactly one example cluster")
+
+	cluster := creds.Clusters[0]
+	methods := cluster.GetAuthMethods()
+	require.Len(t, methods, 1, "template must enable exactly one auth method")
+	assert.Equal(t, types.AuthTypeSASLSCRAM, methods[0], "default active method must be SASL/SCRAM")
+
+	require.NotNil(t, cluster.AuthMethod.SASLScram)
+	assert.True(t, cluster.AuthMethod.SASLScram.Use)
+	assert.Equal(t, "SHA256", cluster.AuthMethod.SASLScram.Mechanism, "default SCRAM mechanism must be SHA256")
+	// Regression guard: substituting a real-looking value here would silently ship a
+	// template that scans without warning the user to fill in their password.
+	assert.Equal(t, "REPLACE_ME", cluster.AuthMethod.SASLScram.Password)
+}
+
+func TestInit_WritesFileAndPrintsNextStep(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "osk-credentials.yaml")
+
+	out, err := runCmd(t, "--output", target)
+	require.NoError(t, err)
+
+	written, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, oskTemplate, written, "written file must equal embedded template bytes")
+
+	creds, errs := types.NewOSKCredentialsFromFile(target)
+	require.Empty(t, errs, "written file must be parser-valid")
+	require.NotNil(t, creds)
+
+	expectedNextStep := "kcp scan clusters --source-type osk --credentials-file " + target
+	assert.Contains(t, out, expectedNextStep, "stdout must contain shell-ready next-step invocation with the actual output path")
+}
+
+// Mutates os.Chdir, so this test cannot run in parallel and other cwd-sensitive
+// tests in this file must also stay sequential.
+func TestInit_DefaultPathInCwd(t *testing.T) {
+	dir := t.TempDir()
+	originalCwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
+
+	require.NoError(t, os.Chdir(dir))
+
+	out, err := runCmd(t)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(dir, defaultOutputPath))
+	require.NoError(t, statErr, "default invocation must write %s in the working directory", defaultOutputPath)
+
+	expectedNextStep := "kcp scan clusters --source-type osk --credentials-file " + defaultOutputPath
+	assert.Contains(t, out, expectedNextStep, "printed next-step must reference the relative default path")
+}
+
+func TestInit_FailsOnExistingFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "osk-credentials.yaml")
+	original := []byte("# existing user content; do not clobber\n")
+	require.NoError(t, os.WriteFile(target, original, 0600))
+
+	_, err := runCmd(t, "--output", target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), target, "error must name the existing file")
+
+	after, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, after, "existing file must remain byte-for-byte unchanged")
+}
+
+func TestInit_HelpTextSurfacesOSKAndExcludesMSK(t *testing.T) {
+	cmd := NewInitCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--help"})
+	require.NoError(t, cmd.Execute())
+
+	helpOutput := buf.String()
+	lower := strings.ToLower(helpOutput)
+	assert.True(t,
+		strings.Contains(lower, "osk") || strings.Contains(lower, "open source kafka"),
+		"init --help must mention OSK or Open Source Kafka",
+	)
+	assert.Contains(t, lower, "kcp discover", "init --help must point MSK users at kcp discover")
+}
+
+func TestInit_FailsWhenParentDirMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing", "credentials.yaml")
+
+	_, err := runCmd(t, "--output", missing)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), missing, "error must surface the failing path")
+}
+
+// O_EXCL on the open path must treat a symlink-at-target the same as a file-at-target,
+// otherwise we'd silently overwrite whatever the link points at.
+func TestInit_SymlinkAtTargetDoesNotFollow(t *testing.T) {
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.yaml")
+	original := []byte("# protected by symlink test\n")
+	require.NoError(t, os.WriteFile(realFile, original, 0600))
+
+	link := filepath.Join(dir, "credentials.yaml")
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	_, err := runCmd(t, "--output", link)
+	require.Error(t, err, "init must refuse to write through a pre-existing symlink")
+
+	after, readErr := os.ReadFile(realFile)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, after, "symlink target must not have been overwritten")
+}
+
+func TestInit_RegisteredOnRoot(t *testing.T) {
+	// Use a fresh root rather than the real RootCmd to avoid its logging side effects
+	// and version banner during test execution.
+	root := &cobra.Command{Use: "kcp"}
+	root.AddCommand(NewInitCmd())
+
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"--help"})
+	require.NoError(t, root.Execute())
+
+	help := buf.String()
+	assert.Contains(t, help, "init", "root help must list 'init' as a subcommand")
+	lower := strings.ToLower(help)
+	assert.True(t,
+		strings.Contains(lower, "osk") || strings.Contains(lower, "open source kafka"),
+		"root help short text for init must mention OSK / Open Source Kafka",
+	)
+}

--- a/cmd/init/osk_credentials_template.yaml
+++ b/cmd/init/osk_credentials_template.yaml
@@ -1,0 +1,69 @@
+# osk-credentials.yaml
+#
+# Connection and authentication details for one or more Open Source Kafka (OSK) clusters.
+# Edit the values below before running:
+#   kcp scan clusters --source-type osk --credentials-file osk-credentials.yaml
+#
+# Exactly one auth method per cluster may have `use: true`. The block below is set up for
+# SASL/SCRAM-SHA-256 (a common OSK choice). To use a different method, comment out the
+# active block and uncomment one of the alternatives further down.
+clusters:
+  - id: my-osk-cluster
+    bootstrap_servers:
+      - broker1.example.com:9092
+      - broker2.example.com:9092
+    auth_method:
+      # SASL/SCRAM auth (active by default; SHA256 is typical for OSK, SHA512 also supported)
+      sasl_scram:
+        use: true
+        username: kafkauser
+        # IMPORTANT: replace REPLACE_ME with the actual SASL/SCRAM password before scanning.
+        password: REPLACE_ME
+        mechanism: SHA256
+
+      # for SASL/PLAIN auth
+      # sasl_plain:
+      #   use: true
+      #   username: plainuser
+      #   password: REPLACE_ME
+
+      # for mTLS auth (paths must point to readable PEM files)
+      # tls:
+      #   use: true
+      #   ca_cert: /path/to/ca.pem
+      #   client_cert: /path/to/client-cert.pem
+      #   client_key: /path/to/client-key.pem
+
+      # for unauthenticated TLS (TLS encryption, no client auth)
+      # unauthenticated_tls:
+      #   use: true
+
+      # for unauthenticated plaintext (no TLS, no auth — test environments only)
+      # unauthenticated_plaintext:
+      #   use: true
+
+    # for Jolokia metrics collection (optional; required when scanning with --metrics jolokia)
+    # jolokia:
+    #   endpoints:
+    #     - http://broker1.example.com:8778/jolokia
+    #     - http://broker2.example.com:8778/jolokia
+    #   auth:
+    #     username: monitorUser
+    #     password: REPLACE_ME
+    #   tls:
+    #     ca_cert: /path/to/ca.pem
+    #     insecure_skip_verify: false
+
+    # for Prometheus-based metrics (optional; required when scanning with --metrics prometheus)
+    # prometheus:
+    #   url: http://prometheus.example.com:9090
+    #   auth:
+    #     username: promuser
+    #     password: REPLACE_ME
+    #   tls:
+    #     ca_cert: /path/to/ca.pem
+    #     insecure_skip_verify: false
+
+    metadata:
+      environment: production
+      location: datacenter-1

--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -111,7 +111,7 @@ func NewScanClustersCmd() *cobra.Command {
 	metricsFlags.StringVar(&metricsSource, "metrics", "", "Metrics collection source: 'jolokia' or 'prometheus' (OSK only)")
 	metricsFlags.StringVar(&metricsDuration, "metrics-duration", "", "Duration to poll Jolokia (e.g. 10m, 1h). Required with --metrics jolokia.")
 	metricsFlags.StringVar(&metricsInterval, "metrics-interval", "10s", "Polling interval for Jolokia (e.g. 10s, 30s). Default: 10s.")
-	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Time range to query from Prometheus (e.g. 7d, 30d). Required with --metrics prometheus.")
+	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Time range to query from Prometheus, in whole days with a 'd' suffix (e.g. 1d, 7d, 30d). Required with --metrics prometheus.")
 	scanClustersCmd.Flags().AddFlagSet(metricsFlags)
 
 	_ = scanClustersCmd.MarkFlagRequired("source-type")


### PR DESCRIPTION
At the moment, we do not have a simple starting path for users to run `kcp scan clusters` against their OSK infrastructure (and future Kafka compatible sources if we chose to support them) unlike MSK which has the `kcp discover` command which first hits the AWS APIs to build the initial resource footprint and generates a `msk-credentials.yaml` (previously: `cluster-credentials.yaml`.

Therefore, instead of pushing users to read the documentation to construct their own credentials or use templated example YAMLs from the repo/docs pages, there is a simple `kcp init` command:

```shell
❯ kcp init --help
Scaffold an osk-credentials.yaml template for Open Source Kafka (OSK) clusters.

This command writes a commented template that covers all five supported auth methods
(SASL/SCRAM, SASL/PLAIN, mTLS, unauthenticated TLS, unauthenticated plaintext) and the
optional Jolokia and Prometheus metrics sections. SASL/SCRAM-SHA-256 is the active
default; the other methods are present but commented out.

Edit the generated file before running 'kcp scan clusters' — at minimum, replace the
placeholder bootstrap servers and the REPLACE_ME SASL/SCRAM password.

This command is OSK only. For AWS MSK clusters, use 'kcp discover' instead — it scans
the AWS account and writes msk-credentials.yaml automatically.

Scaffold an osk-credentials.yaml template for Open Source Kafka

Executing kcp with build version=0.0.0-localdev commit=a13ff375987a2bcd934e1c53c7ab22b3daff400d date=2026-04-30T08:09:31Z
✅ Wrote osk-credentials template to osk-credentials.yaml
⚠️  Edit the file before scanning: replace the placeholder bootstrap servers and the REPLACE_ME SASL/SCRAM password.
Next step:
  kcp scan clusters --source-type osk --credentials-file osk-credentials.yaml
```

This will generate a YAML that the user can edit to suit their needs (viewable [here](https://github.com/confluentinc/kcp/blob/aa5d801c9ee78e0c4a3527596d03d105dbd255eb/cmd/init/osk_credentials_template.yaml)) with blocks commented out on how they may look. **This shouldn't replace the documentation as we can't account for everything within this YAML but it should be a suitable starting place for most users.**

---

I am not totally set on this being a standalone command either -- it could instead be a sub-command of `kcp scan clusters` where the initial command stays untouched, but if a user needs the credentials file generated, they can run `kcp scan clusters init`. However, this might be too deep in the command tree to find naturally?

Moreover, the `kcp init` command name might imply to users that is absolutely where they must start, which is not the case for MSK clusters -- this should never be needed for MSK clusters. Therefore, it might be applicable to change the name of the command from `kcp init` to `kcp credentials` or `kcp credentials init` to avoid the natural assumption that `init` is the first command that should be ran by the user. If we were to follow the `kcp credentials init` command flow, we could also have a `kcp credentials validate` which just ensures the credentials file schema is valid for kcp to read, correct data types have been used and placeholders haven't been left in.

Alternatively, we scrap this altogether and focus purely on documenting how an OSK cluster's credentials YAML should be set up in the documentation page to avoid any confusion.