### PR TITLE
refactor(ci): refactor Semaphore structure and test deployment.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,20 +45,47 @@ blocks:
                 cache store frontend-dependencies node_modules/;
               fi
 
+  - name: 'resolve go dependencies'
+    dependencies: []
+    task:
+      jobs:
+        - name: 'go dependencies'
+          commands:
+            - cache restore go-mod-cache
+            - go mod download
+      epilogue:
+        on_pass:
+          commands:
+            - >-
+              if [ "$SEMAPHORE_GIT_WORKING_BRANCH" = "main" ]; then
+                cache delete go-mod-cache;
+                cache store go-mod-cache "${GOPATH}/pkg/mod";
+              fi
+
   - name: 'test'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     task:
       jobs:
         - name: 'run tests'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - (cd cmd/ui/frontend && npx playwright install chromium chromium-headless-shell --with-deps)
             - make test-go GOTEST_FLAGS="-p 1 -parallel 4 -count=1"
             - make test-playwright
+      epilogue:
+        on_pass:
+          commands:
+            - >-
+              if [ "$SEMAPHORE_GIT_WORKING_BRANCH" = "main" ]; then
+                cache delete go-build-cache;
+                cache store go-build-cache "$HOME/.cache/go-build";
+              fi
 
   - name: 'terraform validation tests'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
       when: "change_in(['/internal/services/hcl/', '/internal/types/types.go', '/cmd/create_asset/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
@@ -73,11 +100,13 @@ blocks:
         - name: 'terraform validation'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-tf-validation GOTEST_FLAGS="-p 1 -parallel 4 -count=1"
 
   - name: 'integration: osk scan'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
       when: "change_in(['/cmd/scan/', '/internal/sources/', '/internal/client/', '/internal/types/', '/internal/services/jmx/', '/internal/services/prometheus/', '/internal/services/kafka/', '/integration-tests/osk-scan/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
@@ -89,11 +118,13 @@ blocks:
         - name: 'osk scan'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-osk-scan
 
   - name: 'integration: kafka connect scan'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
       when: "change_in(['/cmd/scan/self_managed_connectors/', '/internal/types/self_managed_connect.go', '/integration-tests/osk-scan/docker-compose.yml', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
@@ -105,11 +136,13 @@ blocks:
         - name: 'kafka connect scan'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-kafka-connect
 
   - name: 'integration: schema registry scan'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
       when: "change_in(['/cmd/scan/schema_registry/', '/internal/client/schema_registry.go', '/internal/services/schema_registry/', '/integration-tests/schema-registry/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
@@ -117,11 +150,13 @@ blocks:
         - name: 'schema registry scan'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-schema-registry
 
   - name: 'integration: migration e2e'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
       when: "change_in(['/cmd/migration/', '/internal/services/migration/', '/internal/types/migration_config.go', '/internal/types/migration_state.go', '/internal/types/migration_constants.go', '/internal/services/gateway/', '/internal/services/clusterlink/', '/internal/services/offset/', '/integration-tests/migration/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
@@ -142,6 +177,8 @@ blocks:
         - name: 'migration e2e'
           commands:
             - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-migration-setup
             - make test-migration
@@ -154,7 +191,7 @@ blocks:
             - cache store minikube-cache ~/.minikube/cache/
 
   - name: 'static analysis'
-    dependencies: ['resolve frontend dependencies']
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     task:
       env_vars:
         - name: TRIVY_DB_REPOSITORIES
@@ -167,6 +204,8 @@ blocks:
           - export "PATH=${GOPATH}/bin:${PATH}"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
           - cache restore frontend-dependencies
+          - cache restore go-mod-cache
+          - cache restore go-build-cache
           - cd cmd/ui/frontend && yarn install && yarn build && cd -
       jobs:
         - name: 'golangci-lint'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,34 +45,38 @@ blocks:
                 cache store frontend-dependencies node_modules/;
               fi
 
-  - name: 'test and security scan'
+  - name: 'test'
     dependencies: ['resolve frontend dependencies']
     task:
-      env_vars:
-        - name: TRIVY_DB_REPOSITORIES
-          value: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
-
       jobs:
         - name: 'run tests'
           commands:
             - cache restore frontend-dependencies
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - (cd cmd/ui/frontend && npx playwright install chromium chromium-headless-shell --with-deps)
-            - |
-              if [ "$SKIP_TERRAFORM_VALIDATION" = "true" ]; then
-                echo "ERROR: SKIP_TERRAFORM_VALIDATION cannot be set in CI"
-                echo "This environment variable is for local development only."
-                echo "All tests must run with full Terraform validation in CI."
-                exit 1
-              fi
             - make test-go GOTEST_FLAGS="-p 1 -parallel 4 -count=1"
             - make test-playwright
 
-        - name: 'trivy scan'
+  - name: 'terraform validation tests'
+    dependencies: ['resolve frontend dependencies']
+    run:
+      when: "change_in(['/internal/services/hcl/', '/internal/types/types.go', '/cmd/create_asset/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
+    task:
+      prologue:
+        commands:
+          # Terraform is not pre-installed on Semaphore agents
+          - curl -sLO https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_linux_amd64.zip
+          - unzip -q terraform_1.9.5_linux_amd64.zip
+          - sudo install terraform /usr/local/bin/
+          - terraform version
+      jobs:
+        - name: 'terraform validation'
           commands:
-            - trivy fs --scanners vuln --show-suppressed --db-repository=$TRIVY_DB_REPOSITORIES --severity HIGH,CRITICAL --exit-code 1 .
+            - cache restore frontend-dependencies
+            - cd cmd/ui/frontend && yarn install && yarn build && cd -
+            - make test-tf-validation GOTEST_FLAGS="-p 1 -parallel 4 -count=1"
 
-  - name: 'osk scan tests'
+  - name: 'integration: osk scan'
     dependencies: ['resolve frontend dependencies']
     run:
       when: "change_in(['/cmd/scan/', '/internal/sources/', '/internal/client/', '/internal/types/', '/internal/services/jmx/', '/internal/services/prometheus/', '/internal/services/kafka/', '/integration-tests/osk-scan/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
@@ -88,10 +92,10 @@ blocks:
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-osk-scan
 
-  - name: 'kafka connect scan tests'
+  - name: 'integration: kafka connect scan'
     dependencies: ['resolve frontend dependencies']
     run:
-      when: "change_in(['/cmd/scan/self_managed_connectors/', '/internal/types/types.go', '/internal/types/state.go', '/internal/utils/cluster_display.go', '/integration-tests/osk-scan/docker-compose.yml', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
+      when: "change_in(['/cmd/scan/self_managed_connectors/', '/internal/types/self_managed_connect.go', '/integration-tests/osk-scan/docker-compose.yml', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
       prologue:
         commands:
@@ -104,7 +108,7 @@ blocks:
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-kafka-connect
 
-  - name: 'schema registry scan tests'
+  - name: 'integration: schema registry scan'
     dependencies: ['resolve frontend dependencies']
     run:
       when: "change_in(['/cmd/scan/schema_registry/', '/internal/client/schema_registry.go', '/internal/services/schema_registry/', '/integration-tests/schema-registry/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
@@ -116,7 +120,7 @@ blocks:
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-schema-registry
 
-  - name: 'e2e migration tests'
+  - name: 'integration: migration e2e'
     dependencies: ['resolve frontend dependencies']
     run:
       when: "change_in(['/cmd/migration/', '/internal/services/migration/', '/internal/types/migration_config.go', '/internal/types/migration_state.go', '/internal/types/migration_constants.go', '/internal/services/gateway/', '/internal/services/clusterlink/', '/internal/services/offset/', '/integration-tests/migration/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
@@ -149,9 +153,12 @@ blocks:
           commands:
             - cache store minikube-cache ~/.minikube/cache/
 
-  - name: 'lint'
+  - name: 'static analysis'
     dependencies: ['resolve frontend dependencies']
     task:
+      env_vars:
+        - name: TRIVY_DB_REPOSITORIES
+          value: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
       prologue:
         commands:
           - sem-version go 1.25.9
@@ -167,3 +174,7 @@ blocks:
             - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.3/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
             - git fetch origin main
             - golangci-lint run --config .golangci.yml ./...
+
+        - name: 'trivy scan'
+          commands:
+            - trivy fs --scanners vuln --show-suppressed --db-repository=$TRIVY_DB_REPOSITORIES --severity HIGH,CRITICAL --exit-code 1 .

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,14 +87,14 @@ blocks:
   - name: 'terraform validation tests'
     dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     run:
-      when: "change_in(['/internal/services/hcl/', '/internal/types/types.go', '/cmd/create_asset/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
+      when: "change_in(['/internal/services/hcl/', '/internal/types/types.go', '/internal/types/kafka.go', '/cmd/create_asset/', '/Makefile', '/.semaphore/semaphore.yml'], {default_branch: 'main'})"
     task:
       prologue:
         commands:
           # Terraform is not pre-installed on Semaphore agents
           - curl -sLO https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_linux_amd64.zip
           - unzip -q terraform_1.9.5_linux_amd64.zip
-          - sudo install terraform /usr/local/bin/
+          - sudo install terraform /usr/local/bin/terraform
           - terraform version
       jobs:
         - name: 'terraform validation'

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,13 @@ pre-commit-install: ## Install git pre-commit hooks
 # Tests
 # ==============================================================================
 
-.PHONY: test-go test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry
+.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry
 
-test-go: build-frontend ## Run Go unit tests
+test-go: build-frontend ## Run Go unit tests (excludes Terraform validation; see test-tf-validation)
 	go test $(GOTEST_FLAGS) ./...
+
+test-tf-validation: build-frontend ## Run Terraform validation tests (requires terraform on PATH)
+	go test -tags=terraform_validation -timeout 15m $(GOTEST_FLAGS) ./internal/services/hcl/...
 
 test-playwright: build ## Run Playwright browser tests
 	@cd cmd/ui/frontend && npx playwright test --reporter=list

--- a/internal/services/hcl/migration_infra_hcl_service_test.go
+++ b/internal/services/hcl/migration_infra_hcl_service_test.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (

--- a/internal/services/hcl/migration_scripts_hcl_service_test.go
+++ b/internal/services/hcl/migration_scripts_hcl_service_test.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (

--- a/internal/services/hcl/migration_scripts_snapshot_test.go
+++ b/internal/services/hcl/migration_scripts_snapshot_test.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (

--- a/internal/services/hcl/reverse_proxy_hcl_service_test.go
+++ b/internal/services/hcl/reverse_proxy_hcl_service_test.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (

--- a/internal/services/hcl/snapshot_test_helper.go
+++ b/internal/services/hcl/snapshot_test_helper.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (
@@ -20,10 +22,6 @@ var pluginCacheDir string
 // TestMain pre-warms the Terraform plugin cache so parallel tests don't race
 // to download the same providers simultaneously.
 func TestMain(m *testing.M) {
-	if os.Getenv("SKIP_TERRAFORM_VALIDATION") == "true" {
-		os.Exit(m.Run())
-	}
-
 	pluginCacheDir = filepath.Join(os.TempDir(), "terraform-plugin-cache")
 	if err := os.MkdirAll(pluginCacheDir, 0o755); err != nil {
 		log.Fatalf("could not create plugin cache directory: %v", err)
@@ -187,12 +185,6 @@ func schemaProjectToFiles(project types.MigrationScriptsTerraformProject) map[st
 // directory and running terraform init + validate. This does NOT deploy infrastructure.
 func validateTerraformProject(t *testing.T, files map[string]string) {
 	t.Helper()
-
-	// Skip if SKIP_TERRAFORM_VALIDATION env var is set (for faster local iteration)
-	if os.Getenv("SKIP_TERRAFORM_VALIDATION") == "true" {
-		t.Log("Skipping Terraform validation (SKIP_TERRAFORM_VALIDATION=true)")
-		return
-	}
 
 	// Create temp directory (auto-cleanup after test)
 	tempDir := t.TempDir()

--- a/internal/services/hcl/target_infra_hcl_service_test.go
+++ b/internal/services/hcl/target_infra_hcl_service_test.go
@@ -1,3 +1,5 @@
+//go:build terraform_validation
+
 package hcl
 
 import (

--- a/internal/types/self_managed_connect.go
+++ b/internal/types/self_managed_connect.go
@@ -1,0 +1,62 @@
+package types
+
+type ConnectAuthMethod string
+
+const (
+	ConnectAuthMethodSaslScram       ConnectAuthMethod = "SASL/SCRAM"
+	ConnectAuthMethodTls             ConnectAuthMethod = "TLS"
+	ConnectAuthMethodUnauthenticated ConnectAuthMethod = "Unauthenticated"
+)
+
+type ConnectSaslScramAuth struct {
+	Username string
+	Password string
+}
+
+type ConnectTlsAuth struct {
+	CACert     string
+	ClientCert string
+	ClientKey  string
+}
+
+type SelfManagedConnector struct {
+	Name        string         `json:"name"`
+	Config      map[string]any `json:"config"`
+	State       string         `json:"state,omitempty"`
+	ConnectHost string         `json:"connect_host,omitempty"`
+}
+
+type SelfManagedConnectors struct {
+	Connectors []SelfManagedConnector `json:"connectors"`
+}
+
+// mergeSelfManagedConnectors merges connectors, with new taking precedence for duplicates (by name)
+func mergeSelfManagedConnectors(newConnectors, oldConnectors *SelfManagedConnectors) *SelfManagedConnectors {
+	if oldConnectors == nil || len(oldConnectors.Connectors) == 0 {
+		return newConnectors
+	}
+	if newConnectors == nil || len(newConnectors.Connectors) == 0 {
+		return oldConnectors
+	}
+
+	connectorsByName := make(map[string]SelfManagedConnector)
+	for _, c := range oldConnectors.Connectors {
+		connectorsByName[c.Name] = c
+	}
+	for _, c := range newConnectors.Connectors {
+		connectorsByName[c.Name] = c // new takes precedence
+	}
+
+	merged := make([]SelfManagedConnector, 0, len(connectorsByName))
+	for _, c := range connectorsByName {
+		merged = append(merged, c)
+	}
+
+	return &SelfManagedConnectors{Connectors: merged}
+}
+
+func (c *KafkaAdminClientInformation) SetSelfManagedConnectors(connectors []SelfManagedConnector) {
+	c.SelfManagedConnectors = &SelfManagedConnectors{
+		Connectors: connectors,
+	}
+}

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -409,31 +409,6 @@ func mergeAcls(newAcls, oldAcls []Acls) []Acls {
 	return merged
 }
 
-// mergeSelfManagedConnectors merges connectors, with new taking precedence for duplicates (by name)
-func mergeSelfManagedConnectors(newConnectors, oldConnectors *SelfManagedConnectors) *SelfManagedConnectors {
-	if oldConnectors == nil || len(oldConnectors.Connectors) == 0 {
-		return newConnectors
-	}
-	if newConnectors == nil || len(newConnectors.Connectors) == 0 {
-		return oldConnectors
-	}
-
-	connectorsByName := make(map[string]SelfManagedConnector)
-	for _, c := range oldConnectors.Connectors {
-		connectorsByName[c.Name] = c
-	}
-	for _, c := range newConnectors.Connectors {
-		connectorsByName[c.Name] = c // new takes precedence
-	}
-
-	merged := make([]SelfManagedConnector, 0, len(connectorsByName))
-	for _, c := range connectorsByName {
-		merged = append(merged, c)
-	}
-
-	return &SelfManagedConnectors{Connectors: merged}
-}
-
 type DiscoveredCluster struct {
 	Name                        string                      `json:"name"`
 	Arn                         string                      `json:"arn"`
@@ -587,17 +562,6 @@ type ConnectorSummary struct {
 	ConnectorConfiguration           map[string]string                                             `json:"connector_configuration"`
 }
 
-type SelfManagedConnector struct {
-	Name        string         `json:"name"`
-	Config      map[string]any `json:"config"`
-	State       string         `json:"state,omitempty"`
-	ConnectHost string         `json:"connect_host,omitempty"`
-}
-
-type SelfManagedConnectors struct {
-	Connectors []SelfManagedConnector `json:"connectors"`
-}
-
 type KafkaAdminClientInformation struct {
 	ClusterID             string                 `json:"cluster_id"`
 	DiscoveredBrokers     []string               `json:"discovered_brokers,omitempty"`
@@ -618,12 +582,6 @@ func (c *KafkaAdminClientInformation) SetTopics(topicDetails []TopicDetails) {
 	c.Topics = &Topics{
 		Details: topicDetails,
 		Summary: CalculateTopicSummaryFromDetails(topicDetails),
-	}
-}
-
-func (c *KafkaAdminClientInformation) SetSelfManagedConnectors(connectors []SelfManagedConnector) {
-	c.SelfManagedConnectors = &SelfManagedConnectors{
-		Connectors: connectors,
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -73,25 +73,6 @@ func AllAuthTypes() []string {
 	}
 }
 
-type ConnectAuthMethod string
-
-const (
-	ConnectAuthMethodSaslScram       ConnectAuthMethod = "SASL/SCRAM"
-	ConnectAuthMethodTls             ConnectAuthMethod = "TLS"
-	ConnectAuthMethodUnauthenticated ConnectAuthMethod = "Unauthenticated"
-)
-
-type ConnectSaslScramAuth struct {
-	Username string
-	Password string
-}
-
-type ConnectTlsAuth struct {
-	CACert     string
-	ClientCert string
-	ClientKey  string
-}
-
 type MigrationType int
 
 const (


### PR DESCRIPTION
Restructuring the projects CI test suite so that long-executing tests like the Terraform (Terratest) validation tests do not run on every commit. They are now gated behind a build tag `//go:build terraform_validation`.

- In the Makefile, they can be triggered with `test-tf-validation`.
- In Semaphore, the tests are only ran when the surrounding files have been modified.

---

More changes include:
- reorganising the job blocks in the CI so that they are appropriately labelled + grouped (see before + after screenshots).
- caching Go dependencies (will work when merged).
- refactoring the internal self-managed connectors structs/functions/constants to their separate file + set a new `on_change` in Semaphore to reduce the frequency the tests will be deployed.

**Before:**
<img width="663" height="880" alt="Screenshot 2026-05-12 at 09 28 10" src="https://github.com/user-attachments/assets/f2779b83-4d7d-44db-b9c3-f71536645f5a" />

**After:**
<img width="657" height="1042" alt="Screenshot 2026-05-12 at 09 28 21" src="https://github.com/user-attachments/assets/e410e3fb-daac-4884-96e2-b0ee7f2196da" />
