### PR TITLE
feat: add Connect cluster metrics collection via Jolokia/Prometheus

### DIFF
--- a/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
+++ b/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
@@ -29,6 +29,7 @@
         "ec2:DescribeVpcs",
         "ec2:RevokeSecurityGroupEgress",
         "route53:AssociateVPCWithHostedZone",
+        "route53:ChangeResourceRecordSets",
         "route53:ChangeTagsForResource",
         "route53:CreateHostedZone",
         "route53:DeleteHostedZone",

--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -475,8 +475,13 @@ func collectPrometheusMetrics(ctx context.Context, clusterCreds types.OSKCluster
 		))
 	}
 
+	var labels map[string]string
+	if clusterCreds.Prometheus.Filter != nil {
+		labels = clusterCreds.Prometheus.Filter.Labels
+	}
+
 	promClient := client.NewPrometheusClient(clusterCreds.Prometheus.URL, promOpts...)
-	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.BrokerQueryDefinitions())
+	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.BrokerQueryDefinitions(), labels)
 	return promService.CollectMetrics(ctx, queryRange)
 }
 

--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -117,7 +117,7 @@ For self-managed connector discovery, run ` + "`kcp scan self-managed-connectors
 	metricsFlags.StringVar(&metricsSource, "metrics", "", "Metrics collection source: 'jolokia' or 'prometheus' (OSK only)")
 	metricsFlags.StringVar(&metricsDuration, "metrics-duration", "", "Duration to poll Jolokia (e.g. 10m, 1h). Required with --metrics jolokia.")
 	metricsFlags.StringVar(&metricsInterval, "metrics-interval", "10s", "Polling interval for Jolokia (e.g. 10s, 30s). Default: 10s.")
-	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Time range to query from Prometheus (e.g. 7d, 30d). Required with --metrics prometheus.")
+	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Day range to query from Prometheus (e.g. 7d, 30d). Required with --metrics prometheus.")
 	scanClustersCmd.Flags().AddFlagSet(metricsFlags)
 
 	_ = scanClustersCmd.MarkFlagRequired("source-type")

--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/build_info"
@@ -174,7 +173,7 @@ func preRunScanClusters(cmd *cobra.Command, args []string) error {
 			if metricsRange == "" {
 				return fmt.Errorf("--metrics-range is required when --metrics prometheus is set")
 			}
-			if _, err := parseDurationDays(metricsRange); err != nil {
+			if _, err := utils.ParseDurationDays(metricsRange); err != nil {
 				return fmt.Errorf("invalid --metrics-range '%s': must be like 1d, 7d, 30d", metricsRange)
 			}
 			if cmd.Flags().Changed("metrics-duration") {
@@ -448,7 +447,7 @@ func collectJolokiaMetrics(ctx context.Context, clusterCreds types.OSKClusterAut
 		jolokiaOpts = append(jolokiaOpts, client.WithJolokiaTLS(clusterCreds.Jolokia.TLS.CACert, clusterCreds.Jolokia.TLS.InsecureSkipVerify))
 	}
 
-	jmxService := jmx.NewJMXService(clusterCreds.Jolokia.Endpoints, jolokiaOpts...)
+	jmxService := jmx.NewJMXService(clusterCreds.Jolokia.Endpoints, jmx.BrokerMetricDefinitions(), jolokiaOpts...)
 	return jmxService.CollectOverDuration(ctx, duration, interval)
 }
 
@@ -457,7 +456,7 @@ func collectPrometheusMetrics(ctx context.Context, clusterCreds types.OSKCluster
 		return nil, fmt.Errorf("no prometheus config for cluster %s", clusterCreds.ID)
 	}
 
-	queryRange, _ := parseDurationDays(metricsRange)
+	queryRange, _ := utils.ParseDurationDays(metricsRange)
 
 	slog.Info("collecting Prometheus metrics", "cluster", clusterCreds.ID, "range", metricsRange)
 	fmt.Printf("\n📊 Collecting Prometheus metrics for cluster '%s' (range: %s)...\n", clusterCreds.ID, metricsRange)
@@ -477,18 +476,7 @@ func collectPrometheusMetrics(ctx context.Context, clusterCreds types.OSKCluster
 	}
 
 	promClient := client.NewPrometheusClient(clusterCreds.Prometheus.URL, promOpts...)
-	promService := prometheussvc.NewPrometheusService(promClient)
+	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.BrokerQueryDefinitions())
 	return promService.CollectMetrics(ctx, queryRange)
 }
 
-// parseDurationDays parses duration strings like "1d", "7d", "30d" into time.Duration
-func parseDurationDays(s string) (time.Duration, error) {
-	if len(s) < 2 || s[len(s)-1] != 'd' {
-		return 0, fmt.Errorf("must end with 'd' (e.g. 7d, 30d)")
-	}
-	days, err := strconv.Atoi(s[:len(s)-1])
-	if err != nil || days <= 0 {
-		return 0, fmt.Errorf("invalid number of days")
-	}
-	return time.Duration(days) * 24 * time.Hour, nil
-}

--- a/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
+++ b/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
@@ -157,6 +157,7 @@ func NewScanSelfManagedConnectorsCmd() *cobra.Command {
 
 	selfManagedConnectorsCmd.MarkFlagsMutuallyExclusive("use-sasl-scram", "use-tls", "use-unauthenticated")
 	selfManagedConnectorsCmd.MarkFlagsOneRequired("use-sasl-scram", "use-tls", "use-unauthenticated")
+	selfManagedConnectorsCmd.MarkFlagsMutuallyExclusive("metrics-duration", "metrics-range")
 
 	return selfManagedConnectorsCmd
 }
@@ -182,37 +183,29 @@ func preRunScanSelfManagedConnectors(cmd *cobra.Command, args []string) error {
 		if metricsSource != "jolokia" && metricsSource != "prometheus" {
 			return fmt.Errorf("invalid --metrics '%s': must be 'jolokia' or 'prometheus'", metricsSource)
 		}
-		if credentialsFile == "" {
-			return fmt.Errorf("--credentials-file is required when --metrics is set")
-		}
+		_ = cmd.MarkFlagRequired("credentials-file")
 		switch metricsSource {
 		case "jolokia":
-			if metricsDuration == "" {
-				return fmt.Errorf("--metrics-duration is required when --metrics jolokia is set")
-			}
-			if _, err := time.ParseDuration(metricsDuration); err != nil {
+			_ = cmd.MarkFlagRequired("metrics-duration")
+			if _, err := time.ParseDuration(metricsDuration); metricsDuration != "" && err != nil {
 				return fmt.Errorf("invalid --metrics-duration '%s': %w", metricsDuration, err)
 			}
 			if _, err := time.ParseDuration(metricsInterval); err != nil {
 				return fmt.Errorf("invalid --metrics-interval '%s': %w", metricsInterval, err)
 			}
-			duration, _ := time.ParseDuration(metricsDuration)
-			interval, _ := time.ParseDuration(metricsInterval)
-			if duration <= interval {
-				return fmt.Errorf("--metrics-duration (%s) must be greater than --metrics-interval (%s) to collect at least one data point", metricsDuration, metricsInterval)
-			}
-			if cmd.Flags().Changed("metrics-range") {
-				return fmt.Errorf("--metrics-range cannot be used with --metrics jolokia")
+			if metricsDuration != "" {
+				duration, _ := time.ParseDuration(metricsDuration)
+				interval, _ := time.ParseDuration(metricsInterval)
+				if duration <= interval {
+					return fmt.Errorf("--metrics-duration (%s) must be greater than --metrics-interval (%s) to collect at least one data point", metricsDuration, metricsInterval)
+				}
 			}
 		case "prometheus":
-			if metricsRange == "" {
-				return fmt.Errorf("--metrics-range is required when --metrics prometheus is set")
-			}
-			if _, err := utils.ParseDurationDays(metricsRange); err != nil {
-				return fmt.Errorf("invalid --metrics-range '%s': must be like 1d, 7d, 30d", metricsRange)
-			}
-			if cmd.Flags().Changed("metrics-duration") {
-				return fmt.Errorf("--metrics-duration cannot be used with --metrics prometheus")
+			_ = cmd.MarkFlagRequired("metrics-range")
+			if metricsRange != "" {
+				if _, err := utils.ParseDurationDays(metricsRange); err != nil {
+					return fmt.Errorf("invalid --metrics-range '%s': must be like 1d, 7d, 30d", metricsRange)
+				}
 			}
 		}
 	}
@@ -297,6 +290,28 @@ func parseScanSelfManagedConnectorsOpts() (*SelfManagedConnectorsScannerOpts, er
 		}
 	}
 
+	// If metrics are requested, resolve the cluster credentials from the credentials file
+	var metricsClusterCreds *types.OSKClusterAuth
+	if metricsSource != "" && credentialsFile != "" {
+		creds, errs := types.NewOSKCredentialsFromFile(credentialsFile)
+		if len(errs) > 0 {
+			return nil, fmt.Errorf("failed to load credentials file: %v", errs)
+		}
+		lookupID := oskClusterID
+		if detectedSourceType == types.SourceTypeMSK {
+			lookupID = clusterArn
+		}
+		for i, c := range creds.Clusters {
+			if c.ID == lookupID {
+				metricsClusterCreds = &creds.Clusters[i]
+				break
+			}
+		}
+		if metricsClusterCreds == nil {
+			return nil, fmt.Errorf("cluster %q not found in credentials file %s; metrics collection requires a matching cluster entry", lookupID, credentialsFile)
+		}
+	}
+
 	opts := SelfManagedConnectorsScannerOpts{
 		StateFile:      stateFile,
 		State:          state,
@@ -314,11 +329,11 @@ func parseScanSelfManagedConnectorsOpts() (*SelfManagedConnectorsScannerOpts, er
 			ClientCert: tlsClientCert,
 			ClientKey:  tlsClientKey,
 		},
-		MetricsSource:   metricsSource,
-		CredentialsFile: credentialsFile,
-		MetricsDuration: metricsDuration,
-		MetricsInterval: metricsInterval,
-		MetricsRange:    metricsRange,
+		MetricsSource:       metricsSource,
+		MetricsClusterCreds: metricsClusterCreds,
+		MetricsDuration:     metricsDuration,
+		MetricsInterval:     metricsInterval,
+		MetricsRange:        metricsRange,
 	}
 
 	return &opts, nil

--- a/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
+++ b/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
@@ -28,6 +29,12 @@ var (
 	tlsCaCert     string
 	tlsClientCert string
 	tlsClientKey  string
+
+	metricsSource   string
+	metricsDuration string
+	metricsInterval string
+	metricsRange    string
+	credentialsFile string
 )
 
 func NewScanSelfManagedConnectorsCmd() *cobra.Command {
@@ -57,7 +64,16 @@ func NewScanSelfManagedConnectorsCmd() *cobra.Command {
     --connect-rest-url http://connect:8083 \
     --cluster-id my-cluster \
     --source-type osk \
-    --use-unauthenticated`,
+    --use-unauthenticated
+
+  # Scan with Jolokia metrics collection
+  kcp scan self-managed-connectors \
+    --state-file kcp-state.json \
+    --connect-rest-url http://connect:8083 \
+    --cluster-id my-cluster \
+    --use-unauthenticated \
+    --metrics jolokia --metrics-duration 5m --metrics-interval 10s \
+    --credentials-file osk-credentials.yaml`,
 		SilenceErrors: true,
 		PreRunE:       preRunScanSelfManagedConnectors,
 		RunE:          runScanSelfManagedConnectors,
@@ -103,6 +119,16 @@ func NewScanSelfManagedConnectorsCmd() *cobra.Command {
 	selfManagedConnectorsCmd.Flags().AddFlagSet(tlsFlags)
 	groups[tlsFlags] = "TLS Credentials"
 
+	metricsFlags := pflag.NewFlagSet("metrics", pflag.ExitOnError)
+	metricsFlags.SortFlags = false
+	metricsFlags.StringVar(&metricsSource, "metrics", "", "Metrics backend: 'jolokia' or 'prometheus'. Requires --credentials-file.")
+	metricsFlags.StringVar(&metricsDuration, "metrics-duration", "", "Duration to poll Jolokia metrics (e.g., 5m, 30m). Required with --metrics jolokia.")
+	metricsFlags.StringVar(&metricsInterval, "metrics-interval", "10s", "Polling interval for Jolokia metrics (default: 10s).")
+	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Time range to query from Prometheus (e.g., 7d, 30d). Required with --metrics prometheus.")
+	metricsFlags.StringVar(&credentialsFile, "credentials-file", "", "Path to OSK credentials file containing Jolokia/Prometheus configuration.")
+	selfManagedConnectorsCmd.Flags().AddFlagSet(metricsFlags)
+	groups[metricsFlags] = "Metrics Collection"
+
 	selfManagedConnectorsCmd.SetUsageFunc(func(c *cobra.Command) error {
 		fmt.Printf("%s\n\n", c.Short)
 
@@ -110,8 +136,8 @@ func NewScanSelfManagedConnectorsCmd() *cobra.Command {
 			fmt.Printf("Examples:\n%s\n\n", c.Example)
 		}
 
-		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authMethodFlags, saslScramFlags, tlsFlags}
-		groupNames := []string{"Required Flags", "Optional Flags", "Authentication Method (choose one)", "SASL/SCRAM Credentials", "TLS Credentials"}
+		flagOrder := []*pflag.FlagSet{requiredFlags, optionalFlags, authMethodFlags, saslScramFlags, tlsFlags, metricsFlags}
+		groupNames := []string{"Required Flags", "Optional Flags", "Authentication Method (choose one)", "SASL/SCRAM Credentials", "TLS Credentials", "Metrics Collection"}
 
 		for i, fs := range flagOrder {
 			usage := fs.FlagUsages()
@@ -149,6 +175,46 @@ func preRunScanSelfManagedConnectors(cmd *cobra.Command, args []string) error {
 		_ = cmd.MarkFlagRequired("tls-ca-cert")
 		_ = cmd.MarkFlagRequired("tls-client-cert")
 		_ = cmd.MarkFlagRequired("tls-client-key")
+	}
+
+	// Validate metrics flags
+	if metricsSource != "" {
+		if metricsSource != "jolokia" && metricsSource != "prometheus" {
+			return fmt.Errorf("invalid --metrics '%s': must be 'jolokia' or 'prometheus'", metricsSource)
+		}
+		if credentialsFile == "" {
+			return fmt.Errorf("--credentials-file is required when --metrics is set")
+		}
+		switch metricsSource {
+		case "jolokia":
+			if metricsDuration == "" {
+				return fmt.Errorf("--metrics-duration is required when --metrics jolokia is set")
+			}
+			if _, err := time.ParseDuration(metricsDuration); err != nil {
+				return fmt.Errorf("invalid --metrics-duration '%s': %w", metricsDuration, err)
+			}
+			if _, err := time.ParseDuration(metricsInterval); err != nil {
+				return fmt.Errorf("invalid --metrics-interval '%s': %w", metricsInterval, err)
+			}
+			duration, _ := time.ParseDuration(metricsDuration)
+			interval, _ := time.ParseDuration(metricsInterval)
+			if duration <= interval {
+				return fmt.Errorf("--metrics-duration (%s) must be greater than --metrics-interval (%s) to collect at least one data point", metricsDuration, metricsInterval)
+			}
+			if cmd.Flags().Changed("metrics-range") {
+				return fmt.Errorf("--metrics-range cannot be used with --metrics jolokia")
+			}
+		case "prometheus":
+			if metricsRange == "" {
+				return fmt.Errorf("--metrics-range is required when --metrics prometheus is set")
+			}
+			if _, err := utils.ParseDurationDays(metricsRange); err != nil {
+				return fmt.Errorf("invalid --metrics-range '%s': must be like 1d, 7d, 30d", metricsRange)
+			}
+			if cmd.Flags().Changed("metrics-duration") {
+				return fmt.Errorf("--metrics-duration cannot be used with --metrics prometheus")
+			}
+		}
 	}
 
 	return nil
@@ -248,6 +314,11 @@ func parseScanSelfManagedConnectorsOpts() (*SelfManagedConnectorsScannerOpts, er
 			ClientCert: tlsClientCert,
 			ClientKey:  tlsClientKey,
 		},
+		MetricsSource:   metricsSource,
+		CredentialsFile: credentialsFile,
+		MetricsDuration: metricsDuration,
+		MetricsInterval: metricsInterval,
+		MetricsRange:    metricsRange,
 	}
 
 	return &opts, nil

--- a/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
+++ b/cmd/scan/self_managed_connectors/cmd_scan_self_managed_connectors.go
@@ -124,7 +124,7 @@ func NewScanSelfManagedConnectorsCmd() *cobra.Command {
 	metricsFlags.StringVar(&metricsSource, "metrics", "", "Metrics backend: 'jolokia' or 'prometheus'. Requires --credentials-file.")
 	metricsFlags.StringVar(&metricsDuration, "metrics-duration", "", "Duration to poll Jolokia metrics (e.g., 5m, 30m). Required with --metrics jolokia.")
 	metricsFlags.StringVar(&metricsInterval, "metrics-interval", "10s", "Polling interval for Jolokia metrics (default: 10s).")
-	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Time range to query from Prometheus (e.g., 7d, 30d). Required with --metrics prometheus.")
+	metricsFlags.StringVar(&metricsRange, "metrics-range", "", "Day range to query from Prometheus (e.g. 7d, 30d). Required with --metrics prometheus.")
 	metricsFlags.StringVar(&credentialsFile, "credentials-file", "", "Path to OSK credentials file containing Jolokia/Prometheus configuration.")
 	selfManagedConnectorsCmd.Flags().AddFlagSet(metricsFlags)
 	groups[metricsFlags] = "Metrics Collection"

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -427,8 +427,13 @@ func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx conte
 		))
 	}
 
+	var labels map[string]string
+	if clusterCreds.Prometheus.Filter != nil {
+		labels = clusterCreds.Prometheus.Filter.Labels
+	}
+
 	promClient := client.NewPrometheusClient(clusterCreds.Prometheus.URL, promOpts...)
-	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.ConnectQueryDefinitions())
+	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.ConnectQueryDefinitions(), labels)
 	return promService.CollectMetrics(ctx, queryRange)
 }
 

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -43,11 +43,11 @@ type SelfManagedConnectorsScannerOpts struct {
 	SaslScramAuth  types.ConnectSaslScramAuth
 	TlsAuth        types.ConnectTlsAuth
 
-	MetricsSource   string
-	CredentialsFile string
-	MetricsDuration string
-	MetricsInterval string
-	MetricsRange    string
+	MetricsSource       string
+	MetricsClusterCreds *types.OSKClusterAuth
+	MetricsDuration     string
+	MetricsInterval     string
+	MetricsRange        string
 }
 
 type SelfManagedConnectorsScanner struct {
@@ -58,11 +58,11 @@ type SelfManagedConnectorsScanner struct {
 	ClusterID  string
 	client     ConnectAPIClient
 
-	metricsSource   string
-	credentialsFile string
-	metricsDuration string
-	metricsInterval string
-	metricsRange    string
+	metricsSource       string
+	metricsClusterCreds *types.OSKClusterAuth
+	metricsDuration     string
+	metricsInterval     string
+	metricsRange        string
 }
 
 func NewSelfManagedConnectorsScanner(opts SelfManagedConnectorsScannerOpts) *SelfManagedConnectorsScanner {
@@ -79,17 +79,17 @@ func NewSelfManagedConnectorsScanner(opts SelfManagedConnectorsScannerOpts) *Sel
 	}
 
 	return &SelfManagedConnectorsScanner{
-		StateFile:       opts.StateFile,
-		State:           opts.State,
-		SourceType:      opts.SourceType,
-		ClusterArn:      opts.ClusterArn,
-		ClusterID:       opts.ClusterID,
-		client:          connectClient,
-		metricsSource:   opts.MetricsSource,
-		credentialsFile: opts.CredentialsFile,
-		metricsDuration: opts.MetricsDuration,
-		metricsInterval: opts.MetricsInterval,
-		metricsRange:    opts.MetricsRange,
+		StateFile:           opts.StateFile,
+		State:               opts.State,
+		SourceType:          opts.SourceType,
+		ClusterArn:          opts.ClusterArn,
+		ClusterID:           opts.ClusterID,
+		client:              connectClient,
+		metricsSource:       opts.MetricsSource,
+		metricsClusterCreds: opts.MetricsClusterCreds,
+		metricsDuration:     opts.MetricsDuration,
+		metricsInterval:     opts.MetricsInterval,
+		metricsRange:        opts.MetricsRange,
 	}
 }
 
@@ -344,39 +344,15 @@ func (s *SelfManagedConnectorsScanner) updateStateWithConnectors(connectors []ty
 }
 
 func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context) (*types.ProcessedClusterMetrics, error) {
-	creds, errs := types.NewOSKCredentialsFromFile(s.credentialsFile)
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("failed to load credentials file: %v", errs)
-	}
-
-	// Find the cluster in credentials that matches our cluster ID
-	clusterID := s.ClusterID
-	if s.SourceType == types.SourceTypeMSK {
-		clusterID = s.ClusterArn
-	}
-
-	var clusterCreds *types.OSKClusterAuth
-	for i, c := range creds.Clusters {
-		if c.ID == clusterID {
-			clusterCreds = &creds.Clusters[i]
-			break
-		}
-	}
-
-	// If no exact match, use the first cluster in the credentials file
-	if clusterCreds == nil {
-		if len(creds.Clusters) == 0 {
-			return nil, fmt.Errorf("no clusters found in credentials file")
-		}
-		clusterCreds = &creds.Clusters[0]
-		slog.Info("using first cluster from credentials file for metrics", "cluster", clusterCreds.ID)
+	if s.metricsClusterCreds == nil {
+		return nil, fmt.Errorf("no cluster credentials provided for metrics collection")
 	}
 
 	switch s.metricsSource {
 	case "jolokia":
-		return s.collectConnectJolokiaMetrics(ctx, *clusterCreds)
+		return s.collectConnectJolokiaMetrics(ctx, *s.metricsClusterCreds)
 	case "prometheus":
-		return s.collectConnectPrometheusMetrics(ctx, *clusterCreds)
+		return s.collectConnectPrometheusMetrics(ctx, *s.metricsClusterCreds)
 	default:
 		return nil, fmt.Errorf("unsupported metrics source: %s", s.metricsSource)
 	}

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -1,6 +1,7 @@
 package self_managed_connectors
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -11,6 +12,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/client"
+	jmx "github.com/confluentinc/kcp/internal/services/jmx"
+	prometheussvc "github.com/confluentinc/kcp/internal/services/prometheus"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 )
@@ -38,6 +42,12 @@ type SelfManagedConnectorsScannerOpts struct {
 	AuthMethod     types.ConnectAuthMethod
 	SaslScramAuth  types.ConnectSaslScramAuth
 	TlsAuth        types.ConnectTlsAuth
+
+	MetricsSource   string
+	CredentialsFile string
+	MetricsDuration string
+	MetricsInterval string
+	MetricsRange    string
 }
 
 type SelfManagedConnectorsScanner struct {
@@ -47,6 +57,12 @@ type SelfManagedConnectorsScanner struct {
 	ClusterArn string
 	ClusterID  string
 	client     ConnectAPIClient
+
+	metricsSource   string
+	credentialsFile string
+	metricsDuration string
+	metricsInterval string
+	metricsRange    string
 }
 
 func NewSelfManagedConnectorsScanner(opts SelfManagedConnectorsScannerOpts) *SelfManagedConnectorsScanner {
@@ -63,12 +79,17 @@ func NewSelfManagedConnectorsScanner(opts SelfManagedConnectorsScannerOpts) *Sel
 	}
 
 	return &SelfManagedConnectorsScanner{
-		StateFile:  opts.StateFile,
-		State:      opts.State,
-		SourceType: opts.SourceType,
-		ClusterArn: opts.ClusterArn,
-		ClusterID:  opts.ClusterID,
-		client:     connectClient,
+		StateFile:       opts.StateFile,
+		State:           opts.State,
+		SourceType:      opts.SourceType,
+		ClusterArn:      opts.ClusterArn,
+		ClusterID:       opts.ClusterID,
+		client:          connectClient,
+		metricsSource:   opts.MetricsSource,
+		credentialsFile: opts.CredentialsFile,
+		metricsDuration: opts.MetricsDuration,
+		metricsInterval: opts.MetricsInterval,
+		metricsRange:    opts.MetricsRange,
 	}
 }
 
@@ -141,11 +162,25 @@ func (s *SelfManagedConnectorsScanner) Run() error {
 		return fmt.Errorf("failed to update state: %v", err)
 	}
 
+	if s.metricsSource != "" {
+		slog.Info("collecting Connect metrics", "source", s.metricsSource, "cluster", clusterName)
+		metrics, err := s.collectConnectMetrics(context.Background())
+		if err != nil {
+			slog.Warn("Connect metrics collection failed", "error", err)
+		} else {
+			if err := s.updateStateWithConnectMetrics(metrics); err != nil {
+				slog.Warn("failed to update state with Connect metrics", "error", err)
+			} else {
+				slog.Info("collected Connect metrics", "data_points", len(metrics.Metrics), "cluster", clusterName)
+			}
+		}
+	}
+
 	if err := s.State.PersistStateFile(s.StateFile); err != nil {
 		return fmt.Errorf("failed to save state file: %v", err)
 	}
 
-	fmt.Printf("✅ Self-managed connector scan complete for cluster %s\n", clusterName)
+	slog.Info("self-managed connector scan complete", "cluster", clusterName)
 	return nil
 }
 
@@ -298,6 +333,134 @@ func (s *SelfManagedConnectorsScanner) updateStateWithConnectors(connectors []ty
 			if cluster.ID == s.ClusterID {
 				s.State.OSKSources.Clusters[i].KafkaAdminClientInformation.SetSelfManagedConnectors(connectors)
 				slog.Info(fmt.Sprintf("✅ updated cluster %s with self-managed connector information", clusterName))
+				return nil
+			}
+		}
+		return fmt.Errorf("OSK cluster with ID %s not found in state file", s.ClusterID)
+
+	default:
+		return fmt.Errorf("unsupported source type: %s", s.SourceType)
+	}
+}
+
+func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context) (*types.ProcessedClusterMetrics, error) {
+	creds, errs := types.NewOSKCredentialsFromFile(s.credentialsFile)
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed to load credentials file: %v", errs)
+	}
+
+	// Find the cluster in credentials that matches our cluster ID
+	clusterID := s.ClusterID
+	if s.SourceType == types.SourceTypeMSK {
+		clusterID = s.ClusterArn
+	}
+
+	var clusterCreds *types.OSKClusterAuth
+	for i, c := range creds.Clusters {
+		if c.ID == clusterID {
+			clusterCreds = &creds.Clusters[i]
+			break
+		}
+	}
+
+	// If no exact match, use the first cluster in the credentials file
+	if clusterCreds == nil {
+		if len(creds.Clusters) == 0 {
+			return nil, fmt.Errorf("no clusters found in credentials file")
+		}
+		clusterCreds = &creds.Clusters[0]
+		slog.Info("using first cluster from credentials file for metrics", "cluster", clusterCreds.ID)
+	}
+
+	switch s.metricsSource {
+	case "jolokia":
+		return s.collectConnectJolokiaMetrics(ctx, *clusterCreds)
+	case "prometheus":
+		return s.collectConnectPrometheusMetrics(ctx, *clusterCreds)
+	default:
+		return nil, fmt.Errorf("unsupported metrics source: %s", s.metricsSource)
+	}
+}
+
+func (s *SelfManagedConnectorsScanner) collectConnectJolokiaMetrics(ctx context.Context, clusterCreds types.OSKClusterAuth) (*types.ProcessedClusterMetrics, error) {
+	if !clusterCreds.HasJolokiaConfig() {
+		return nil, fmt.Errorf("no jolokia config in credentials for cluster %s", clusterCreds.ID)
+	}
+
+	duration, _ := time.ParseDuration(s.metricsDuration)
+	interval, _ := time.ParseDuration(s.metricsInterval)
+
+	slog.Info("collecting Connect Jolokia metrics", "cluster", clusterCreds.ID, "duration", duration, "interval", interval)
+
+	var jolokiaOpts []client.JolokiaOption
+	if clusterCreds.Jolokia.Auth != nil {
+		jolokiaOpts = append(jolokiaOpts, client.WithJolokiaBasicAuth(clusterCreds.Jolokia.Auth.Username, clusterCreds.Jolokia.Auth.Password))
+	}
+	if clusterCreds.Jolokia.TLS != nil {
+		jolokiaOpts = append(jolokiaOpts, client.WithJolokiaTLS(clusterCreds.Jolokia.TLS.CACert, clusterCreds.Jolokia.TLS.InsecureSkipVerify))
+	}
+
+	jmxService := jmx.NewJMXService(clusterCreds.Jolokia.Endpoints, jmx.ConnectMetricDefinitions(), jolokiaOpts...)
+	return jmxService.CollectOverDuration(ctx, duration, interval)
+}
+
+func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx context.Context, clusterCreds types.OSKClusterAuth) (*types.ProcessedClusterMetrics, error) {
+	if !clusterCreds.HasPrometheusConfig() {
+		return nil, fmt.Errorf("no prometheus config in credentials for cluster %s", clusterCreds.ID)
+	}
+
+	queryRange, _ := utils.ParseDurationDays(s.metricsRange)
+
+	slog.Info("collecting Connect Prometheus metrics", "cluster", clusterCreds.ID, "range", s.metricsRange)
+
+	var promOpts []client.PrometheusOption
+	if clusterCreds.Prometheus.Auth != nil {
+		promOpts = append(promOpts, client.WithPrometheusBasicAuth(
+			clusterCreds.Prometheus.Auth.Username,
+			clusterCreds.Prometheus.Auth.Password,
+		))
+	}
+	if clusterCreds.Prometheus.TLS != nil {
+		promOpts = append(promOpts, client.WithPrometheusTLS(
+			clusterCreds.Prometheus.TLS.CACert,
+			clusterCreds.Prometheus.TLS.InsecureSkipVerify,
+		))
+	}
+
+	promClient := client.NewPrometheusClient(clusterCreds.Prometheus.URL, promOpts...)
+	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.ConnectQueryDefinitions())
+	return promService.CollectMetrics(ctx, queryRange)
+}
+
+func (s *SelfManagedConnectorsScanner) updateStateWithConnectMetrics(metrics *types.ProcessedClusterMetrics) error {
+	switch s.SourceType {
+	case types.SourceTypeMSK:
+		if s.State.MSKSources == nil {
+			return fmt.Errorf("no MSK sources found in state file")
+		}
+		for i, region := range s.State.MSKSources.Regions {
+			for j, cluster := range region.Clusters {
+				if cluster.Arn == s.ClusterArn {
+					if s.State.MSKSources.Regions[i].Clusters[j].KafkaAdminClientInformation.SelfManagedConnectors == nil {
+						return fmt.Errorf("no self-managed connectors in state for cluster %s", s.ClusterArn)
+					}
+					s.State.MSKSources.Regions[i].Clusters[j].KafkaAdminClientInformation.SelfManagedConnectors.Metrics = metrics
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("cluster with ARN %s not found in state file", s.ClusterArn)
+
+	case types.SourceTypeOSK:
+		if s.State.OSKSources == nil {
+			return fmt.Errorf("no OSK sources found in state file")
+		}
+		for i, cluster := range s.State.OSKSources.Clusters {
+			if cluster.ID == s.ClusterID {
+				if s.State.OSKSources.Clusters[i].KafkaAdminClientInformation.SelfManagedConnectors == nil {
+					return fmt.Errorf("no self-managed connectors in state for cluster %s", s.ClusterID)
+				}
+				s.State.OSKSources.Clusters[i].KafkaAdminClientInformation.SelfManagedConnectors.Metrics = metrics
 				return nil
 			}
 		}

--- a/cmd/ui/frontend/src/types/api/metrics.ts
+++ b/cmd/ui/frontend/src/types/api/metrics.ts
@@ -51,6 +51,7 @@ export interface MetricQueryInfo {
   curl_command?: string
   query_duration?: string
   aggregation_note: string
+  label_filter?: Record<string, string>
 }
 
 /**

--- a/docs/assets/osk-configuration/.pages
+++ b/docs/assets/osk-configuration/.pages
@@ -2,3 +2,4 @@ title: OSK Configuration
 nav:
   - OSK credentials: osk-credentials.md
   - Metrics collection: metrics-collection.md
+  - Connect metrics collection: connect-metrics-collection.md

--- a/docs/assets/osk-configuration/connect-metrics-collection.md
+++ b/docs/assets/osk-configuration/connect-metrics-collection.md
@@ -112,14 +112,15 @@ clusters:
     #       job: confluent/connect-jmx-exporter
 ```
 
-!!! note "Jolokia endpoints for Connect vs brokers"
-
-    When collecting **broker** metrics (`kcp scan clusters --metrics jolokia`),
-    the Jolokia endpoints point to **Kafka broker** Jolokia agents. When
-    collecting **Connect** metrics (`kcp scan self-managed-connectors --metrics jolokia`),
-    the same credentials file is used but the endpoints should point to
-    **Connect worker** Jolokia agents, which typically run on a different
-    host and/or port.
+> [!NOTE]
+> **Jolokia endpoints for Connect vs brokers**
+>
+> When collecting **broker** metrics (`kcp scan clusters --metrics jolokia`),
+> the Jolokia endpoints point to **Kafka broker** Jolokia agents. When
+> collecting **Connect** metrics (`kcp scan self-managed-connectors --metrics jolokia`),
+> the same credentials file is used but the endpoints should point to
+> **Connect worker** Jolokia agents, which typically run on a different
+> host and/or port.
 
 ## Filtering by Connect cluster (Prometheus)
 

--- a/docs/assets/osk-configuration/connect-metrics-collection.md
+++ b/docs/assets/osk-configuration/connect-metrics-collection.md
@@ -107,6 +107,9 @@ clusters:
     # Alternative: query Prometheus for historical Connect metrics
     # prometheus:
     #   url: http://prometheus:9090
+    #   filter:                     # scope queries to this Connect cluster
+    #     labels:
+    #       job: confluent/connect-jmx-exporter
 ```
 
 !!! note "Jolokia endpoints for Connect vs brokers"
@@ -117,6 +120,32 @@ clusters:
     the same credentials file is used but the endpoints should point to
     **Connect worker** Jolokia agents, which typically run on a different
     host and/or port.
+
+## Filtering by Connect cluster (Prometheus)
+
+When a single Prometheus instance scrapes multiple Connect clusters, all
+metrics are combined by default. Use `filter.labels` in the credentials file
+to scope queries to a specific Connect cluster:
+
+```yaml
+prometheus:
+  url: http://prometheus:9090
+  filter:
+    labels:
+      job: confluent/connect-jmx-exporter
+```
+
+This appends `{job="confluent/connect-jmx-exporter"}` to every PromQL query,
+returning metrics only for that Connect cluster. The label name and value
+depend on your Prometheus scrape configuration — common labels include `job`,
+`component`, `namespace`, or `pod`.
+
+To discover available labels, query Prometheus directly:
+
+```bash
+curl -s -G 'http://prometheus:9090/api/v1/query' \
+  --data-urlencode 'query=kafka_connect_worker_connector_count' | jq '.data.result[].metric'
+```
 
 ## Worked examples
 

--- a/docs/assets/osk-configuration/connect-metrics-collection.md
+++ b/docs/assets/osk-configuration/connect-metrics-collection.md
@@ -67,8 +67,8 @@ JVM — no additional configuration is required beyond the Jolokia agent.
 
 | Metric                    | PromQL query                                                  |
 | ------------------------- | ------------------------------------------------------------- |
-| `connector-count`         | `kafka_connect_worker_connector_count`                        |
-| `task-count`              | `kafka_connect_worker_task_count`                             |
+| `connector-count`         | `sum(kafka_connect_worker_connector_count)`                   |
+| `task-count`              | `sum(kafka_connect_worker_task_count)`                        |
 | `source-record-write-rate`| `sum(kafka_connect_source_task_source_record_write_rate)`     |
 | `source-record-poll-rate` | `sum(kafka_connect_source_task_source_record_poll_rate)`      |
 | `incoming-byte-rate`      | `sum(kafka_connect_network_io_incoming_byte_rate)`            |

--- a/docs/assets/osk-configuration/connect-metrics-collection.md
+++ b/docs/assets/osk-configuration/connect-metrics-collection.md
@@ -1,0 +1,144 @@
+---
+title: Connect metrics collection (OSK)
+---
+
+# Connect metrics collection — OSK
+
+[`kcp scan self-managed-connectors`](../command-reference/scan/self-managed-connectors.md)
+supports collecting Kafka Connect worker metrics using the same two backends
+as [broker metrics collection](metrics-collection.md):
+
+| Backend      | Mode                  | Required flags                                                  | Required `osk-credentials.yaml` block |
+| ------------ | --------------------- | --------------------------------------------------------------- | ------------------------------------- |
+| `jolokia`    | Live polling          | `--metrics jolokia` + `--metrics-duration` (`--metrics-interval` optional, default `10s`) | [`jolokia:`](osk-credentials.md) |
+| `prometheus` | Historical query      | `--metrics prometheus` + `--metrics-range`                      | [`prometheus:`](osk-credentials.md) |
+
+Both backends produce the same `ProcessedClusterMetrics` shape inside
+`kcp-state.json`, stored under `self_managed_connectors.metrics` for the
+matched cluster.
+
+## How it works
+
+1. `kcp scan self-managed-connectors` discovers connectors via the Connect REST
+   API (`--connect-rest-url`).
+2. If `--metrics` is set, it then collects Connect worker metrics from
+   Jolokia or Prometheus using the credentials file (`--credentials-file`).
+3. Both connector details and metrics are written to the state file.
+
+The `--credentials-file` uses the same `osk-credentials.yaml` format as
+`kcp scan clusters`, but the Jolokia endpoints should point to **Connect
+worker** Jolokia instances, not Kafka broker instances.
+
+## Metrics collected
+
+Connect metrics span three levels: worker (cluster-wide), client (network),
+and per-task (connector throughput).
+
+| Metric                    | Description                                         | Type                | Level    |
+| ------------------------- | --------------------------------------------------- | ------------------- | -------- |
+| `connector-count`         | Number of connectors running on the worker          | Gauge               | Worker   |
+| `task-count`              | Number of tasks running on the worker               | Gauge               | Worker   |
+| `incoming-byte-rate`      | Bytes/sec received from Kafka brokers               | Gauge (aggregated)  | Client   |
+| `outgoing-byte-rate`      | Bytes/sec sent to Kafka brokers                     | Gauge (aggregated)  | Client   |
+| `connection-count`        | Active connections to Kafka brokers                 | Gauge (aggregated)  | Client   |
+| `request-rate`            | Requests/sec to Kafka brokers                       | Gauge (aggregated)  | Client   |
+| `source-record-write-rate`| Records/sec written to Kafka (after transforms)     | Gauge (aggregated)  | Per-task |
+| `source-record-poll-rate` | Records/sec polled from source system               | Gauge (aggregated)  | Per-task |
+
+## Jolokia MBean paths
+
+| Metric                    | MBean path                                                                    | Attribute                |
+| ------------------------- | ----------------------------------------------------------------------------- | ------------------------ |
+| `connector-count`         | `kafka.connect:type=connect-worker-metrics`                                   | `connector-count`        |
+| `task-count`              | `kafka.connect:type=connect-worker-metrics`                                   | `task-count`             |
+| `incoming-byte-rate`      | `kafka.connect:client-id=*,type=connect-metrics`                              | `incoming-byte-rate`     |
+| `outgoing-byte-rate`      | `kafka.connect:client-id=*,type=connect-metrics`                              | `outgoing-byte-rate`     |
+| `connection-count`        | `kafka.connect:client-id=*,type=connect-metrics`                              | `connection-count`       |
+| `request-rate`            | `kafka.connect:client-id=*,type=connect-metrics`                              | `request-rate`           |
+| `source-record-write-rate`| `kafka.connect:type=source-task-metrics,connector=*,task=*`                   | `source-record-write-rate`|
+| `source-record-poll-rate` | `kafka.connect:type=source-task-metrics,connector=*,task=*`                   | `source-record-poll-rate` |
+
+Client-level metrics (`incoming-byte-rate`, `outgoing-byte-rate`,
+`connection-count`, `request-rate`) use wildcard MBean patterns and are summed
+across all matching MBeans. Jolokia reads these directly from the Connect worker
+JVM — no additional configuration is required beyond the Jolokia agent.
+
+## Prometheus PromQL queries
+
+| Metric                    | PromQL query                                                  |
+| ------------------------- | ------------------------------------------------------------- |
+| `connector-count`         | `kafka_connect_worker_connector_count`                        |
+| `task-count`              | `kafka_connect_worker_task_count`                             |
+| `source-record-write-rate`| `sum(kafka_connect_source_task_source_record_write_rate)`     |
+| `source-record-poll-rate` | `sum(kafka_connect_source_task_source_record_poll_rate)`      |
+| `incoming-byte-rate`      | `sum(kafka_connect_network_io_incoming_byte_rate)`            |
+| `outgoing-byte-rate`      | `sum(kafka_connect_network_io_outgoing_byte_rate)`            |
+| `connection-count`        | `sum(kafka_connect_network_io_connection_count)`              |
+| `request-rate`            | `sum(kafka_connect_network_io_request_rate)`                  |
+
+These metric names are produced by the Prometheus JMX Exporter with standard
+Kafka Connect JMX rules. The worker-level and task-level metrics
+(`kafka_connect_worker_*`, `kafka_connect_source_task_*`) are typically exported
+by default. The client-level metrics (`kafka_connect_network_io_*`) require the
+JMX exporter to whitelist the `kafka.connect:client-id=*,type=connect-metrics`
+MBean pattern — if these are not exported, `kcp` logs a warning and continues
+collecting the remaining metrics.
+
+## Credentials file
+
+The same `osk-credentials.yaml` is used, with the `jolokia` or `prometheus`
+block pointing to the Connect worker endpoints:
+
+```yaml
+clusters:
+  - id: my-kafka-cluster
+    bootstrap_servers:
+      - broker1:9092
+    auth_method:
+      unauthenticated_plaintext:
+        use: true
+    # For Connect metrics via Jolokia — point to Connect workers, not brokers
+    jolokia:
+      endpoints:
+        - http://connect-worker1:8781/jolokia
+      auth:                         # optional
+        username: monitorRole
+        password: secret
+    # Alternative: query Prometheus for historical Connect metrics
+    # prometheus:
+    #   url: http://prometheus:9090
+```
+
+!!! note "Jolokia endpoints for Connect vs brokers"
+
+    When collecting **broker** metrics (`kcp scan clusters --metrics jolokia`),
+    the Jolokia endpoints point to **Kafka broker** Jolokia agents. When
+    collecting **Connect** metrics (`kcp scan self-managed-connectors --metrics jolokia`),
+    the same credentials file is used but the endpoints should point to
+    **Connect worker** Jolokia agents, which typically run on a different
+    host and/or port.
+
+## Worked examples
+
+```bash
+# Discover connectors + collect live Jolokia metrics for 5 minutes
+kcp scan self-managed-connectors \
+  --state-file kcp-state.json \
+  --connect-rest-url http://connect:8083 \
+  --cluster-id my-kafka-cluster \
+  --use-unauthenticated \
+  --credentials-file osk-credentials.yaml \
+  --metrics jolokia --metrics-duration 5m --metrics-interval 10s
+
+# Discover connectors + pull historical Prometheus metrics (last 7 days)
+kcp scan self-managed-connectors \
+  --state-file kcp-state.json \
+  --connect-rest-url http://connect:8083 \
+  --cluster-id my-kafka-cluster \
+  --use-unauthenticated \
+  --credentials-file osk-credentials.yaml \
+  --metrics prometheus --metrics-range 7d
+```
+
+After either run, the state file contains both connector details and metrics
+under the matched cluster's `self_managed_connectors` block.

--- a/docs/assets/osk-configuration/metrics-collection.md
+++ b/docs/assets/osk-configuration/metrics-collection.md
@@ -8,6 +8,12 @@ For MSK, `kcp discover` pulls cluster metrics straight from CloudWatch. OSK
 clusters do not have an equivalent metrics surface, so [`kcp scan clusters`](../command-reference/scan/clusters.md)
 supports two collection backends, selected with `--metrics <source>`:
 
+!!! tip "Connect cluster metrics"
+
+    For collecting metrics from Kafka Connect workers (connector count, task
+    throughput, byte rates), see
+    [Connect metrics collection](connect-metrics-collection.md).
+
 | Backend      | Mode                  | Required flags                                                  | Required `osk-credentials.yaml` block |
 | ------------ | --------------------- | --------------------------------------------------------------- | ------------------------------------- |
 | `jolokia`    | Live polling          | `--metrics jolokia` + `--metrics-duration` (`--metrics-interval` optional, default `10s`) | [`jolokia:`](osk-credentials.md) |

--- a/docs/assets/osk-configuration/metrics-collection.md
+++ b/docs/assets/osk-configuration/metrics-collection.md
@@ -144,6 +144,13 @@ Prometheus JMX Exporter with a standard Kafka configuration. If your exporter
 uses custom relabelling rules that rename these metrics, the queries will return
 empty results.
 
+## Filtering by cluster (Prometheus)
+
+When a single Prometheus instance scrapes multiple Kafka clusters, use
+`filter.labels` in `osk-credentials.yaml` to scope queries to a specific
+cluster. See the [`prometheus` field reference](osk-credentials.md#prometheus--optional-for-historical-metrics)
+for details.
+
 ## Worked examples
 
 ```bash

--- a/docs/assets/osk-configuration/metrics-collection.md
+++ b/docs/assets/osk-configuration/metrics-collection.md
@@ -8,11 +8,12 @@ For MSK, `kcp discover` pulls cluster metrics straight from CloudWatch. OSK
 clusters do not have an equivalent metrics surface, so [`kcp scan clusters`](../command-reference/scan/clusters.md)
 supports two collection backends, selected with `--metrics <source>`:
 
-!!! tip "Connect cluster metrics"
-
-    For collecting metrics from Kafka Connect workers (connector count, task
-    throughput, byte rates), see
-    [Connect metrics collection](connect-metrics-collection.md).
+> [!TIP]
+> **Connect cluster metrics**
+>
+> For collecting metrics from Kafka Connect workers (connector count, task
+> throughput, byte rates), see
+> [Connect metrics collection](connect-metrics-collection.md).
 
 | Backend      | Mode                  | Required flags                                                  | Required `osk-credentials.yaml` block |
 | ------------ | --------------------- | --------------------------------------------------------------- | ------------------------------------- |

--- a/docs/assets/osk-configuration/osk-credentials.md
+++ b/docs/assets/osk-configuration/osk-credentials.md
@@ -157,6 +157,9 @@ prometheus:
   tls:                          # optional — omit for plain HTTP
     ca_cert: /path/to/ca.pem
     insecure_skip_verify: false
+  filter:                       # optional — scope queries to a specific target
+    labels:
+      job: confluent/kafka-jmx-exporter
 ```
 
 | Field                       | Required | Description                                                          |
@@ -165,6 +168,7 @@ prometheus:
 | `auth.username` / `password`| no       | HTTP basic auth credentials.                                         |
 | `tls.ca_cert`               | no       | CA certificate for HTTPS Prometheus endpoints.                       |
 | `tls.insecure_skip_verify`  | no       | Skip TLS verification (test environments only).                      |
+| `filter.labels`             | no       | Map of Prometheus label selectors to scope queries. When set, all PromQL queries include these as `{key="value"}` filters. Useful when a single Prometheus scrapes multiple clusters. |
 
 `jolokia` and `prometheus` are mutually exclusive per scan invocation — `--metrics`
 selects which one `kcp` reads. You can keep both blocks in the file and switch

--- a/docs/assets/osk-configuration/osk-credentials.md
+++ b/docs/assets/osk-configuration/osk-credentials.md
@@ -105,8 +105,8 @@ clusters:
 | `id`                | string           | yes      | Unique identifier for the cluster. Used as the cluster key in `kcp-state.json` and as the `--cluster-id` value for downstream `create-asset` commands. |
 | `bootstrap_servers` | list of strings  | yes      | Broker `host:port` addresses.                                                                                                                |
 | `auth_method`       | object           | yes      | Authentication method. Choose **exactly one** sub-block (see below).                                                                         |
-| `jolokia`           | object           | no       | Jolokia HTTP endpoints for live JMX metrics. Required if you pass `--metrics jolokia` on `kcp scan clusters`.                                |
-| `prometheus`        | object           | no       | Prometheus HTTP API for historical metrics. Required if you pass `--metrics prometheus` on `kcp scan clusters`.                              |
+| `jolokia`           | object           | no       | Jolokia HTTP endpoints for live JMX metrics. Required if you pass `--metrics jolokia` on `kcp scan clusters` or `kcp scan self-managed-connectors`. For Connect metrics, point endpoints to Connect workers rather than brokers. |
+| `prometheus`        | object           | no       | Prometheus HTTP API for historical metrics. Required if you pass `--metrics prometheus` on `kcp scan clusters` or `kcp scan self-managed-connectors`. |
 | `metadata`          | map<string,string> | no     | Free-form labels surfaced in reports and the UI (e.g. `environment`, `location`).                                                            |
 
 ### `auth_method` — pick one
@@ -173,4 +173,5 @@ between them by changing the flag.
 ## Where to go next
 
 - [`kcp scan clusters`](../command-reference/scan/clusters.md) — pass this file with `--credentials-file`.
-- [Metrics collection](metrics-collection.md) — design notes on Jolokia vs Prometheus, the metrics that `kcp` records, and how rates are computed.
+- [Metrics collection](metrics-collection.md) — design notes on Jolokia vs Prometheus, the broker metrics that `kcp` records, and how rates are computed.
+- [Connect metrics collection](connect-metrics-collection.md) — collecting metrics from Kafka Connect workers.

--- a/integration-tests/osk-scan/credentials/connect-jolokia.yaml
+++ b/integration-tests/osk-scan/credentials/connect-jolokia.yaml
@@ -1,0 +1,13 @@
+clusters:
+  - id: osk-kafka
+    bootstrap_servers:
+      - localhost:9092
+    auth_method:
+      unauthenticated_plaintext:
+        use: true
+    jolokia:
+      endpoints:
+        - http://localhost:8781/jolokia
+    metadata:
+      environment: test
+      location: osk-scan

--- a/integration-tests/osk-scan/docker-compose.yml
+++ b/integration-tests/osk-scan/docker-compose.yml
@@ -113,6 +113,7 @@ services:
       - kafka
     ports:
       - "8083:8083"
+      - "8781:8781"
     environment:
       CONNECT_BOOTSTRAP_SERVERS: 'osk-kafka:29092'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'localhost'
@@ -134,7 +135,11 @@ services:
         echo "Waiting for Kafka to be ready..."
         cub kafka-ready -b osk-kafka:29092 1 120
 
-        echo "Starting Kafka Connect..."
+        echo "Downloading Jolokia agent..."
+        curl -sSL https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.7.2/jolokia-jvm-1.7.2.jar -o /tmp/jolokia-agent.jar
+
+        echo "Starting Kafka Connect with Jolokia..."
+        export KAFKA_OPTS="-javaagent:/tmp/jolokia-agent.jar=port=8781,host=0.0.0.0"
         /etc/confluent/docker/run &
         CONNECT_PID=$$!
 

--- a/integration-tests/osk-scan/docker-compose.yml
+++ b/integration-tests/osk-scan/docker-compose.yml
@@ -155,20 +155,6 @@ services:
           WAIT_TIME=$$((WAIT_TIME + 2))
         done
 
-        # Create a sample connector for testing
-        echo "Creating sample MirrorHeartbeat connector..."
-        curl -X POST http://localhost:8083/connectors -H "Content-Type: application/json" -d '{
-          "name": "test-heartbeat",
-          "config": {
-            "connector.class": "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector",
-            "tasks.max": "1",
-            "source.cluster.alias": "source",
-            "target.cluster.alias": "target",
-            "source.cluster.bootstrap.servers": "osk-kafka:29092",
-            "target.cluster.bootstrap.servers": "osk-kafka:29092"
-          }
-        }' || true
-
         wait $$CONNECT_PID
 
   kafka-jmx-auth:

--- a/integration-tests/osk-scan/run-connect.sh
+++ b/integration-tests/osk-scan/run-connect.sh
@@ -113,7 +113,7 @@ else
         --metrics-interval 10s \
         --credentials-file integration-tests/osk-scan/credentials/connect-jolokia.yaml
 
-    METRICS_COUNT=$(jq '.osk_sources.clusters[0].kafka_admin_client_information.self_managed_connectors.metrics.metrics | length // 0' "$STATE")
+    METRICS_COUNT=$(jq '.osk_sources.clusters[0].kafka_admin_client_information.self_managed_connectors.metrics.results | length // 0' "$STATE")
     echo "  Connect metrics data points: $METRICS_COUNT"
     if [ "$METRICS_COUNT" -le 0 ]; then
         echo "ERROR: expected at least one Connect metrics data point, found $METRICS_COUNT"

--- a/integration-tests/osk-scan/run-connect.sh
+++ b/integration-tests/osk-scan/run-connect.sh
@@ -82,6 +82,48 @@ if [ "$CONNECTOR_HOST_COUNT" -le 0 ]; then
 fi
 echo ""
 
+# ---- Connect metrics collection via Jolokia ----
+echo ""
+echo "Testing Connect metrics collection via Jolokia..."
+
+# Wait for Jolokia to be ready on the Connect worker
+echo "Waiting for Jolokia on Connect worker (port 8781)..."
+JOLOKIA_WAIT=0
+JOLOKIA_MAX=30
+while [ $JOLOKIA_WAIT -lt $JOLOKIA_MAX ]; do
+    if curl -s http://localhost:8781/jolokia/version > /dev/null 2>&1; then
+        echo "Jolokia is ready on Connect worker!"
+        break
+    fi
+    sleep 2
+    JOLOKIA_WAIT=$((JOLOKIA_WAIT + 2))
+done
+
+if [ $JOLOKIA_WAIT -ge $JOLOKIA_MAX ]; then
+    echo "WARNING: Jolokia not ready on Connect worker within ${JOLOKIA_MAX}s, skipping metrics test"
+else
+    echo "Running: ./kcp scan self-managed-connectors with --metrics jolokia"
+    ./kcp scan self-managed-connectors \
+        --state-file "$STATE" \
+        --connect-rest-url http://localhost:8083 \
+        --cluster-id osk-kafka \
+        --use-unauthenticated \
+        --metrics jolokia \
+        --metrics-duration 30s \
+        --metrics-interval 10s \
+        --credentials-file integration-tests/osk-scan/credentials/connect-jolokia.yaml
+
+    METRICS_COUNT=$(jq '.osk_sources.clusters[0].kafka_admin_client_information.self_managed_connectors.metrics.metrics | length // 0' "$STATE")
+    echo "  Connect metrics data points: $METRICS_COUNT"
+    if [ "$METRICS_COUNT" -le 0 ]; then
+        echo "ERROR: expected at least one Connect metrics data point, found $METRICS_COUNT"
+        exit 1
+    fi
+    echo "  Connect metrics collection test passed!"
+fi
+
+echo ""
+
 # Clean up Connect (leave base Kafka running for potential other tests)
 echo "Stopping Kafka Connect..."
 cd "$SCRIPT_DIR"

--- a/integration-tests/osk-scan/run-connect.sh
+++ b/integration-tests/osk-scan/run-connect.sh
@@ -40,22 +40,38 @@ if [ $WAIT_TIME -ge $MAX_WAIT ]; then
     exit 1
 fi
 
-# Wait for the test connector to be registered (created inside the container startup)
-echo "Waiting for test connector to be registered..."
+# Create test connector with retry (Connect may need time after REST is up
+# to finish its internal group rebalance before accepting connectors)
+echo "Creating test connector..."
 CONN_WAIT=0
 CONN_MAX=60
+CONNECTOR_CREATED=false
 while [ $CONN_WAIT -lt $CONN_MAX ]; do
-    CONN_COUNT=$(curl -s http://localhost:8083/connectors 2>/dev/null | jq 'length // 0' 2>/dev/null || echo 0)
-    if [ "$CONN_COUNT" -gt 0 ]; then
-        echo "Connector registered! ($CONN_COUNT connector(s) found)"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8083/connectors \
+        -H "Content-Type: application/json" \
+        -d '{
+          "name": "test-heartbeat",
+          "config": {
+            "connector.class": "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector",
+            "tasks.max": "1",
+            "source.cluster.alias": "source",
+            "target.cluster.alias": "target",
+            "source.cluster.bootstrap.servers": "osk-kafka:29092",
+            "target.cluster.bootstrap.servers": "osk-kafka:29092"
+          }
+        }' 2>/dev/null)
+    if [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "200" ]; then
+        echo "Connector created! (HTTP $HTTP_CODE)"
+        CONNECTOR_CREATED=true
         break
     fi
+    echo "Connector creation returned HTTP $HTTP_CODE, retrying... ($CONN_WAIT/$CONN_MAX seconds)"
     sleep 2
     CONN_WAIT=$((CONN_WAIT + 2))
 done
 
-if [ $CONN_WAIT -ge $CONN_MAX ]; then
-    echo "ERROR: No connectors registered within ${CONN_MAX}s"
+if [ "$CONNECTOR_CREATED" != "true" ]; then
+    echo "ERROR: Failed to create connector within ${CONN_MAX}s"
     echo "Connect REST response: $(curl -s http://localhost:8083/connectors 2>/dev/null)"
     exit 1
 fi

--- a/integration-tests/osk-scan/run-connect.sh
+++ b/integration-tests/osk-scan/run-connect.sh
@@ -40,9 +40,25 @@ if [ $WAIT_TIME -ge $MAX_WAIT ]; then
     exit 1
 fi
 
-# Additional wait for Connect to fully initialize
-echo "Waiting for Connect to fully initialize..."
-sleep 5
+# Wait for the test connector to be registered (created inside the container startup)
+echo "Waiting for test connector to be registered..."
+CONN_WAIT=0
+CONN_MAX=60
+while [ $CONN_WAIT -lt $CONN_MAX ]; do
+    CONN_COUNT=$(curl -s http://localhost:8083/connectors 2>/dev/null | jq 'length // 0' 2>/dev/null || echo 0)
+    if [ "$CONN_COUNT" -gt 0 ]; then
+        echo "Connector registered! ($CONN_COUNT connector(s) found)"
+        break
+    fi
+    sleep 2
+    CONN_WAIT=$((CONN_WAIT + 2))
+done
+
+if [ $CONN_WAIT -ge $CONN_MAX ]; then
+    echo "ERROR: No connectors registered within ${CONN_MAX}s"
+    echo "Connect REST response: $(curl -s http://localhost:8083/connectors 2>/dev/null)"
+    exit 1
+fi
 
 # Create a state file for the test
 STATE="test-state-kafka-connect.json"

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -70,6 +70,11 @@ func ConnectMetricDefinitions() MetricDefinitions {
 			{"connector-count", "kafka.connect:type=connect-worker-metrics", "connector-count"},
 			{"task-count", "kafka.connect:type=connect-worker-metrics", "task-count"},
 		},
+		Aggregates: []AggregateMBeanConfig{
+			{"incoming-byte-rate", "kafka.connect:client-id=*,type=connect-metrics", "incoming-byte-rate"},
+			{"outgoing-byte-rate", "kafka.connect:client-id=*,type=connect-metrics", "outgoing-byte-rate"},
+			{"connection-count", "kafka.connect:client-id=*,type=connect-metrics", "connection-count"},
+		},
 	}
 }
 

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -74,6 +74,7 @@ func ConnectMetricDefinitions() MetricDefinitions {
 			{"incoming-byte-rate", "kafka.connect:client-id=*,type=connect-metrics", "incoming-byte-rate"},
 			{"outgoing-byte-rate", "kafka.connect:client-id=*,type=connect-metrics", "outgoing-byte-rate"},
 			{"connection-count", "kafka.connect:client-id=*,type=connect-metrics", "connection-count"},
+			{"request-rate", "kafka.connect:client-id=*,type=connect-metrics", "request-rate"},
 		},
 	}
 }

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -75,6 +75,8 @@ func ConnectMetricDefinitions() MetricDefinitions {
 			{"outgoing-byte-rate", "kafka.connect:client-id=*,type=connect-metrics", "outgoing-byte-rate"},
 			{"connection-count", "kafka.connect:client-id=*,type=connect-metrics", "connection-count"},
 			{"request-rate", "kafka.connect:client-id=*,type=connect-metrics", "request-rate"},
+			{"source-record-write-rate", "kafka.connect:type=source-task-metrics,connector=*,task=*", "source-record-write-rate"},
+			{"source-record-poll-rate", "kafka.connect:type=source-task-metrics,connector=*,task=*", "source-record-poll-rate"},
 		},
 	}
 }

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -10,45 +10,67 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
-// counterMBeanConfig defines a rate MBean whose Count field is a monotonic counter.
-type counterMBeanConfig struct {
+// CounterMBeanConfig defines a rate MBean whose Count field is a monotonic counter.
+type CounterMBeanConfig struct {
 	Name  string
 	MBean string
 }
 
-// gaugeMBeanConfig defines a MBean that returns a point-in-time gauge value.
-type gaugeMBeanConfig struct {
+// GaugeMBeanConfig defines a MBean that returns a point-in-time gauge value.
+type GaugeMBeanConfig struct {
 	Name     string
 	MBean    string
 	ValueKey string
 }
 
-// aggregateMBeanConfig defines a MBean that requires wildcard pattern + aggregation.
-type aggregateMBeanConfig struct {
+// AggregateMBeanConfig defines a MBean that requires wildcard pattern + aggregation.
+type AggregateMBeanConfig struct {
 	Name      string
 	MBean     string
 	Attribute string
 }
 
-var counterMBeans = []counterMBeanConfig{
-	{"BytesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"},
-	{"BytesOutPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"},
-	{"MessagesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec"},
+// MetricDefinitions holds all metric definitions for a JMX collection target.
+type MetricDefinitions struct {
+	Counters        []CounterMBeanConfig
+	Gauges          []GaugeMBeanConfig
+	Controller      []GaugeMBeanConfig
+	Aggregates      []AggregateMBeanConfig
+	UnitConversions map[string]float64
 }
 
-var gaugeMBeans = []gaugeMBeanConfig{
-	{"PartitionCount", "kafka.server:type=ReplicaManager,name=PartitionCount", "Value"},
+// BrokerMetricDefinitions returns the standard Kafka broker metric definitions.
+func BrokerMetricDefinitions() MetricDefinitions {
+	return MetricDefinitions{
+		Counters: []CounterMBeanConfig{
+			{"BytesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"},
+			{"BytesOutPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"},
+			{"MessagesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec"},
+		},
+		Gauges: []GaugeMBeanConfig{
+			{"PartitionCount", "kafka.server:type=ReplicaManager,name=PartitionCount", "Value"},
+		},
+		Controller: []GaugeMBeanConfig{
+			{"GlobalPartitionCount", "kafka.controller:type=KafkaController,name=GlobalPartitionCount", "Value"},
+		},
+		Aggregates: []AggregateMBeanConfig{
+			{"ClientConnectionCount", "kafka.server:type=socket-server-metrics,listener=*,networkProcessor=*", "connection-count"},
+			{"TotalLocalStorageUsage", "kafka.log:type=Log,name=Size,*", "Value"},
+		},
+		UnitConversions: map[string]float64{
+			"TotalLocalStorageUsage": 1024 * 1024 * 1024,
+		},
+	}
 }
 
-// controllerMBeans are MBeans that only exist on the active controller broker.
-// We try all brokers and use the first successful response (no summing).
-var controllerMBeans = []gaugeMBeanConfig{
-	{"GlobalPartitionCount", "kafka.controller:type=KafkaController,name=GlobalPartitionCount", "Value"},
-}
-
-var aggregateMBeans = []aggregateMBeanConfig{
-	{"ClientConnectionCount", "kafka.server:type=socket-server-metrics,listener=*,networkProcessor=*", "connection-count"},
-	{"TotalLocalStorageUsage", "kafka.log:type=Log,name=Size,*", "Value"},
+// ConnectMetricDefinitions returns metric definitions for Kafka Connect workers.
+func ConnectMetricDefinitions() MetricDefinitions {
+	return MetricDefinitions{
+		Gauges: []GaugeMBeanConfig{
+			{"connector-count", "kafka.connect:type=connect-worker-metrics", "connector-count"},
+			{"task-count", "kafka.connect:type=connect-worker-metrics", "task-count"},
+		},
+	}
 }
 
 // rawSample holds raw counter and gauge readings from a single poll.
@@ -69,15 +91,16 @@ type jmxSnapshot struct {
 // JMXService collects JMX metrics from Kafka brokers via Jolokia
 type JMXService struct {
 	clients []*client.JolokiaClient
+	metrics MetricDefinitions
 }
 
 // NewJMXService creates a new JMX service with Jolokia clients for each broker endpoint
-func NewJMXService(endpoints []string, opts ...client.JolokiaOption) *JMXService {
+func NewJMXService(endpoints []string, defs MetricDefinitions, opts ...client.JolokiaOption) *JMXService {
 	clients := make([]*client.JolokiaClient, len(endpoints))
 	for i, endpoint := range endpoints {
 		clients[i] = client.NewJolokiaClient(endpoint, opts...)
 	}
-	return &JMXService{clients: clients}
+	return &JMXService{clients: clients, metrics: defs}
 }
 
 // collectRawSample reads raw counter and gauge values from all brokers.
@@ -88,7 +111,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 		gauges:    make(map[string]float64),
 	}
 
-	for _, mb := range counterMBeans {
+	for _, mb := range s.metrics.Counters {
 		for _, brokerClient := range s.clients {
 			value, err := brokerClient.ReadMBean(ctx, mb.MBean)
 			if err != nil {
@@ -103,7 +126,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 		}
 	}
 
-	for _, mb := range gaugeMBeans {
+	for _, mb := range s.metrics.Gauges {
 		for _, brokerClient := range s.clients {
 			value, err := brokerClient.ReadMBean(ctx, mb.MBean)
 			if err != nil {
@@ -120,7 +143,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 
 	// Controller MBeans only exist on the active controller broker.
 	// Try all brokers; use the first successful response.
-	for _, mb := range controllerMBeans {
+	for _, mb := range s.metrics.Controller {
 		found := false
 		for _, brokerClient := range s.clients {
 			value, err := brokerClient.ReadMBean(ctx, mb.MBean)
@@ -141,7 +164,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 		}
 	}
 
-	for _, amb := range aggregateMBeans {
+	for _, amb := range s.metrics.Aggregates {
 		var total float64
 		for _, brokerClient := range s.clients {
 			val, err := brokerClient.ReadMBeanAggregate(ctx, amb.MBean, amb.Attribute)
@@ -158,7 +181,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 }
 
 // computeSnapshot computes metrics from two consecutive raw samples.
-func computeSnapshot(prev, curr *rawSample) *jmxSnapshot {
+func computeSnapshot(prev, curr *rawSample, unitConversions map[string]float64) *jmxSnapshot {
 	elapsed := curr.timestamp.Sub(prev.timestamp).Seconds()
 	snapshot := &jmxSnapshot{
 		start:   prev.timestamp,
@@ -181,8 +204,10 @@ func computeSnapshot(prev, curr *rawSample) *jmxSnapshot {
 		snapshot.metrics[name] = value
 	}
 
-	if bytes, ok := snapshot.metrics["TotalLocalStorageUsage"]; ok {
-		snapshot.metrics["TotalLocalStorageUsage"] = bytes / (1024 * 1024 * 1024)
+	for metricName, divisor := range unitConversions {
+		if raw, ok := snapshot.metrics[metricName]; ok {
+			snapshot.metrics[metricName] = raw / divisor
+		}
 	}
 
 	return snapshot
@@ -218,12 +243,12 @@ func (s *JMXService) CollectOverDuration(ctx context.Context, duration, interval
 		select {
 		case <-ctx.Done():
 			result := toProcessedClusterMetrics(snapshots, startTime, duration, interval)
-			result.QueryInfo = buildJMXQueryInfo(brokerURLs, duration, interval)
+			result.QueryInfo = buildJMXQueryInfo(brokerURLs, duration, interval, s.metrics)
 			return result, ctx.Err()
 		case <-ticker.C:
 			if time.Now().After(deadline) {
 				result := toProcessedClusterMetrics(snapshots, startTime, duration, interval)
-				result.QueryInfo = buildJMXQueryInfo(brokerURLs, duration, interval)
+				result.QueryInfo = buildJMXQueryInfo(brokerURLs, duration, interval, s.metrics)
 				return result, nil
 			}
 
@@ -233,7 +258,7 @@ func (s *JMXService) CollectOverDuration(ctx context.Context, duration, interval
 				continue
 			}
 
-			snapshot := computeSnapshot(prevSample, currSample)
+			snapshot := computeSnapshot(prevSample, currSample, s.metrics.UnitConversions)
 			snapshots = append(snapshots, *snapshot)
 			prevSample = currSample
 
@@ -308,7 +333,7 @@ func calculateAggregates(snapshots []jmxSnapshot) map[string]types.MetricAggrega
 
 // buildJMXQueryInfo generates MetricQueryInfo entries for all JMX metrics,
 // including the MBean path and a curl command to reproduce the query.
-func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration) []types.MetricQueryInfo {
+func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration, defs MetricDefinitions) []types.MetricQueryInfo {
 	if len(brokerURLs) == 0 {
 		return nil
 	}
@@ -319,7 +344,7 @@ func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration) []
 
 	var infos []types.MetricQueryInfo
 
-	for _, mb := range counterMBeans {
+	for _, mb := range defs.Counters {
 		infos = append(infos, types.MetricQueryInfo{
 			MetricName:    mb.Name,
 			SourceType:    types.MetricBackendJolokia,
@@ -335,7 +360,7 @@ func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration) []
 		})
 	}
 
-	for _, mb := range gaugeMBeans {
+	for _, mb := range defs.Gauges {
 		infos = append(infos, types.MetricQueryInfo{
 			MetricName:    mb.Name,
 			SourceType:    types.MetricBackendJolokia,
@@ -351,7 +376,7 @@ func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration) []
 		})
 	}
 
-	for _, mb := range controllerMBeans {
+	for _, mb := range defs.Controller {
 		infos = append(infos, types.MetricQueryInfo{
 			MetricName:    mb.Name,
 			SourceType:    types.MetricBackendJolokia,
@@ -367,7 +392,7 @@ func buildJMXQueryInfo(brokerURLs []string, duration, interval time.Duration) []
 		})
 	}
 
-	for _, mb := range aggregateMBeans {
+	for _, mb := range defs.Aggregates {
 		infos = append(infos, types.MetricQueryInfo{
 			MetricName:    mb.Name,
 			SourceType:    types.MetricBackendJolokia,

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -339,7 +339,7 @@ func TestConnectMetricDefinitions(t *testing.T) {
 	assert.Nil(t, defs.UnitConversions)
 
 	// Connect definitions should have aggregate metrics for client-level byte rates
-	require.Len(t, defs.Aggregates, 3)
+	require.Len(t, defs.Aggregates, 4)
 	aggNames := make([]string, len(defs.Aggregates))
 	for i, a := range defs.Aggregates {
 		aggNames[i] = a.Name
@@ -347,4 +347,5 @@ func TestConnectMetricDefinitions(t *testing.T) {
 	assert.Contains(t, aggNames, "incoming-byte-rate")
 	assert.Contains(t, aggNames, "outgoing-byte-rate")
 	assert.Contains(t, aggNames, "connection-count")
+	assert.Contains(t, aggNames, "request-rate")
 }

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -65,7 +65,7 @@ func TestComputeSnapshot_RatesFromCounterDeltas(t *testing.T) {
 		gauges:    map[string]float64{"PartitionCount": 50, "GlobalPartitionCount": 20, "ClientConnectionCount": 5, "TotalLocalStorageUsage": 2147483648},
 	}
 
-	snapshot := computeSnapshot(prev, curr)
+	snapshot := computeSnapshot(prev, curr, BrokerMetricDefinitions().UnitConversions)
 
 	assert.Equal(t, 1000.0, snapshot.metrics["BytesInPerSec"])
 	assert.Equal(t, 500.0, snapshot.metrics["BytesOutPerSec"])
@@ -91,7 +91,7 @@ func TestComputeSnapshot_CounterResetProducesZeroNotNegative(t *testing.T) {
 		gauges:    map[string]float64{"PartitionCount": 50},
 	}
 
-	snapshot := computeSnapshot(prev, curr)
+	snapshot := computeSnapshot(prev, curr, nil)
 
 	// Counter metrics should be absent (skipped), not negative
 	_, hasBytes := snapshot.metrics["BytesInPerSec"]
@@ -153,7 +153,7 @@ func TestCollectOverDuration_ReturnsProcessedClusterMetrics(t *testing.T) {
 	server := mockJolokiaServer(t)
 	defer server.Close()
 
-	svc := NewJMXService([]string{server.URL})
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions())
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
@@ -185,14 +185,15 @@ func TestCollectOverDuration_PopulatesQueryInfo(t *testing.T) {
 	server := mockJolokiaServer(t)
 	defer server.Close()
 
-	svc := NewJMXService([]string{server.URL})
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions())
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.QueryInfo)
 
-	expectedCount := len(counterMBeans) + len(gaugeMBeans) + len(controllerMBeans) + len(aggregateMBeans)
+	defs := BrokerMetricDefinitions()
+	expectedCount := len(defs.Counters) + len(defs.Gauges) + len(defs.Controller) + len(defs.Aggregates)
 	assert.Len(t, result.QueryInfo, expectedCount)
 
 	for _, qi := range result.QueryInfo {
@@ -220,9 +221,10 @@ func TestCollectOverDuration_PopulatesQueryInfo(t *testing.T) {
 
 func TestBuildJMXQueryInfo(t *testing.T) {
 	brokerURLs := []string{"http://broker1:8778/jolokia", "http://broker2:8778/jolokia"}
-	infos := buildJMXQueryInfo(brokerURLs, 5*time.Minute, 10*time.Second)
+	defs := BrokerMetricDefinitions()
+	infos := buildJMXQueryInfo(brokerURLs, 5*time.Minute, 10*time.Second, defs)
 
-	expectedCount := len(counterMBeans) + len(gaugeMBeans) + len(controllerMBeans) + len(aggregateMBeans)
+	expectedCount := len(defs.Counters) + len(defs.Gauges) + len(defs.Controller) + len(defs.Aggregates)
 	assert.Len(t, infos, expectedCount)
 
 	// All entries should have Statistic, Period, and QueryDuration
@@ -254,8 +256,8 @@ func TestBuildJMXQueryInfo(t *testing.T) {
 	assert.Contains(t, infos[6].AggregationNote, "Wildcard")
 
 	// Empty brokerURLs should return nil
-	assert.Nil(t, buildJMXQueryInfo(nil, 5*time.Minute, 10*time.Second))
-	assert.Nil(t, buildJMXQueryInfo([]string{}, 5*time.Minute, 10*time.Second))
+	assert.Nil(t, buildJMXQueryInfo(nil, 5*time.Minute, 10*time.Second, defs))
+	assert.Nil(t, buildJMXQueryInfo([]string{}, 5*time.Minute, 10*time.Second, defs))
 }
 
 func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
@@ -294,7 +296,7 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := NewJMXService([]string{server.URL})
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions())
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
@@ -318,9 +320,23 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 }
 
 func TestCollectOverDuration_DurationMustExceedInterval(t *testing.T) {
-	svc := NewJMXService([]string{"http://localhost:1"})
+	svc := NewJMXService([]string{"http://localhost:1"}, BrokerMetricDefinitions())
 	_, err := svc.CollectOverDuration(context.Background(), 5*time.Second, 5*time.Second)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be greater than")
+}
+
+func TestConnectMetricDefinitions(t *testing.T) {
+	defs := ConnectMetricDefinitions()
+
+	require.Len(t, defs.Gauges, 2)
+	assert.Equal(t, "connector-count", defs.Gauges[0].Name)
+	assert.Equal(t, "task-count", defs.Gauges[1].Name)
+
+	// Connect definitions should have no counters, controller, or aggregates
+	assert.Empty(t, defs.Counters)
+	assert.Empty(t, defs.Controller)
+	assert.Empty(t, defs.Aggregates)
+	assert.Nil(t, defs.UnitConversions)
 }

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -334,9 +334,17 @@ func TestConnectMetricDefinitions(t *testing.T) {
 	assert.Equal(t, "connector-count", defs.Gauges[0].Name)
 	assert.Equal(t, "task-count", defs.Gauges[1].Name)
 
-	// Connect definitions should have no counters, controller, or aggregates
 	assert.Empty(t, defs.Counters)
 	assert.Empty(t, defs.Controller)
-	assert.Empty(t, defs.Aggregates)
 	assert.Nil(t, defs.UnitConversions)
+
+	// Connect definitions should have aggregate metrics for client-level byte rates
+	require.Len(t, defs.Aggregates, 3)
+	aggNames := make([]string, len(defs.Aggregates))
+	for i, a := range defs.Aggregates {
+		aggNames[i] = a.Name
+	}
+	assert.Contains(t, aggNames, "incoming-byte-rate")
+	assert.Contains(t, aggNames, "outgoing-byte-rate")
+	assert.Contains(t, aggNames, "connection-count")
 }

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -338,8 +338,8 @@ func TestConnectMetricDefinitions(t *testing.T) {
 	assert.Empty(t, defs.Controller)
 	assert.Nil(t, defs.UnitConversions)
 
-	// Connect definitions should have aggregate metrics for client-level byte rates
-	require.Len(t, defs.Aggregates, 4)
+	// Connect definitions should have aggregate metrics for client-level and task-level metrics
+	require.Len(t, defs.Aggregates, 6)
 	aggNames := make([]string, len(defs.Aggregates))
 	for i, a := range defs.Aggregates {
 		aggNames[i] = a.Name
@@ -348,4 +348,6 @@ func TestConnectMetricDefinitions(t *testing.T) {
 	assert.Contains(t, aggNames, "outgoing-byte-rate")
 	assert.Contains(t, aggNames, "connection-count")
 	assert.Contains(t, aggNames, "request-rate")
+	assert.Contains(t, aggNames, "source-record-write-rate")
+	assert.Contains(t, aggNames, "source-record-poll-rate")
 }

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -44,6 +44,7 @@ func ConnectQueryDefinitions() []MetricQuery {
 		{"incoming-byte-rate", "sum(kafka_connect_connect_metrics_incoming_byte_rate)", "kafka_connect_connect_metrics_incoming_byte_rate"},
 		{"outgoing-byte-rate", "sum(kafka_connect_connect_metrics_outgoing_byte_rate)", "kafka_connect_connect_metrics_outgoing_byte_rate"},
 		{"connection-count", "sum(kafka_connect_connect_metrics_connection_count)", "kafka_connect_connect_metrics_connection_count"},
+		{"request-rate", "sum(kafka_connect_connect_metrics_request_rate)", "kafka_connect_connect_metrics_request_rate"},
 	}
 }
 

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -13,7 +13,8 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
-type metricQuery struct {
+// MetricQuery defines a single Prometheus metric to collect.
+type MetricQuery struct {
 	Label string
 	// Query is a format string. %s is replaced with the rate window (e.g. "5m", "4h").
 	// Queries without %s are used as-is.
@@ -22,24 +23,36 @@ type metricQuery struct {
 	PrometheusMetric string
 }
 
-var prometheusQueries = []metricQuery{
-	{"BytesInPerSec", "sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[%s]))", "kafka_server_brokertopicmetrics_bytesinpersec_total"},
-	{"BytesOutPerSec", "sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[%s]))", "kafka_server_brokertopicmetrics_bytesoutpersec_total"},
-	{"MessagesInPerSec", "sum(rate(kafka_server_brokertopicmetrics_messagesinpersec_total[%s]))", "kafka_server_brokertopicmetrics_messagesinpersec_total"},
-	{"PartitionCount", "sum(kafka_server_replicamanager_partitioncount)", "kafka_server_replicamanager_partitioncount"},
-	{"GlobalPartitionCount", "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}", "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}"},
-	{"ClientConnectionCount", "sum(kafka_server_socketservermetrics_connection_count)", "kafka_server_socketservermetrics_connection_count"},
-	{"TotalLocalStorageUsage", "sum(kafka_log_log_size) / (1024*1024*1024)", "kafka_log_log_size"},
+// BrokerQueryDefinitions returns the standard Kafka broker Prometheus queries.
+func BrokerQueryDefinitions() []MetricQuery {
+	return []MetricQuery{
+		{"BytesInPerSec", "sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[%s]))", "kafka_server_brokertopicmetrics_bytesinpersec_total"},
+		{"BytesOutPerSec", "sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[%s]))", "kafka_server_brokertopicmetrics_bytesoutpersec_total"},
+		{"MessagesInPerSec", "sum(rate(kafka_server_brokertopicmetrics_messagesinpersec_total[%s]))", "kafka_server_brokertopicmetrics_messagesinpersec_total"},
+		{"PartitionCount", "sum(kafka_server_replicamanager_partitioncount)", "kafka_server_replicamanager_partitioncount"},
+		{"GlobalPartitionCount", "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}", "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}"},
+		{"ClientConnectionCount", "sum(kafka_server_socketservermetrics_connection_count)", "kafka_server_socketservermetrics_connection_count"},
+		{"TotalLocalStorageUsage", "sum(kafka_log_log_size) / (1024*1024*1024)", "kafka_log_log_size"},
+	}
+}
+
+// ConnectQueryDefinitions returns Prometheus queries for Kafka Connect worker metrics.
+func ConnectQueryDefinitions() []MetricQuery {
+	return []MetricQuery{
+		{"connector-count", "kafka_connect_connect_worker_metrics_connector_count", "kafka_connect_connect_worker_metrics_connector_count"},
+		{"task-count", "kafka_connect_connect_worker_metrics_task_count", "kafka_connect_connect_worker_metrics_task_count"},
+	}
 }
 
 // PrometheusService collects Kafka metrics from a Prometheus server
 type PrometheusService struct {
-	client *client.PrometheusClient
+	client  *client.PrometheusClient
+	queries []MetricQuery
 }
 
 // NewPrometheusService creates a new Prometheus metrics service
-func NewPrometheusService(promClient *client.PrometheusClient) *PrometheusService {
-	return &PrometheusService{client: promClient}
+func NewPrometheusService(promClient *client.PrometheusClient, queries []MetricQuery) *PrometheusService {
+	return &PrometheusService{client: promClient, queries: queries}
 }
 
 // SelectStep chooses an appropriate query step based on the time range
@@ -80,7 +93,7 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 	var allMetrics []types.ProcessedMetric
 	valuesByLabel := make(map[string][]float64)
 
-	for _, mq := range prometheusQueries {
+	for _, mq := range s.queries {
 		query := mq.Query
 		if strings.Contains(query, "%s") {
 			query = fmt.Sprintf(query, rateWindow)
@@ -88,7 +101,6 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		results, err := s.client.QueryRange(ctx, query, start, end, step)
 		if err != nil {
 			slog.Warn("Prometheus query failed, skipping metric", "label", mq.Label, "error", err)
-			fmt.Printf("   ⚠️  Query failed for %s: %v\n", mq.Label, err)
 			continue
 		}
 
@@ -98,7 +110,6 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		}
 		if dataPoints == 0 {
 			slog.Warn("Prometheus query returned no data points", "label", mq.Label, "query", query)
-			fmt.Printf("   ⚠️  No data returned for %s — metric may not be exposed by your Prometheus exporter\n", mq.Label)
 		}
 
 		for _, result := range results {
@@ -132,18 +143,18 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		},
 		Metrics:    allMetrics,
 		Aggregates: aggregates,
-		QueryInfo:  buildPrometheusQueryInfo(s.client.BaseURL(), rateWindow, step, queryRange, start, end),
+		QueryInfo:  buildPrometheusQueryInfo(s.client.BaseURL(), rateWindow, step, queryRange, start, end, s.queries),
 	}, nil
 }
 
 // buildPrometheusQueryInfo generates MetricQueryInfo entries for all Prometheus metrics,
 // including the resolved PromQL query and a curl command to reproduce it.
-func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange time.Duration, start, end time.Time) []types.MetricQueryInfo {
-	infos := make([]types.MetricQueryInfo, 0, len(prometheusQueries))
+func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange time.Duration, start, end time.Time, queries []MetricQuery) []types.MetricQueryInfo {
+	infos := make([]types.MetricQueryInfo, 0, len(queries))
 	periodSec := int32(step.Seconds())
 	durationStr := types.FormatQueryDuration(queryRange)
 
-	for _, mq := range prometheusQueries {
+	for _, mq := range queries {
 		resolvedQuery := mq.Query
 		if strings.Contains(resolvedQuery, "%s") {
 			resolvedQuery = fmt.Sprintf(resolvedQuery, rateWindow)

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -42,8 +42,8 @@ func BrokerQueryDefinitions() []MetricQuery {
 // require the JMX exporter to whitelist kafka.connect:client-id=*,type=connect-metrics.
 func ConnectQueryDefinitions() []MetricQuery {
 	return []MetricQuery{
-		{"connector-count", "kafka_connect_worker_connector_count", "kafka_connect_worker_connector_count"},
-		{"task-count", "kafka_connect_worker_task_count", "kafka_connect_worker_task_count"},
+		{"connector-count", "sum(kafka_connect_worker_connector_count)", "kafka_connect_worker_connector_count"},
+		{"task-count", "sum(kafka_connect_worker_task_count)", "kafka_connect_worker_task_count"},
 		{"source-record-write-rate", "sum(kafka_connect_source_task_source_record_write_rate)", "kafka_connect_source_task_source_record_write_rate"},
 		{"source-record-poll-rate", "sum(kafka_connect_source_task_source_record_poll_rate)", "kafka_connect_source_task_source_record_poll_rate"},
 		{"incoming-byte-rate", "sum(kafka_connect_network_io_incoming_byte_rate)", "kafka_connect_network_io_incoming_byte_rate"},
@@ -138,8 +138,8 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 	}
 
 	if len(allMetrics) == 0 {
-		fmt.Printf("\n   ⚠️  No metrics data was collected from Prometheus. Ensure your Prometheus instance is scraping Kafka broker metrics.\n")
-		fmt.Printf("   See %sosk-configuration/metrics-collection/#prometheus-promql-queries for expected metric names.\n", build_info.DocsURL())
+		slog.Warn("No metrics data was collected from Prometheus. Ensure your Prometheus instance is scraping the expected metrics.",
+			"docs", build_info.DocsURL()+"osk-configuration/metrics-collection/#prometheus-promql-queries")
 	}
 
 	aggregates := calculateAggregates(valuesByLabel)

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -57,11 +57,50 @@ func ConnectQueryDefinitions() []MetricQuery {
 type PrometheusService struct {
 	client  *client.PrometheusClient
 	queries []MetricQuery
+	labels  map[string]string
 }
 
-// NewPrometheusService creates a new Prometheus metrics service
-func NewPrometheusService(promClient *client.PrometheusClient, queries []MetricQuery) *PrometheusService {
-	return &PrometheusService{client: promClient, queries: queries}
+// NewPrometheusService creates a new Prometheus metrics service.
+// Labels is an optional map of Prometheus label selectors to scope queries
+// to a specific target (e.g. {"job": "confluent/connect-jmx-exporter"}).
+// Pass nil for no filtering.
+func NewPrometheusService(promClient *client.PrometheusClient, queries []MetricQuery, labels map[string]string) *PrometheusService {
+	return &PrometheusService{client: promClient, queries: queries, labels: labels}
+}
+
+// applyLabelFilter injects label selectors into a PromQL query by finding
+// the metric name and appending {key="value",...} after it.
+func applyLabelFilter(query, metricName string, labels map[string]string) string {
+	if len(labels) == 0 || metricName == "" {
+		return query
+	}
+
+	var parts []string
+	for k, v := range labels {
+		parts = append(parts, fmt.Sprintf("%s=\"%s\"", k, v))
+	}
+	labelStr := strings.Join(parts, ",")
+
+	// Extract the base metric name (without any existing selector)
+	baseName := metricName
+	if idx := strings.Index(metricName, "{"); idx >= 0 {
+		baseName = metricName[:idx]
+	}
+
+	// Find where the metric name appears in the query and look for existing braces
+	idx := strings.Index(query, baseName)
+	if idx < 0 {
+		return query
+	}
+
+	afterName := idx + len(baseName)
+	if afterName < len(query) && query[afterName] == '{' {
+		// Insert our labels at the start of the existing selector
+		return query[:afterName+1] + labelStr + "," + query[afterName+1:]
+	}
+
+	// No existing selector — add one
+	return query[:afterName] + "{" + labelStr + "}" + query[afterName:]
 }
 
 // SelectStep chooses an appropriate query step based on the time range
@@ -107,6 +146,7 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		if strings.Contains(query, "%s") {
 			query = fmt.Sprintf(query, rateWindow)
 		}
+		query = applyLabelFilter(query, mq.PrometheusMetric, s.labels)
 		results, err := s.client.QueryRange(ctx, query, start, end, step)
 		if err != nil {
 			slog.Warn("Prometheus query failed, skipping metric", "label", mq.Label, "error", err)
@@ -152,13 +192,13 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 		},
 		Metrics:    allMetrics,
 		Aggregates: aggregates,
-		QueryInfo:  buildPrometheusQueryInfo(s.client.BaseURL(), rateWindow, step, queryRange, start, end, s.queries),
+		QueryInfo:  buildPrometheusQueryInfo(s.client.BaseURL(), rateWindow, step, queryRange, start, end, s.queries, s.labels),
 	}, nil
 }
 
 // buildPrometheusQueryInfo generates MetricQueryInfo entries for all Prometheus metrics,
 // including the resolved PromQL query and a curl command to reproduce it.
-func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange time.Duration, start, end time.Time, queries []MetricQuery) []types.MetricQueryInfo {
+func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange time.Duration, start, end time.Time, queries []MetricQuery, labels map[string]string) []types.MetricQueryInfo {
 	infos := make([]types.MetricQueryInfo, 0, len(queries))
 	periodSec := int32(step.Seconds())
 	durationStr := types.FormatQueryDuration(queryRange)
@@ -168,6 +208,7 @@ func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange t
 		if strings.Contains(resolvedQuery, "%s") {
 			resolvedQuery = fmt.Sprintf(resolvedQuery, rateWindow)
 		}
+		resolvedQuery = applyLabelFilter(resolvedQuery, mq.PrometheusMetric, labels)
 
 		var statistic string
 		var note string

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -41,6 +41,9 @@ func ConnectQueryDefinitions() []MetricQuery {
 	return []MetricQuery{
 		{"connector-count", "kafka_connect_connect_worker_metrics_connector_count", "kafka_connect_connect_worker_metrics_connector_count"},
 		{"task-count", "kafka_connect_connect_worker_metrics_task_count", "kafka_connect_connect_worker_metrics_task_count"},
+		{"incoming-byte-rate", "sum(kafka_connect_connect_metrics_incoming_byte_rate)", "kafka_connect_connect_metrics_incoming_byte_rate"},
+		{"outgoing-byte-rate", "sum(kafka_connect_connect_metrics_outgoing_byte_rate)", "kafka_connect_connect_metrics_outgoing_byte_rate"},
+		{"connection-count", "sum(kafka_connect_connect_metrics_connection_count)", "kafka_connect_connect_metrics_connection_count"},
 	}
 }
 

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -75,8 +76,18 @@ func applyLabelFilter(query, metricName string, labels map[string]string) string
 		return query
 	}
 
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var parts []string
-	for k, v := range labels {
+	for _, k := range keys {
+		// Escape backslashes and double quotes in label values for valid PromQL
+		v := strings.ReplaceAll(labels[k], `\`, `\\`)
+		v = strings.ReplaceAll(v, `"`, `\"`)
 		parts = append(parts, fmt.Sprintf("%s=\"%s\"", k, v))
 	}
 	labelStr := strings.Join(parts, ",")

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -38,12 +38,18 @@ func BrokerQueryDefinitions() []MetricQuery {
 
 // ConnectQueryDefinitions returns Prometheus queries for Kafka Connect worker metrics.
 // Metric names match the JMX exporter naming convention (kafka_connect_worker_*).
+// Client-level metrics (incoming/outgoing-byte-rate, connection-count, request-rate)
+// require the JMX exporter to whitelist kafka.connect:client-id=*,type=connect-metrics.
 func ConnectQueryDefinitions() []MetricQuery {
 	return []MetricQuery{
 		{"connector-count", "kafka_connect_worker_connector_count", "kafka_connect_worker_connector_count"},
 		{"task-count", "kafka_connect_worker_task_count", "kafka_connect_worker_task_count"},
 		{"source-record-write-rate", "sum(kafka_connect_source_task_source_record_write_rate)", "kafka_connect_source_task_source_record_write_rate"},
 		{"source-record-poll-rate", "sum(kafka_connect_source_task_source_record_poll_rate)", "kafka_connect_source_task_source_record_poll_rate"},
+		{"incoming-byte-rate", "sum(kafka_connect_network_io_incoming_byte_rate)", "kafka_connect_network_io_incoming_byte_rate"},
+		{"outgoing-byte-rate", "sum(kafka_connect_network_io_outgoing_byte_rate)", "kafka_connect_network_io_outgoing_byte_rate"},
+		{"connection-count", "sum(kafka_connect_network_io_connection_count)", "kafka_connect_network_io_connection_count"},
+		{"request-rate", "sum(kafka_connect_network_io_request_rate)", "kafka_connect_network_io_request_rate"},
 	}
 }
 

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -37,14 +37,13 @@ func BrokerQueryDefinitions() []MetricQuery {
 }
 
 // ConnectQueryDefinitions returns Prometheus queries for Kafka Connect worker metrics.
+// Metric names match the JMX exporter naming convention (kafka_connect_worker_*).
 func ConnectQueryDefinitions() []MetricQuery {
 	return []MetricQuery{
-		{"connector-count", "kafka_connect_connect_worker_metrics_connector_count", "kafka_connect_connect_worker_metrics_connector_count"},
-		{"task-count", "kafka_connect_connect_worker_metrics_task_count", "kafka_connect_connect_worker_metrics_task_count"},
-		{"incoming-byte-rate", "sum(kafka_connect_connect_metrics_incoming_byte_rate)", "kafka_connect_connect_metrics_incoming_byte_rate"},
-		{"outgoing-byte-rate", "sum(kafka_connect_connect_metrics_outgoing_byte_rate)", "kafka_connect_connect_metrics_outgoing_byte_rate"},
-		{"connection-count", "sum(kafka_connect_connect_metrics_connection_count)", "kafka_connect_connect_metrics_connection_count"},
-		{"request-rate", "sum(kafka_connect_connect_metrics_request_rate)", "kafka_connect_connect_metrics_request_rate"},
+		{"connector-count", "kafka_connect_worker_connector_count", "kafka_connect_worker_connector_count"},
+		{"task-count", "kafka_connect_worker_task_count", "kafka_connect_worker_task_count"},
+		{"source-record-write-rate", "sum(kafka_connect_source_task_source_record_write_rate)", "kafka_connect_source_task_source_record_write_rate"},
+		{"source-record-poll-rate", "sum(kafka_connect_source_task_source_record_poll_rate)", "kafka_connect_source_task_source_record_poll_rate"},
 	}
 }
 

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -241,6 +241,7 @@ func buildPrometheusQueryInfo(promBaseURL, rateWindow string, step, queryRange t
 			PrometheusMetricName: mq.PrometheusMetric,
 			CurlCommand:          fmt.Sprintf("curl -G '%s/api/v1/query_range' --data-urlencode 'query=%s' --data-urlencode 'start=%s' --data-urlencode 'end=%s' --data-urlencode 'step=%ds'", promBaseURL, resolvedQuery, start.Format(time.RFC3339), end.Format(time.RFC3339), int(step.Seconds())),
 			AggregationNote:      note,
+			LabelFilter:          labels,
 		})
 	}
 

--- a/internal/services/prometheus/prometheus_service_test.go
+++ b/internal/services/prometheus/prometheus_service_test.go
@@ -75,7 +75,7 @@ func TestPrometheusService_CollectMetrics(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestPrometheusService_CollectMetrics_MissingMetric(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
 
 	result, err := svc.CollectMetrics(context.Background(), 7*24*time.Hour)
 	require.NoError(t, err)
@@ -143,15 +143,15 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.QueryInfo)
 
-	// Should have one entry per prometheusQueries (7)
-	assert.Len(t, result.QueryInfo, len(prometheusQueries))
+	// Should have one entry per query definition (7)
+	assert.Len(t, result.QueryInfo, len(BrokerQueryDefinitions()))
 
 	for _, qi := range result.QueryInfo {
 		assert.Equal(t, types.MetricBackendPrometheus, qi.SourceType)
@@ -186,9 +186,9 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 func TestBuildPrometheusQueryInfo(t *testing.T) {
 	end := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	start := end.Add(-24 * time.Hour)
-	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end)
+	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end, BrokerQueryDefinitions())
 
-	assert.Len(t, infos, len(prometheusQueries))
+	assert.Len(t, infos, len(BrokerQueryDefinitions()))
 
 	// Rate-based metrics should have rate() in the aggregation note
 	for _, info := range infos[:3] {

--- a/internal/services/prometheus/prometheus_service_test.go
+++ b/internal/services/prometheus/prometheus_service_test.go
@@ -295,6 +295,20 @@ func TestApplyLabelFilter(t *testing.T) {
 			labels,
 			"sum(kafka_connect_worker_connector_count)",
 		},
+		{
+			"multiple labels are sorted deterministically",
+			"sum(kafka_connect_worker_connector_count)",
+			"kafka_connect_worker_connector_count",
+			map[string]string{"namespace": "confluent", "job": "connect-exporter"},
+			`sum(kafka_connect_worker_connector_count{job="connect-exporter",namespace="confluent"})`,
+		},
+		{
+			"label values with special characters are escaped",
+			"sum(kafka_connect_worker_connector_count)",
+			"kafka_connect_worker_connector_count",
+			map[string]string{"job": `value"with\quotes`},
+			`sum(kafka_connect_worker_connector_count{job="value\"with\\quotes"})`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/prometheus/prometheus_service_test.go
+++ b/internal/services/prometheus/prometheus_service_test.go
@@ -75,7 +75,7 @@ func TestPrometheusService_CollectMetrics(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestPrometheusService_CollectMetrics_MissingMetric(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 7*24*time.Hour)
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions())
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 func TestBuildPrometheusQueryInfo(t *testing.T) {
 	end := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	start := end.Add(-24 * time.Hour)
-	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end, BrokerQueryDefinitions())
+	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end, BrokerQueryDefinitions(), nil)
 
 	assert.Len(t, infos, len(BrokerQueryDefinitions()))
 
@@ -239,6 +239,68 @@ func TestPrometheusService_StepSelection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			step := SelectStep(tt.duration)
 			assert.Equal(t, tt.expected, step)
+		})
+	}
+}
+
+func TestApplyLabelFilter(t *testing.T) {
+	labels := map[string]string{"job": "confluent/connect-jmx-exporter"}
+
+	tests := []struct {
+		name       string
+		query      string
+		metricName string
+		labels     map[string]string
+		expected   string
+	}{
+		{
+			"no labels returns query unchanged",
+			"sum(kafka_connect_worker_connector_count)",
+			"kafka_connect_worker_connector_count",
+			nil,
+			"sum(kafka_connect_worker_connector_count)",
+		},
+		{
+			"simple metric gets label selector",
+			"kafka_connect_worker_task_count",
+			"kafka_connect_worker_task_count",
+			labels,
+			`kafka_connect_worker_task_count{job="confluent/connect-jmx-exporter"}`,
+		},
+		{
+			"sum-wrapped metric gets label selector",
+			"sum(kafka_connect_worker_connector_count)",
+			"kafka_connect_worker_connector_count",
+			labels,
+			`sum(kafka_connect_worker_connector_count{job="confluent/connect-jmx-exporter"})`,
+		},
+		{
+			"rate-wrapped metric gets label selector",
+			"sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[5m]))",
+			"kafka_server_brokertopicmetrics_bytesinpersec_total",
+			labels,
+			`sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total{job="confluent/connect-jmx-exporter"}[5m]))`,
+		},
+		{
+			"metric with existing selector gets labels appended",
+			`kafka_controller_kafkacontroller_value{name="GlobalPartitionCount"}`,
+			`kafka_controller_kafkacontroller_value{name="GlobalPartitionCount"}`,
+			labels,
+			`kafka_controller_kafkacontroller_value{job="confluent/connect-jmx-exporter",name="GlobalPartitionCount"}`,
+		},
+		{
+			"empty metric name returns query unchanged",
+			"sum(kafka_connect_worker_connector_count)",
+			"",
+			labels,
+			"sum(kafka_connect_worker_connector_count)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyLabelFilter(tt.query, tt.metricName, tt.labels)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/types/osk_credentials.go
+++ b/internal/types/osk_credentials.go
@@ -53,9 +53,16 @@ type JolokiaTLSConfig struct {
 
 // PrometheusConfig holds Prometheus connection details for metrics queries
 type PrometheusConfig struct {
-	URL  string                `yaml:"url"`
-	Auth *PrometheusAuthConfig `yaml:"auth,omitempty"`
-	TLS  *PrometheusTLSConfig  `yaml:"tls,omitempty"`
+	URL    string                  `yaml:"url"`
+	Auth   *PrometheusAuthConfig   `yaml:"auth,omitempty"`
+	TLS    *PrometheusTLSConfig    `yaml:"tls,omitempty"`
+	Filter *PrometheusFilterConfig `yaml:"filter,omitempty"`
+}
+
+// PrometheusFilterConfig holds label selectors to scope Prometheus queries to a specific target.
+// When set, label selectors are appended to all PromQL queries (e.g. {job="confluent/connect-jmx-exporter"}).
+type PrometheusFilterConfig struct {
+	Labels map[string]string `yaml:"labels,omitempty"`
 }
 
 // PrometheusAuthConfig holds HTTP basic auth credentials for Prometheus

--- a/internal/types/self_managed_connect.go
+++ b/internal/types/self_managed_connect.go
@@ -27,7 +27,8 @@ type SelfManagedConnector struct {
 }
 
 type SelfManagedConnectors struct {
-	Connectors []SelfManagedConnector `json:"connectors"`
+	Connectors []SelfManagedConnector   `json:"connectors"`
+	Metrics    *ProcessedClusterMetrics `json:"metrics,omitempty"`
 }
 
 // mergeSelfManagedConnectors merges connectors, with new taking precedence for duplicates (by name)

--- a/internal/types/self_managed_connect.go
+++ b/internal/types/self_managed_connect.go
@@ -53,11 +53,26 @@ func mergeSelfManagedConnectors(newConnectors, oldConnectors *SelfManagedConnect
 		merged = append(merged, c)
 	}
 
-	return &SelfManagedConnectors{Connectors: merged}
+	result := &SelfManagedConnectors{Connectors: merged}
+
+	// Preserve metrics: prefer new, fall back to old
+	if newConnectors.Metrics != nil {
+		result.Metrics = newConnectors.Metrics
+	} else if oldConnectors.Metrics != nil {
+		result.Metrics = oldConnectors.Metrics
+	}
+
+	return result
 }
 
 func (c *KafkaAdminClientInformation) SetSelfManagedConnectors(connectors []SelfManagedConnector) {
+	// Preserve existing metrics when updating connectors
+	var existingMetrics *ProcessedClusterMetrics
+	if c.SelfManagedConnectors != nil {
+		existingMetrics = c.SelfManagedConnectors.Metrics
+	}
 	c.SelfManagedConnectors = &SelfManagedConnectors{
 		Connectors: connectors,
+		Metrics:    existingMetrics,
 	}
 }

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -664,9 +664,10 @@ type MetricQueryInfo struct {
 	PrometheusMetricName string `json:"prometheus_metric_name,omitempty"`
 
 	// Shared fields
-	CurlCommand     string `json:"curl_command,omitempty"` // Jolokia curl or Prometheus API curl
-	QueryDuration   string `json:"query_duration,omitempty"`
-	AggregationNote string `json:"aggregation_note"`
+	CurlCommand     string            `json:"curl_command,omitempty"` // Jolokia curl or Prometheus API curl
+	QueryDuration   string            `json:"query_duration,omitempty"`
+	AggregationNote string            `json:"aggregation_note"`
+	LabelFilter     map[string]string `json:"label_filter,omitempty"`
 }
 
 // FormatQueryDuration formats a duration for display, using days when >= 24h.

--- a/internal/utils/duration.go
+++ b/internal/utils/duration.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ParseDurationDays parses duration strings like "1d", "7d", "30d" into time.Duration.
+func ParseDurationDays(s string) (time.Duration, error) {
+	if len(s) < 2 || s[len(s)-1] != 'd' {
+		return 0, fmt.Errorf("must end with 'd' (e.g. 7d, 30d)")
+	}
+	days, err := strconv.Atoi(s[:len(s)-1])
+	if err != nil || days <= 0 {
+		return 0, fmt.Errorf("invalid number of days")
+	}
+	return time.Duration(days) * 24 * time.Hour, nil
+}


### PR DESCRIPTION
## Summary
- Refactor JMX and Prometheus services to accept injectable metric definitions, enabling reuse for both Kafka broker and Connect worker metrics
- Add `--metrics` flags to `scan self-managed-connectors` command to collect Connect worker metrics via Jolokia or Prometheus
- Add Prometheus label filtering via `filter.labels` in credentials file to scope queries to specific clusters
- Add Jolokia agent to Connect container in integration tests for end-to-end testing
- Add documentation for Connect metrics collection and Prometheus filtering

## Connect metrics collected (8 metrics)

| Metric | Description | Level |
|---|---|---|
| `connector-count` | Number of connectors running | Worker |
| `task-count` | Number of tasks running | Worker |
| `incoming-byte-rate` | Bytes/sec received from Kafka brokers | Client |
| `outgoing-byte-rate` | Bytes/sec sent to Kafka brokers | Client |
| `connection-count` | Active connections to Kafka brokers | Client |
| `request-rate` | Requests/sec to Kafka brokers | Client |
| `source-record-write-rate` | Records/sec written to Kafka (after transforms) | Per-task |
| `source-record-poll-rate` | Records/sec polled from source system | Per-task |

## Prometheus label filtering

Optional `filter.labels` in `osk-credentials.yaml` scopes Prometheus queries to a specific cluster:

```yaml
prometheus:
  url: http://prometheus:9090
  filter:
    labels:
      job: confluent/connect-jmx-exporter
```

Applied to both `scan clusters` and `scan self-managed-connectors`. Without filter, queries sum across all scraped targets (existing behaviour).

## Changes

### Code
- **Injectable metric definitions**: Extract `MetricDefinitions`/`MetricQuery` types with `BrokerMetricDefinitions()` and `ConnectMetricDefinitions()`/`ConnectQueryDefinitions()` factory functions
- **New flags on `scan self-managed-connectors`**: `--metrics jolokia|prometheus`, `--metrics-duration`, `--metrics-interval`, `--metrics-range`, `--credentials-file` with full validation
- **State file**: Connect metrics stored under `SelfManagedConnectors.Metrics` (reuses `ProcessedClusterMetrics` type)
- **Metrics preservation**: `mergeSelfManagedConnectors` and `SetSelfManagedConnectors` preserve existing metrics on re-scan
- **Prometheus label filtering**: `PrometheusFilterConfig` type, `applyLabelFilter()` function injecting `{key="value"}` into PromQL queries
- **Shared utility**: Extract `parseDurationDays` to `internal/utils/duration.go`

### Integration tests
- Jolokia agent on Connect container (port 8781)
- New credentials file `connect-jolokia.yaml`
- Extended `run-connect.sh` to test Connect metrics collection

### Documentation
- New page: `docs/assets/osk-configuration/connect-metrics-collection.md`
- Updated `metrics-collection.md` with link to Connect metrics and filtering section
- Updated `osk-credentials.md` with `filter.labels` schema and Connect references

## Test results

### Unit tests
All passing:
- `internal/services/jmx` — 6 tests including `TestConnectMetricDefinitions`
- `internal/services/prometheus` — 11 tests including `TestApplyLabelFilter` (6 cases)
- `cmd/scan/clusters` — 14 tests
- `cmd/scan/self_managed_connectors` — 16 tests
- `internal/types` — 60+ tests
- `internal/utils` — includes `ParseDurationDays`

### Integration test (`run-connect.sh`)
```
Kafka Connect Scan Test — PASSED
  Connectors: 1 (with connect_host populated: 1)
  Connect metrics data points: 4
  Connect metrics collection test passed!
```

### Manual E2E — Local Docker (Jolokia)
Collected `connector-count: 1`, `task-count: 1` over 2 polling intervals.

### Manual E2E — OSK Playground (Prometheus, no filter)
```json
{
  "connector-count": { "avg": 1.999, "max": 2, "min": 0 },
  "task-count": { "avg": 1.999, "max": 2, "min": 0 },
  "source-record-write-rate": { "avg": 10.04, "max": 10.80, "min": 9.30 },
  "source-record-poll-rate": { "avg": 10.04, "max": 10.98, "min": 9.44 }
}
```
connector-count = 2 (both BasicAuth and mTLS Connect clusters combined)

### Manual E2E — OSK Playground (Prometheus, with filter)
Filter: `{job="confluent/connect-jmx-exporter"}`
```json
{
  "connector-count": { "avg": 1, "max": 1, "min": 1 },
  "task-count": { "avg": 1, "max": 1, "min": 1 },
  "source-record-write-rate": { "avg": 10.05, "max": 10.88, "min": 9.32 },
  "source-record-poll-rate": { "avg": 10.04, "max": 10.83, "min": 9.25 }
}
```
connector-count = 1 (BasicAuth Connect cluster only) — filtering works correctly.

## Notes
- Client-level Prometheus metrics (`incoming-byte-rate`, `outgoing-byte-rate`, `connection-count`, `request-rate`) require the JMX exporter to whitelist `kafka.connect:client-id=*,type=connect-metrics`. These are always available via Jolokia.
- State file structure and command naming may evolve as the team finalises the Connect cluster entity design.
- Jolokia is not currently available on the OSK playground Connect workers — only the JMX Prometheus exporter is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)