### PR TITLE
feat: kcp report plan — sizing + cluster-type mapping (experimental)

### DIFF
--- a/cmd/report/cmd_report.go
+++ b/cmd/report/cmd_report.go
@@ -10,8 +10,8 @@ import (
 func NewReportCmd() *cobra.Command {
 	reportCmd := &cobra.Command{
 		Use:           "report",
-		Short:         "Generate a report of costs for given region(s)",
-		Long:          "Generate a report of costs for the given region(s) based on the data collected by `kcp discover`",
+		Short:         "Generate reports (costs, metrics, migration plan) from kcp scan data",
+		Long:          "Generate reports from the data collected by `kcp discover` / `kcp scan ...`. Subcommands: `costs` (AWS bill reconciliation), `metrics` (CloudWatch throughput aggregates), `plan` (deterministic migration plan).",
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 	}

--- a/cmd/report/cmd_report.go
+++ b/cmd/report/cmd_report.go
@@ -3,6 +3,7 @@ package report
 import (
 	"github.com/confluentinc/kcp/cmd/report/costs"
 	"github.com/confluentinc/kcp/cmd/report/metrics"
+	"github.com/confluentinc/kcp/cmd/report/plan"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ func NewReportCmd() *cobra.Command {
 
 	reportCmd.AddCommand(costs.NewReportCostsCmd())
 	reportCmd.AddCommand(metrics.NewReportMetricsCmd())
+	reportCmd.AddCommand(plan.NewReportPlanCmd())
 
 	return reportCmd
 }

--- a/cmd/report/plan/cmd_report_plan.go
+++ b/cmd/report/plan/cmd_report_plan.go
@@ -1,0 +1,198 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/confluentinc/kcp/internal/services/plan"
+	"github.com/confluentinc/kcp/internal/services/report"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	stateFile  string
+	planInputs string
+	outputDir  string
+	output     string
+	configPath string
+)
+
+func NewReportPlanCmd() *cobra.Command {
+	reportPlanCmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Generate a deterministic Migration Plan from a kcp state file",
+		Long: "Generate a deterministic Migration Plan from a kcp-state.json produced by `kcp discover` and `kcp scan ...`. " +
+			"The same state file + same plan-inputs + same KCP version produce a byte-identical plan, so the output is auditable.\n\n" +
+			"**Output:** writes `plan.md` and/or `plan.json` to `--output-dir` (default `./plan-output`).",
+		Example: `  # Minimal: state file in, plan.md/plan.json out
+  kcp report plan --state-file kcp-state.json
+
+  # With customer overrides
+  kcp report plan --state-file kcp-state.json --plan-inputs plan-inputs.yaml
+
+  # JSON only
+  kcp report plan --state-file kcp-state.json --output json`,
+		SilenceErrors: true,
+		PreRunE:       preRunReportPlan,
+		RunE:          runReportPlan,
+	}
+
+	groups := map[*pflag.FlagSet]string{}
+
+	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
+	requiredFlags.SortFlags = false
+	requiredFlags.StringVar(&stateFile, "state-file", "", "Path to the kcp state file written by `kcp discover` + `kcp scan ...`.")
+	reportPlanCmd.Flags().AddFlagSet(requiredFlags)
+	groups[requiredFlags] = "Required Flags"
+
+	optionalFlags := pflag.NewFlagSet("optional", pflag.ExitOnError)
+	optionalFlags.SortFlags = false
+	optionalFlags.StringVar(&planInputs, "plan-inputs", "", "Path to plan-inputs.yaml with per-customer overrides. All fields optional.")
+	optionalFlags.StringVar(&outputDir, "output-dir", "./plan-output", "Directory to write plan.md / plan.json into.")
+	optionalFlags.StringVar(&output, "output", "md,json", "Comma-separated output formats: md, json, or both.")
+	optionalFlags.StringVar(&configPath, "config", "", "Path to a plan-config.yaml override. Embedded config is the default.")
+	reportPlanCmd.Flags().AddFlagSet(optionalFlags)
+	groups[optionalFlags] = "Optional Flags"
+
+	reportPlanCmd.SetUsageFunc(func(c *cobra.Command) error {
+		fmt.Printf("%s\n\n", c.Short)
+		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags}
+		groupNames := []string{"Required Flags", "Optional Flags"}
+		for i, fs := range flagOrder {
+			usage := fs.FlagUsages()
+			if usage != "" {
+				fmt.Printf("%s:\n%s\n", groupNames[i], usage)
+			}
+		}
+		fmt.Println("All flags can be provided via environment variables (uppercase, with underscores).")
+		return nil
+	})
+
+	_ = reportPlanCmd.MarkFlagRequired("state-file")
+	return reportPlanCmd
+}
+
+func preRunReportPlan(cmd *cobra.Command, _ []string) error {
+	return utils.BindEnvToFlags(cmd)
+}
+
+func runReportPlan(_ *cobra.Command, _ []string) error {
+	if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+		return fmt.Errorf("state file does not exist: %s", stateFile)
+	}
+	state, err := loadState(stateFile)
+	if err != nil {
+		return fmt.Errorf("load --state-file %s: %w", stateFile, err)
+	}
+
+	cfg, err := plan.LoadPlanConfig(configPath)
+	if err != nil {
+		if configPath != "" {
+			return fmt.Errorf("load --config %s: %w", configPath, err)
+		}
+		return fmt.Errorf("load embedded plan-config: %w", err)
+	}
+
+	rawInputs, err := plan.LoadPlanInputs(planInputs)
+	if err != nil {
+		return fmt.Errorf("load --plan-inputs %s: %w", planInputs, err)
+	}
+	inputs := plan.ResolvePlanInputs(rawInputs, cfg)
+
+	rs := report.NewReportService()
+	processed := rs.ProcessState(*state)
+
+	svc := plan.NewPlanService(cfg, nil)
+	p, err := svc.Build(processed, inputs, stateFile)
+	if err != nil {
+		return fmt.Errorf("build plan: %w", err)
+	}
+
+	writeMD, writeJSON, err := parseOutputFormats(output)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create --output-dir %s: %w", outputDir, err)
+	}
+
+	if writeMD {
+		data, err := plan.RenderMarkdown(p)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(outputDir, "plan.md")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("write plan.md: %w", err)
+		}
+		fmt.Println("wrote", path)
+	}
+	if writeJSON {
+		data, err := plan.RenderJSON(p)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(outputDir, "plan.json")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("write plan.json: %w", err)
+		}
+		fmt.Println("wrote", path)
+	}
+	return nil
+}
+
+// loadState reads the state file and falls back to a pre-0.7 layout —
+// `regions` at the top level instead of `msk_sources.regions` — when the
+// modern unmarshal produces a state with no source data. The fallback uses
+// a typed decode (not a map round-trip), so byte ordering of the original
+// state file does not influence the resulting `*types.State`.
+func loadState(path string) (*types.State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	state, err := types.NewStateFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	if state.MSKSources != nil || state.OSKSources != nil {
+		return state, nil
+	}
+	// Legacy MSK-only shape: try `{ "regions": [...] }`.
+	var legacy struct {
+		Regions []types.DiscoveredRegion `json:"regions"`
+	}
+	if jerr := json.Unmarshal(data, &legacy); jerr == nil && len(legacy.Regions) > 0 {
+		state.MSKSources = &types.MSKSourcesState{Regions: legacy.Regions}
+	}
+	return state, nil
+}
+
+// parseOutputFormats accepts a comma-separated `md,json` list (or the legacy
+// `both`). Returns flags for each format and an actionable error if the
+// input names anything else.
+func parseOutputFormats(raw string) (md bool, jsonOut bool, err error) {
+	if raw == "" || raw == "both" {
+		return true, true, nil
+	}
+	for _, f := range strings.Split(raw, ",") {
+		switch strings.TrimSpace(f) {
+		case "md":
+			md = true
+		case "json":
+			jsonOut = true
+		default:
+			return false, false, fmt.Errorf("--output %q is invalid; valid values are md, json, or md,json", raw)
+		}
+	}
+	if !md && !jsonOut {
+		return false, false, fmt.Errorf("--output %q produced no formats; supply at least md or json", raw)
+	}
+	return md, jsonOut, nil
+}

--- a/cmd/report/plan/cmd_report_plan.go
+++ b/cmd/report/plan/cmd_report_plan.go
@@ -123,7 +123,7 @@ func runReportPlan(_ *cobra.Command, _ []string) error {
 	}
 
 	if writeMD {
-		data, err := plan.RenderMarkdown(p)
+		data, err := plan.RenderMarkdown(p, cfg)
 		if err != nil {
 			return err
 		}

--- a/cmd/report/plan/cmd_report_plan.go
+++ b/cmd/report/plan/cmd_report_plan.go
@@ -28,7 +28,7 @@ func NewReportPlanCmd() *cobra.Command {
 		Use:   "plan",
 		Short: "Generate a deterministic Migration Plan from a kcp state file",
 		Long: "Generate a deterministic Migration Plan from a kcp-state.json produced by `kcp discover` and `kcp scan ...`. " +
-			"The same state file + same plan-inputs + same KCP version produce a byte-identical plan, so the output is auditable.\n\n" +
+			"The same state file + same plan-inputs + same KCP version produce a byte-identical plan (modulo the `generated_at` timestamp), so the output is auditable.\n\n" +
 			"**Output:** writes `plan.md` and/or `plan.json` to `--output-dir` (default `./plan-output`).",
 		Example: `  # Minimal: state file in, plan.md/plan.json out
   kcp report plan --state-file kcp-state.json

--- a/docs/assets/plan-inputs.example.yaml
+++ b/docs/assets/plan-inputs.example.yaml
@@ -1,20 +1,51 @@
 # plan-inputs.yaml — per-customer overrides for `kcp report plan`.
 #
 # All fields are optional. Pinned defaults live in plan-config.yaml
-# (embedded in the KCP binary). A missing field falls back to its default;
-# nothing in this file is required.
+# (embedded in the KCP binary). A missing field falls back to its default.
 #
+# MVP scope:
+#   - sizing knobs
+#   - customer-declared hard requirements that force Dedicated
+#   - existing VPC connectivity for the Dedicated networking path
+#
+# Usage:
 #   kcp report plan \
 #     --state-file kcp-state.json \
 #     --plan-inputs plan-inputs.yaml \
 #     --output-dir ./plan-output
 
 # ---------------------------------------------------------------------------
-# Sizing overrides — defaults are in plan-config.yaml; touch only for
-# explicit reasons (sizing precision, SLA target, etc.)
+# Sizing overrides
 # ---------------------------------------------------------------------------
 # sla_target: "99.9"                  # 99.9 (default) | 99.95 | 99.99
-# sizing_percentile: P95              # default P95
-# headroom_fraction: 0.30             # default 0.30
+# sizing_percentile: p95              # p95 (default) | p99 | max — lowercase per Confluent dashboards
+# headroom_fraction: 0.30             # default 0.30 — extra capacity above the chosen percentile
 # privatelink_safety_threshold: 0.80  # default 0.80 (peak burst as fraction of PrivateLink cap)
-# spiky_workload_ratio: 2.0           # default 2.0 (peak / P95)
+# spiky_workload_ratio: 2.0           # default 2.0 (peak / P95 ratio above which a workload is flagged "spiky")
+
+# ---------------------------------------------------------------------------
+# Customer-declared hard requirements (force Dedicated)
+# ---------------------------------------------------------------------------
+# Most customers say `false` for all three. Setting any to `true` flips the
+# verdict from Enterprise to Dedicated, which costs ~5–10× per month — the
+# Plan surfaces a ⚠ cost callout on the verdict when one of these fires.
+# Ask your Confluent account team if you're unsure.
+#
+# enforce_schemas_at_the_broker: false              # true → broker rejects records without a registered schema
+# requires_high_throughput_rest_produce_api: false  # true → producing over Kafka REST Produce v3 at high throughput
+# requires_99_95_sla_within_a_single_zone: false    # true → Dedicated Single-Zone 99.95% SLA (different from sla_target)
+
+# Target cloud is implicit AWS for MSK migrations. Override only when
+# consolidating to Azure / GCP — non-AWS targets require Dedicated when the
+# source uses mTLS auth.
+# target_cloud: aws                   # aws (default) | azure | gcp
+
+# ---------------------------------------------------------------------------
+# Existing VPC connectivity (Dedicated-path networking)
+# ---------------------------------------------------------------------------
+# If your apps already reach MSK via Transit Gateway or VPC Peering today,
+# the same pattern is the path of least resistance on Confluent Cloud — but
+# both options are Dedicated-only. On Enterprise the Plan picks PrivateLink
+# vs PNI based on peak burst.
+#
+# existing_vpc_connectivity: privatelink_or_pni  # privatelink_or_pni (default) | transit_gateway | vpc_peering

--- a/docs/assets/plan-inputs.example.yaml
+++ b/docs/assets/plan-inputs.example.yaml
@@ -1,0 +1,20 @@
+# plan-inputs.yaml — per-customer overrides for `kcp report plan`.
+#
+# All fields are optional. Pinned defaults live in plan-config.yaml
+# (embedded in the KCP binary). A missing field falls back to its default;
+# nothing in this file is required.
+#
+#   kcp report plan \
+#     --state-file kcp-state.json \
+#     --plan-inputs plan-inputs.yaml \
+#     --output-dir ./plan-output
+
+# ---------------------------------------------------------------------------
+# Sizing overrides — defaults are in plan-config.yaml; touch only for
+# explicit reasons (sizing precision, SLA target, etc.)
+# ---------------------------------------------------------------------------
+# sla_target: "99.9"                  # 99.9 (default) | 99.95 | 99.99
+# sizing_percentile: P95              # default P95
+# headroom_fraction: 0.30             # default 0.30
+# privatelink_safety_threshold: 0.80  # default 0.80 (peak burst as fraction of PrivateLink cap)
+# spiky_workload_ratio: 2.0           # default 2.0 (peak / P95)

--- a/docs/assets/plan.sample.json
+++ b/docs/assets/plan.sample.json
@@ -3,132 +3,436 @@
     "source": "Amazon MSK",
     "state_file_path": "./kcp-state.json",
     "kcp_version": "0.7.2",
-    "generated_at": "2026-05-12T12:00:00Z",
+    "generated_at": "2026-05-15T15:00:00Z",
     "plan_schema_version": "1-experimental"
   },
   "inputs": {
+    "raw": {
+      "target_cloud": "azure"
+    },
     "sla_target": "99.9",
-    "sizing_percentile": "P95",
+    "sizing_percentile": "p95",
     "headroom_fraction": 0.3,
     "privatelink_safety_threshold": 0.8,
-    "spiky_workload_ratio": 2
+    "spiky_workload_ratio": 2,
+    "enforce_schemas_at_the_broker": false,
+    "requires_high_throughput_rest_produce_api": false,
+    "requires_99_95_sla_within_a_single_zone": false,
+    "target_cloud": "azure",
+    "existing_vpc_connectivity": "privatelink_or_pni"
   },
   "source_environment": {
     "clusters": [
       {
-        "cluster_id": "cluster-a",
+        "cluster_id": "heavy-acls",
         "region": "us-east-1",
         "broker_count": 3,
-        "topic_count": 250
+        "topic_count": 65
       },
       {
-        "cluster_id": "cluster-b",
+        "cluster_id": "mtls-to-azure",
         "region": "us-east-1",
-        "broker_count": 9,
-        "topic_count": 400
+        "broker_count": 3,
+        "topic_count": 38
+      },
+      {
+        "cluster_id": "small-orders",
+        "region": "us-east-1",
+        "broker_count": 3,
+        "topic_count": 42
+      },
+      {
+        "cluster_id": "steady-events",
+        "region": "us-east-1",
+        "broker_count": 6,
+        "topic_count": 120
       }
     ],
     "total_regions": 1
   },
   "sizing": [
     {
-      "cluster_id": "cluster-a",
-      "p95_in_mbps": 12,
-      "p95_out_mbps": 18,
+      "cluster_id": "heavy-acls",
+      "sized_in_mbps": 15,
+      "sized_out_mbps": 25,
       "peak_in_mbps": 18,
-      "peak_out_mbps": 27,
-      "user_partitions": 600,
-      "internal_partitions": 50,
-      "ingress_ratio": 0.2,
-      "egress_ratio": 0.1,
-      "partition_ratio": 0.2,
-      "max_ratio": 0.2,
+      "peak_out_mbps": 30,
+      "user_partitions": 300,
+      "internal_partitions": 0,
+      "ingress_ratio": 0.25,
+      "egress_ratio": 0.1388888888888889,
+      "partition_ratio": 0.1,
+      "max_ratio": 0.25,
+      "max_ratio_driver": "ingress",
       "sized_ecku": 1,
       "sla_floor_ecku": 1,
       "final_ecku": 1,
       "peak_burst_in_ratio": 0.3,
-      "peak_burst_out_ratio": 0.15,
+      "peak_burst_out_ratio": 0.16666666666666666,
       "peak_burst_ecku": 1,
       "peak_burst_pct_of_pl_cap": 10,
       "spiky_ingress": false,
       "spiky_egress": false,
       "citations": [
-        { "path": "cluster[cluster-a].metrics.aggregates.BytesInPerSec.p95",  "value": 12582912 },
-        { "path": "cluster[cluster-a].metrics.aggregates.BytesOutPerSec.p95", "value": 18874368 },
-        { "path": "cluster[cluster-a].kafka_admin_client_information.topics.summary.total_partitions", "value": 600 }
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesInPerSec.p95",
+          "value": 15728640
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 26214400
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesInPerSec.max",
+          "value": 18874368
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesOutPerSec.max",
+          "value": 31457280
+        },
+        {
+          "path": "cluster[heavy-acls].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 300
+        }
       ]
     },
     {
-      "cluster_id": "cluster-b",
-      "p95_in_mbps": 90,
-      "p95_out_mbps": 900,
-      "peak_in_mbps": 140,
-      "peak_out_mbps": 1400,
-      "user_partitions": 1500,
-      "internal_partitions": 80,
-      "ingress_ratio": 1.5,
-      "egress_ratio": 5,
-      "partition_ratio": 0.5,
-      "max_ratio": 5,
-      "sized_ecku": 7,
+      "cluster_id": "mtls-to-azure",
+      "sized_in_mbps": 12,
+      "sized_out_mbps": 18,
+      "peak_in_mbps": 15,
+      "peak_out_mbps": 22,
+      "user_partitions": 250,
+      "internal_partitions": 0,
+      "ingress_ratio": 0.2,
+      "egress_ratio": 0.1,
+      "partition_ratio": 0.08333333333333333,
+      "max_ratio": 0.2,
+      "max_ratio_driver": "ingress",
+      "sized_ecku": 1,
       "sla_floor_ecku": 1,
-      "final_ecku": 7,
-      "peak_burst_in_ratio": 2.33,
-      "peak_burst_out_ratio": 7.78,
-      "peak_burst_ecku": 8,
-      "peak_burst_pct_of_pl_cap": 80,
+      "final_ecku": 1,
+      "peak_burst_in_ratio": 0.25,
+      "peak_burst_out_ratio": 0.12222222222222222,
+      "peak_burst_ecku": 1,
+      "peak_burst_pct_of_pl_cap": 10,
       "spiky_ingress": false,
       "spiky_egress": false,
       "citations": [
-        { "path": "cluster[cluster-b].metrics.aggregates.BytesInPerSec.p95",  "value": 94371840 },
-        { "path": "cluster[cluster-b].metrics.aggregates.BytesOutPerSec.p95", "value": 943718400 },
-        { "path": "cluster[cluster-b].kafka_admin_client_information.topics.summary.total_partitions", "value": 1500 }
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.p95",
+          "value": 12582912
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 18874368
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.max",
+          "value": 15728640
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.max",
+          "value": 23068672
+        },
+        {
+          "path": "cluster[mtls-to-azure].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 250
+        }
+      ]
+    },
+    {
+      "cluster_id": "small-orders",
+      "sized_in_mbps": 10,
+      "sized_out_mbps": 20,
+      "peak_in_mbps": 12,
+      "peak_out_mbps": 22,
+      "user_partitions": 200,
+      "internal_partitions": 0,
+      "ingress_ratio": 0.16666666666666666,
+      "egress_ratio": 0.1111111111111111,
+      "partition_ratio": 0.06666666666666667,
+      "max_ratio": 0.16666666666666666,
+      "max_ratio_driver": "ingress",
+      "sized_ecku": 1,
+      "sla_floor_ecku": 1,
+      "final_ecku": 1,
+      "peak_burst_in_ratio": 0.2,
+      "peak_burst_out_ratio": 0.12222222222222222,
+      "peak_burst_ecku": 1,
+      "peak_burst_pct_of_pl_cap": 10,
+      "spiky_ingress": false,
+      "spiky_egress": false,
+      "citations": [
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesInPerSec.p95",
+          "value": 10485760
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 20971520
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesInPerSec.max",
+          "value": 12582912
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesOutPerSec.max",
+          "value": 23068672
+        },
+        {
+          "path": "cluster[small-orders].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "cluster_id": "steady-events",
+      "sized_in_mbps": 100,
+      "sized_out_mbps": 180,
+      "peak_in_mbps": 130,
+      "peak_out_mbps": 240,
+      "user_partitions": 800,
+      "internal_partitions": 0,
+      "ingress_ratio": 1.6666666666666667,
+      "egress_ratio": 1,
+      "partition_ratio": 0.26666666666666666,
+      "max_ratio": 1.6666666666666667,
+      "max_ratio_driver": "ingress",
+      "sized_ecku": 3,
+      "sla_floor_ecku": 1,
+      "final_ecku": 3,
+      "peak_burst_in_ratio": 2.1666666666666665,
+      "peak_burst_out_ratio": 1.3333333333333333,
+      "peak_burst_ecku": 3,
+      "peak_burst_pct_of_pl_cap": 30,
+      "spiky_ingress": false,
+      "spiky_egress": false,
+      "citations": [
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesInPerSec.p95",
+          "value": 104857600
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 188743680
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesInPerSec.max",
+          "value": 136314880
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesOutPerSec.max",
+          "value": 251658240
+        },
+        {
+          "path": "cluster[steady-events].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 800
+        }
       ]
     }
   ],
   "cluster_type_decision": [
-    { "cluster_id": "cluster-a", "verdict": "Enterprise" },
-    { "cluster_id": "cluster-b", "verdict": "Enterprise" }
+    {
+      "cluster_id": "heavy-acls",
+      "verdict": "Dedicated",
+      "triggers": [
+        {
+          "row_id": "acl_count_exceeds_cap",
+          "description": "ACL count exceeds Enterprise cap",
+          "evidence": "4001 ACLs \u003e Enterprise cap 4000"
+        }
+      ],
+      "topology": "MultiZone",
+      "final_cku": 1
+    },
+    {
+      "cluster_id": "mtls-to-azure",
+      "verdict": "Dedicated",
+      "triggers": [
+        {
+          "row_id": "mtls_on_non_aws_target",
+          "description": "Source uses mTLS, target is non-AWS",
+          "evidence": "target_cloud=\"azure\""
+        }
+      ],
+      "topology": "MultiZone",
+      "final_cku": 1
+    },
+    {
+      "cluster_id": "small-orders",
+      "verdict": "Enterprise"
+    },
+    {
+      "cluster_id": "steady-events",
+      "verdict": "Enterprise"
+    }
   ],
   "networking_decision": [
     {
-      "cluster_id": "cluster-a",
+      "cluster_id": "heavy-acls",
+      "verdict": "PNI",
+      "peak_burst_ecku": 1,
+      "percentage_of_cap": 10,
+      "reason": "Dedicated cluster — PNI required (no TGW / VPC Peering override)"
+    },
+    {
+      "cluster_id": "mtls-to-azure",
+      "verdict": "PNI",
+      "peak_burst_ecku": 1,
+      "percentage_of_cap": 10,
+      "reason": "Dedicated cluster — PNI required (no TGW / VPC Peering override)"
+    },
+    {
+      "cluster_id": "small-orders",
       "verdict": "PrivateLink",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "Peak burst 1 eCKU below 80% of 10 eCKU PrivateLink cap"
+      "reason": "peak burst 1 eCKU = 10% of PrivateLink's 10 eCKU cap (safety threshold 80%)"
     },
     {
-      "cluster_id": "cluster-b",
-      "verdict": "PNI",
-      "peak_burst_ecku": 8,
-      "percentage_of_cap": 80,
-      "reason": "Peak burst 8 eCKU at 80% of PrivateLink cap — exceeds 80% safety threshold"
+      "cluster_id": "steady-events",
+      "verdict": "PrivateLink",
+      "peak_burst_ecku": 3,
+      "percentage_of_cap": 30,
+      "reason": "peak burst 3 eCKU = 30% of PrivateLink's 10 eCKU cap (safety threshold 80%)"
     }
   ],
   "sizing_appendix": [
     {
-      "cluster_id": "cluster-a",
+      "cluster_id": "heavy-acls",
+      "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
+      "intermediate_steps": [
+        "ingress ratio = 15.00 MBps / 60 = 0.2500",
+        "egress ratio  = 25.00 MBps / 180 = 0.1389",
+        "partition ratio = 300 / 3000 = 0.1000",
+        "max ratio = 0.2500",
+        "sized = CEIL(0.2500 * 1.30) = 1  (1 + 0.30 headroom)",
+        "final = max(1 sized, 1 SLA floor) = 1 eCKU"
+      ],
+      "citations": [
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesInPerSec.p95",
+          "value": 15728640
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 26214400
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesInPerSec.max",
+          "value": 18874368
+        },
+        {
+          "path": "cluster[heavy-acls].metrics.aggregates.BytesOutPerSec.max",
+          "value": 31457280
+        },
+        {
+          "path": "cluster[heavy-acls].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 300
+        }
+      ]
+    },
+    {
+      "cluster_id": "mtls-to-azure",
       "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
       "intermediate_steps": [
         "ingress ratio = 12.00 MBps / 60 = 0.2000",
         "egress ratio  = 18.00 MBps / 180 = 0.1000",
-        "partition ratio = 600 / 3000 = 0.2000",
+        "partition ratio = 250 / 3000 = 0.0833",
         "max ratio = 0.2000",
         "sized = CEIL(0.2000 * 1.30) = 1  (1 + 0.30 headroom)",
         "final = max(1 sized, 1 SLA floor) = 1 eCKU"
+      ],
+      "citations": [
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.p95",
+          "value": 12582912
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 18874368
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.max",
+          "value": 15728640
+        },
+        {
+          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.max",
+          "value": 23068672
+        },
+        {
+          "path": "cluster[mtls-to-azure].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 250
+        }
       ]
     },
     {
-      "cluster_id": "cluster-b",
+      "cluster_id": "small-orders",
       "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
       "intermediate_steps": [
-        "ingress ratio = 90.00 MBps / 60 = 1.5000",
-        "egress ratio  = 900.00 MBps / 180 = 5.0000",
-        "partition ratio = 1500 / 3000 = 0.5000",
-        "max ratio = 5.0000",
-        "sized = CEIL(5.0000 * 1.30) = 7  (1 + 0.30 headroom)",
-        "final = max(7 sized, 1 SLA floor) = 7 eCKU"
+        "ingress ratio = 10.00 MBps / 60 = 0.1667",
+        "egress ratio  = 20.00 MBps / 180 = 0.1111",
+        "partition ratio = 200 / 3000 = 0.0667",
+        "max ratio = 0.1667",
+        "sized = CEIL(0.1667 * 1.30) = 1  (1 + 0.30 headroom)",
+        "final = max(1 sized, 1 SLA floor) = 1 eCKU"
+      ],
+      "citations": [
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesInPerSec.p95",
+          "value": 10485760
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 20971520
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesInPerSec.max",
+          "value": 12582912
+        },
+        {
+          "path": "cluster[small-orders].metrics.aggregates.BytesOutPerSec.max",
+          "value": 23068672
+        },
+        {
+          "path": "cluster[small-orders].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "cluster_id": "steady-events",
+      "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
+      "intermediate_steps": [
+        "ingress ratio = 100.00 MBps / 60 = 1.6667",
+        "egress ratio  = 180.00 MBps / 180 = 1.0000",
+        "partition ratio = 800 / 3000 = 0.2667",
+        "max ratio = 1.6667",
+        "sized = CEIL(1.6667 * 1.30) = 3  (1 + 0.30 headroom)",
+        "final = max(3 sized, 1 SLA floor) = 3 eCKU"
+      ],
+      "citations": [
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesInPerSec.p95",
+          "value": 104857600
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesOutPerSec.p95",
+          "value": 188743680
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesInPerSec.max",
+          "value": 136314880
+        },
+        {
+          "path": "cluster[steady-events].metrics.aggregates.BytesOutPerSec.max",
+          "value": 251658240
+        },
+        {
+          "path": "cluster[steady-events].kafka_admin_client_information.topics.summary.total_partitions",
+          "value": 800
+        }
       ]
     }
   ]

--- a/docs/assets/plan.sample.json
+++ b/docs/assets/plan.sample.json
@@ -1,0 +1,135 @@
+{
+  "header": {
+    "source": "Amazon MSK",
+    "state_file_path": "./kcp-state.json",
+    "kcp_version": "0.7.2",
+    "generated_at": "2026-05-12T12:00:00Z",
+    "plan_schema_version": "1-experimental"
+  },
+  "inputs": {
+    "sla_target": "99.9",
+    "sizing_percentile": "P95",
+    "headroom_fraction": 0.3,
+    "privatelink_safety_threshold": 0.8,
+    "spiky_workload_ratio": 2
+  },
+  "source_environment": {
+    "clusters": [
+      {
+        "cluster_id": "cluster-a",
+        "region": "us-east-1",
+        "broker_count": 3,
+        "topic_count": 250
+      },
+      {
+        "cluster_id": "cluster-b",
+        "region": "us-east-1",
+        "broker_count": 9,
+        "topic_count": 400
+      }
+    ],
+    "total_regions": 1
+  },
+  "sizing": [
+    {
+      "cluster_id": "cluster-a",
+      "p95_in_mbps": 12,
+      "p95_out_mbps": 18,
+      "peak_in_mbps": 18,
+      "peak_out_mbps": 27,
+      "user_partitions": 600,
+      "internal_partitions": 50,
+      "ingress_ratio": 0.2,
+      "egress_ratio": 0.1,
+      "partition_ratio": 0.2,
+      "max_ratio": 0.2,
+      "sized_ecku": 1,
+      "sla_floor_ecku": 1,
+      "final_ecku": 1,
+      "peak_burst_in_ratio": 0.3,
+      "peak_burst_out_ratio": 0.15,
+      "peak_burst_ecku": 1,
+      "peak_burst_pct_of_pl_cap": 10,
+      "spiky_ingress": false,
+      "spiky_egress": false,
+      "citations": [
+        { "path": "cluster[cluster-a].metrics.aggregates.BytesInPerSec.p95",  "value": 12582912 },
+        { "path": "cluster[cluster-a].metrics.aggregates.BytesOutPerSec.p95", "value": 18874368 },
+        { "path": "cluster[cluster-a].kafka_admin_client_information.topics.summary.total_partitions", "value": 600 }
+      ]
+    },
+    {
+      "cluster_id": "cluster-b",
+      "p95_in_mbps": 90,
+      "p95_out_mbps": 900,
+      "peak_in_mbps": 140,
+      "peak_out_mbps": 1400,
+      "user_partitions": 1500,
+      "internal_partitions": 80,
+      "ingress_ratio": 1.5,
+      "egress_ratio": 5,
+      "partition_ratio": 0.5,
+      "max_ratio": 5,
+      "sized_ecku": 7,
+      "sla_floor_ecku": 1,
+      "final_ecku": 7,
+      "peak_burst_in_ratio": 2.33,
+      "peak_burst_out_ratio": 7.78,
+      "peak_burst_ecku": 8,
+      "peak_burst_pct_of_pl_cap": 80,
+      "spiky_ingress": false,
+      "spiky_egress": false,
+      "citations": [
+        { "path": "cluster[cluster-b].metrics.aggregates.BytesInPerSec.p95",  "value": 94371840 },
+        { "path": "cluster[cluster-b].metrics.aggregates.BytesOutPerSec.p95", "value": 943718400 },
+        { "path": "cluster[cluster-b].kafka_admin_client_information.topics.summary.total_partitions", "value": 1500 }
+      ]
+    }
+  ],
+  "cluster_type_decision": [
+    { "cluster_id": "cluster-a", "verdict": "Enterprise" },
+    { "cluster_id": "cluster-b", "verdict": "Enterprise" }
+  ],
+  "networking_decision": [
+    {
+      "cluster_id": "cluster-a",
+      "verdict": "PrivateLink",
+      "peak_burst_ecku": 1,
+      "percentage_of_cap": 10,
+      "reason": "Peak burst 1 eCKU below 80% of 10 eCKU PrivateLink cap"
+    },
+    {
+      "cluster_id": "cluster-b",
+      "verdict": "PNI",
+      "peak_burst_ecku": 8,
+      "percentage_of_cap": 80,
+      "reason": "Peak burst 8 eCKU at 80% of PrivateLink cap — exceeds 80% safety threshold"
+    }
+  ],
+  "sizing_appendix": [
+    {
+      "cluster_id": "cluster-a",
+      "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
+      "intermediate_steps": [
+        "ingress ratio = 12.00 MBps / 60 = 0.2000",
+        "egress ratio  = 18.00 MBps / 180 = 0.1000",
+        "partition ratio = 600 / 3000 = 0.2000",
+        "max ratio = 0.2000",
+        "sized = CEIL(0.2000 * 1.30) = 1  (1 + 0.30 headroom)",
+        "final = max(1 sized, 1 SLA floor) = 1 eCKU"
+      ]
+    },
+    {
+      "cluster_id": "cluster-b",
+      "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
+      "intermediate_steps": [
+        "ingress ratio = 90.00 MBps / 60 = 1.5000",
+        "egress ratio  = 900.00 MBps / 180 = 5.0000",
+        "partition ratio = 1500 / 3000 = 0.5000",
+        "max ratio = 5.0000",
+        "sized = CEIL(5.0000 * 1.30) = 7  (1 + 0.30 headroom)",
+        "final = max(7 sized, 1 SLA floor) = 7 eCKU"
+      ]
+    }
+  ]
+}

--- a/docs/assets/plan.sample.md
+++ b/docs/assets/plan.sample.md
@@ -1,0 +1,48 @@
+# Migration Plan — Amazon MSK → Confluent Cloud
+
+_Generated 2026-05-12 12:00:00 UTC by KCP 0.7.2 from `./kcp-state.json`._
+
+## Definitions
+
+- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. ~30 MB/s ingress + 90 MB/s egress per eCKU at the per-eCKU caps used below.
+- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 so a transient spike doesn't permanently inflate the recommended cluster size.
+- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom.
+- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.
+
+## 1. Source Environment
+
+- **2** source clusters across **1** region(s)
+
+| Cluster | Region | Brokers | Topics |
+|---|---|---:|---:|
+| cluster-a | us-east-1 | 3 | 250 |
+| cluster-b | us-east-1 | 9 | 400 |
+
+## 2. Sizing & Cluster Decisions
+
+| Cluster | P95 in / out (MBps) | Partitions | Final eCKU | Cluster Type | Networking |
+|---|---|---:|---:|---|---|
+| cluster-a | 12.0 / 18.0 | 600 | 1 | Enterprise | PrivateLink |
+| cluster-b | 90.0 / 900.0 | 1500 | 7 | Enterprise | PNI |
+
+### Why these recommendations
+
+- **cluster-a** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — Peak burst 1 eCKU below 80% of 10 eCKU PrivateLink cap.
+- **cluster-b** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PNI** — Peak burst 9 eCKU at 90% of PrivateLink cap — exceeds 80% safety threshold.
+
+## Appendix A1 — Sizing Math
+
+<details><summary>Show sizing math per cluster</summary>
+
+Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.
+
+Formula: `CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))`
+
+| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |
+|---|---:|---:|---:|---|---:|---:|---:|
+| cluster-a | 0.2000 | 0.1000 | 0.2000 | **0.2000** (partitions) | 1 | 1 | 1 |
+| cluster-b | 1.5000 | 5.0000 | 0.5000 | **5.0000** (egress) | 7 | 1 | 7 |
+
+Max-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.
+
+</details>

--- a/docs/assets/plan.sample.md
+++ b/docs/assets/plan.sample.md
@@ -1,37 +1,44 @@
 # Migration Plan — Amazon MSK → Confluent Cloud
 
-_Generated 2026-05-12 12:00:00 UTC by KCP 0.7.2 from `./kcp-state.json`._
+_Generated 2026-05-15 15:00:00 UTC by KCP 0.7.2 from `./kcp-state.json`._
 
 ## Definitions
 
-- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. ~30 MB/s ingress + 90 MB/s egress per eCKU at the per-eCKU caps used below.
-- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 so a transient spike doesn't permanently inflate the recommended cluster size.
-- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom.
-- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.
+- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. 60 MB/s ingress + 180 MB/s egress per eCKU at the per-eCKU caps used below.
+- **CKU** — Confluent Kafka Unit, the Dedicated-tier equivalent of eCKU. Sizing math is the same; only the unit name changes. Dedicated clusters always render with `CKU`.
+- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 (override with `sizing_percentile`) so a transient spike doesn't permanently inflate the recommended cluster size.
+- **Final size** — the recommended eCKU (Enterprise) or CKU (Dedicated) count for the cluster. `(floor)` next to a value means the SLA minimum was binding (the math came in below the floor and was rounded up).
+- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom. Enterprise only.
+- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst; **always required on Dedicated**.
 
 ## 1. Source Environment
 
-- **2** source clusters across **1** region(s)
+- **4** source clusters across **1** region · **15** brokers · **265** topics
 
 | Cluster | Region | Brokers | Topics |
 |---|---|---:|---:|
-| cluster-a | us-east-1 | 3 | 250 |
-| cluster-b | us-east-1 | 9 | 400 |
+| heavy-acls | us-east-1 | 3 | 65 |
+| mtls-to-azure | us-east-1 | 3 | 38 |
+| small-orders | us-east-1 | 3 | 42 |
+| steady-events | us-east-1 | 6 | 120 |
 
 ## 2. Sizing & Cluster Decisions
 
-| Cluster | P95 in / out (MBps) | Partitions | Final eCKU | Cluster Type | Networking |
+| Cluster | P95 in / out (MBps) | Partitions | Final size | Cluster Type | Networking |
 |---|---|---:|---:|---|---|
-| cluster-a | 12.0 / 18.0 | 600 | 1 | Enterprise | PrivateLink |
-| cluster-b | 90.0 / 900.0 | 1500 | 7 | Enterprise | PNI |
+| heavy-acls | 15.0 / 25.0 | 300 | 1 CKU | Dedicated Multi-Zone (MZ) | PNI |
+| mtls-to-azure | 12.0 / 18.0 | 250 | 1 CKU | Dedicated Multi-Zone (MZ) | PNI |
+| small-orders | 10.0 / 20.0 | 200 | 1 eCKU | Enterprise | PrivateLink |
+| steady-events | 100.0 / 180.0 | 800 | 3 eCKU | Enterprise | PrivateLink |
 
-### Why these recommendations
+### Why These Recommendations
 
-- **cluster-a** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — Peak burst 1 eCKU below 80% of 10 eCKU PrivateLink cap.
-- **cluster-b** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PNI** — Peak burst 9 eCKU at 90% of PrivateLink cap — exceeds 80% safety threshold.
+- **heavy-acls** — Cluster type **Dedicated Multi-Zone (MZ)** — ACL count exceeds Enterprise cap (4001 ACLs > Enterprise cap 4000). Networking **PNI** — Dedicated cluster — PNI required (no TGW / VPC Peering override).
+- **mtls-to-azure** — Cluster type **Dedicated Multi-Zone (MZ)** — Source uses mTLS, target is non-AWS (target_cloud="azure"). Networking **PNI** — Dedicated cluster — PNI required (no TGW / VPC Peering override).
+- **small-orders** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — peak burst 1 eCKU = 10% of PrivateLink's 10 eCKU cap (safety threshold 80%).
+- **steady-events** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — peak burst 3 eCKU = 30% of PrivateLink's 10 eCKU cap (safety threshold 80%).
 
 ## Appendix A1 — Sizing Math
-
 <details><summary>Show sizing math per cluster</summary>
 
 Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.
@@ -40,9 +47,12 @@ Formula: `CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))
 
 | Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |
 |---|---:|---:|---:|---|---:|---:|---:|
-| cluster-a | 0.2000 | 0.1000 | 0.2000 | **0.2000** (partitions) | 1 | 1 | 1 |
-| cluster-b | 1.5000 | 5.0000 | 0.5000 | **5.0000** (egress) | 7 | 1 | 7 |
+| heavy-acls | 0.2500 | 0.1389 | 0.1000 | **0.2500** (ingress) | 1 | 1 | 1 |
+| mtls-to-azure | 0.2000 | 0.1000 | 0.0833 | **0.2000** (ingress) | 1 | 1 | 1 |
+| small-orders | 0.1667 | 0.1111 | 0.0667 | **0.1667** (ingress) | 1 | 1 | 1 |
+| steady-events | 1.6667 | 1.0000 | 0.2667 | **1.6667** (ingress) | 3 | 1 | 3 |
 
 Max-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.
 
 </details>
+

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -1,0 +1,71 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// HardLimit is one row of the Enterprise → Dedicated escalation catalog.
+// Check is a Go function value (refactor-safe; compile-checked) that
+// compares the relevant Plan field against the cap in plan-config.yaml's
+// `enterprise_caps`. Returning true → Dedicated.
+//
+// Evidence carries the concrete numbers that fired the rule so the
+// rendered plan can show "sized 14 eCKU > PNI cap 32" rather than an
+// opaque "rule fired".
+type HardLimit struct {
+	ID          string
+	Description string
+	Check       func(cfg *PlanConfig, inputs types.PlanInputsResolved, sizing types.ClusterSizing) (fired bool, evidence string)
+}
+
+// HardLimitCatalog enumerates the rules that escalate a cluster from
+// Enterprise to Dedicated. Only rules whose inputs are state-file-derived
+// today are listed — adding a rule without a real signal would let a
+// YAML toggle flip the verdict without evidence, undermining the
+// "deterministic from the state file" guarantee.
+var HardLimitCatalog = []HardLimit{
+	{
+		ID:          "eCKU_exceeds_pni_cap",
+		Description: "Sized eCKU exceeds Enterprise PNI cap",
+		Check: func(cfg *PlanConfig, _ types.PlanInputsResolved, sizing types.ClusterSizing) (bool, string) {
+			cap := cfg.EnterpriseCaps.PNIMaxECKU
+			if sizing.FinalECKU > cap {
+				return true, fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, cap)
+			}
+			return false, ""
+		},
+	},
+}
+
+// DecideClusterType returns the recommended Confluent Cloud cluster type
+// for one source cluster.
+//
+// Standard is intentionally not a verdict here: MSK migration workloads
+// benefit from Enterprise's elastic scaling and PrivateLink/PNI options
+// that Standard doesn't offer. The design pins Enterprise as the default;
+// hard-limit rules escalate to Dedicated when an Enterprise cap is
+// exceeded or a workload constraint can't be served on Enterprise.
+func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
+	var fired []types.HardLimitTrigger
+	for _, hl := range HardLimitCatalog {
+		if hl.Check == nil {
+			continue
+		}
+		ok, evidence := hl.Check(cfg, inputs, sizing)
+		if ok {
+			fired = append(fired, types.HardLimitTrigger{
+				RowID:       hl.ID,
+				Description: hl.Description,
+				Evidence:    evidence,
+			})
+		}
+	}
+
+	verdict := types.ClusterTypeEnterprise
+	if len(fired) > 0 {
+		verdict = types.ClusterTypeDedicated
+	}
+	return types.ClusterTypeDecision{ClusterID: c.Name, Verdict: verdict, Triggers: fired}
+}

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -6,66 +6,178 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
-// HardLimit is one row of the Enterprise → Dedicated escalation catalog.
-// Check is a Go function value (refactor-safe; compile-checked) that
-// compares the relevant Plan field against the cap in plan-config.yaml's
-// `enterprise_caps`. Returning true → Dedicated.
-//
-// Evidence carries the concrete numbers that fired the rule so the
-// rendered plan can show "sized 14 eCKU > PNI cap 32" rather than an
-// opaque "rule fired".
-type HardLimit struct {
-	ID          string
-	Description string
-	Check       func(cfg *PlanConfig, inputs types.PlanInputsResolved, sizing types.ClusterSizing) (fired bool, evidence string)
+// hardLimit is one row of the Enterprise → Dedicated escalation catalog.
+// Evidence carries the concrete values that fired the rule so the rendered
+// plan can show "sized 14 eCKU > PNI cap 32" rather than "rule fired".
+// CustomerDeclared marks rules whose only signal is a `plan-inputs.yaml`
+// flag — renderer surfaces a ⚠ cost callout for those.
+type hardLimit struct {
+	id               string
+	description      string
+	customerDeclared bool
+	check            func(cfg *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, sizing types.ClusterSizing) (fired bool, evidence string)
 }
 
-// HardLimitCatalog enumerates the rules that escalate a cluster from
-// Enterprise to Dedicated. Only rules whose inputs are state-file-derived
-// today are listed — adding a rule without a real signal would let a
-// YAML toggle flip the verdict without evidence, undermining the
-// "deterministic from the state file" guarantee.
-var HardLimitCatalog = []HardLimit{
+// Rule IDs — referenced by both the catalog and the topology logic.
+// Kept as constants so a typo in either site is a compile error rather
+// than a silently-skipped rule.
+const (
+	ruleECKUExceedsPNICap          = "eCKU_exceeds_pni_cap"
+	ruleACLCountExceedsCap         = "acl_count_exceeds_cap"
+	ruleBrokerSideSchemaValidation = "broker_side_schema_validation_required"
+	ruleRESTProduceHighThroughput  = "rest_produce_api_high_throughput"
+	ruleSLA9995SingleZone          = "sla_99_95_single_zone"
+	ruleMTLSOnNonAWSTarget         = "mtls_on_non_aws_target"
+)
+
+// hardLimitCatalog enumerates the rules that escalate a cluster from
+// Enterprise to Dedicated. Rules 1-2 are state-derived; rules 3-5 read
+// a `plan-inputs.yaml` flag and are marked customerDeclared; rule 6
+// combines source state with the plan-input `target_cloud`.
+var hardLimitCatalog = []hardLimit{
 	{
-		ID:          "eCKU_exceeds_pni_cap",
-		Description: "Sized eCKU exceeds Enterprise PNI cap",
-		Check: func(cfg *PlanConfig, _ types.PlanInputsResolved, sizing types.ClusterSizing) (bool, string) {
-			cap := cfg.EnterpriseCaps.PNIMaxECKU
-			if sizing.FinalECKU > cap {
-				return true, fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, cap)
+		id:          ruleECKUExceedsPNICap,
+		description: "Sized eCKU exceeds Enterprise PNI cap",
+		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, _ types.ProcessedCluster, sizing types.ClusterSizing) (bool, string) {
+			pniCap := cfg.EnterpriseCaps.PNIMaxECKU
+			if sizing.FinalECKU > pniCap {
+				return true, fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, pniCap)
 			}
 			return false, ""
 		},
 	},
+	{
+		id:          ruleACLCountExceedsCap,
+		description: "ACL count exceeds Enterprise cap",
+		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+			aclCap := cfg.EnterpriseCaps.ACLCountCap
+			if aclCap <= 0 {
+				return false, ""
+			}
+			acls := cluster.KafkaAdminClientInformation.Acls
+			// `null` (admin scan didn't run) is distinct from `0 ACLs` — skip
+			// rather than emit a wrong verdict.
+			if acls == nil {
+				return false, ""
+			}
+			if count := len(acls); count > aclCap {
+				return true, fmt.Sprintf("%d ACLs > Enterprise cap %d", count, aclCap)
+			}
+			return false, ""
+		},
+	},
+	{
+		id:               ruleBrokerSideSchemaValidation,
+		description:      "Broker-side schema ID validation required",
+		customerDeclared: true,
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+			if inputs.EnforceSchemasAtTheBroker {
+				return true, "`enforce_schemas_at_the_broker: true`"
+			}
+			return false, ""
+		},
+	},
+	{
+		id:               ruleRESTProduceHighThroughput,
+		description:      "High-throughput Kafka REST Produce v3 required",
+		customerDeclared: true,
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+			if inputs.RequiresHighThroughputRESTProduceAPI {
+				return true, "`requires_high_throughput_rest_produce_api: true`"
+			}
+			return false, ""
+		},
+	},
+	{
+		id:               ruleSLA9995SingleZone,
+		description:      "99.95% single-zone SLA required",
+		customerDeclared: true,
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+			if inputs.Requires9995SLAWithinSingleZone {
+				return true, "`requires_99_95_sla_within_a_single_zone: true`"
+			}
+			return false, ""
+		},
+	},
+	{
+		id:          ruleMTLSOnNonAWSTarget,
+		description: "Source uses mTLS, target is non-AWS",
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+			if !sourceUsesMTLS(cluster) {
+				return false, ""
+			}
+			target := inputs.TargetCloud
+			if target == "" {
+				target = "aws"
+			}
+			if target == "aws" {
+				return false, ""
+			}
+			return true, fmt.Sprintf("target_cloud=%q", target)
+		},
+	},
+}
+
+// sourceUsesMTLS reads `MskClusterConfig.Provisioned.ClientAuthentication.Tls.Enabled`
+// from `kcp scan clusters` output. Returns false when any layer is unpopulated
+// (the admin scan didn't run, or the cluster is OSK).
+func sourceUsesMTLS(c types.ProcessedCluster) bool {
+	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
+	if prov == nil || prov.ClientAuthentication == nil || prov.ClientAuthentication.Tls == nil {
+		return false
+	}
+	tls := prov.ClientAuthentication.Tls
+	return tls.Enabled != nil && *tls.Enabled
 }
 
 // DecideClusterType returns the recommended Confluent Cloud cluster type
 // for one source cluster.
 //
-// Standard is intentionally not a verdict here: MSK migration workloads
+// Standard is intentionally not a verdict: MSK migration workloads
 // benefit from Enterprise's elastic scaling and PrivateLink/PNI options
-// that Standard doesn't offer. The design pins Enterprise as the default;
-// hard-limit rules escalate to Dedicated when an Enterprise cap is
-// exceeded or a workload constraint can't be served on Enterprise.
+// that Standard doesn't offer. Enterprise is the default; hard-limit
+// rules escalate to Dedicated when a cap is exceeded or a workload
+// constraint can't be served on Enterprise.
 func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
 	var fired []types.HardLimitTrigger
-	for _, hl := range HardLimitCatalog {
-		if hl.Check == nil {
+	for _, hl := range hardLimitCatalog {
+		if hl.check == nil {
 			continue
 		}
-		ok, evidence := hl.Check(cfg, inputs, sizing)
+		ok, evidence := hl.check(cfg, inputs, c, sizing)
 		if ok {
 			fired = append(fired, types.HardLimitTrigger{
-				RowID:       hl.ID,
-				Description: hl.Description,
-				Evidence:    evidence,
+				RowID:            hl.id,
+				Description:      hl.description,
+				Evidence:         evidence,
+				CustomerDeclared: hl.customerDeclared,
 			})
 		}
 	}
 
 	verdict := types.ClusterTypeEnterprise
+	topology := types.TopologyNotApplicable
+	var finalCKU *int
 	if len(fired) > 0 {
 		verdict = types.ClusterTypeDedicated
+		// Single-Zone wins when the 99.95% SLA rule fires; otherwise
+		// Multi-Zone is the Dedicated default.
+		topology = types.TopologyMultiZone
+		for _, t := range fired {
+			if t.RowID == ruleSLA9995SingleZone {
+				topology = types.TopologySingleZone
+				break
+			}
+		}
+		// Dedicated tier is sized in CKU. Same number as eCKU, different unit.
+		cku := sizing.FinalECKU
+		finalCKU = &cku
 	}
-	return types.ClusterTypeDecision{ClusterID: c.Name, Verdict: verdict, Triggers: fired}
+	return types.ClusterTypeDecision{
+		ClusterID: c.Name,
+		Verdict:   verdict,
+		Triggers:  fired,
+		Topology:  topology,
+		FinalCKU:  finalCKU,
+	}
 }

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -1,0 +1,39 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecideClusterType_DefaultEnterprise(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
+	d := DecideClusterType(types.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
+	assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+	assert.Empty(t, d.Triggers)
+}
+
+func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
+	cfg := defaultCfg(t)
+	// pni_max_eCKU = 32; size at 33 to fire the rule.
+	sizing := types.ClusterSizing{ClusterID: "huge", FinalECKU: 33}
+	d := DecideClusterType(types.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
+	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+	assert.Len(t, d.Triggers, 1)
+	assert.Equal(t, "eCKU_exceeds_pni_cap", d.Triggers[0].RowID)
+	assert.Contains(t, d.Triggers[0].Evidence, "33 eCKU")
+	assert.Contains(t, d.Triggers[0].Evidence, "32 eCKU")
+}
+
+func TestHardLimitCatalogIsWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, hl := range HardLimitCatalog {
+		assert.NotEmpty(t, hl.ID)
+		assert.NotEmpty(t, hl.Description)
+		assert.NotNil(t, hl.Check, "all listed rules must be wired (no nil Check until the input is real)")
+		assert.False(t, seen[hl.ID], "duplicate ID %q", hl.ID)
+		seen[hl.ID] = true
+	}
+}

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -3,8 +3,10 @@ package plan
 import (
 	"testing"
 
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecideClusterType_DefaultEnterprise(t *testing.T) {
@@ -27,13 +29,168 @@ func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 	assert.Contains(t, d.Triggers[0].Evidence, "32 eCKU")
 }
 
+func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
+	cfg := defaultCfg(t)
+	// acl_count_cap = 4000; emit 4001 ACLs.
+	acls := make([]types.Acls, 4001)
+	c := types.ProcessedCluster{Name: "many-acls"}
+	c.KafkaAdminClientInformation.Acls = acls
+	sizing := types.ClusterSizing{ClusterID: "many-acls", FinalECKU: 5}
+
+	d := DecideClusterType(c, sizing, cfg, defaultInputs())
+	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+	assert.Len(t, d.Triggers, 1)
+	assert.Equal(t, "acl_count_exceeds_cap", d.Triggers[0].RowID)
+	assert.Contains(t, d.Triggers[0].Evidence, "4001")
+	assert.False(t, d.Triggers[0].CustomerDeclared, "state-derived rules must not carry the cost-callout marker")
+}
+
+func TestDecideClusterType_ACLRuleSkippedWhenNilACLs(t *testing.T) {
+	// `null` (admin scan didn't run) is distinct from `0 ACLs`.
+	cfg := defaultCfg(t)
+	c := types.ProcessedCluster{Name: "no-admin-scan"}
+	c.KafkaAdminClientInformation.Acls = nil
+	sizing := types.ClusterSizing{ClusterID: "no-admin-scan", FinalECKU: 5}
+
+	d := DecideClusterType(c, sizing, cfg, defaultInputs())
+	assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip the rule, not fire it")
+}
+
+func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "small", FinalECKU: 5}
+	c := types.ProcessedCluster{Name: "small"}
+
+	cases := []struct {
+		name        string
+		mutator     func(*types.PlanInputsResolved)
+		ruleID      string
+		evidenceHas string // substring the evidence must name (the flag, not just its value)
+	}{
+		{
+			name:        "broker-side schema validation forces Dedicated",
+			mutator:     func(in *types.PlanInputsResolved) { in.EnforceSchemasAtTheBroker = true },
+			ruleID:      ruleBrokerSideSchemaValidation,
+			evidenceHas: "enforce_schemas_at_the_broker",
+		},
+		{
+			name:        "REST Produce v3 high-throughput forces Dedicated",
+			mutator:     func(in *types.PlanInputsResolved) { in.RequiresHighThroughputRESTProduceAPI = true },
+			ruleID:      ruleRESTProduceHighThroughput,
+			evidenceHas: "requires_high_throughput_rest_produce_api",
+		},
+		{
+			name:        "99.95 single-zone SLA forces Dedicated",
+			mutator:     func(in *types.PlanInputsResolved) { in.Requires9995SLAWithinSingleZone = true },
+			ruleID:      ruleSLA9995SingleZone,
+			evidenceHas: "requires_99_95_sla_within_a_single_zone",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := defaultInputs()
+			tc.mutator(&in)
+			d := DecideClusterType(c, sizing, cfg, in)
+			assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+			assert.Len(t, d.Triggers, 1)
+			assert.Equal(t, tc.ruleID, d.Triggers[0].RowID)
+			assert.True(t, d.Triggers[0].CustomerDeclared, "customer-declared rules must carry the cost-callout marker")
+			assert.Contains(t, d.Triggers[0].Evidence, tc.evidenceHas, "evidence must name the flag the customer flipped")
+		})
+	}
+}
+
+func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "mtls", FinalECKU: 5}
+	enabled := true
+	c := types.ProcessedCluster{Name: "mtls"}
+	c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{
+		ClientAuthentication: &kafkatypes.ClientAuthentication{
+			Tls: &kafkatypes.Tls{Enabled: &enabled},
+		},
+	}
+
+	t.Run("aws target leaves Enterprise", func(t *testing.T) {
+		in := defaultInputs()
+		in.TargetCloud = "aws"
+		d := DecideClusterType(c, sizing, cfg, in)
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+	})
+
+	t.Run("azure target forces Dedicated", func(t *testing.T) {
+		in := defaultInputs()
+		in.TargetCloud = "azure"
+		d := DecideClusterType(c, sizing, cfg, in)
+		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+		assert.Len(t, d.Triggers, 1)
+		assert.Equal(t, "mtls_on_non_aws_target", d.Triggers[0].RowID)
+		assert.False(t, d.Triggers[0].CustomerDeclared, "mTLS rule is state-derived, not a wrong-click risk")
+	})
+
+	t.Run("no mTLS source — rule skipped regardless of target", func(t *testing.T) {
+		c2 := types.ProcessedCluster{Name: "scram"}
+		in := defaultInputs()
+		in.TargetCloud = "gcp"
+		d := DecideClusterType(c2, sizing, cfg, in)
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+	})
+}
+
+func TestDecideClusterType_Topology(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 4}
+	c := types.ProcessedCluster{Name: "x"}
+
+	t.Run("Enterprise verdict has no topology", func(t *testing.T) {
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+		assert.Equal(t, types.TopologyNotApplicable, d.Topology)
+		assert.Nil(t, d.FinalCKU, "Enterprise clusters are sized in eCKU only — no FinalCKU mirror")
+	})
+
+	t.Run("Dedicated via eCKU cap → Multi-Zone", func(t *testing.T) {
+		big := types.ClusterSizing{ClusterID: "big", FinalECKU: 33}
+		d := DecideClusterType(c, big, cfg, defaultInputs())
+		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, types.TopologyMultiZone, d.Topology)
+		require.NotNil(t, d.FinalCKU)
+		assert.Equal(t, 33, *d.FinalCKU, "FinalCKU mirrors the sizing's FinalECKU value")
+	})
+
+	t.Run("Dedicated via 99.95 single-zone SLA → Single-Zone", func(t *testing.T) {
+		in := defaultInputs()
+		in.Requires9995SLAWithinSingleZone = true
+		d := DecideClusterType(c, sizing, cfg, in)
+		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, types.TopologySingleZone, d.Topology)
+		require.NotNil(t, d.FinalCKU)
+		assert.Equal(t, 4, *d.FinalCKU)
+	})
+
+	t.Run("rule 5 wins topology when combined with other rules", func(t *testing.T) {
+		// 99.95 SLA flag + ACL-cap exceeded → both rules fire; topology
+		// must escalate to Single-Zone (more restrictive).
+		acls := make([]types.Acls, 4001)
+		c2 := types.ProcessedCluster{Name: "combo"}
+		c2.KafkaAdminClientInformation.Acls = acls
+		in := defaultInputs()
+		in.Requires9995SLAWithinSingleZone = true
+		d := DecideClusterType(c2, sizing, cfg, in)
+		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, types.TopologySingleZone, d.Topology)
+		assert.GreaterOrEqual(t, len(d.Triggers), 2, "both rules should have fired")
+	})
+}
+
 func TestHardLimitCatalogIsWellFormed(t *testing.T) {
 	seen := map[string]bool{}
-	for _, hl := range HardLimitCatalog {
-		assert.NotEmpty(t, hl.ID)
-		assert.NotEmpty(t, hl.Description)
-		assert.NotNil(t, hl.Check, "all listed rules must be wired (no nil Check until the input is real)")
-		assert.False(t, seen[hl.ID], "duplicate ID %q", hl.ID)
-		seen[hl.ID] = true
+	for _, hl := range hardLimitCatalog {
+		assert.NotEmpty(t, hl.id)
+		assert.NotEmpty(t, hl.description)
+		assert.NotNil(t, hl.check, "all listed rules must be wired (no nil check until the input is real)")
+		assert.False(t, seen[hl.id], "duplicate id %q", hl.id)
+		seen[hl.id] = true
 	}
 }

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -82,17 +82,33 @@ func (c *PlanConfig) Validate() error {
 	if c.SchemaVersion != ExpectedSchemaVersion {
 		return fmt.Errorf("plan-config schema_version %d does not match expected %d", c.SchemaVersion, ExpectedSchemaVersion)
 	}
-	if c.EnterpriseCaps.PerECKUIngressMBps == 0 {
-		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_ingress_mbps is required")
+	caps := c.EnterpriseCaps
+	if caps.PerECKUIngressMBps <= 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_ingress_mbps must be > 0")
 	}
-	if c.EnterpriseCaps.PerECKUEgressMBps == 0 {
-		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_egress_mbps is required")
+	if caps.PerECKUEgressMBps <= 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_egress_mbps must be > 0")
 	}
-	if c.EnterpriseCaps.PerECKUPartitionRate == 0 {
-		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_partition_rate is required")
+	if caps.PerECKUPartitionRate <= 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_partition_rate must be > 0")
 	}
-	if c.EnterpriseCaps.PrivateLinkMaxECKU == 0 {
-		return fmt.Errorf("plan-config enterprise_caps.privatelink_max_eCKU is required")
+	if caps.PrivateLinkMaxECKU <= 0 {
+		return fmt.Errorf("plan-config enterprise_caps.privatelink_max_eCKU must be > 0")
+	}
+	// pni_max_eCKU is load-bearing for the Enterprise→Dedicated rule; a 0
+	// here would force every non-zero FinalECKU to trip the cap.
+	if caps.PNIMaxECKU <= 0 {
+		return fmt.Errorf("plan-config enterprise_caps.pni_max_eCKU must be > 0")
+	}
+	defaults := c.PlanInputDefaults
+	if defaults.HeadroomFraction < 0 || defaults.HeadroomFraction > 1 {
+		return fmt.Errorf("plan-config plan_input_defaults.headroom_fraction must be in [0, 1] (got %v)", defaults.HeadroomFraction)
+	}
+	if defaults.PrivateLinkSafetyThreshold <= 0 || defaults.PrivateLinkSafetyThreshold > 1 {
+		return fmt.Errorf("plan-config plan_input_defaults.privatelink_safety_threshold must be in (0, 1] (got %v)", defaults.PrivateLinkSafetyThreshold)
+	}
+	if defaults.SpikyWorkloadRatio <= 1 {
+		return fmt.Errorf("plan-config plan_input_defaults.spiky_workload_ratio must be > 1 (got %v) — a spike must be larger than the baseline", defaults.SpikyWorkloadRatio)
 	}
 	return nil
 }

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -1,0 +1,98 @@
+package plan
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+
+	"github.com/goccy/go-yaml"
+)
+
+//go:embed plan-config.yaml
+var embeddedPlanConfig []byte
+
+// ExpectedSchemaVersion is the schema_version this loader understands.
+// Bump in lockstep with breaking YAML structure changes.
+const ExpectedSchemaVersion = 1
+
+// PlanConfig is the deserialized plan-config.yaml. The embedded copy is
+// the default; an admin-supplied override file replaces only the fields
+// it specifies (standard yaml unmarshal semantics — slices replace whole,
+// maps merge by key).
+type PlanConfig struct {
+	SchemaVersion            int    `yaml:"schema_version"`
+	LastVerified             string `yaml:"last_verified"`
+	KCPVersionAtVerification string `yaml:"kcp_version_at_verification"`
+
+	EnterpriseCaps    EnterpriseCaps    `yaml:"enterprise_caps"`
+	ClusterLinking    ClusterLinking    `yaml:"cluster_linking"`
+	PlanInputDefaults PlanInputDefaults `yaml:"plan_input_defaults"`
+}
+
+type EnterpriseCaps struct {
+	PerECKUIngressMBps   int    `yaml:"per_eCKU_ingress_mbps"`
+	PerECKUEgressMBps    int    `yaml:"per_eCKU_egress_mbps"`
+	PerECKUPartitionRate int    `yaml:"per_eCKU_partition_rate"`
+	PrivateLinkMaxECKU   int    `yaml:"privatelink_max_eCKU"`
+	PNIMaxECKU           int    `yaml:"pni_max_eCKU"`
+	ACLCountCap          int    `yaml:"acl_count_cap"`
+	Source               string `yaml:"source"`
+}
+
+type ClusterLinking struct {
+	SourceMinKafkaVersion string `yaml:"source_min_kafka_version"`
+	ExpressTierSupported  string `yaml:"express_tier_supported"`
+	Source                string `yaml:"source"`
+}
+
+type PlanInputDefaults struct {
+	SizingPercentile           string         `yaml:"sizing_percentile"`
+	HeadroomFraction           float64        `yaml:"headroom_fraction"`
+	PrivateLinkSafetyThreshold float64        `yaml:"privatelink_safety_threshold"`
+	SpikyWorkloadRatio         float64        `yaml:"spiky_workload_ratio"`
+	SLAFloorECKU               map[string]int `yaml:"sla_floor_eCKU"`
+}
+
+// LoadPlanConfig returns the embedded plan-config.yaml, optionally
+// overridden by the file at overridePath. Pass an empty string to skip
+// the override.
+func LoadPlanConfig(overridePath string) (*PlanConfig, error) {
+	cfg := &PlanConfig{}
+	if err := yaml.Unmarshal(embeddedPlanConfig, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse embedded plan-config.yaml: %w", err)
+	}
+
+	if overridePath != "" {
+		data, err := os.ReadFile(overridePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read plan-config override %s: %w", overridePath, err)
+		}
+		if err := yaml.Unmarshal(data, cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse plan-config override %s: %w", overridePath, err)
+		}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (c *PlanConfig) Validate() error {
+	if c.SchemaVersion != ExpectedSchemaVersion {
+		return fmt.Errorf("plan-config schema_version %d does not match expected %d", c.SchemaVersion, ExpectedSchemaVersion)
+	}
+	if c.EnterpriseCaps.PerECKUIngressMBps == 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_ingress_mbps is required")
+	}
+	if c.EnterpriseCaps.PerECKUEgressMBps == 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_egress_mbps is required")
+	}
+	if c.EnterpriseCaps.PerECKUPartitionRate == 0 {
+		return fmt.Errorf("plan-config enterprise_caps.per_eCKU_partition_rate is required")
+	}
+	if c.EnterpriseCaps.PrivateLinkMaxECKU == 0 {
+		return fmt.Errorf("plan-config enterprise_caps.privatelink_max_eCKU is required")
+	}
+	return nil
+}

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -51,6 +51,15 @@ type PlanInputDefaults struct {
 	PrivateLinkSafetyThreshold float64        `yaml:"privatelink_safety_threshold"`
 	SpikyWorkloadRatio         float64        `yaml:"spiky_workload_ratio"`
 	SLAFloorECKU               map[string]int `yaml:"sla_floor_eCKU"`
+
+	// Customer-declared hard requirements (all default false).
+	EnforceSchemasAtTheBroker            bool `yaml:"enforce_schemas_at_the_broker"`
+	RequiresHighThroughputRESTProduceAPI bool `yaml:"requires_high_throughput_rest_produce_api"`
+	Requires9995SLAWithinSingleZone      bool `yaml:"requires_99_95_sla_within_a_single_zone"`
+
+	// Target cloud + existing VPC connectivity (Dedicated-path networking).
+	TargetCloud             string `yaml:"target_cloud"`
+	ExistingVPCConnectivity string `yaml:"existing_vpc_connectivity"`
 }
 
 // LoadPlanConfig returns the embedded plan-config.yaml, optionally

--- a/internal/services/plan/config_test.go
+++ b/internal/services/plan/config_test.go
@@ -19,7 +19,7 @@ func TestLoadPlanConfigEmbedded(t *testing.T) {
 	assert.Equal(t, 3000, cfg.EnterpriseCaps.PerECKUPartitionRate)
 	assert.Equal(t, 10, cfg.EnterpriseCaps.PrivateLinkMaxECKU)
 	assert.Equal(t, 32, cfg.EnterpriseCaps.PNIMaxECKU)
-	assert.Equal(t, "P95", cfg.PlanInputDefaults.SizingPercentile)
+	assert.Equal(t, "p95", cfg.PlanInputDefaults.SizingPercentile)
 	assert.InDelta(t, 0.30, cfg.PlanInputDefaults.HeadroomFraction, 0.0001)
 	assert.InDelta(t, 0.80, cfg.PlanInputDefaults.PrivateLinkSafetyThreshold, 0.0001)
 }
@@ -36,7 +36,7 @@ plan_input_defaults:
 	require.NoError(t, err)
 	assert.InDelta(t, 0.45, cfg.PlanInputDefaults.HeadroomFraction, 0.0001)
 	// Untouched defaults keep embedded values.
-	assert.Equal(t, "P95", cfg.PlanInputDefaults.SizingPercentile)
+	assert.Equal(t, "p95", cfg.PlanInputDefaults.SizingPercentile)
 	assert.Equal(t, 60, cfg.EnterpriseCaps.PerECKUIngressMBps)
 }
 

--- a/internal/services/plan/config_test.go
+++ b/internal/services/plan/config_test.go
@@ -1,0 +1,67 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPlanConfigEmbedded(t *testing.T) {
+	cfg, err := LoadPlanConfig("")
+	require.NoError(t, err)
+
+	assert.Equal(t, ExpectedSchemaVersion, cfg.SchemaVersion)
+	assert.Equal(t, 60, cfg.EnterpriseCaps.PerECKUIngressMBps)
+	assert.Equal(t, 180, cfg.EnterpriseCaps.PerECKUEgressMBps)
+	assert.Equal(t, 3000, cfg.EnterpriseCaps.PerECKUPartitionRate)
+	assert.Equal(t, 10, cfg.EnterpriseCaps.PrivateLinkMaxECKU)
+	assert.Equal(t, 32, cfg.EnterpriseCaps.PNIMaxECKU)
+	assert.Equal(t, "P95", cfg.PlanInputDefaults.SizingPercentile)
+	assert.InDelta(t, 0.30, cfg.PlanInputDefaults.HeadroomFraction, 0.0001)
+	assert.InDelta(t, 0.80, cfg.PlanInputDefaults.PrivateLinkSafetyThreshold, 0.0001)
+}
+
+func TestLoadPlanConfigOverride(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "override.yaml")
+	require.NoError(t, os.WriteFile(overridePath, []byte(`
+plan_input_defaults:
+  headroom_fraction: 0.45
+`), 0o644))
+
+	cfg, err := LoadPlanConfig(overridePath)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.45, cfg.PlanInputDefaults.HeadroomFraction, 0.0001)
+	// Untouched defaults keep embedded values.
+	assert.Equal(t, "P95", cfg.PlanInputDefaults.SizingPercentile)
+	assert.Equal(t, 60, cfg.EnterpriseCaps.PerECKUIngressMBps)
+}
+
+func TestLoadPlanConfigErrors(t *testing.T) {
+	t.Run("malformed YAML returns useful error", func(t *testing.T) {
+		dir := t.TempDir()
+		bad := filepath.Join(dir, "bad.yaml")
+		require.NoError(t, os.WriteFile(bad, []byte("plan_input_defaults: [oops"), 0o644))
+		_, err := LoadPlanConfig(bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse plan-config override")
+	})
+
+	t.Run("missing override file is wrapped", func(t *testing.T) {
+		_, err := LoadPlanConfig("/no/such/path/x.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read plan-config override")
+	})
+
+	t.Run("schema_version mismatch rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "x.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("schema_version: 99\n"), 0o644))
+		_, err := LoadPlanConfig(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema_version 99 does not match expected 1")
+	})
+}

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -1,0 +1,65 @@
+package plan
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/goccy/go-yaml"
+)
+
+const defaultSLATarget = "99.9"
+
+// LoadPlanInputs reads plan-inputs.yaml. Returns nil *PlanInputs if path
+// is empty (no file supplied is a valid state — the Plan still generates
+// from defaults). Missing fields never fail because no field is required
+// at the YAML schema level.
+func LoadPlanInputs(path string) (*types.PlanInputs, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read plan-inputs %s: %w", path, err)
+	}
+	var in types.PlanInputs
+	if err := yaml.Unmarshal(data, &in); err != nil {
+		return nil, fmt.Errorf("failed to parse plan-inputs %s: %w", path, err)
+	}
+	return &in, nil
+}
+
+// ResolvePlanInputs merges customer-supplied PlanInputs with pinned
+// defaults from PlanConfig. Customer-set fields win; everything else
+// falls back to PlanConfig.PlanInputDefaults. Raw is preserved so
+// downstream consumers can detect which fields the customer explicitly
+// set (e.g. the hard-limit catalog reads Raw.Requires9995SingleZoneSLA).
+func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsResolved {
+	out := types.PlanInputsResolved{
+		Raw:                        in,
+		SizingPercentile:           cfg.PlanInputDefaults.SizingPercentile,
+		HeadroomFraction:           cfg.PlanInputDefaults.HeadroomFraction,
+		PrivateLinkSafetyThreshold: cfg.PlanInputDefaults.PrivateLinkSafetyThreshold,
+		SpikyWorkloadRatio:         cfg.PlanInputDefaults.SpikyWorkloadRatio,
+		SLATarget:                  defaultSLATarget,
+	}
+	if in == nil {
+		return out
+	}
+	if in.SLATarget != nil {
+		out.SLATarget = *in.SLATarget
+	}
+	if in.SizingPercentile != nil {
+		out.SizingPercentile = *in.SizingPercentile
+	}
+	if in.HeadroomFraction != nil {
+		out.HeadroomFraction = *in.HeadroomFraction
+	}
+	if in.PrivateLinkSafetyThreshold != nil {
+		out.PrivateLinkSafetyThreshold = *in.PrivateLinkSafetyThreshold
+	}
+	if in.SpikyWorkloadRatio != nil {
+		out.SpikyWorkloadRatio = *in.SpikyWorkloadRatio
+	}
+	return out
+}

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -32,8 +32,8 @@ func LoadPlanInputs(path string) (*types.PlanInputs, error) {
 // ResolvePlanInputs merges customer-supplied PlanInputs with pinned
 // defaults from PlanConfig. Customer-set fields win; everything else
 // falls back to PlanConfig.PlanInputDefaults. Raw is preserved so
-// downstream consumers can detect which fields the customer explicitly
-// set (e.g. the hard-limit catalog reads Raw.Requires9995SingleZoneSLA).
+// downstream consumers can detect which sizing fields the customer
+// explicitly set (HeadroomFraction, SLATarget, SizingPercentile, etc.).
 func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsResolved {
 	out := types.PlanInputsResolved{
 		Raw:                        in,

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -35,13 +35,19 @@ func LoadPlanInputs(path string) (*types.PlanInputs, error) {
 // downstream consumers can detect which sizing fields the customer
 // explicitly set (HeadroomFraction, SLATarget, SizingPercentile, etc.).
 func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsResolved {
+	defaults := cfg.PlanInputDefaults
 	out := types.PlanInputsResolved{
-		Raw:                        in,
-		SizingPercentile:           cfg.PlanInputDefaults.SizingPercentile,
-		HeadroomFraction:           cfg.PlanInputDefaults.HeadroomFraction,
-		PrivateLinkSafetyThreshold: cfg.PlanInputDefaults.PrivateLinkSafetyThreshold,
-		SpikyWorkloadRatio:         cfg.PlanInputDefaults.SpikyWorkloadRatio,
-		SLATarget:                  defaultSLATarget,
+		Raw:                                  in,
+		SizingPercentile:                     defaults.SizingPercentile,
+		HeadroomFraction:                     defaults.HeadroomFraction,
+		PrivateLinkSafetyThreshold:           defaults.PrivateLinkSafetyThreshold,
+		SpikyWorkloadRatio:                   defaults.SpikyWorkloadRatio,
+		SLATarget:                            defaultSLATarget,
+		EnforceSchemasAtTheBroker:            defaults.EnforceSchemasAtTheBroker,
+		RequiresHighThroughputRESTProduceAPI: defaults.RequiresHighThroughputRESTProduceAPI,
+		Requires9995SLAWithinSingleZone:      defaults.Requires9995SLAWithinSingleZone,
+		TargetCloud:                          defaults.TargetCloud,
+		ExistingVPCConnectivity:              defaults.ExistingVPCConnectivity,
 	}
 	if in == nil {
 		return out
@@ -60,6 +66,21 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	}
 	if in.SpikyWorkloadRatio != nil {
 		out.SpikyWorkloadRatio = *in.SpikyWorkloadRatio
+	}
+	if in.EnforceSchemasAtTheBroker != nil {
+		out.EnforceSchemasAtTheBroker = *in.EnforceSchemasAtTheBroker
+	}
+	if in.RequiresHighThroughputRESTProduceAPI != nil {
+		out.RequiresHighThroughputRESTProduceAPI = *in.RequiresHighThroughputRESTProduceAPI
+	}
+	if in.Requires9995SLAWithinSingleZone != nil {
+		out.Requires9995SLAWithinSingleZone = *in.Requires9995SLAWithinSingleZone
+	}
+	if in.TargetCloud != nil {
+		out.TargetCloud = *in.TargetCloud
+	}
+	if in.ExistingVPCConnectivity != nil {
+		out.ExistingVPCConnectivity = *in.ExistingVPCConnectivity
 	}
 	return out
 }

--- a/internal/services/plan/inputs_test.go
+++ b/internal/services/plan/inputs_test.go
@@ -58,7 +58,7 @@ func TestResolvePlanInputsDefaults(t *testing.T) {
 	t.Run("nil inputs yields defaults from plan-config", func(t *testing.T) {
 		resolved := ResolvePlanInputs(nil, cfg)
 		assert.Nil(t, resolved.Raw)
-		assert.Equal(t, "P95", resolved.SizingPercentile)
+		assert.Equal(t, "p95", resolved.SizingPercentile)
 		assert.InDelta(t, 0.30, resolved.HeadroomFraction, 0.0001)
 		assert.InDelta(t, 0.80, resolved.PrivateLinkSafetyThreshold, 0.0001)
 		assert.InDelta(t, 2.0, resolved.SpikyWorkloadRatio, 0.0001)
@@ -73,7 +73,7 @@ func TestResolvePlanInputsDefaults(t *testing.T) {
 		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001)
 		assert.Equal(t, "99.95", resolved.SLATarget)
 		// Untouched defaults persist.
-		assert.Equal(t, "P95", resolved.SizingPercentile)
+		assert.Equal(t, "p95", resolved.SizingPercentile)
 		// Raw preserves the pointer.
 		assert.Same(t, in, resolved.Raw)
 	})

--- a/internal/services/plan/inputs_test.go
+++ b/internal/services/plan/inputs_test.go
@@ -1,0 +1,80 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPlanInputsEmptyPath(t *testing.T) {
+	in, err := LoadPlanInputs("")
+	require.NoError(t, err)
+	assert.Nil(t, in)
+}
+
+func TestLoadPlanInputsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan-inputs.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+sla_target: "99.95"
+sizing_percentile: P95
+headroom_fraction: 0.45
+spiky_workload_ratio: 2.5
+`), 0o644))
+
+	in, err := LoadPlanInputs(path)
+	require.NoError(t, err)
+	require.NotNil(t, in)
+	assert.Equal(t, "99.95", *in.SLATarget)
+	assert.InDelta(t, 0.45, *in.HeadroomFraction, 0.0001)
+	assert.InDelta(t, 2.5, *in.SpikyWorkloadRatio, 0.0001)
+}
+
+func TestLoadPlanInputsErrors(t *testing.T) {
+	t.Run("missing file is wrapped", func(t *testing.T) {
+		_, err := LoadPlanInputs("/no/such/inputs.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read plan-inputs")
+	})
+
+	t.Run("malformed YAML is wrapped", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("headroom_fraction: [oops"), 0o644))
+		_, err := LoadPlanInputs(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse plan-inputs")
+	})
+}
+
+func TestResolvePlanInputsDefaults(t *testing.T) {
+	cfg, err := LoadPlanConfig("")
+	require.NoError(t, err)
+
+	t.Run("nil inputs yields defaults from plan-config", func(t *testing.T) {
+		resolved := ResolvePlanInputs(nil, cfg)
+		assert.Nil(t, resolved.Raw)
+		assert.Equal(t, "P95", resolved.SizingPercentile)
+		assert.InDelta(t, 0.30, resolved.HeadroomFraction, 0.0001)
+		assert.InDelta(t, 0.80, resolved.PrivateLinkSafetyThreshold, 0.0001)
+		assert.InDelta(t, 2.0, resolved.SpikyWorkloadRatio, 0.0001)
+		assert.Equal(t, "99.9", resolved.SLATarget)
+	})
+
+	t.Run("customer values override defaults", func(t *testing.T) {
+		hf := 0.45
+		sla := "99.95"
+		in := &types.PlanInputs{HeadroomFraction: &hf, SLATarget: &sla}
+		resolved := ResolvePlanInputs(in, cfg)
+		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001)
+		assert.Equal(t, "99.95", resolved.SLATarget)
+		// Untouched defaults persist.
+		assert.Equal(t, "P95", resolved.SizingPercentile)
+		// Raw preserves the pointer.
+		assert.Same(t, in, resolved.Raw)
+	})
+}

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -6,22 +6,56 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
-// DecideNetworking applies the safety threshold for PrivateLink vs PNI.
+// Customer-set values of `existing_vpc_connectivity` that select a
+// Dedicated-only networking option matching the customer's current MSK
+// topology (path of least resistance).
+const (
+	vpcConnectivityTransitGateway = "transit_gateway"
+	vpcConnectivityVPCPeering     = "vpc_peering"
+)
+
+// DecideNetworking picks the Confluent Cloud networking product for one
+// cluster.
 //
-//	Dedicated → PNI
-//	Else PrivateLink if peak_burst_eCKU < threshold * privatelink_max_eCKU
-//	Else PNI
+//	Dedicated + existing_vpc_connectivity == transit_gateway → Transit Gateway
+//	Dedicated + existing_vpc_connectivity == vpc_peering     → VPC Peering
+//	Dedicated (otherwise)                                    → PNI
+//	Enterprise + peak_burst < threshold × privatelink_max_eCKU → PrivateLink
+//	Enterprise (otherwise)                                   → PNI
+//
+// `existing_vpc_connectivity` is only honored on the Dedicated path —
+// Transit Gateway and VPC Peering are Dedicated-only products. On
+// Enterprise the PrivateLink-vs-PNI flip remains driven by the safety
+// threshold.
 func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
 	caps := cfg.EnterpriseCaps
 	threshold := inputs.PrivateLinkSafetyThreshold
 
 	if ct.Verdict == types.ClusterTypeDedicated {
+		switch inputs.ExistingVPCConnectivity {
+		case vpcConnectivityTransitGateway:
+			return types.NetworkingDecision{
+				ClusterID:       sizing.ClusterID,
+				Verdict:         types.NetworkingTransitGateway,
+				PeakBurstECKU:   sizing.PeakBurstECKU,
+				PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+				Reason:          "Dedicated cluster + existing_vpc_connectivity=transit_gateway — match the customer's source topology",
+			}
+		case vpcConnectivityVPCPeering:
+			return types.NetworkingDecision{
+				ClusterID:       sizing.ClusterID,
+				Verdict:         types.NetworkingVPCPeering,
+				PeakBurstECKU:   sizing.PeakBurstECKU,
+				PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+				Reason:          "Dedicated cluster + existing_vpc_connectivity=vpc_peering — match the customer's source topology",
+			}
+		}
 		return types.NetworkingDecision{
 			ClusterID:       sizing.ClusterID,
 			Verdict:         types.NetworkingPNI,
 			PeakBurstECKU:   sizing.PeakBurstECKU,
 			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-			Reason:          "Dedicated cluster — PNI required",
+			Reason:          "Dedicated cluster — PNI required (no TGW / VPC Peering override)",
 		}
 	}
 
@@ -32,7 +66,7 @@ func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, 
 			Verdict:         types.NetworkingPrivateLink,
 			PeakBurstECKU:   sizing.PeakBurstECKU,
 			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-			Reason:          fmt.Sprintf("Peak burst %d eCKU below %.0f%% of %d eCKU PrivateLink cap", sizing.PeakBurstECKU, threshold*100, caps.PrivateLinkMaxECKU),
+			Reason:          fmt.Sprintf("peak burst %d eCKU = %.0f%% of PrivateLink's %d eCKU cap (safety threshold %.0f%%)", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, caps.PrivateLinkMaxECKU, threshold*100),
 		}
 	}
 	return types.NetworkingDecision{
@@ -40,6 +74,6 @@ func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, 
 		Verdict:         types.NetworkingPNI,
 		PeakBurstECKU:   sizing.PeakBurstECKU,
 		PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-		Reason:          fmt.Sprintf("Peak burst %d eCKU at %.0f%% of PrivateLink cap — exceeds %.0f%% safety threshold", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, threshold*100),
+		Reason:          fmt.Sprintf("peak burst %d eCKU = %.0f%% of PrivateLink's %d eCKU cap, over the %.0f%% safety threshold", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, caps.PrivateLinkMaxECKU, threshold*100),
 	}
 }

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -1,0 +1,45 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// DecideNetworking applies the safety threshold for PrivateLink vs PNI.
+//
+//	Dedicated → PNI
+//	Else PrivateLink if peak_burst_eCKU < threshold * privatelink_max_eCKU
+//	Else PNI
+func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
+	caps := cfg.EnterpriseCaps
+	threshold := inputs.PrivateLinkSafetyThreshold
+
+	if ct.Verdict == types.ClusterTypeDedicated {
+		return types.NetworkingDecision{
+			ClusterID:       sizing.ClusterID,
+			Verdict:         types.NetworkingPNI,
+			PeakBurstECKU:   sizing.PeakBurstECKU,
+			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+			Reason:          "Dedicated cluster — PNI required",
+		}
+	}
+
+	thresholdECKU := threshold * float64(caps.PrivateLinkMaxECKU)
+	if float64(sizing.PeakBurstECKU) < thresholdECKU {
+		return types.NetworkingDecision{
+			ClusterID:       sizing.ClusterID,
+			Verdict:         types.NetworkingPrivateLink,
+			PeakBurstECKU:   sizing.PeakBurstECKU,
+			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+			Reason:          fmt.Sprintf("Peak burst %d eCKU below %.0f%% of %d eCKU PrivateLink cap", sizing.PeakBurstECKU, threshold*100, caps.PrivateLinkMaxECKU),
+		}
+	}
+	return types.NetworkingDecision{
+		ClusterID:       sizing.ClusterID,
+		Verdict:         types.NetworkingPNI,
+		PeakBurstECKU:   sizing.PeakBurstECKU,
+		PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+		Reason:          fmt.Sprintf("Peak burst %d eCKU at %.0f%% of PrivateLink cap — exceeds %.0f%% safety threshold", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, threshold*100),
+	}
+}

--- a/internal/services/plan/networking_test.go
+++ b/internal/services/plan/networking_test.go
@@ -7,13 +7,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDecideNetworking_DedicatedAlwaysPNI(t *testing.T) {
+func TestDecideNetworking_DedicatedDefaultsToPNI(t *testing.T) {
+	// Dedicated + no `existing_vpc_connectivity` override → PNI.
 	cfg := defaultCfg(t)
 	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
 	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 	assert.Contains(t, d.Reason, "Dedicated")
+}
+
+func TestDecideNetworking_DedicatedTransitGateway(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	in := defaultInputs()
+	in.ExistingVPCConnectivity = "transit_gateway"
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingTransitGateway, d.Verdict)
+	assert.Contains(t, d.Reason, "transit_gateway")
+}
+
+func TestDecideNetworking_DedicatedVPCPeering(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	in := defaultInputs()
+	in.ExistingVPCConnectivity = "vpc_peering"
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingVPCPeering, d.Verdict)
+	assert.Contains(t, d.Reason, "vpc_peering")
+}
+
+func TestDecideNetworking_EnterpriseIgnoresVPCConnectivity(t *testing.T) {
+	// TGW / VPC Peering are Dedicated-only products. An Enterprise cluster
+	// with `existing_vpc_connectivity: transit_gateway` falls back to the
+	// PrivateLink-vs-PNI flip, not TGW.
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	in := defaultInputs()
+	in.ExistingVPCConnectivity = "transit_gateway"
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
 }
 
 func TestDecideNetworking_PrivateLinkBelowThreshold(t *testing.T) {
@@ -31,7 +67,7 @@ func TestDecideNetworking_PNIWhenOverThreshold(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
-	assert.Contains(t, d.Reason, "exceeds")
+	assert.Contains(t, d.Reason, "over the")
 }
 
 func TestDecideNetworking_BoundaryAt80Percent(t *testing.T) {

--- a/internal/services/plan/networking_test.go
+++ b/internal/services/plan/networking_test.go
@@ -1,0 +1,45 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecideNetworking_DedicatedAlwaysPNI(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Contains(t, d.Reason, "Dedicated")
+}
+
+func TestDecideNetworking_PrivateLinkBelowThreshold(t *testing.T) {
+	// PrivateLink cap = 10, threshold 0.80 → cap-7 fits, cap-8 doesn't.
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 7, PeakBurstPctOfPLCap: 70}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+}
+
+func TestDecideNetworking_PNIWhenOverThreshold(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 9, PeakBurstPctOfPLCap: 90}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Contains(t, d.Reason, "exceeds")
+}
+
+func TestDecideNetworking_BoundaryAt80Percent(t *testing.T) {
+	// At exactly 80% of cap (8 eCKU of 10), the rule is "less than" — flips
+	// to PNI. Lock the boundary.
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 8, PeakBurstPctOfPLCap: 80}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+}

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -1,0 +1,41 @@
+# plan-config.yaml — Embedded defaults for `kcp report plan`.
+#
+# Single source of truth for Confluent product facts and the customer-tunable
+# sizing defaults. MVP scope: sizing + cluster-type + networking decisions.
+#
+# Override precedence (lowest → highest):
+#   1. This file (embedded in the KCP binary at build time)
+#   2. --config <path> CLI flag (admin override)
+#   3. plan-inputs.yaml (per-customer override of plan_input_defaults only)
+
+schema_version: 1
+last_verified: 2026-05-11
+kcp_version_at_verification: 0.7.2
+
+# `source:` URLs are documentation provenance — they record where each
+# embedded number came from. Not consumed at runtime today; the future
+# drift-detection CI tooling (which lives outside this file) will read them.
+
+enterprise_caps:
+  per_eCKU_ingress_mbps: 60
+  per_eCKU_egress_mbps: 180
+  per_eCKU_partition_rate: 3000
+  privatelink_max_eCKU: 10
+  pni_max_eCKU: 32
+  acl_count_cap: 4000  # HARDCODED — no canonical public doc
+  source: https://docs.confluent.io/cloud/current/clusters/cluster-types.html
+
+cluster_linking:
+  source_min_kafka_version: "2.4.0"
+  express_tier_supported: unknown  # verify per release
+  source: https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/
+
+plan_input_defaults:
+  sizing_percentile: P95           # alternatives: P99, max
+  headroom_fraction: 0.30          # 0.0..1.0
+  privatelink_safety_threshold: 0.80  # peak-burst ratio at which PrivateLink → PNI
+  spiky_workload_ratio: 2.0        # peak / P95 ratio above which a workload is "spiky"
+  sla_floor_eCKU:
+    "99.9":  1
+    "99.95": 1
+    "99.99": 2

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -1,20 +1,19 @@
 # plan-config.yaml — Embedded defaults for `kcp report plan`.
 #
 # Single source of truth for Confluent product facts and the customer-tunable
-# sizing defaults. MVP scope: sizing + cluster-type + networking decisions.
+# sizing defaults. MVP scope: sizing + cluster-type (rules 1–6) + networking.
 #
 # Override precedence (lowest → highest):
 #   1. This file (embedded in the KCP binary at build time)
 #   2. --config <path> CLI flag (admin override)
 #   3. plan-inputs.yaml (per-customer override of plan_input_defaults only)
+#
+# Unsourced constants (no canonical public doc) carry an inline TODO(verify):
+# comment naming the relevant rule for maintainers to re-check each release.
 
 schema_version: 1
-last_verified: 2026-05-11
+last_verified: 2026-05-15
 kcp_version_at_verification: 0.7.2
-
-# `source:` URLs are documentation provenance — they record where each
-# embedded number came from. Not consumed at runtime today; the future
-# drift-detection CI tooling (which lives outside this file) will read them.
 
 enterprise_caps:
   per_eCKU_ingress_mbps: 60
@@ -22,20 +21,31 @@ enterprise_caps:
   per_eCKU_partition_rate: 3000
   privatelink_max_eCKU: 10
   pni_max_eCKU: 32
-  acl_count_cap: 4000  # HARDCODED — no canonical public doc
+  acl_count_cap: 4000  # TODO(verify): — no canonical public doc; re-verify with CC product team each release.
   source: https://docs.confluent.io/cloud/current/clusters/cluster-types.html
 
 cluster_linking:
-  source_min_kafka_version: "2.4.0"
-  express_tier_supported: unknown  # verify per release
+  source_min_kafka_version: "2.4.0"  # TODO(verify): — pin a permalink before shipping
+  express_tier_supported: unknown    # verify per release
   source: https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/
 
 plan_input_defaults:
-  sizing_percentile: P95           # alternatives: P99, max
+  sizing_percentile: p95           # alternatives: p99, max — lowercase to match Confluent dashboards
   headroom_fraction: 0.30          # 0.0..1.0
-  privatelink_safety_threshold: 0.80  # peak-burst ratio at which PrivateLink → PNI
+  privatelink_safety_threshold: 0.80  # TODO(verify): — internal heuristic; no peer-reviewed Confluent source
   spiky_workload_ratio: 2.0        # peak / P95 ratio above which a workload is "spiky"
   sla_floor_eCKU:
     "99.9":  1
     "99.95": 1
     "99.99": 2
+
+  # Customer-declared hard requirements (all default false). A wrong `true`
+  # flips Enterprise → Dedicated (5–10× monthly); the renderer surfaces a
+  # ⚠ cost callout on the verdict when one of these is the trigger.
+  enforce_schemas_at_the_broker: false
+  requires_high_throughput_rest_produce_api: false
+  requires_99_95_sla_within_a_single_zone: false
+
+  # Target cloud + existing VPC connectivity (Dedicated-path networking).
+  target_cloud: aws                              # MSK is AWS-only; hidden on the MSK path
+  existing_vpc_connectivity: privatelink_or_pni  # privatelink_or_pni (default) | transit_gateway | vpc_peering

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -75,11 +75,100 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 			TopicCount:  topicCount(c),
 			BrokerCount: brokerCount(c),
 		})
+		plan.OpenQuestions = append(plan.OpenQuestions, detectOpenQuestions(c, sizing)...)
 	}
 	plan.SourceEnvironment.TotalRegions = countRegions(state)
 	plan.SizingAppendix = buildSizingAppendix(plan.Sizing, s.cfg, inputs)
 
+	// Stable order: blocker OQs first, acknowledgement OQs last; tie-break
+	// on cluster ID so two clusters of equal priority sort alphabetically.
+	sort.SliceStable(plan.OpenQuestions, func(i, j int) bool {
+		pi, pj := openQuestionPriority(plan.OpenQuestions[i].ID), openQuestionPriority(plan.OpenQuestions[j].ID)
+		if pi != pj {
+			return pi < pj
+		}
+		return plan.OpenQuestions[i].ClusterID < plan.OpenQuestions[j].ClusterID
+	})
+
 	return plan, nil
+}
+
+// detectOpenQuestions surfaces state-file gaps and inferred-signal quirks
+// per cluster. The Plan still ships a recommendation in each case (the
+// SLA floor for degraded sizing, the verdict from the other rules when
+// Rule 2 is skipped, etc.) — the OQ tells the customer what action will
+// upgrade that recommendation.
+func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing) []types.OpenQuestion {
+	var oqs []types.OpenQuestion
+	if sizing.Degraded {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "missing_p95_metrics",
+			ClusterID:  c.Name,
+			Title:      "No P95 throughput metrics — sizing fell back to SLA floor",
+			Body:       sizing.DegradedReason,
+			HowToClose: "Re-run `kcp scan metrics` against this cluster.",
+		})
+	}
+	if c.KafkaAdminClientInformation.Acls == nil {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "acls_not_scanned",
+			ClusterID:  c.Name,
+			Title:      "Admin scan didn't populate ACLs — cap-vs-Enterprise rule was skipped",
+			Body:       "The `acl_count_exceeds_cap` hard-limit rule needs the ACL list to evaluate. With `acls == null` the rule is treated as inconclusive; the verdict resolves on the other rules.",
+			HowToClose: "Re-run `kcp scan clusters` with admin credentials to populate the ACL list.",
+		})
+	}
+	if brokerCount(c) == 0 {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "broker_inventory_empty",
+			ClusterID:  c.Name,
+			Title:      "Source environment shows 0 brokers — likely an incomplete scan",
+			Body:       "`AWSClientInformation.Nodes` is empty for this cluster. The Source Environment table reads as `Brokers: 0`, which is almost certainly wrong for a real MSK cluster.",
+			HowToClose: "Re-run `kcp discover` against the source account / region to populate the broker inventory.",
+		})
+	}
+	if topicCount(c) == 0 {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "topic_inventory_empty",
+			ClusterID:  c.Name,
+			Title:      "Source environment shows 0 topics — likely an incomplete scan",
+			Body:       "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero).",
+			HowToClose: "Re-run `kcp scan clusters` with admin credentials to populate the topic list.",
+		})
+	}
+	// Spiky workload is an informational signal, not an Open Question:
+	// the P95-based sizing + Enterprise elasticity absorbs occasional
+	// spikes, so there's nothing the customer MUST do. The rationale
+	// renderer surfaces a one-line note inline so the customer still
+	// sees the signal and knows the override path (`sizing_percentile: p99`)
+	// exists if they want tighter sizing.
+	return oqs
+}
+
+// Priority order for OQs. Lower number renders first. Constants here so
+// every OQ has an explicit rank — a new ID without a priority entry
+// falls through to oqPriorityUnknown and renders last.
+const (
+	oqPriorityMissingMetrics  = iota // missing P95 → sizing fell back to floor
+	oqPriorityBrokerInventory        // broker count == 0 (scan gap)
+	oqPriorityTopicInventory         // topic count == 0 (scan gap)
+	oqPriorityACLsNotScanned         // Acls == nil (admin-cred gap)
+	oqPriorityUnknown                // fallback for new IDs added without a priority entry
+)
+
+func openQuestionPriority(id string) int {
+	switch id {
+	case "missing_p95_metrics":
+		return oqPriorityMissingMetrics
+	case "broker_inventory_empty":
+		return oqPriorityBrokerInventory
+	case "topic_inventory_empty":
+		return oqPriorityTopicInventory
+	case "acls_not_scanned":
+		return oqPriorityACLsNotScanned
+	default:
+		return oqPriorityUnknown
+	}
 }
 
 func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
@@ -129,8 +218,8 @@ func buildSizingAppendix(sizings []types.ClusterSizing, cfg *PlanConfig, inputs 
 			ClusterID: s.ClusterID,
 			Formula:   fmt.Sprintf("CEIL(max(P95In/%d, P95Out/%d, partitions/%d) * (1 + %.2f headroom))", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps, caps.PerECKUPartitionRate, inputs.HeadroomFraction),
 			IntermediateSteps: []string{
-				fmt.Sprintf("ingress ratio = %.2f MBps / %d = %.4f", s.P95InMBps, caps.PerECKUIngressMBps, s.IngressRatio),
-				fmt.Sprintf("egress ratio  = %.2f MBps / %d = %.4f", s.P95OutMBps, caps.PerECKUEgressMBps, s.EgressRatio),
+				fmt.Sprintf("ingress ratio = %.2f MBps / %d = %.4f", s.SizedInMBps, caps.PerECKUIngressMBps, s.IngressRatio),
+				fmt.Sprintf("egress ratio  = %.2f MBps / %d = %.4f", s.SizedOutMBps, caps.PerECKUEgressMBps, s.EgressRatio),
 				fmt.Sprintf("partition ratio = %d / %d = %.4f", s.UserPartitions, caps.PerECKUPartitionRate, s.PartitionRatio),
 				fmt.Sprintf("max ratio = %.4f", s.MaxRatio),
 				fmt.Sprintf("sized = CEIL(%.4f * %.2f) = %d  (1 + %.2f headroom)", s.MaxRatio, 1+inputs.HeadroomFraction, s.SizedECKU, inputs.HeadroomFraction),

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -1,0 +1,143 @@
+package plan
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/confluentinc/kcp/internal/services/report"
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// PlanService orchestrates the deterministic plan-generation pipeline.
+// MVP scope: source-environment summary, sizing, cluster-type, networking.
+// Auth approach, switchover, red flags, etc. land in follow-up PRs.
+type PlanService struct {
+	cfg *PlanConfig
+	now func() time.Time
+}
+
+// NewPlanService wires a PlanConfig into a PlanService. now is overridable
+// for deterministic tests; pass nil for time.Now.
+func NewPlanService(cfg *PlanConfig, now func() time.Time) *PlanService {
+	if now == nil {
+		now = time.Now
+	}
+	return &PlanService{cfg: cfg, now: now}
+}
+
+// Build produces a Plan from a ProcessedState and resolved plan-inputs.
+// Each step is a pure function so the test surface is the orchestration,
+// not its parts.
+func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsResolved, stateFilePath string) (*types.Plan, error) {
+	clusters := collectClusters(state)
+	// Stable sort by (Region, Name, Arn) so two clusters that share a name
+	// across regions still get a deterministic order.
+	sort.SliceStable(clusters, func(i, j int) bool {
+		if clusters[i].Region != clusters[j].Region {
+			return clusters[i].Region < clusters[j].Region
+		}
+		if clusters[i].Name != clusters[j].Name {
+			return clusters[i].Name < clusters[j].Name
+		}
+		return clusters[i].Arn < clusters[j].Arn
+	})
+
+	plan := &types.Plan{
+		Header: types.PlanHeader{
+			Source:            "Amazon MSK",
+			StateFilePath:     stateFilePath,
+			KCPVersion:        build_info.Version,
+			GeneratedAt:       s.now().UTC(),
+			PlanSchemaVersion: "1-experimental",
+		},
+		Inputs: inputs,
+	}
+
+	for _, c := range clusters {
+		// ProcessState doesn't populate Aggregates on the top-level path —
+		// only the per-subcommand date-filtered helpers do. Fill it in if
+		// the cluster has raw metrics but no aggregates, so sizing has P95.
+		if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
+			c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
+		}
+		sizing := ComputeClusterSizing(c, s.cfg, inputs)
+		ct := DecideClusterType(c, sizing, s.cfg, inputs)
+		net := DecideNetworking(sizing, ct, s.cfg, inputs)
+
+		plan.Sizing = append(plan.Sizing, sizing)
+		plan.ClusterTypeDecision = append(plan.ClusterTypeDecision, ct)
+		plan.NetworkingDecision = append(plan.NetworkingDecision, net)
+		plan.SourceEnvironment.Clusters = append(plan.SourceEnvironment.Clusters, types.SourceClusterSummary{
+			ClusterID:   c.Name,
+			Region:      c.Region,
+			TopicCount:  topicCount(c),
+			BrokerCount: brokerCount(c),
+		})
+	}
+	plan.SourceEnvironment.TotalRegions = countRegions(state)
+	plan.SizingAppendix = buildSizingAppendix(plan.Sizing, s.cfg, inputs)
+
+	return plan, nil
+}
+
+func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
+	var out []types.ProcessedCluster
+	for _, src := range state.Sources {
+		if src.MSKData == nil {
+			continue
+		}
+		for _, region := range src.MSKData.Regions {
+			out = append(out, region.Clusters...)
+		}
+	}
+	return out
+}
+
+func countRegions(state types.ProcessedState) int {
+	regions := map[string]struct{}{}
+	for _, src := range state.Sources {
+		if src.MSKData != nil {
+			for _, r := range src.MSKData.Regions {
+				regions[r.Name] = struct{}{}
+			}
+		}
+	}
+	return len(regions)
+}
+
+func topicCount(c types.ProcessedCluster) int {
+	if c.KafkaAdminClientInformation.Topics == nil {
+		return 0
+	}
+	return c.KafkaAdminClientInformation.Topics.Summary.Topics
+}
+
+func brokerCount(c types.ProcessedCluster) int {
+	return len(c.AWSClientInformation.Nodes)
+}
+
+func buildSizingAppendix(sizings []types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.SizingMathDetail {
+	caps := cfg.EnterpriseCaps
+	out := make([]types.SizingMathDetail, 0, len(sizings))
+	for _, s := range sizings {
+		if s.Degraded {
+			continue
+		}
+		out = append(out, types.SizingMathDetail{
+			ClusterID: s.ClusterID,
+			Formula:   fmt.Sprintf("CEIL(max(P95In/%d, P95Out/%d, partitions/%d) * (1 + %.2f headroom))", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps, caps.PerECKUPartitionRate, inputs.HeadroomFraction),
+			IntermediateSteps: []string{
+				fmt.Sprintf("ingress ratio = %.2f MBps / %d = %.4f", s.P95InMBps, caps.PerECKUIngressMBps, s.IngressRatio),
+				fmt.Sprintf("egress ratio  = %.2f MBps / %d = %.4f", s.P95OutMBps, caps.PerECKUEgressMBps, s.EgressRatio),
+				fmt.Sprintf("partition ratio = %d / %d = %.4f", s.UserPartitions, caps.PerECKUPartitionRate, s.PartitionRatio),
+				fmt.Sprintf("max ratio = %.4f", s.MaxRatio),
+				fmt.Sprintf("sized = CEIL(%.4f * %.2f) = %d  (1 + %.2f headroom)", s.MaxRatio, 1+inputs.HeadroomFraction, s.SizedECKU, inputs.HeadroomFraction),
+				fmt.Sprintf("final = max(%d sized, %d SLA floor) = %d eCKU", s.SizedECKU, s.SLAFloorECKU, s.FinalECKU),
+			},
+			Citations: s.Citations,
+		})
+	}
+	return out
+}

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -1,0 +1,136 @@
+package plan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fixedNow() time.Time {
+	return time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+}
+
+func twoClusterState() types.ProcessedState {
+	// b-cluster intentionally listed first so the sort proves it works.
+	return types.ProcessedState{
+		Sources: []types.ProcessedSource{
+			{
+				Type: types.SourceTypeMSK,
+				MSKData: &types.ProcessedMSKSource{
+					Regions: []types.ProcessedRegion{
+						{
+							Name: "us-east-1",
+							Clusters: []types.ProcessedCluster{
+								fixtureCluster("b-cluster", 100, 5.0, 5.0, 6.0, 6.0),
+								fixtureCluster("a-cluster", 50, 1.0, 1.0, 2.0, 2.0),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPlanServiceBuild_BasicShape(t *testing.T) {
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(twoClusterState(), defaultInputs(), "kcp-state.json")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Amazon MSK", p.Header.Source)
+	assert.Equal(t, "1-experimental", p.Header.PlanSchemaVersion)
+	assert.Equal(t, "kcp-state.json", p.Header.StateFilePath)
+	assert.Equal(t, 1, p.SourceEnvironment.TotalRegions)
+	assert.Len(t, p.Sizing, 2)
+	assert.Len(t, p.ClusterTypeDecision, 2)
+	assert.Len(t, p.NetworkingDecision, 2)
+	assert.Len(t, p.SizingAppendix, 2)
+}
+
+func TestPlanServiceBuild_DeterministicByteIdenticalJSON(t *testing.T) {
+	// Build the same plan twice and ensure the rendered JSON is byte-equal.
+	// This is the load-bearing reproducibility test.
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	state := twoClusterState()
+	inputs := defaultInputs()
+
+	p1, err := svc.Build(state, inputs, "x.json")
+	require.NoError(t, err)
+	p2, err := svc.Build(state, inputs, "x.json")
+	require.NoError(t, err)
+
+	j1, err := RenderJSON(p1)
+	require.NoError(t, err)
+	j2, err := RenderJSON(p2)
+	require.NoError(t, err)
+	assert.Equal(t, string(j1), string(j2), "rendered JSON must be byte-identical across builds")
+}
+
+func TestPlanServiceBuild_StableSortAcrossRegions(t *testing.T) {
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{
+					// Same cluster name in two regions to prove (Region, Name) sort.
+					{Name: "us-west-2", Clusters: []types.ProcessedCluster{
+						withRegion(fixtureCluster("collide", 10, 1.0, 1.0, 1.0, 1.0), "us-west-2"),
+					}},
+					{Name: "us-east-1", Clusters: []types.ProcessedCluster{
+						withRegion(fixtureCluster("collide", 10, 1.0, 1.0, 1.0, 1.0), "us-east-1"),
+					}},
+				},
+			},
+		}},
+	}
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(state, defaultInputs(), "x.json")
+	require.NoError(t, err)
+
+	require.Len(t, p.SourceEnvironment.Clusters, 2)
+	// us-east-1 sorts before us-west-2.
+	assert.Equal(t, "us-east-1", p.SourceEnvironment.Clusters[0].Region)
+	assert.Equal(t, "us-west-2", p.SourceEnvironment.Clusters[1].Region)
+}
+
+func TestPlanServiceBuild_EmptyState(t *testing.T) {
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(types.ProcessedState{}, defaultInputs(), "")
+	require.NoError(t, err)
+	assert.Empty(t, p.Sizing)
+	assert.Empty(t, p.SourceEnvironment.Clusters)
+	assert.Equal(t, 0, p.SourceEnvironment.TotalRegions)
+}
+
+func TestPlanServiceBuild_DegradedClusterStillRenders(t *testing.T) {
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{{
+					Name: "us-east-1",
+					Clusters: []types.ProcessedCluster{{
+						Name:                        "no-metrics",
+						Region:                      "us-east-1",
+						KafkaAdminClientInformation: types.KafkaAdminClientInformation{Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: 5}}},
+					}},
+				}},
+			},
+		}},
+	}
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(state, defaultInputs(), "x.json")
+	require.NoError(t, err)
+	require.Len(t, p.Sizing, 1)
+	assert.True(t, p.Sizing[0].Degraded)
+	// No appendix entry for degraded clusters (nothing to show).
+	assert.Empty(t, p.SizingAppendix)
+}
+
+func withRegion(c types.ProcessedCluster, region string) types.ProcessedCluster {
+	c.Region = region
+	return c
+}

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,133 @@ func TestPlanServiceBuild_StableSortAcrossRegions(t *testing.T) {
 	// us-east-1 sorts before us-west-2.
 	assert.Equal(t, "us-east-1", p.SourceEnvironment.Clusters[0].Region)
 	assert.Equal(t, "us-west-2", p.SourceEnvironment.Clusters[1].Region)
+}
+
+// The Source Environment table renders BrokerCount + TopicCount per
+// cluster. Regression guard: both values must come from the populated
+// state fields (`AWSClientInformation.Nodes` length and
+// `KafkaAdminClientInformation.Topics.Summary.Topics`) rather than
+// silently defaulting to zero — a zero in the rendered plan reads as
+// "no brokers / no topics" which is a meaningfully wrong impression.
+func TestPlanServiceBuild_SourceEnvironmentBrokerAndTopicCount(t *testing.T) {
+	c := fixtureCluster("populated", 200, 10, 20, 12, 22)
+	c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+	c.KafkaAdminClientInformation.Topics.Summary.Topics = 42
+
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{
+					{Name: "us-east-1", Clusters: []types.ProcessedCluster{c}},
+				},
+			},
+		}},
+	}
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(state, defaultInputs(), "x.json")
+	require.NoError(t, err)
+	require.Len(t, p.SourceEnvironment.Clusters, 1)
+	got := p.SourceEnvironment.Clusters[0]
+	assert.Equal(t, 3, got.BrokerCount, "BrokerCount must reflect len(AWSClientInformation.Nodes)")
+	assert.Equal(t, 42, got.TopicCount, "TopicCount must reflect KafkaAdminClientInformation.Topics.Summary.Topics")
+}
+
+// Unit-level coverage for the helpers — catches a bad rename / wrong
+// field path before the integration test does.
+func TestBrokerCountAndTopicCountReadFromState(t *testing.T) {
+	c := types.ProcessedCluster{Name: "ut"}
+	assert.Equal(t, 0, brokerCount(c))
+	assert.Equal(t, 0, topicCount(c))
+
+	c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 5)
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 17}}
+	assert.Equal(t, 5, brokerCount(c))
+	assert.Equal(t, 17, topicCount(c))
+}
+
+// Each MVP open-question detector surfaces a specific state-file gap.
+// The shipping recommendation still exists for every cluster; the OQ is
+// the action that upgrades it.
+func TestDetectOpenQuestions(t *testing.T) {
+	t.Run("missing P95 metrics → missing_p95_metrics OQ", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "noMetrics"}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		sizing := types.ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
+
+		oqs := detectOpenQuestions(c, sizing)
+		assertContainsOQ(t, oqs, "missing_p95_metrics", "Re-run `kcp scan metrics`")
+	})
+
+	t.Run("nil ACLs → acls_not_scanned OQ", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "noAcls"}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = nil
+
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1})
+		assertContainsOQ(t, oqs, "acls_not_scanned", "admin credentials")
+	})
+
+	t.Run("zero brokers → broker_inventory_empty OQ", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "noBrokers"}
+		c.AWSClientInformation.Nodes = nil
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1})
+		assertContainsOQ(t, oqs, "broker_inventory_empty", "kcp discover")
+	})
+
+	t.Run("zero topics → topic_inventory_empty OQ", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "noTopics"}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 0}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1})
+		assertContainsOQ(t, oqs, "topic_inventory_empty", "kcp scan clusters")
+	})
+
+	t.Run("spiky workload does NOT generate an OQ (FYI only)", func(t *testing.T) {
+		// Spiky is informational — Enterprise elasticity absorbs the
+		// spike, so there's nothing the customer MUST do. The renderer
+		// surfaces it as a one-line note in the rationale section, not
+		// as an Actions Needed item.
+		c := types.ProcessedCluster{Name: "spiky"}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		sizing := types.ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
+
+		oqs := detectOpenQuestions(c, sizing)
+		assert.Empty(t, oqs, "spiky clusters should NOT emit an OQ — informational only")
+	})
+
+	t.Run("fully populated cluster emits no OQs", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "complete"}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2})
+		assert.Empty(t, oqs, "happy-path clusters should not surface OQs")
+	})
+}
+
+func assertContainsOQ(t *testing.T, oqs []types.OpenQuestion, id, expectedSubstring string) {
+	t.Helper()
+	for _, oq := range oqs {
+		if oq.ID == id {
+			if expectedSubstring != "" {
+				assert.Contains(t, oq.HowToClose, expectedSubstring)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected an OpenQuestion with ID %q, got: %+v", id, oqs)
 }
 
 func TestPlanServiceBuild_EmptyState(t *testing.T) {

--- a/internal/services/plan/render_json.go
+++ b/internal/services/plan/render_json.go
@@ -1,0 +1,19 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// RenderJSON serialises a Plan to canonical 2-space-indented JSON. Stable
+// key ordering comes for free from struct field order — any map members
+// are encoded by Go's stdlib in sorted key order since Go 1.12.
+func RenderJSON(p *types.Plan) ([]byte, error) {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render plan as JSON: %w", err)
+	}
+	return data, nil
+}

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -25,18 +25,43 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	writeDefinitions(&b, cfg)
 	writeSourceEnvironment(&b, p)
 	writeSizingAndDecisions(&b, p)
+	writeOpenQuestions(&b, p)
 	writeSizingAppendix(&b, p, cfg)
 
 	return b.Bytes(), nil
+}
+
+func writeOpenQuestions(b *bytes.Buffer, p *types.Plan) {
+	if len(p.OpenQuestions) == 0 {
+		return
+	}
+	b.WriteString("## 3. Actions Needed\n\n")
+	b.WriteString("Each item below is a concrete action that tightens the recommendation in **Sizing & Cluster Decisions**. The current recommendation stands; doing these closes a state-file or scan gap.\n\n")
+	for i, oq := range p.OpenQuestions {
+		title := oq.Title
+		if oq.ClusterID != "" {
+			title = fmt.Sprintf("`%s` — %s", oq.ClusterID, title)
+		}
+		fmt.Fprintf(b, "%d. **%s**\n", i+1, title)
+		if oq.Body != "" {
+			fmt.Fprintf(b, "   - %s\n", oq.Body)
+		}
+		if oq.HowToClose != "" {
+			fmt.Fprintf(b, "   - _How to close:_ %s\n", oq.HowToClose)
+		}
+	}
+	b.WriteString("\n")
 }
 
 func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
 	caps := cfg.EnterpriseCaps
 	b.WriteString("## Definitions\n\n")
 	fmt.Fprintf(b, "- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. %d MB/s ingress + %d MB/s egress per eCKU at the per-eCKU caps used below.\n", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps)
+	b.WriteString("- **CKU** — Confluent Kafka Unit, the Dedicated-tier equivalent of eCKU. Sizing math is the same; only the unit name changes. Dedicated clusters always render with `CKU`.\n")
 	b.WriteString("- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 (override with `sizing_percentile`) so a transient spike doesn't permanently inflate the recommended cluster size.\n")
-	fmt.Fprintf(b, "- **PrivateLink** — single-AZ private connectivity, up to %d eCKU. The default network when the cluster fits inside it with headroom.\n", caps.PrivateLinkMaxECKU)
-	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to %d eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.\n\n", caps.PNIMaxECKU)
+	b.WriteString("- **Final size** — the recommended eCKU (Enterprise) or CKU (Dedicated) count for the cluster. `(floor)` next to a value means the SLA minimum was binding (the math came in below the floor and was rounded up).\n")
+	fmt.Fprintf(b, "- **PrivateLink** — single-AZ private connectivity, up to %d eCKU. The default network when the cluster fits inside it with headroom. Enterprise only.\n", caps.PrivateLinkMaxECKU)
+	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to %d eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst; **always required on Dedicated**.\n\n", caps.PNIMaxECKU)
 }
 
 func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
@@ -45,7 +70,22 @@ func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
 		b.WriteString("_No clusters found in the state file. Re-run `kcp discover` / `kcp scan ...` and try again._\n\n")
 		return
 	}
-	fmt.Fprintf(b, "- **%d** source clusters across **%d** region(s)\n\n", len(p.SourceEnvironment.Clusters), p.SourceEnvironment.TotalRegions)
+	totalBrokers := 0
+	totalTopics := 0
+	for _, c := range p.SourceEnvironment.Clusters {
+		totalBrokers += c.BrokerCount
+		totalTopics += c.TopicCount
+	}
+	regionWord := "region"
+	if p.SourceEnvironment.TotalRegions != 1 {
+		regionWord = "regions"
+	}
+	clusterWord := "cluster"
+	if len(p.SourceEnvironment.Clusters) != 1 {
+		clusterWord = "clusters"
+	}
+	fmt.Fprintf(b, "- **%d** source %s across **%d** %s · **%d** brokers · **%d** topics\n\n",
+		len(p.SourceEnvironment.Clusters), clusterWord, p.SourceEnvironment.TotalRegions, regionWord, totalBrokers, totalTopics)
 	b.WriteString("| Cluster | Region | Brokers | Topics |\n")
 	b.WriteString("|---|---|---:|---:|\n")
 	for _, c := range p.SourceEnvironment.Clusters {
@@ -61,56 +101,100 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan) {
 		return
 	}
 
-	b.WriteString("| Cluster | P95 in / out (MBps) | Partitions | Final eCKU | Cluster Type | Networking |\n")
+	// Build cluster_id-keyed lookups so the rendered table can't silently
+	// mis-pair a cluster's sizing with another cluster's verdict — earlier
+	// the loop indexed all three slices by `i`, which was correct for plans
+	// built by PlanService.Build() but fragile under any other construction.
+	ctByID := make(map[string]types.ClusterTypeDecision, len(p.ClusterTypeDecision))
+	for _, d := range p.ClusterTypeDecision {
+		ctByID[d.ClusterID] = d
+	}
+	netByID := make(map[string]types.NetworkingDecision, len(p.NetworkingDecision))
+	for _, d := range p.NetworkingDecision {
+		netByID[d.ClusterID] = d
+	}
+
+	percentileLabel := percentileHeader(p.Inputs.SizingPercentile)
+	fmt.Fprintf(b, "| Cluster | %s in / out (MBps) | Partitions | Final size | Cluster Type | Networking |\n", percentileLabel)
 	b.WriteString("|---|---|---:|---:|---|---|\n")
-	for i, s := range p.Sizing {
-		ct := types.ClusterType("")
-		net := types.Networking("")
-		if i < len(p.ClusterTypeDecision) {
-			ct = p.ClusterTypeDecision[i].Verdict
-		}
-		if i < len(p.NetworkingDecision) {
-			net = p.NetworkingDecision[i].Verdict
-		}
+	for _, s := range p.Sizing {
+		ctDecision := ctByID[s.ClusterID]
+		net := netByID[s.ClusterID].Verdict
+		ctLabel := clusterTypeLabel(ctDecision)
+		sizeCell := formatSizeCell(s.FinalECKU, ctDecision, s.Degraded)
 		if s.Degraded {
-			fmt.Fprintf(b, "| %s | _sizing degraded_ | %d | %d (floor) | %s | %s |\n",
-				s.ClusterID, s.UserPartitions, s.FinalECKU, ct, net)
+			fmt.Fprintf(b, "| %s | _metrics missing_ | %d | %s | %s | %s |\n",
+				s.ClusterID, s.UserPartitions, sizeCell, ctLabel, net)
 			continue
 		}
-		fmt.Fprintf(b, "| %s | %.1f / %.1f | %d | %d | %s | %s |\n",
-			s.ClusterID, s.P95InMBps, s.P95OutMBps, s.UserPartitions, s.FinalECKU, ct, net)
+		fmt.Fprintf(b, "| %s | %.1f / %.1f | %d | %s | %s | %s |\n",
+			s.ClusterID, s.SizedInMBps, s.SizedOutMBps, s.UserPartitions, sizeCell, ctLabel, net)
 	}
 	b.WriteString("\n")
 
 	// Per-cluster rationale: each line cites the cluster-type decision and
 	// the networking decision. Reads cleanly even for 30+ clusters because
 	// each entry is one or two lines.
-	b.WriteString("### Why these recommendations\n\n")
-	for i, s := range p.Sizing {
+	b.WriteString("### Why These Recommendations\n\n")
+	for _, s := range p.Sizing {
 		if s.Degraded {
-			fmt.Fprintf(b, "- **%s** — %s. Final eCKU defaults to the SLA floor (%d). Re-run with metrics to lock in throughput-based sizing.\n", s.ClusterID, s.DegradedReason, s.FinalECKU)
+			// Symptom-only here; the action lives in Actions Needed
+			// (so it isn't duplicated across two surfaces).
+			fmt.Fprintf(b, "- **%s** — metrics missing (%s). Final eCKU defaults to the SLA floor (%d). See Actions Needed below.\n", s.ClusterID, s.DegradedReason, s.FinalECKU)
 			continue
 		}
 		var pieces []string
-		if i < len(p.ClusterTypeDecision) {
-			ct := p.ClusterTypeDecision[i]
+		var customerDeclaredTriggers []string
+		if ct, ok := ctByID[s.ClusterID]; ok {
+			ctLabel := clusterTypeLabel(ct)
 			if len(ct.Triggers) == 0 {
-				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", ct.Verdict))
+				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", ctLabel))
 			} else {
 				rules := make([]string, 0, len(ct.Triggers))
 				for _, t := range ct.Triggers {
 					rules = append(rules, fmt.Sprintf("%s (%s)", t.Description, t.Evidence))
+					if t.CustomerDeclared {
+						customerDeclaredTriggers = append(customerDeclaredTriggers, t.RowID)
+					}
 				}
-				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — %s", ct.Verdict, strings.Join(rules, "; ")))
+				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — %s", ctLabel, strings.Join(rules, "; ")))
 			}
 		}
-		if i < len(p.NetworkingDecision) {
-			n := p.NetworkingDecision[i]
+		if n, ok := netByID[s.ClusterID]; ok {
 			pieces = append(pieces, fmt.Sprintf("Networking **%s** — %s", n.Verdict, n.Reason))
 		}
 		fmt.Fprintf(b, "- **%s** — %s.\n", s.ClusterID, strings.Join(pieces, ". "))
+		if len(customerDeclaredTriggers) > 0 {
+			fmt.Fprintf(b, costCalloutTemplate, strings.Join(customerDeclaredTriggers, ", "))
+		}
+		// Spiky-workload note (FYI only — sizing already absorbs the spike).
+		if s.SpikyIngress || s.SpikyEgress {
+			fmt.Fprintf(b, "  - _Note: %s. Sizing is P95-based and Enterprise elasticity absorbs the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s))
+		}
 	}
 	b.WriteString("\n")
+}
+
+// spikyDescription returns the inline "peak X vs P95 Y (Zx)" phrasing
+// for the FYI note on spiky clusters. Guards against P95==0 (the spiky
+// flag fires for any positive peak when P95 is zero — `peak > 2.0 * 0`)
+// so the ratio doesn't render as +Inf.
+func spikyDescription(s types.ClusterSizing) string {
+	var parts []string
+	if s.SpikyIngress {
+		parts = append(parts, formatSpikeRatio("ingress", s.PeakInMBps, s.SizedInMBps))
+	}
+	if s.SpikyEgress {
+		parts = append(parts, formatSpikeRatio("egress", s.PeakOutMBps, s.SizedOutMBps))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func formatSpikeRatio(dir string, peak, p95 float64) string {
+	if p95 <= 0 {
+		return fmt.Sprintf("%s peak %.0f MB/s (no P95 baseline)", dir, peak)
+	}
+	return fmt.Sprintf("%s peak %.0f MB/s vs P95 %.0f MB/s (%.1fx)", dir, peak, p95, peak/p95)
 }
 
 func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
@@ -138,4 +222,57 @@ func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 	}
 	b.WriteString("\nMax-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.\n\n")
 	b.WriteString("</details>\n\n")
+}
+
+// costCalloutTemplate surfaces a ⚠ warning when a customer-declared
+// flag flipped the cluster to Dedicated — a wrong `true` costs 5–10×
+// monthly, so the callout names the rules and the recovery path.
+const costCalloutTemplate = "  - > ⚠ **Cost callout:** Dedicated was forced by customer-declared `plan-inputs.yaml` flag(s) — %s. Dedicated costs ~5–10× Enterprise per month for an equivalent footprint. If a flag was set in error, flip it to `false` and re-run; confirm with your Confluent account team if unsure.\n"
+
+// percentileHeader returns the uppercase label rendered in the throughput
+// column header so the customer can see which percentile produced the
+// numbers (P95 / P99 / Max).
+func percentileHeader(percentile string) string {
+	switch percentile {
+	case "p99":
+		return "P99"
+	case "max":
+		return "Max"
+	default:
+		return "P95"
+	}
+}
+
+// clusterTypeLabel returns the customer-facing label for a cluster-type
+// decision. Dedicated clusters carry a topology suffix (MZ vs SZ) so the
+// reader can see at a glance whether the verdict is Multi-Zone or the
+// 99.95%-SLA-driven Single-Zone variant. Enterprise renders as-is.
+func clusterTypeLabel(ct types.ClusterTypeDecision) string {
+	if ct.Verdict != types.ClusterTypeDedicated {
+		return string(ct.Verdict)
+	}
+	switch ct.Topology {
+	case types.TopologySingleZone:
+		return "Dedicated Single-Zone (SZ)"
+	case types.TopologyMultiZone:
+		return "Dedicated Multi-Zone (MZ)"
+	default:
+		return "Dedicated"
+	}
+}
+
+// formatSizeCell renders the "Final size" column. Enterprise clusters
+// are sized in eCKU; Dedicated clusters are sized in CKU (same integer,
+// different unit per the Confluent product taxonomy).
+func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) string {
+	suffix := "eCKU"
+	value := finalECKU
+	if ct.Verdict == types.ClusterTypeDedicated && ct.FinalCKU != nil {
+		suffix = "CKU"
+		value = *ct.FinalCKU
+	}
+	if degraded {
+		return fmt.Sprintf("%d %s (floor)", value, suffix)
+	}
+	return fmt.Sprintf("%d %s", value, suffix)
 }

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -1,0 +1,151 @@
+package plan
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// RenderMarkdown emits a human-readable Plan: Source Environment table,
+// Sizing & Cluster Decisions table with full rationale, collapsed
+// Appendix A1 with the sizing math expansion. MVP scope — no auth /
+// switchover / red flag sections (each lands with its own follow-up).
+func RenderMarkdown(p *types.Plan) ([]byte, error) {
+	var b bytes.Buffer
+
+	fmt.Fprintf(&b, "# Migration Plan — %s → Confluent Cloud\n\n", p.Header.Source)
+	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath)
+
+	writeDefinitions(&b)
+	writeSourceEnvironment(&b, p)
+	writeSizingAndDecisions(&b, p)
+	writeSizingAppendix(&b, p)
+
+	return b.Bytes(), nil
+}
+
+func writeDefinitions(b *bytes.Buffer) {
+	b.WriteString("## Definitions\n\n")
+	b.WriteString("- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. ~30 MB/s ingress + 90 MB/s egress per eCKU at the per-eCKU caps used below.\n")
+	b.WriteString("- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 so a transient spike doesn't permanently inflate the recommended cluster size.\n")
+	b.WriteString("- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom.\n")
+	b.WriteString("- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.\n\n")
+}
+
+func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
+	b.WriteString("## 1. Source Environment\n\n")
+	if len(p.SourceEnvironment.Clusters) == 0 {
+		b.WriteString("_No clusters found in the state file. Re-run `kcp discover` / `kcp scan ...` and try again._\n\n")
+		return
+	}
+	fmt.Fprintf(b, "- **%d** source clusters across **%d** region(s)\n\n", len(p.SourceEnvironment.Clusters), p.SourceEnvironment.TotalRegions)
+	b.WriteString("| Cluster | Region | Brokers | Topics |\n")
+	b.WriteString("|---|---|---:|---:|\n")
+	for _, c := range p.SourceEnvironment.Clusters {
+		fmt.Fprintf(b, "| %s | %s | %d | %d |\n", c.ClusterID, c.Region, c.BrokerCount, c.TopicCount)
+	}
+	b.WriteString("\n")
+}
+
+func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan) {
+	b.WriteString("## 2. Sizing & Cluster Decisions\n\n")
+	if len(p.Sizing) == 0 {
+		b.WriteString("_No clusters to size._\n\n")
+		return
+	}
+
+	b.WriteString("| Cluster | P95 in / out (MBps) | Partitions | Final eCKU | Cluster Type | Networking |\n")
+	b.WriteString("|---|---|---:|---:|---|---|\n")
+	for i, s := range p.Sizing {
+		ct := types.ClusterType("")
+		net := types.Networking("")
+		if i < len(p.ClusterTypeDecision) {
+			ct = p.ClusterTypeDecision[i].Verdict
+		}
+		if i < len(p.NetworkingDecision) {
+			net = p.NetworkingDecision[i].Verdict
+		}
+		if s.Degraded {
+			fmt.Fprintf(b, "| %s | _sizing degraded_ | %d | %d (floor) | %s | %s |\n",
+				s.ClusterID, s.UserPartitions, s.FinalECKU, ct, net)
+			continue
+		}
+		fmt.Fprintf(b, "| %s | %.1f / %.1f | %d | %d | %s | %s |\n",
+			s.ClusterID, s.P95InMBps, s.P95OutMBps, s.UserPartitions, s.FinalECKU, ct, net)
+	}
+	b.WriteString("\n")
+
+	// Per-cluster rationale: each line cites the cluster-type decision and
+	// the networking decision. Reads cleanly even for 30+ clusters because
+	// each entry is one or two lines.
+	b.WriteString("### Why these recommendations\n\n")
+	for i, s := range p.Sizing {
+		if s.Degraded {
+			fmt.Fprintf(b, "- **%s** — %s. Final eCKU defaults to the SLA floor (%d). Re-run with metrics to lock in throughput-based sizing.\n", s.ClusterID, s.DegradedReason, s.FinalECKU)
+			continue
+		}
+		var pieces []string
+		if i < len(p.ClusterTypeDecision) {
+			ct := p.ClusterTypeDecision[i]
+			if len(ct.Triggers) == 0 {
+				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", ct.Verdict))
+			} else {
+				rules := make([]string, 0, len(ct.Triggers))
+				for _, t := range ct.Triggers {
+					rules = append(rules, fmt.Sprintf("%s (%s)", t.Description, t.Evidence))
+				}
+				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — %s", ct.Verdict, strings.Join(rules, "; ")))
+			}
+		}
+		if i < len(p.NetworkingDecision) {
+			n := p.NetworkingDecision[i]
+			pieces = append(pieces, fmt.Sprintf("Networking **%s** — %s", n.Verdict, n.Reason))
+		}
+		fmt.Fprintf(b, "- **%s** — %s.\n", s.ClusterID, strings.Join(pieces, ". "))
+	}
+	b.WriteString("\n")
+}
+
+func writeSizingAppendix(b *bytes.Buffer, p *types.Plan) {
+	if len(p.SizingAppendix) == 0 {
+		return
+	}
+	b.WriteString("## Appendix A1 — Sizing Math\n")
+	b.WriteString("<details><summary>Show sizing math per cluster</summary>\n\n")
+	b.WriteString("Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.\n\n")
+	// The formula is identical for every cluster (caps + headroom are
+	// constants, not per-cluster). Print it once, then a single audit
+	// table covers every cluster in a row.
+	fmt.Fprintf(b, "Formula: `%s`\n\n", p.SizingAppendix[0].Formula)
+	b.WriteString("| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |\n")
+	b.WriteString("|---|---:|---:|---:|---|---:|---:|---:|\n")
+	for i, s := range p.Sizing {
+		_ = i
+		if s.Degraded {
+			fmt.Fprintf(b, "| %s | _degraded_ | _degraded_ | %d / 3000 | _n/a_ | _n/a_ | %d | %d |\n",
+				s.ClusterID, s.UserPartitions, s.SLAFloorECKU, s.FinalECKU)
+			continue
+		}
+		driver := sizingDriver(s)
+		fmt.Fprintf(b, "| %s | %.4f | %.4f | %.4f | **%.4f** (%s) | %d | %d | %d |\n",
+			s.ClusterID, s.IngressRatio, s.EgressRatio, s.PartitionRatio, s.MaxRatio, driver, s.SizedECKU, s.SLAFloorECKU, s.FinalECKU)
+	}
+	b.WriteString("\nMax-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.\n\n")
+	b.WriteString("</details>\n\n")
+}
+
+// sizingDriver returns the label of the ratio that won max() for a cluster.
+// Used in the appendix table so the reader can see at a glance which
+// dimension (ingress, egress, or partitions) drove the eCKU number.
+func sizingDriver(s types.ClusterSizing) string {
+	switch {
+	case s.MaxRatio == s.EgressRatio:
+		return "egress"
+	case s.MaxRatio == s.IngressRatio:
+		return "ingress"
+	default:
+		return "partitions"
+	}
+}

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -12,26 +12,31 @@ import (
 // Sizing & Cluster Decisions table with full rationale, collapsed
 // Appendix A1 with the sizing math expansion. MVP scope — no auth /
 // switchover / red flag sections (each lands with its own follow-up).
-func RenderMarkdown(p *types.Plan) ([]byte, error) {
+//
+// cfg is read for product-fact numbers in the Definitions block and for
+// the partition cap rendered in the appendix; pass the same PlanConfig
+// the PlanService used to build the plan.
+func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	var b bytes.Buffer
 
 	fmt.Fprintf(&b, "# Migration Plan — %s → Confluent Cloud\n\n", p.Header.Source)
 	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath)
 
-	writeDefinitions(&b)
+	writeDefinitions(&b, cfg)
 	writeSourceEnvironment(&b, p)
 	writeSizingAndDecisions(&b, p)
-	writeSizingAppendix(&b, p)
+	writeSizingAppendix(&b, p, cfg)
 
 	return b.Bytes(), nil
 }
 
-func writeDefinitions(b *bytes.Buffer) {
+func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
+	caps := cfg.EnterpriseCaps
 	b.WriteString("## Definitions\n\n")
-	b.WriteString("- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. ~30 MB/s ingress + 90 MB/s egress per eCKU at the per-eCKU caps used below.\n")
-	b.WriteString("- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 so a transient spike doesn't permanently inflate the recommended cluster size.\n")
-	b.WriteString("- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom.\n")
-	b.WriteString("- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.\n\n")
+	fmt.Fprintf(b, "- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. %d MB/s ingress + %d MB/s egress per eCKU at the per-eCKU caps used below.\n", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps)
+	b.WriteString("- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 (override with `sizing_percentile`) so a transient spike doesn't permanently inflate the recommended cluster size.\n")
+	fmt.Fprintf(b, "- **PrivateLink** — single-AZ private connectivity, up to %d eCKU. The default network when the cluster fits inside it with headroom.\n", caps.PrivateLinkMaxECKU)
+	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to %d eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst.\n\n", caps.PNIMaxECKU)
 }
 
 func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
@@ -108,10 +113,11 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan) {
 	b.WriteString("\n")
 }
 
-func writeSizingAppendix(b *bytes.Buffer, p *types.Plan) {
+func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 	if len(p.SizingAppendix) == 0 {
 		return
 	}
+	partitionCap := cfg.EnterpriseCaps.PerECKUPartitionRate
 	b.WriteString("## Appendix A1 — Sizing Math\n")
 	b.WriteString("<details><summary>Show sizing math per cluster</summary>\n\n")
 	b.WriteString("Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.\n\n")
@@ -121,31 +127,15 @@ func writeSizingAppendix(b *bytes.Buffer, p *types.Plan) {
 	fmt.Fprintf(b, "Formula: `%s`\n\n", p.SizingAppendix[0].Formula)
 	b.WriteString("| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |\n")
 	b.WriteString("|---|---:|---:|---:|---|---:|---:|---:|\n")
-	for i, s := range p.Sizing {
-		_ = i
+	for _, s := range p.Sizing {
 		if s.Degraded {
-			fmt.Fprintf(b, "| %s | _degraded_ | _degraded_ | %d / 3000 | _n/a_ | _n/a_ | %d | %d |\n",
-				s.ClusterID, s.UserPartitions, s.SLAFloorECKU, s.FinalECKU)
+			fmt.Fprintf(b, "| %s | _degraded_ | _degraded_ | %d / %d | _n/a_ | _n/a_ | %d | %d |\n",
+				s.ClusterID, s.UserPartitions, partitionCap, s.SLAFloorECKU, s.FinalECKU)
 			continue
 		}
-		driver := sizingDriver(s)
 		fmt.Fprintf(b, "| %s | %.4f | %.4f | %.4f | **%.4f** (%s) | %d | %d | %d |\n",
-			s.ClusterID, s.IngressRatio, s.EgressRatio, s.PartitionRatio, s.MaxRatio, driver, s.SizedECKU, s.SLAFloorECKU, s.FinalECKU)
+			s.ClusterID, s.IngressRatio, s.EgressRatio, s.PartitionRatio, s.MaxRatio, s.MaxRatioDriver, s.SizedECKU, s.SLAFloorECKU, s.FinalECKU)
 	}
 	b.WriteString("\nMax-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.\n\n")
 	b.WriteString("</details>\n\n")
-}
-
-// sizingDriver returns the label of the ratio that won max() for a cluster.
-// Used in the appendix table so the reader can see at a glance which
-// dimension (ingress, egress, or partitions) drove the eCKU number.
-func sizingDriver(s types.ClusterSizing) string {
-	switch {
-	case s.MaxRatio == s.EgressRatio:
-		return "egress"
-	case s.MaxRatio == s.IngressRatio:
-		return "ingress"
-	default:
-		return "partitions"
-	}
 }

--- a/internal/services/plan/render_markdown_test.go
+++ b/internal/services/plan/render_markdown_test.go
@@ -1,0 +1,171 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Renderer must surface a ⚠ cost callout when a customer-declared flag
+// is the reason a cluster was escalated to Dedicated — a wrong `true`
+// costs 5–10× monthly and the customer needs to see it inline with the
+// verdict, not buried in an appendix.
+func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "wrong-click", FinalECKU: 5, SizedInMBps: 10, SizedOutMBps: 10, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{
+				ClusterID: "wrong-click",
+				Verdict:   types.ClusterTypeDedicated,
+				Triggers: []types.HardLimitTrigger{
+					{
+						RowID:            "sla_99_95_single_zone",
+						Description:      "99.95% SLA within a single zone required",
+						Evidence:         "plan-inputs.yaml requires_99_95_sla_within_a_single_zone: true",
+						CustomerDeclared: true,
+					},
+				},
+			},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "wrong-click", Verdict: types.NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
+		},
+	}
+
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.Contains(t, body, "⚠", "cost callout must be surfaced for customer-declared Dedicated escalations")
+	assert.Contains(t, body, "5–10×", "must communicate the order-of-magnitude cost delta")
+	assert.Contains(t, body, "sla_99_95_single_zone", "must name the rule that fired so the customer can find the flag")
+}
+
+// Spiky FYI guards against P95 == 0 (the spiky flag fires for any
+// positive peak when P95 is zero — `peak > 2.0 * 0`). Without the
+// guard the renderer would print "+Inf" or "NaN" as the multiplier.
+func TestRenderMarkdown_SpikyNoteHandlesZeroP95(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "zero-p95", FinalECKU: 1, SizedInMBps: 0, PeakInMBps: 5, SpikyIngress: true, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{{ClusterID: "zero-p95", Verdict: types.ClusterTypeEnterprise}},
+		NetworkingDecision:  []types.NetworkingDecision{{ClusterID: "zero-p95", Verdict: types.NetworkingPrivateLink, Reason: "fits"}},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	assert.NotContains(t, body, "+Inf", "must not leak +Inf from peak/p95 when p95 is zero")
+	assert.NotContains(t, body, "NaN")
+	assert.Contains(t, body, "no P95 baseline", "must surface the missing-baseline phrase instead of a bogus ratio")
+}
+
+// Dedicated clusters render with MZ/SZ topology suffix so the reader
+// sees at a glance whether the verdict is Multi-Zone or the
+// 99.95%-SLA-driven Single-Zone variant. The size column flips from
+// eCKU to CKU because Dedicated uses a different unit.
+func TestRenderMarkdown_DedicatedTopologyAndCKULabel(t *testing.T) {
+	cfg := defaultCfg(t)
+	cku := 4
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "ent-small", FinalECKU: 2, SizedInMBps: 10, SizedOutMBps: 20, MaxRatioDriver: "ingress"},
+			{ClusterID: "ded-mz", FinalECKU: 4, SizedInMBps: 100, SizedOutMBps: 180, MaxRatioDriver: "ingress"},
+			{ClusterID: "ded-sz", FinalECKU: 4, SizedInMBps: 50, SizedOutMBps: 80, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{ClusterID: "ent-small", Verdict: types.ClusterTypeEnterprise},
+			{
+				ClusterID: "ded-mz",
+				Verdict:   types.ClusterTypeDedicated,
+				Topology:  types.TopologyMultiZone,
+				FinalCKU:  &cku,
+				Triggers:  []types.HardLimitTrigger{{RowID: "eCKU_exceeds_pni_cap", Description: "x", Evidence: "y"}},
+			},
+			{
+				ClusterID: "ded-sz",
+				Verdict:   types.ClusterTypeDedicated,
+				Topology:  types.TopologySingleZone,
+				FinalCKU:  &cku,
+				Triggers:  []types.HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95 SZ", Evidence: "flag", CustomerDeclared: true}},
+			},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "ent-small", Verdict: types.NetworkingPrivateLink, Reason: "fits"},
+			{ClusterID: "ded-mz", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "ded-sz", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+		},
+	}
+
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+
+	// Enterprise row: unit stays as eCKU, no topology suffix.
+	assert.Contains(t, body, "2 eCKU")
+	assert.Regexp(t, `ent-small.*Enterprise`, splitLine(body, "ent-small"))
+
+	// Dedicated MZ row: unit flips to CKU, label gets MZ suffix.
+	assert.Contains(t, body, "4 CKU")
+	assert.Contains(t, body, "Dedicated Multi-Zone (MZ)")
+
+	// Dedicated SZ row: same unit, SZ suffix.
+	assert.Contains(t, body, "Dedicated Single-Zone (SZ)")
+}
+
+// splitLine returns the substring of body that starts with the cluster
+// name through end-of-line — handy for per-row assertions.
+func splitLine(body, clusterID string) string {
+	idx := strings.Index(body, clusterID)
+	if idx < 0 {
+		return ""
+	}
+	rel := strings.Index(body[idx:], "\n")
+	if rel < 0 {
+		return body[idx:]
+	}
+	return body[idx : idx+rel]
+}
+
+// State-derived Dedicated verdicts (e.g. eCKU exceeds PNI cap) reflect
+// real source-environment facts, not wrong clicks. No callout — the
+// recommendation isn't recoverable by flipping a YAML flag.
+func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "real-big", FinalECKU: 50, SizedInMBps: 4000, SizedOutMBps: 4000, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{
+				ClusterID: "real-big",
+				Verdict:   types.ClusterTypeDedicated,
+				Triggers: []types.HardLimitTrigger{
+					{
+						RowID:       "eCKU_exceeds_pni_cap",
+						Description: "Sized eCKU exceeds Enterprise PNI cap",
+						Evidence:    "sized 50 eCKU > PNI cap 32 eCKU",
+						// CustomerDeclared deliberately false — this is state-derived.
+					},
+				},
+			},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "real-big", Verdict: types.NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
+		},
+	}
+
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.NotContains(t, body, "⚠", "state-derived Dedicated escalations must not surface the wrong-click callout")
+	assert.NotContains(t, body, "5–10×")
+}

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -30,8 +30,9 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 	caps := cfg.EnterpriseCaps
 	aggs := c.ClusterMetrics.Aggregates
 
-	p95InBytes, haveIn := pickPercentile(aggs, "BytesInPerSec", "P95")
-	p95OutBytes, haveOut := pickPercentile(aggs, "BytesOutPerSec", "P95")
+	pct := normalizePercentile(inputs.SizingPercentile)
+	p95InBytes, haveIn := pickPercentile(aggs, "BytesInPerSec", pct)
+	p95OutBytes, haveOut := pickPercentile(aggs, "BytesOutPerSec", pct)
 	if !haveIn || !haveOut {
 		slaFloor := slaFloorECKU(inputs.SLATarget, cfg.PlanInputDefaults.SLAFloorECKU)
 		return types.ClusterSizing{
@@ -40,10 +41,10 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 			SLAFloorECKU:   slaFloor,
 			FinalECKU:      slaFloor,
 			Degraded:       true,
-			DegradedReason: missingMetricsReason(haveIn, haveOut),
+			DegradedReason: missingMetricsReason(haveIn, haveOut, pct),
 			Citations: []types.FieldCitation{
-				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.p95", c.Name), Value: nil},
-				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.p95", c.Name), Value: nil},
+				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.%s", c.Name, citationKey(pct)), Value: nil},
+				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.%s", c.Name, citationKey(pct)), Value: nil},
 			},
 		}
 	}
@@ -65,7 +66,7 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 	ingressRatio := p95InMBps / float64(caps.PerECKUIngressMBps)
 	egressRatio := p95OutMBps / float64(caps.PerECKUEgressMBps)
 	partitionRatio := float64(userPartitions) / float64(caps.PerECKUPartitionRate)
-	maxRatio := maxOf(ingressRatio, egressRatio, partitionRatio)
+	maxRatio, maxDriver := pickMaxDriver(ingressRatio, egressRatio, partitionRatio)
 
 	sized := int(math.Ceil(maxRatio * (1.0 + inputs.HeadroomFraction)))
 	if sized < 1 {
@@ -99,6 +100,7 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 		EgressRatio:         egressRatio,
 		PartitionRatio:      partitionRatio,
 		MaxRatio:            maxRatio,
+		MaxRatioDriver:      maxDriver,
 		SizedECKU:           sized,
 		SLAFloorECKU:        slaFloor,
 		FinalECKU:           final,
@@ -109,13 +111,55 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 		SpikyIngress:        peakInMBps > spikyRatio*p95InMBps,
 		SpikyEgress:         peakOutMBps > spikyRatio*p95OutMBps,
 		Citations: []types.FieldCitation{
-			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.p95", c.Name), Value: p95InBytes},
-			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.p95", c.Name), Value: p95OutBytes},
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.%s", c.Name, citationKey(pct)), Value: p95InBytes},
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.%s", c.Name, citationKey(pct)), Value: p95OutBytes},
 			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.max", c.Name), Value: peakInBytes},
 			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.max", c.Name), Value: peakOutBytes},
 			{Path: fmt.Sprintf("cluster[%s].kafka_admin_client_information.topics.summary.total_partitions", c.Name), Value: userPartitions},
 		},
 	}
+}
+
+// normalizePercentile maps the customer's sizing_percentile input (P95 |
+// P99 | max) to the field name pickPercentile uses. Unknown values fall
+// back to "P95" so a stray input doesn't silently use the wrong column —
+// the validation hook on PlanInputs is the actual typo guard.
+func normalizePercentile(s string) string {
+	switch s {
+	case "P95", "P99", "max":
+		return s
+	default:
+		return "P95"
+	}
+}
+
+// citationKey is the lowercase token the citation path uses for the
+// chosen percentile — keeps the path string consistent with the JSON
+// field name in MetricAggregate (e.g. "p95" not "P95").
+func citationKey(pct string) string {
+	switch pct {
+	case "P99":
+		return "p99"
+	case "max":
+		return "max"
+	default:
+		return "p95"
+	}
+}
+
+// pickMaxDriver returns the largest of the three ratios and the label
+// of the dimension that produced it ("ingress" | "egress" | "partitions").
+// Ties resolve to the first ratio that touches the max, in the order
+// ingress, egress, partitions — stable and not float-equality dependent.
+func pickMaxDriver(ingress, egress, partitions float64) (float64, string) {
+	maxR, driver := ingress, "ingress"
+	if egress > maxR {
+		maxR, driver = egress, "egress"
+	}
+	if partitions > maxR {
+		maxR, driver = partitions, "partitions"
+	}
+	return maxR, driver
 }
 
 func userPartitionsOf(c types.ProcessedCluster) int {
@@ -125,14 +169,14 @@ func userPartitionsOf(c types.ProcessedCluster) int {
 	return c.KafkaAdminClientInformation.Topics.Summary.TotalPartitions
 }
 
-func missingMetricsReason(haveIn, haveOut bool) string {
+func missingMetricsReason(haveIn, haveOut bool, pct string) string {
 	switch {
 	case !haveIn && !haveOut:
-		return "no BytesInPerSec or BytesOutPerSec P95; re-run kcp scan metrics"
+		return fmt.Sprintf("no BytesInPerSec or BytesOutPerSec %s; re-run kcp scan metrics", pct)
 	case !haveIn:
-		return "no BytesInPerSec P95; re-run kcp scan metrics"
+		return fmt.Sprintf("no BytesInPerSec %s; re-run kcp scan metrics", pct)
 	default:
-		return "no BytesOutPerSec P95; re-run kcp scan metrics"
+		return fmt.Sprintf("no BytesOutPerSec %s; re-run kcp scan metrics", pct)
 	}
 }
 

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -1,0 +1,181 @@
+package plan
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// bytesPerMBps turns CloudWatch byte-rates into MBps (1024 * 1024).
+const bytesPerMBps = 1_048_576.0
+
+// ComputeClusterSizing implements the deterministic sizing formula:
+//
+//	max_ratio = max(P95In/per_eCKU_ingress_mbps,
+//	                P95Out/per_eCKU_egress_mbps,
+//	                user_partitions/per_eCKU_partition_rate)
+//	sized_eCKU = CEIL(max_ratio * (1 + headroom))
+//	final_eCKU = max(sized_eCKU, SLA_floor)
+//
+// Peak burst eCKU is derived from instantaneous max metric values and used
+// downstream to decide PrivateLink vs PNI.
+//
+// When throughput metrics are missing (e.g. `kcp discover` ran without
+// `kcp scan metrics`), the function returns a degraded ClusterSizing with
+// FinalECKU = SLA floor and Degraded = true rather than failing the whole
+// plan build. The renderer surfaces the gap so the customer knows the
+// sizing column is a placeholder.
+func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterSizing {
+	caps := cfg.EnterpriseCaps
+	aggs := c.ClusterMetrics.Aggregates
+
+	p95InBytes, haveIn := pickPercentile(aggs, "BytesInPerSec", "P95")
+	p95OutBytes, haveOut := pickPercentile(aggs, "BytesOutPerSec", "P95")
+	if !haveIn || !haveOut {
+		slaFloor := slaFloorECKU(inputs.SLATarget, cfg.PlanInputDefaults.SLAFloorECKU)
+		return types.ClusterSizing{
+			ClusterID:      c.Name,
+			UserPartitions: userPartitionsOf(c),
+			SLAFloorECKU:   slaFloor,
+			FinalECKU:      slaFloor,
+			Degraded:       true,
+			DegradedReason: missingMetricsReason(haveIn, haveOut),
+			Citations: []types.FieldCitation{
+				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.p95", c.Name), Value: nil},
+				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.p95", c.Name), Value: nil},
+			},
+		}
+	}
+
+	peakInBytes, _ := pickPercentile(aggs, "BytesInPerSec", "max")
+	peakOutBytes, _ := pickPercentile(aggs, "BytesOutPerSec", "max")
+
+	p95InMBps := p95InBytes / bytesPerMBps
+	p95OutMBps := p95OutBytes / bytesPerMBps
+	peakInMBps := peakInBytes / bytesPerMBps
+	peakOutMBps := peakOutBytes / bytesPerMBps
+
+	userPartitions := userPartitionsOf(c)
+	internalPartitions := 0
+	if topics := c.KafkaAdminClientInformation.Topics; topics != nil {
+		internalPartitions = topics.Summary.TotalInternalPartitions
+	}
+
+	ingressRatio := p95InMBps / float64(caps.PerECKUIngressMBps)
+	egressRatio := p95OutMBps / float64(caps.PerECKUEgressMBps)
+	partitionRatio := float64(userPartitions) / float64(caps.PerECKUPartitionRate)
+	maxRatio := maxOf(ingressRatio, egressRatio, partitionRatio)
+
+	sized := int(math.Ceil(maxRatio * (1.0 + inputs.HeadroomFraction)))
+	if sized < 1 {
+		sized = 1
+	}
+	slaFloor := slaFloorECKU(inputs.SLATarget, cfg.PlanInputDefaults.SLAFloorECKU)
+	final := sized
+	if slaFloor > final {
+		final = slaFloor
+	}
+
+	peakBurstInRatio := peakInMBps / float64(caps.PerECKUIngressMBps)
+	peakBurstOutRatio := peakOutMBps / float64(caps.PerECKUEgressMBps)
+	peakBurstECKU := int(math.Ceil(maxOf(peakBurstInRatio, peakBurstOutRatio)))
+	if peakBurstECKU < final {
+		peakBurstECKU = final
+	}
+	peakBurstPctOfPLCap := 100.0 * float64(peakBurstECKU) / float64(caps.PrivateLinkMaxECKU)
+
+	spikyRatio := inputs.SpikyWorkloadRatio
+
+	return types.ClusterSizing{
+		ClusterID:           c.Name,
+		P95InMBps:           p95InMBps,
+		P95OutMBps:          p95OutMBps,
+		PeakInMBps:          peakInMBps,
+		PeakOutMBps:         peakOutMBps,
+		UserPartitions:      userPartitions,
+		InternalPartitions:  internalPartitions,
+		IngressRatio:        ingressRatio,
+		EgressRatio:         egressRatio,
+		PartitionRatio:      partitionRatio,
+		MaxRatio:            maxRatio,
+		SizedECKU:           sized,
+		SLAFloorECKU:        slaFloor,
+		FinalECKU:           final,
+		PeakBurstInRatio:    peakBurstInRatio,
+		PeakBurstOutRatio:   peakBurstOutRatio,
+		PeakBurstECKU:       peakBurstECKU,
+		PeakBurstPctOfPLCap: peakBurstPctOfPLCap,
+		SpikyIngress:        peakInMBps > spikyRatio*p95InMBps,
+		SpikyEgress:         peakOutMBps > spikyRatio*p95OutMBps,
+		Citations: []types.FieldCitation{
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.p95", c.Name), Value: p95InBytes},
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.p95", c.Name), Value: p95OutBytes},
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.max", c.Name), Value: peakInBytes},
+			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.max", c.Name), Value: peakOutBytes},
+			{Path: fmt.Sprintf("cluster[%s].kafka_admin_client_information.topics.summary.total_partitions", c.Name), Value: userPartitions},
+		},
+	}
+}
+
+func userPartitionsOf(c types.ProcessedCluster) int {
+	if c.KafkaAdminClientInformation.Topics == nil {
+		return 0
+	}
+	return c.KafkaAdminClientInformation.Topics.Summary.TotalPartitions
+}
+
+func missingMetricsReason(haveIn, haveOut bool) string {
+	switch {
+	case !haveIn && !haveOut:
+		return "no BytesInPerSec or BytesOutPerSec P95; re-run kcp scan metrics"
+	case !haveIn:
+		return "no BytesInPerSec P95; re-run kcp scan metrics"
+	default:
+		return "no BytesOutPerSec P95; re-run kcp scan metrics"
+	}
+}
+
+func pickPercentile(aggs map[string]types.MetricAggregate, label, field string) (float64, bool) {
+	a, ok := aggs[label]
+	if !ok {
+		return 0, false
+	}
+	var ptr *float64
+	switch field {
+	case "P95":
+		ptr = a.P95
+	case "P99":
+		ptr = a.P99
+	case "max":
+		ptr = a.Maximum
+	case "min":
+		ptr = a.Minimum
+	case "avg":
+		ptr = a.Average
+	}
+	if ptr == nil {
+		return 0, false
+	}
+	return *ptr, true
+}
+
+func maxOf(vals ...float64) float64 {
+	m := math.Inf(-1)
+	for _, v := range vals {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+func slaFloorECKU(target string, floors map[string]int) int {
+	if target == "" {
+		target = "99.9"
+	}
+	if v, ok := floors[target]; ok {
+		return v
+	}
+	return 1
+}

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -90,8 +90,8 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 
 	return types.ClusterSizing{
 		ClusterID:           c.Name,
-		P95InMBps:           p95InMBps,
-		P95OutMBps:          p95OutMBps,
+		SizedInMBps:         p95InMBps,
+		SizedOutMBps:        p95OutMBps,
 		PeakInMBps:          peakInMBps,
 		PeakOutMBps:         peakOutMBps,
 		UserPartitions:      userPartitions,
@@ -120,31 +120,28 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 	}
 }
 
-// normalizePercentile maps the customer's sizing_percentile input (P95 |
-// P99 | max) to the field name pickPercentile uses. Unknown values fall
-// back to "P95" so a stray input doesn't silently use the wrong column —
-// the validation hook on PlanInputs is the actual typo guard.
+// normalizePercentile maps the customer's sizing_percentile input
+// (p95 | p99 | max) to the canonical lowercase form. Accepts legacy
+// uppercase variants (`P95`, `P99`) for back-compat with pre-spec
+// inputs, but the canonical surface is lowercase to match Confluent
+// dashboards. Unknown values fall back to "p95".
 func normalizePercentile(s string) string {
 	switch s {
-	case "P95", "P99", "max":
-		return s
-	default:
-		return "P95"
-	}
-}
-
-// citationKey is the lowercase token the citation path uses for the
-// chosen percentile — keeps the path string consistent with the JSON
-// field name in MetricAggregate (e.g. "p95" not "P95").
-func citationKey(pct string) string {
-	switch pct {
-	case "P99":
+	case "p95", "P95":
+		return "p95"
+	case "p99", "P99":
 		return "p99"
 	case "max":
 		return "max"
 	default:
 		return "p95"
 	}
+}
+
+// citationKey is the lowercase token the citation path uses — same as
+// the percentile itself now that the input is lowercase.
+func citationKey(pct string) string {
+	return pct
 }
 
 // pickMaxDriver returns the largest of the three ratios and the label
@@ -169,14 +166,18 @@ func userPartitionsOf(c types.ProcessedCluster) int {
 	return c.KafkaAdminClientInformation.Topics.Summary.TotalPartitions
 }
 
+// missingMetricsReason returns the SYMPTOM only — what's missing from
+// the state file. The action (re-run `kcp scan metrics`) is appended by
+// callers that render the value, so it isn't duplicated when the same
+// reason flows into both the rationale line and the Open Questions section.
 func missingMetricsReason(haveIn, haveOut bool, pct string) string {
 	switch {
 	case !haveIn && !haveOut:
-		return fmt.Sprintf("no BytesInPerSec or BytesOutPerSec %s; re-run kcp scan metrics", pct)
+		return fmt.Sprintf("no BytesInPerSec or BytesOutPerSec %s in state file", pct)
 	case !haveIn:
-		return fmt.Sprintf("no BytesInPerSec %s; re-run kcp scan metrics", pct)
+		return fmt.Sprintf("no BytesInPerSec %s in state file", pct)
 	default:
-		return fmt.Sprintf("no BytesOutPerSec %s; re-run kcp scan metrics", pct)
+		return fmt.Sprintf("no BytesOutPerSec %s in state file", pct)
 	}
 }
 
@@ -187,9 +188,9 @@ func pickPercentile(aggs map[string]types.MetricAggregate, label, field string) 
 	}
 	var ptr *float64
 	switch field {
-	case "P95":
+	case "p95":
 		ptr = a.P95
-	case "P99":
+	case "p99":
 		ptr = a.P99
 	case "max":
 		ptr = a.Maximum

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -1,0 +1,107 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureCluster builds a ProcessedCluster with the metric aggregates that
+// drive the sizing formula. Caller passes in P95/peak values in MBps.
+func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMBps, peakOutMBps float64) types.ProcessedCluster {
+	p95In := p95InMBps * bytesPerMBps
+	p95Out := p95OutMBps * bytesPerMBps
+	peakIn := peakInMBps * bytesPerMBps
+	peakOut := peakOutMBps * bytesPerMBps
+	return types.ProcessedCluster{
+		Name:   name,
+		Region: "us-east-1",
+		ClusterMetrics: types.ProcessedClusterMetrics{
+			Aggregates: map[string]types.MetricAggregate{
+				"BytesInPerSec":  {P95: &p95In, Maximum: &peakIn},
+				"BytesOutPerSec": {P95: &p95Out, Maximum: &peakOut},
+			},
+		},
+		KafkaAdminClientInformation: types.KafkaAdminClientInformation{
+			Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: partitions}},
+		},
+	}
+}
+
+func defaultInputs() types.PlanInputsResolved {
+	return types.PlanInputsResolved{
+		SLATarget:                  "99.9",
+		SizingPercentile:           "P95",
+		HeadroomFraction:           0.30,
+		PrivateLinkSafetyThreshold: 0.80,
+		SpikyWorkloadRatio:         2.0,
+	}
+}
+
+func defaultCfg(t *testing.T) *PlanConfig {
+	t.Helper()
+	cfg, err := LoadPlanConfig("")
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestComputeClusterSizing_EgressDominant(t *testing.T) {
+	// Read-heavy fan-out workload: egress at ~995 MBps drives the max ratio
+	// well above ingress and partitions, so the egress dimension wins and
+	// sizing snaps to 8 eCKU.
+	c := fixtureCluster("read-heavy", 2058, 88.7, 994.8, 99.0, 1200.0)
+	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+
+	assert.False(t, s.Degraded)
+	assert.InDelta(t, 88.7, s.P95InMBps, 0.1)
+	assert.InDelta(t, 994.8, s.P95OutMBps, 0.1)
+	// egress ratio = 994.8 / 180 = 5.5267 dominates; CEIL(5.5267 * 1.30) = 8
+	assert.Equal(t, 8, s.SizedECKU)
+	assert.Equal(t, 8, s.FinalECKU)
+}
+
+func TestComputeClusterSizing_SLAFloorBinds(t *testing.T) {
+	// Tiny workload: 99.99 SLA target forces FinalECKU >= 2 even though the
+	// math says 1.
+	c := fixtureCluster("small", 10, 0.1, 0.1, 0.2, 0.2)
+	inputs := defaultInputs()
+	inputs.SLATarget = "99.99"
+	s := ComputeClusterSizing(c, defaultCfg(t), inputs)
+	assert.Equal(t, 1, s.SizedECKU)
+	assert.Equal(t, 2, s.SLAFloorECKU)
+	assert.Equal(t, 2, s.FinalECKU)
+}
+
+func TestComputeClusterSizing_DegradedOnMissingP95(t *testing.T) {
+	// State file that has zero metric aggregates (kcp discover ran without
+	// kcp scan metrics) should not abort — surface a degraded sizing.
+	c := types.ProcessedCluster{
+		Name:                        "no-metrics",
+		ClusterMetrics:              types.ProcessedClusterMetrics{Aggregates: map[string]types.MetricAggregate{}},
+		KafkaAdminClientInformation: types.KafkaAdminClientInformation{Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: 50}}},
+	}
+	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	require.True(t, s.Degraded)
+	assert.Contains(t, s.DegradedReason, "BytesInPerSec")
+	assert.Equal(t, 50, s.UserPartitions)
+	assert.Equal(t, 1, s.FinalECKU)
+	assert.Equal(t, 1, s.SLAFloorECKU)
+}
+
+func TestComputeClusterSizing_SpikyDetection(t *testing.T) {
+	// Peak 5× P95 → spiky flag fires.
+	c := fixtureCluster("spike", 100, 10.0, 10.0, 50.0, 50.0)
+	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	assert.True(t, s.SpikyIngress)
+	assert.True(t, s.SpikyEgress)
+}
+
+func TestComputeClusterSizing_PartitionWinner(t *testing.T) {
+	// 100k partitions dominate throughput in the max-ratio.
+	c := fixtureCluster("part", 100_000, 1.0, 1.0, 1.0, 1.0)
+	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	// partition ratio = 100000 / 3000 = 33.33; CEIL(33.33 * 1.30) = 44
+	assert.Equal(t, 44, s.SizedECKU)
+}

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -33,7 +33,7 @@ func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMB
 func defaultInputs() types.PlanInputsResolved {
 	return types.PlanInputsResolved{
 		SLATarget:                  "99.9",
-		SizingPercentile:           "P95",
+		SizingPercentile:           "p95",
 		HeadroomFraction:           0.30,
 		PrivateLinkSafetyThreshold: 0.80,
 		SpikyWorkloadRatio:         2.0,
@@ -55,8 +55,8 @@ func TestComputeClusterSizing_EgressDominant(t *testing.T) {
 	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
 
 	assert.False(t, s.Degraded)
-	assert.InDelta(t, 88.7, s.P95InMBps, 0.1)
-	assert.InDelta(t, 994.8, s.P95OutMBps, 0.1)
+	assert.InDelta(t, 88.7, s.SizedInMBps, 0.1)
+	assert.InDelta(t, 994.8, s.SizedOutMBps, 0.1)
 	// egress ratio = 994.8 / 180 = 5.5267 dominates; CEIL(5.5267 * 1.30) = 8
 	assert.Equal(t, 8, s.SizedECKU)
 	assert.Equal(t, 8, s.FinalECKU)

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -675,8 +675,9 @@ func nearestRankIndex(n int, p float64) int {
 }
 
 // calculateMetricsAggregates returns avg, min, max, P95, P99, and count
-// per metric label. Percentiles use the lower-index nearest-rank method:
-// `values[int(N*p)]` after sorting.
+// per metric label. Percentiles use the nearest-rank method (R type 1):
+// after sorting, index = ceil(N*p) - 1, clamped to [0, N-1]. See
+// nearestRankIndex.
 func (rs *ReportService) calculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
 	metricsByLabel := make(map[string][]float64)
 

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -2,6 +2,8 @@ package report
 
 import (
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -645,48 +647,72 @@ func (rs *ReportService) flattenMetrics(cluster types.DiscoveredCluster) types.P
 	}
 }
 
-// calculateMetricsAggregates calculates avg, max, min aggregates for each metric type
+// CalculateMetricsAggregates is the exported entry point for callers outside
+// the report service (e.g. PlanService) that need percentile/aggregate
+// computations on flattened ProcessedMetric data.
+func CalculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
+	rs := NewReportService()
+	return rs.calculateMetricsAggregates(metrics)
+}
+
+// nearestRankIndex returns the index into a sorted N-element slice that
+// corresponds to the p-th percentile using the nearest-rank method
+// (R type 1 / NIST): index = ceil(N * p) - 1, clamped to [0, N-1].
+// For N=20, p=0.95 -> index 18; p=0.99 -> index 19 (distinct ranks).
+// For N<=1 the slice has only one value, returned for any percentile.
+func nearestRankIndex(n int, p float64) int {
+	if n <= 1 {
+		return 0
+	}
+	idx := int(math.Ceil(float64(n)*p)) - 1
+	if idx < 0 {
+		return 0
+	}
+	if idx >= n {
+		return n - 1
+	}
+	return idx
+}
+
+// calculateMetricsAggregates returns avg, min, max, P95, P99, and count
+// per metric label. Percentiles use the lower-index nearest-rank method:
+// `values[int(N*p)]` after sorting.
 func (rs *ReportService) calculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
-	// Group metrics by label (metric type)
 	metricsByLabel := make(map[string][]float64)
 
 	for _, metric := range metrics {
 		if metric.Value != nil {
-			// Remove "Cluster Aggregate - " prefix if present
 			cleanLabel := strings.TrimPrefix(metric.Label, "Cluster Aggregate - ")
 			metricsByLabel[cleanLabel] = append(metricsByLabel[cleanLabel], *metric.Value)
 		}
 	}
 
-	// Calculate aggregates for each metric type
 	aggregates := make(map[string]types.MetricAggregate)
-
 	for label, values := range metricsByLabel {
 		if len(values) == 0 {
 			continue
 		}
 
-		// Calculate min, max, sum for average
+		sort.Float64s(values)
+
 		min := values[0]
-		max := values[0]
+		max := values[len(values)-1]
 		sum := 0.0
-
-		for _, value := range values {
-			if value < min {
-				min = value
-			}
-			if value > max {
-				max = value
-			}
-			sum += value
+		for _, v := range values {
+			sum += v
 		}
-
 		avg := sum / float64(len(values))
+
+		p95 := values[nearestRankIndex(len(values), 0.95)]
+		p99 := values[nearestRankIndex(len(values), 0.99)]
 
 		aggregates[label] = types.MetricAggregate{
 			Average: &avg,
 			Maximum: &max,
 			Minimum: &min,
+			P95:     &p95,
+			P99:     &p99,
+			Count:   len(values),
 		}
 	}
 

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -263,7 +263,7 @@ func (rs *ReportService) filterMSKClusterMetrics(processedState types.ProcessedS
 	}
 
 	filteredMetrics := rs.filterMetricsByDateRange(targetCluster.ClusterMetrics.Metrics, startTime, endTime)
-	aggregates := rs.calculateMetricsAggregates(filteredMetrics)
+	aggregates := CalculateMetricsAggregates(filteredMetrics)
 
 	return &types.ProcessedClusterMetrics{
 		Region:     regionName,
@@ -316,7 +316,7 @@ func (rs *ReportService) filterOSKClusterMetrics(processedState types.ProcessedS
 	filteredMetrics := rs.filterMetricsByDateRange(targetCluster.ClusterMetrics.Metrics, startTime, endTime)
 
 	// Calculate aggregates from filtered metrics
-	aggregates := rs.calculateMetricsAggregates(filteredMetrics)
+	aggregates := CalculateMetricsAggregates(filteredMetrics)
 
 	return &types.ProcessedClusterMetrics{
 		Region:      "", // OSK clusters don't have regions
@@ -367,7 +367,7 @@ func (rs *ReportService) FilterMetrics(processedState types.ProcessedState, regi
 	filteredMetrics := rs.filterMetricsByDateRange(targetCluster.ClusterMetrics.Metrics, startTime, endTime)
 
 	// Calculate aggregates from filtered metrics
-	aggregates := rs.calculateMetricsAggregates(filteredMetrics)
+	aggregates := CalculateMetricsAggregates(filteredMetrics)
 
 	return &types.ProcessedClusterMetrics{
 		Metadata:   targetCluster.ClusterMetrics.Metadata,
@@ -647,14 +647,6 @@ func (rs *ReportService) flattenMetrics(cluster types.DiscoveredCluster) types.P
 	}
 }
 
-// CalculateMetricsAggregates is the exported entry point for callers outside
-// the report service (e.g. PlanService) that need percentile/aggregate
-// computations on flattened ProcessedMetric data.
-func CalculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
-	rs := NewReportService()
-	return rs.calculateMetricsAggregates(metrics)
-}
-
 // nearestRankIndex returns the index into a sorted N-element slice that
 // corresponds to the p-th percentile using the nearest-rank method
 // (R type 1 / NIST): index = ceil(N * p) - 1, clamped to [0, N-1].
@@ -674,11 +666,10 @@ func nearestRankIndex(n int, p float64) int {
 	return idx
 }
 
-// calculateMetricsAggregates returns avg, min, max, P95, P99, and count
-// per metric label. Percentiles use the nearest-rank method (R type 1):
-// after sorting, index = ceil(N*p) - 1, clamped to [0, N-1]. See
+// CalculateMetricsAggregates returns avg, min, max, P95, P99, and count
+// per metric label. Percentiles use the nearest-rank method — see
 // nearestRankIndex.
-func (rs *ReportService) calculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
+func CalculateMetricsAggregates(metrics []types.ProcessedMetric) map[string]types.MetricAggregate {
 	metricsByLabel := make(map[string][]float64)
 
 	for _, metric := range metrics {

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -862,3 +862,60 @@ func TestFilterClusterMetrics_DateFiltering(t *testing.T) {
 		assert.InDelta(t, 400.0, *agg.Maximum, 0.01)
 	})
 }
+
+func TestCalculateMetricsAggregates(t *testing.T) {
+	rs := NewReportService()
+
+	makeMetrics := func(label string, values []float64) []types.ProcessedMetric {
+		out := make([]types.ProcessedMetric, len(values))
+		for i, v := range values {
+			v := v
+			out[i] = types.ProcessedMetric{Label: label, Value: &v}
+		}
+		return out
+	}
+
+	t.Run("computes P95 P99 against fixed 1..100 vector (nearest rank)", func(t *testing.T) {
+		// unsorted on input to prove sort happens
+		values := make([]float64, 100)
+		for i := 0; i < 100; i++ {
+			values[i] = float64(100 - i)
+		}
+		aggs := rs.calculateMetricsAggregates(makeMetrics("BytesInPerSec", values))
+		agg, ok := aggs["BytesInPerSec"]
+		require.True(t, ok)
+		// ceil(100*0.95)-1 = 94 -> sorted[94] = 95
+		// ceil(100*0.99)-1 = 98 -> sorted[98] = 99
+		assert.InDelta(t, 95.0, *agg.P95, 0.0001)
+		assert.InDelta(t, 99.0, *agg.P99, 0.0001)
+		assert.Equal(t, 100, agg.Count)
+	})
+
+	t.Run("P95 and P99 are distinct at N=20", func(t *testing.T) {
+		// Regression: the previous int(N*p) implementation collapsed
+		// P95 == P99 at N=20 (both indexed [19]). Nearest-rank gives
+		// ceil(20*0.95)-1=18 (=19) and ceil(20*0.99)-1=19 (=20).
+		values := make([]float64, 20)
+		for i := 0; i < 20; i++ {
+			values[i] = float64(i + 1)
+		}
+		aggs := rs.calculateMetricsAggregates(makeMetrics("M", values))
+		assert.InDelta(t, 19.0, *aggs["M"].P95, 0.0001)
+		assert.InDelta(t, 20.0, *aggs["M"].P99, 0.0001)
+	})
+
+	t.Run("missing value at the rank doesn't crash", func(t *testing.T) {
+		// 1..100 minus 95 → N=99, ceil(99*0.95)-1=94, sorted[94]=96
+		// (indexes 0..93 hold 1..94; index 94 holds 96 because 95 is absent).
+		values := []float64{}
+		for i := 1; i <= 100; i++ {
+			if i == 95 {
+				continue
+			}
+			values = append(values, float64(i))
+		}
+		aggs := rs.calculateMetricsAggregates(makeMetrics("M", values))
+		require.Equal(t, 99, aggs["M"].Count)
+		assert.InDelta(t, 96.0, *aggs["M"].P95, 0.0001)
+	})
+}

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -864,8 +864,6 @@ func TestFilterClusterMetrics_DateFiltering(t *testing.T) {
 }
 
 func TestCalculateMetricsAggregates(t *testing.T) {
-	rs := NewReportService()
-
 	makeMetrics := func(label string, values []float64) []types.ProcessedMetric {
 		out := make([]types.ProcessedMetric, len(values))
 		for i, v := range values {
@@ -881,7 +879,7 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			values[i] = float64(100 - i)
 		}
-		aggs := rs.calculateMetricsAggregates(makeMetrics("BytesInPerSec", values))
+		aggs := CalculateMetricsAggregates(makeMetrics("BytesInPerSec", values))
 		agg, ok := aggs["BytesInPerSec"]
 		require.True(t, ok)
 		// ceil(100*0.95)-1 = 94 -> sorted[94] = 95
@@ -899,7 +897,7 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 		for i := 0; i < 20; i++ {
 			values[i] = float64(i + 1)
 		}
-		aggs := rs.calculateMetricsAggregates(makeMetrics("M", values))
+		aggs := CalculateMetricsAggregates(makeMetrics("M", values))
 		assert.InDelta(t, 19.0, *aggs["M"].P95, 0.0001)
 		assert.InDelta(t, 20.0, *aggs["M"].P99, 0.0001)
 	})
@@ -914,7 +912,7 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 			}
 			values = append(values, float64(i))
 		}
-		aggs := rs.calculateMetricsAggregates(makeMetrics("M", values))
+		aggs := CalculateMetricsAggregates(makeMetrics("M", values))
 		require.Equal(t, 99, aggs["M"].Count)
 		assert.InDelta(t, 96.0, *aggs["M"].P95, 0.0001)
 	})

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -15,6 +15,20 @@ type Plan struct {
 	ClusterTypeDecision []ClusterTypeDecision `json:"cluster_type_decision"`
 	NetworkingDecision  []NetworkingDecision  `json:"networking_decision"`
 	SizingAppendix      []SizingMathDetail    `json:"sizing_appendix"`
+	OpenQuestions       []OpenQuestion        `json:"open_questions,omitempty"`
+}
+
+// OpenQuestion is a per-cluster (or plan-level) gap the customer needs
+// to close before the Plan recommendation is fully reliable. State-file
+// gaps (missing metrics, missing ACLs) resolve by re-running a `kcp scan`
+// command; inferred-signal questions (spiky workload) resolve by
+// acknowledging or overriding the input.
+type OpenQuestion struct {
+	ID         string `json:"id"`
+	ClusterID  string `json:"cluster_id,omitempty"`
+	Title      string `json:"title"`
+	Body       string `json:"body"`
+	HowToClose string `json:"how_to_close"`
 }
 
 type PlanHeader struct {
@@ -47,9 +61,12 @@ type SourceClusterSummary struct {
 // ----- sizing & decisions -----
 
 type ClusterSizing struct {
-	ClusterID          string  `json:"cluster_id"`
-	P95InMBps          float64 `json:"p95_in_mbps"`
-	P95OutMBps         float64 `json:"p95_out_mbps"`
+	ClusterID string `json:"cluster_id"`
+	// SizedInMBps / SizedOutMBps hold the throughput at the configured
+	// `sizing_percentile` (default p95; alternates p99, max). Read
+	// `plan.inputs.sizing_percentile` to see which percentile was used.
+	SizedInMBps        float64 `json:"sized_in_mbps"`
+	SizedOutMBps       float64 `json:"sized_out_mbps"`
 	PeakInMBps         float64 `json:"peak_in_mbps"`
 	PeakOutMBps        float64 `json:"peak_out_mbps"`
 	UserPartitions     int     `json:"user_partitions"`
@@ -99,29 +116,53 @@ func (c ClusterType) IsValid() bool {
 	}
 }
 
+// Topology distinguishes Multi-Zone (MZ) from Single-Zone (SZ) Dedicated
+// clusters. Only meaningful when Verdict == Dedicated; Enterprise clusters
+// have no topology dimension at this layer.
+type Topology string
+
+const (
+	TopologyNotApplicable Topology = ""
+	TopologyMultiZone     Topology = "MultiZone"
+	TopologySingleZone    Topology = "SingleZone"
+)
+
 type ClusterTypeDecision struct {
 	ClusterID string             `json:"cluster_id"`
 	Verdict   ClusterType        `json:"verdict"`
 	Triggers  []HardLimitTrigger `json:"triggers,omitempty"`
+	// Topology is populated for Dedicated verdicts (MZ default; SZ when the
+	// 99.95% single-zone SLA rule fires). Empty for Enterprise.
+	Topology Topology `json:"topology,omitempty"`
+	// FinalCKU mirrors the sizing's FinalECKU under the Dedicated unit
+	// (Confluent Kafka Unit). Set only when Verdict == Dedicated.
+	FinalCKU *int `json:"final_cku,omitempty"`
 }
 
 type HardLimitTrigger struct {
 	RowID       string `json:"row_id"`
 	Description string `json:"description"`
 	Evidence    string `json:"evidence"`
+	// CustomerDeclared marks rules whose only signal is a customer-set
+	// `plan-inputs.yaml` flag. Renderer surfaces a cost callout on these
+	// so a wrong `true` doesn't quietly flip the verdict from Enterprise
+	// to Dedicated (Dedicated runs 5–10× monthly).
+	CustomerDeclared bool `json:"customer_declared,omitempty"`
 }
 
 // Networking represents the per-cluster networking verdict.
 type Networking string
 
 const (
-	NetworkingPrivateLink Networking = "PrivateLink"
-	NetworkingPNI         Networking = "PNI"
+	NetworkingPrivateLink    Networking = "PrivateLink"
+	NetworkingPNI            Networking = "PNI"
+	NetworkingTransitGateway Networking = "TransitGateway"
+	NetworkingVPCPeering     Networking = "VPCPeering"
 )
 
 func (n Networking) IsValid() bool {
 	switch n {
-	case NetworkingPrivateLink, NetworkingPNI:
+	case NetworkingPrivateLink, NetworkingPNI, NetworkingTransitGateway, NetworkingVPCPeering:
 		return true
 	default:
 		return false
@@ -162,4 +203,14 @@ type PlanInputsResolved struct {
 	HeadroomFraction           float64 `json:"headroom_fraction"`
 	PrivateLinkSafetyThreshold float64 `json:"privatelink_safety_threshold"`
 	SpikyWorkloadRatio         float64 `json:"spiky_workload_ratio"`
+
+	// Customer-declared hard requirements. Booleans (not *bool) — defaults
+	// resolve to false, which is the safe verdict (no escalation to Dedicated).
+	EnforceSchemasAtTheBroker            bool `json:"enforce_schemas_at_the_broker"`
+	RequiresHighThroughputRESTProduceAPI bool `json:"requires_high_throughput_rest_produce_api"`
+	Requires9995SLAWithinSingleZone      bool `json:"requires_99_95_sla_within_a_single_zone"`
+
+	// Target cloud + existing VPC connectivity (Dedicated-path networking).
+	TargetCloud             string `json:"target_cloud"`
+	ExistingVPCConnectivity string `json:"existing_vpc_connectivity"`
 }

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -1,0 +1,161 @@
+package types
+
+import "time"
+
+// Plan is the deterministic Migration Plan emitted by `kcp report plan`.
+// This MVP scope covers source-environment summary, sizing, cluster-type
+// decision, and networking decision only. Auth approach, switchover,
+// red flags, cost reconciliation, and the rest of the §4 surface in the
+// design doc land in follow-up PRs.
+type Plan struct {
+	Header              PlanHeader            `json:"header"`
+	Inputs              PlanInputsResolved    `json:"inputs"`
+	SourceEnvironment   SourceEnvironment     `json:"source_environment"`
+	Sizing              []ClusterSizing       `json:"sizing"`
+	ClusterTypeDecision []ClusterTypeDecision `json:"cluster_type_decision"`
+	NetworkingDecision  []NetworkingDecision  `json:"networking_decision"`
+	SizingAppendix      []SizingMathDetail    `json:"sizing_appendix"`
+}
+
+type PlanHeader struct {
+	Source        string    `json:"source"`
+	StateFilePath string    `json:"state_file_path"`
+	KCPVersion    string    `json:"kcp_version"`
+	GeneratedAt   time.Time `json:"generated_at"`
+
+	// PlanSchemaVersion is a string while the JSON shape is still
+	// shifting: top-level keys (auth_approach, switchover_approach,
+	// red_flags, …) are landing in follow-up PRs. Hub consumers should
+	// treat "1-experimental" as "additive changes only; renames may
+	// happen". Bumps to "1" once §4 of the design ships in full.
+	PlanSchemaVersion string `json:"plan_schema_version"`
+}
+
+type SourceEnvironment struct {
+	Clusters     []SourceClusterSummary `json:"clusters"`
+	TotalRegions int                    `json:"total_regions"`
+}
+
+type SourceClusterSummary struct {
+	ClusterID    string `json:"cluster_id"`
+	Region       string `json:"region"`
+	BrokerCount  int    `json:"broker_count"`
+	TopicCount   int    `json:"topic_count"`
+	KafkaVersion string `json:"kafka_version,omitempty"`
+}
+
+// ----- sizing & decisions -----
+
+type ClusterSizing struct {
+	ClusterID           string          `json:"cluster_id"`
+	P95InMBps           float64         `json:"p95_in_mbps"`
+	P95OutMBps          float64         `json:"p95_out_mbps"`
+	PeakInMBps          float64         `json:"peak_in_mbps"`
+	PeakOutMBps         float64         `json:"peak_out_mbps"`
+	UserPartitions      int             `json:"user_partitions"`
+	InternalPartitions  int             `json:"internal_partitions"`
+	IngressRatio        float64         `json:"ingress_ratio"`
+	EgressRatio         float64         `json:"egress_ratio"`
+	PartitionRatio      float64         `json:"partition_ratio"`
+	MaxRatio            float64         `json:"max_ratio"`
+	SizedECKU           int             `json:"sized_ecku"`
+	SLAFloorECKU        int             `json:"sla_floor_ecku"`
+	FinalECKU           int             `json:"final_ecku"`
+	PeakBurstInRatio    float64         `json:"peak_burst_in_ratio"`
+	PeakBurstOutRatio   float64         `json:"peak_burst_out_ratio"`
+	PeakBurstECKU       int             `json:"peak_burst_ecku"`
+	PeakBurstPctOfPLCap float64         `json:"peak_burst_pct_of_pl_cap"`
+	SpikyIngress        bool            `json:"spiky_ingress"`
+	SpikyEgress         bool            `json:"spiky_egress"`
+	Citations           []FieldCitation `json:"citations"`
+
+	// Degraded is true when throughput metrics were missing from the state
+	// file. Numbers fall back to the SLA floor and the renderer surfaces
+	// the gap rather than silently asserting a sized eCKU.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
+}
+
+// ClusterType represents the Confluent Cloud cluster verdict.
+// Freight is in the Confluent product but not produced by DecideClusterType
+// today — when a rule that emits Freight lands, add the constant then.
+type ClusterType string
+
+const (
+	ClusterTypeEnterprise ClusterType = "Enterprise"
+	ClusterTypeDedicated  ClusterType = "Dedicated"
+)
+
+func (c ClusterType) IsValid() bool {
+	switch c {
+	case ClusterTypeEnterprise, ClusterTypeDedicated:
+		return true
+	default:
+		return false
+	}
+}
+
+type ClusterTypeDecision struct {
+	ClusterID string             `json:"cluster_id"`
+	Verdict   ClusterType        `json:"verdict"`
+	Triggers  []HardLimitTrigger `json:"triggers,omitempty"`
+}
+
+type HardLimitTrigger struct {
+	RowID       string `json:"row_id"`
+	Description string `json:"description"`
+	Evidence    string `json:"evidence"`
+}
+
+// Networking represents the per-cluster networking verdict.
+type Networking string
+
+const (
+	NetworkingPrivateLink Networking = "PrivateLink"
+	NetworkingPNI         Networking = "PNI"
+)
+
+func (n Networking) IsValid() bool {
+	switch n {
+	case NetworkingPrivateLink, NetworkingPNI:
+		return true
+	default:
+		return false
+	}
+}
+
+type NetworkingDecision struct {
+	ClusterID       string     `json:"cluster_id"`
+	Verdict         Networking `json:"verdict"`
+	PeakBurstECKU   int        `json:"peak_burst_ecku"`
+	PercentageOfCap float64    `json:"percentage_of_cap"`
+	Reason          string     `json:"reason"`
+}
+
+// ----- citations & appendix -----
+
+type FieldCitation struct {
+	Path  string `json:"path"`
+	Value any    `json:"value"`
+}
+
+type SizingMathDetail struct {
+	ClusterID         string          `json:"cluster_id"`
+	Formula           string          `json:"formula"`
+	IntermediateSteps []string        `json:"intermediate_steps"`
+	Citations         []FieldCitation `json:"citations,omitempty"`
+}
+
+// PlanInputsResolved is the customer's PlanInputs merged with pinned
+// defaults from plan-config.yaml. Raw preserves the original customer
+// input (nil pointers for fields they didn't set); the flat fields below
+// are the merged values PlanService computes against.
+type PlanInputsResolved struct {
+	Raw *PlanInputs `json:"raw,omitempty"`
+
+	SLATarget                  string  `json:"sla_target"`
+	SizingPercentile           string  `json:"sizing_percentile"`
+	HeadroomFraction           float64 `json:"headroom_fraction"`
+	PrivateLinkSafetyThreshold float64 `json:"privatelink_safety_threshold"`
+	SpikyWorkloadRatio         float64 `json:"spiky_workload_ratio"`
+}

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -47,17 +47,21 @@ type SourceClusterSummary struct {
 // ----- sizing & decisions -----
 
 type ClusterSizing struct {
-	ClusterID           string          `json:"cluster_id"`
-	P95InMBps           float64         `json:"p95_in_mbps"`
-	P95OutMBps          float64         `json:"p95_out_mbps"`
-	PeakInMBps          float64         `json:"peak_in_mbps"`
-	PeakOutMBps         float64         `json:"peak_out_mbps"`
-	UserPartitions      int             `json:"user_partitions"`
-	InternalPartitions  int             `json:"internal_partitions"`
-	IngressRatio        float64         `json:"ingress_ratio"`
-	EgressRatio         float64         `json:"egress_ratio"`
-	PartitionRatio      float64         `json:"partition_ratio"`
-	MaxRatio            float64         `json:"max_ratio"`
+	ClusterID          string  `json:"cluster_id"`
+	P95InMBps          float64 `json:"p95_in_mbps"`
+	P95OutMBps         float64 `json:"p95_out_mbps"`
+	PeakInMBps         float64 `json:"peak_in_mbps"`
+	PeakOutMBps        float64 `json:"peak_out_mbps"`
+	UserPartitions     int     `json:"user_partitions"`
+	InternalPartitions int     `json:"internal_partitions"`
+	IngressRatio       float64 `json:"ingress_ratio"`
+	EgressRatio        float64 `json:"egress_ratio"`
+	PartitionRatio     float64 `json:"partition_ratio"`
+	MaxRatio           float64 `json:"max_ratio"`
+	// MaxRatioDriver names which of the three dimensions produced MaxRatio:
+	// "ingress", "egress", or "partitions". Tracked at compute time so the
+	// renderer never has to do a float-equality comparison to recover it.
+	MaxRatioDriver      string          `json:"max_ratio_driver,omitempty"`
 	SizedECKU           int             `json:"sized_ecku"`
 	SLAFloorECKU        int             `json:"sla_floor_ecku"`
 	FinalECKU           int             `json:"final_ecku"`

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -1,0 +1,19 @@
+package types
+
+// PlanInputs is the parsed plan-inputs.yaml. Pointers distinguish "unset"
+// from the zero value so the loader can echo only the fields the customer
+// explicitly set.
+//
+// MVP scope: only the fields that drive sizing. Customer-self-reported
+// hard-requirement flags (VPC peering, REST Produce v3, single-zone SLA)
+// were intentionally excluded — the goal is "deterministic from the
+// state file"; reintroduce them only alongside state-file-derived
+// detection so a YAML toggle can't flip the verdict without evidence.
+type PlanInputs struct {
+	// Sizing overrides (defaults live in plan-config.yaml).
+	SLATarget                  *string  `yaml:"sla_target,omitempty"`
+	SizingPercentile           *string  `yaml:"sizing_percentile,omitempty"`
+	HeadroomFraction           *float64 `yaml:"headroom_fraction,omitempty"`
+	PrivateLinkSafetyThreshold *float64 `yaml:"privatelink_safety_threshold,omitempty"`
+	SpikyWorkloadRatio         *float64 `yaml:"spiky_workload_ratio,omitempty"`
+}

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -4,16 +4,38 @@ package types
 // from the zero value so the loader can echo only the fields the customer
 // explicitly set.
 //
-// MVP scope: only the fields that drive sizing. Customer-self-reported
-// hard-requirement flags (VPC peering, REST Produce v3, single-zone SLA)
-// were intentionally excluded — the goal is "deterministic from the
-// state file"; reintroduce them only alongside state-file-derived
-// detection so a YAML toggle can't flip the verdict without evidence.
+// MVP scope: sizing knobs + the customer-declared hard-requirement flags
+// that force Dedicated, plus the networking-topology signal that selects
+// PNI / Transit Gateway / VPC Peering on the Dedicated path.
+//
+// Customer-declared flags that flip the cluster-type verdict
+// (`EnforceSchemasAtTheBroker`, `RequiresHighThroughputRESTProduceAPI`,
+// `Requires9995SLAWithinSingleZone`) are wrong-click sensitive — a
+// misfired `true` costs 5–10× monthly. The renderer surfaces a ⚠ cost
+// callout on the Dedicated verdict when any of them is the reason.
 type PlanInputs struct {
 	// Sizing overrides (defaults live in plan-config.yaml).
-	SLATarget                  *string  `yaml:"sla_target,omitempty"`
-	SizingPercentile           *string  `yaml:"sizing_percentile,omitempty"`
-	HeadroomFraction           *float64 `yaml:"headroom_fraction,omitempty"`
-	PrivateLinkSafetyThreshold *float64 `yaml:"privatelink_safety_threshold,omitempty"`
-	SpikyWorkloadRatio         *float64 `yaml:"spiky_workload_ratio,omitempty"`
+	SLATarget                  *string  `yaml:"sla_target,omitempty"                    json:"sla_target,omitempty"`
+	SizingPercentile           *string  `yaml:"sizing_percentile,omitempty"             json:"sizing_percentile,omitempty"`
+	HeadroomFraction           *float64 `yaml:"headroom_fraction,omitempty"             json:"headroom_fraction,omitempty"`
+	PrivateLinkSafetyThreshold *float64 `yaml:"privatelink_safety_threshold,omitempty"  json:"privatelink_safety_threshold,omitempty"`
+	SpikyWorkloadRatio         *float64 `yaml:"spiky_workload_ratio,omitempty"          json:"spiky_workload_ratio,omitempty"`
+
+	// Customer-declared hard requirements that force Dedicated.
+	// Default `false`; only the customer (or an SE on their behalf) sets these.
+	EnforceSchemasAtTheBroker            *bool `yaml:"enforce_schemas_at_the_broker,omitempty"            json:"enforce_schemas_at_the_broker,omitempty"`
+	RequiresHighThroughputRESTProduceAPI *bool `yaml:"requires_high_throughput_rest_produce_api,omitempty" json:"requires_high_throughput_rest_produce_api,omitempty"`
+	Requires9995SLAWithinSingleZone      *bool `yaml:"requires_99_95_sla_within_a_single_zone,omitempty"  json:"requires_99_95_sla_within_a_single_zone,omitempty"`
+
+	// When source auth includes mTLS AND target_cloud is not `aws`,
+	// Dedicated is required because only Dedicated supports mTLS on
+	// Azure / GCP. MSK is AWS-only so this defaults to `aws`.
+	TargetCloud *string `yaml:"target_cloud,omitempty" json:"target_cloud,omitempty"`
+
+	// Existing VPC connectivity to MSK. When set to `transit_gateway`
+	// or `vpc_peering` and the cluster is Dedicated, the same pattern
+	// is recommended for Confluent Cloud. `privatelink_or_pni` (default)
+	// lets the Plan pick between PrivateLink and PNI based on the
+	// safety threshold.
+	ExistingVPCConnectivity *string `yaml:"existing_vpc_connectivity,omitempty" json:"existing_vpc_connectivity,omitempty"`
 }

--- a/internal/types/plan_test.go
+++ b/internal/types/plan_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanJSONRoundTrip(t *testing.T) {
+	t.Run("zero-value plan round-trips", func(t *testing.T) {
+		var p Plan
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		var decoded Plan
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, p, decoded)
+	})
+
+	t.Run("populated plan round-trips deeply equal", func(t *testing.T) {
+		p := Plan{
+			Header: PlanHeader{
+				Source:            "Amazon MSK",
+				StateFilePath:     "kcp-state.json",
+				KCPVersion:        "0.7.2",
+				GeneratedAt:       time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC),
+				PlanSchemaVersion: "1-experimental",
+			},
+			SourceEnvironment: SourceEnvironment{TotalRegions: 1, Clusters: []SourceClusterSummary{{ClusterID: "x", Region: "us-east-1"}}},
+			Sizing: []ClusterSizing{
+				{ClusterID: "x", P95InMBps: 1.0, FinalECKU: 1, Citations: []FieldCitation{{Path: "a", Value: 1.0}}},
+			},
+			ClusterTypeDecision: []ClusterTypeDecision{{ClusterID: "x", Verdict: ClusterTypeEnterprise}},
+			NetworkingDecision:  []NetworkingDecision{{ClusterID: "x", Verdict: NetworkingPrivateLink}},
+		}
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		var decoded Plan
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, p, decoded)
+	})
+}
+
+func TestEnumIsValid(t *testing.T) {
+	assert.True(t, ClusterTypeEnterprise.IsValid())
+	assert.False(t, ClusterType("Bogus").IsValid())
+	assert.True(t, NetworkingPrivateLink.IsValid())
+	assert.False(t, Networking("None").IsValid())
+}

--- a/internal/types/plan_test.go
+++ b/internal/types/plan_test.go
@@ -30,7 +30,7 @@ func TestPlanJSONRoundTrip(t *testing.T) {
 			},
 			SourceEnvironment: SourceEnvironment{TotalRegions: 1, Clusters: []SourceClusterSummary{{ClusterID: "x", Region: "us-east-1"}}},
 			Sizing: []ClusterSizing{
-				{ClusterID: "x", P95InMBps: 1.0, FinalECKU: 1, Citations: []FieldCitation{{Path: "a", Value: 1.0}}},
+				{ClusterID: "x", SizedInMBps: 1.0, FinalECKU: 1, Citations: []FieldCitation{{Path: "a", Value: 1.0}}},
 			},
 			ClusterTypeDecision: []ClusterTypeDecision{{ClusterID: "x", Verdict: ClusterTypeEnterprise}},
 			NetworkingDecision:  []NetworkingDecision{{ClusterID: "x", Verdict: NetworkingPrivateLink}},

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -930,7 +930,9 @@ type MetricAggregate struct {
 	Minimum *float64 `json:"min"`
 	P95     *float64 `json:"p95"`
 	P99     *float64 `json:"p99"`
-	Count   int      `json:"count"`
+	// Count omits when 0 so an aggregate without sample-count data isn't
+	// indistinguishable from one that observed exactly zero samples.
+	Count int `json:"count,omitempty"`
 }
 
 type CostAggregate struct {

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -928,6 +928,9 @@ type MetricAggregate struct {
 	Average *float64 `json:"avg"`
 	Maximum *float64 `json:"max"`
 	Minimum *float64 `json:"min"`
+	P95     *float64 `json:"p95"`
+	P99     *float64 `json:"p99"`
+	Count   int      `json:"count"`
 }
 
 type CostAggregate struct {

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -930,8 +930,9 @@ type MetricAggregate struct {
 	Minimum *float64 `json:"min"`
 	P95     *float64 `json:"p95"`
 	P99     *float64 `json:"p99"`
-	// Count omits when 0 so an aggregate without sample-count data isn't
-	// indistinguishable from one that observed exactly zero samples.
+	// Count is the sample size of the aggregate. With `omitempty`,
+	// "unknown" and "exactly 0 samples" both render as absent — treat
+	// absence as "no sample data".
 	Count int `json:"count,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

New `kcp report plan` subcommand. Consumes a `kcp-state.json` (and an optional `plan-inputs.yaml`) and emits `plan.md` + `plan.json` with:

- Source-environment summary (with fleet-wide broker + topic totals)
- Per-cluster sizing (throughput + partition ratios + headroom; canonical lowercase `p95` / `p99` / `max`)
- Enterprise / Dedicated decision via a 6-rule hard-limit catalog
- Dedicated topology (Multi-Zone / Single-Zone) and CKU unit on Dedicated verdicts
- PrivateLink / PNI / Transit Gateway / VPC Peering networking decision
- Per-cluster rationale lines + ⚠ cost callout when a customer-declared flag forced Dedicated
- "Actions Needed" section listing concrete state-file gaps to close (missing metrics, ACL scan gaps, etc.) — omitted when there are none
- Collapsed sizing-math appendix (single table that scales to multi-dozen-cluster fleets)

**Determinism:** same state file + same plan-inputs + same KCP version → byte-identical JSON output. Verified by a build-twice test (`plan_service_test.go:TestPlanServiceBuild_DeterministicByteIdenticalJSON`) and by repeated runs producing md5-identical normalized JSON.

## Explicitly out of scope (deferred to follow-up PRs)

- Auth approach
- Switchover recommendation + prerequisites
- Red flag rules
- Cost-vs-inventory reconciliation
- Workstreams / decision blockers / open-question catalogue beyond the MVP "Actions Needed" surface

`plan_schema_version` is set to `"1-experimental"` while we iterate on the surface — Migration Hub can consume now with additive-only expectations.

## How it works

```bash
kcp report plan --state-file kcp-state.json

# With overrides
kcp report plan --state-file kcp-state.json --plan-inputs plan-inputs.yaml --output md
```

`plan-inputs.yaml` accepts:

- **Sizing knobs** — `sla_target`, `sizing_percentile`, `headroom_fraction`, `privatelink_safety_threshold`, `spiky_workload_ratio`.
- **Customer-declared hard-requirement flags** — `enforce_schemas_at_the_broker`, `requires_high_throughput_rest_produce_api`, `requires_99_95_sla_within_a_single_zone`. These force Dedicated; setting one in error costs 5–10× monthly, so the renderer surfaces a ⚠ cost callout on the Dedicated verdict whenever one of them is the reason. The callout names the specific flag and the recovery path.
- **Networking-topology signals** — `target_cloud`, `existing_vpc_connectivity` (for the Dedicated path's TGW / VPC Peering variants).

Determinism is preserved: identical state file + identical plan-inputs → identical JSON. The hard-requirement flags participate in the input set; the ⚠ callout is the UX-level guard against accidental Dedicated escalation, not a determinism mechanism.

## Sample output

Two synthetic fixtures live under `docs/assets/`:

- [`plan.sample.md`](https://github.com/confluentinc/kcp/blob/feat/report-plan-cluster-type-mvp/docs/assets/plan.sample.md) — 4-cluster "complete" state with plan-inputs supplied. Exercises every MVP verdict path: Enterprise + PrivateLink, Enterprise + PNI, Dedicated Multi-Zone via state-derived ACL rule, Dedicated Multi-Zone via mTLS-off-AWS. Zero entries in Actions Needed.
- [`plan.sample.json`](https://github.com/confluentinc/kcp/blob/feat/report-plan-cluster-type-mvp/docs/assets/plan.sample.json) — same fixture in canonical JSON. Snake_case keys + `omitempty` so Enterprise verdicts cleanly omit `topology` / `final_cku` / unset plan-input fields.
- [`plan-inputs.example.yaml`](https://github.com/confluentinc/kcp/blob/feat/report-plan-cluster-type-mvp/docs/assets/plan-inputs.example.yaml) — the input-overrides template, grouped by topic with one-line comments on each field.

## Test plan

- [x] `go test ./internal/types/... ./internal/services/plan/... ./internal/services/report/... ./cmd/report/...` passes
- [x] `go vet ./...` clean
- [x] CLI `--help` matches sibling `cmd/report/costs` and `cmd/report/metrics` layout (Required / Optional sections + env-var binding via `utils.BindEnvToFlags`)
- [x] Determinism: repeated runs produce md5-identical normalized JSON (modulo `generated_at`)
- [x] Scale: 30+-cluster fixture produces a readable single audit table
- [x] Graceful degradation: sizing falls back to SLA floor with a `_metrics missing_` marker + an Actions Needed entry when the state file lacks P95 metrics
- [x] Cost callout: customer-declared `requires_99_95_sla_within_a_single_zone: true` lands Dedicated and surfaces the ⚠ callout naming the flag
- [x] Per-rule coverage: one test per hard-limit rule + null-ACLs skip + Enterprise-ignores-VPC-connectivity guard
