### PR TITLE
docs: document Prometheus PromQL queries in metrics collection guide

### DIFF
--- a/docs/assets/osk-configuration/metrics-collection.md
+++ b/docs/assets/osk-configuration/metrics-collection.md
@@ -42,9 +42,9 @@ pre-computed fields including `OneMinuteRate`, `FiveMinuteRate` and
 EWMA samples are highly correlated, so a min/max/average over them
 under-states the true variance in traffic.
 
-Instead, `kcp` reads the `Count` field — a monotonic counter of total bytes
-(or messages) since broker start — and computes the actual rate over each
-sample interval:
+For the **Jolokia** backend, `kcp` reads the `Count` field — a monotonic
+counter of total bytes (or messages) since broker start — and computes the
+actual rate over each sample interval:
 
 ```
 rate = (Count_current - Count_previous) / elapsed_seconds
@@ -52,6 +52,10 @@ rate = (Count_current - Count_previous) / elapsed_seconds
 
 This produces independent data points with real variance, accurately reflecting
 traffic over each interval.
+
+The **Prometheus** backend achieves the same result using PromQL's `rate()`
+function, which computes per-second rates from counters stored in Prometheus
+(see [Prometheus PromQL queries](#prometheus-promql-queries) below).
 
 ## Scan duration and poll interval
 
@@ -91,6 +95,33 @@ Configured under the `jolokia:` block in `osk-credentials.yaml`:
 
 Prometheus uses the same three modes via its own `auth` and `tls` sub-blocks.
 See the [`osk-credentials.yaml` reference](osk-credentials.md) for the full schema.
+
+## Prometheus PromQL queries
+
+Your Prometheus instance must be scraping Kafka broker metrics — typically via a
+[JMX Exporter](https://github.com/prometheus/jmx_exporter) — for the queries
+below to return data. `kcp` submits one query per metric listed in
+[Metrics collected](#metrics-collected) above:
+
+| Metric                  | PromQL query                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `BytesInPerSec`         | `sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[<window>]))`    |
+| `BytesOutPerSec`        | `sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[<window>]))`   |
+| `MessagesInPerSec`      | `sum(rate(kafka_server_brokertopicmetrics_messagesinpersec_total[<window>]))` |
+| `PartitionCount`        | `sum(kafka_server_replicamanager_partitioncount)`                             |
+| `GlobalPartitionCount`  | `sum(kafka_server_replicamanager_partitioncount)`                             |
+| `ClientConnectionCount` | `sum(kafka_server_socketservermetrics_connection_count)`                      |
+| `TotalLocalStorageUsage`| `sum(kafka_log_log_size) / (1024*1024*1024)`                                 |
+
+`<window>` is a rate window automatically selected to be at least 4× the query
+step (minimum `5m`). The step itself is derived from `--metrics-range` as
+described in [Scan duration and poll interval](#scan-duration-and-poll-interval).
+
+These metric names (`kafka_server_brokertopicmetrics_*`,
+`kafka_server_replicamanager_*`, etc.) are the defaults produced by the
+Prometheus JMX Exporter with a standard Kafka configuration. If your exporter
+uses custom relabelling rules that rename these metrics, the queries will return
+empty results.
 
 ## Worked examples
 

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/build_info"
+
 	"github.com/confluentinc/kcp/internal/client"
 	"github.com/confluentinc/kcp/internal/types"
 )
@@ -84,7 +86,17 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		results, err := s.client.QueryRange(ctx, query, start, end, step)
 		if err != nil {
 			slog.Warn("Prometheus query failed, skipping metric", "label", mq.Label, "error", err)
+			fmt.Printf("   ⚠️  Query failed for %s: %v\n", mq.Label, err)
 			continue
+		}
+
+		dataPoints := 0
+		for _, r := range results {
+			dataPoints += len(r.Values)
+		}
+		if dataPoints == 0 {
+			slog.Warn("Prometheus query returned no data points", "label", mq.Label, "query", query)
+			fmt.Printf("   ⚠️  No data returned for %s — metric may not be exposed by your Prometheus exporter\n", mq.Label)
 		}
 
 		for _, result := range results {
@@ -101,6 +113,11 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 				valuesByLabel[mq.Label] = append(valuesByLabel[mq.Label], v)
 			}
 		}
+	}
+
+	if len(allMetrics) == 0 {
+		fmt.Printf("\n   ⚠️  No metrics data was collected from Prometheus. Ensure your Prometheus instance is scraping Kafka broker metrics.\n")
+		fmt.Printf("   See %sosk-configuration/metrics-collection/#prometheus-promql-queries for expected metric names.\n", build_info.DocsURL())
 	}
 
 	aggregates := calculateAggregates(valuesByLabel)


### PR DESCRIPTION
Help users configure their Prometheus setup by listing the exact PromQL queries kcp submits, the expected metric names, and the rate window logic.