### PR TITLE
feat(plan): update Open Questions format and fix networking/ACL logic

### DIFF
--- a/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
+++ b/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
@@ -29,6 +29,7 @@
         "ec2:DescribeVpcs",
         "ec2:RevokeSecurityGroupEgress",
         "route53:AssociateVPCWithHostedZone",
+        "route53:ChangeResourceRecordSets",
         "route53:ChangeTagsForResource",
         "route53:CreateHostedZone",
         "route53:DeleteHostedZone",

--- a/cmd/report/plan/cmd_report_plan.go
+++ b/cmd/report/plan/cmd_report_plan.go
@@ -39,6 +39,7 @@ func NewReportPlanCmd() *cobra.Command {
   # JSON only
   kcp report plan --state-file kcp-state.json --output json`,
 		SilenceErrors: true,
+		SilenceUsage:  true, // don't dump --help on runtime errors (only flag-parse errors should surface usage)
 		PreRunE:       preRunReportPlan,
 		RunE:          runReportPlan,
 	}

--- a/docs/assets/plan-inputs.example.yaml
+++ b/docs/assets/plan-inputs.example.yaml
@@ -7,6 +7,7 @@
 #   - sizing knobs
 #   - customer-declared hard requirements that force Dedicated
 #   - existing VPC connectivity for the Dedicated networking path
+#   - networking triggers that flip the AWS-Enterprise default from PNI to PrivateLink
 #
 # Usage:
 #   kcp report plan \
@@ -20,15 +21,14 @@
 # sla_target: "99.9"                  # 99.9 (default) | 99.95 | 99.99
 # sizing_percentile: p95              # p95 (default) | p99 | max — lowercase per Confluent dashboards
 # headroom_fraction: 0.30             # default 0.30 — extra capacity above the chosen percentile
-# privatelink_safety_threshold: 0.80  # default 0.80 (peak burst as fraction of PrivateLink cap)
 # spiky_workload_ratio: 2.0           # default 2.0 (peak / P95 ratio above which a workload is flagged "spiky")
 
 # ---------------------------------------------------------------------------
 # Customer-declared hard requirements (force Dedicated)
 # ---------------------------------------------------------------------------
 # Most customers say `false` for all three. Setting any to `true` flips the
-# verdict from Enterprise to Dedicated, which costs ~5–10× per month — the
-# Plan surfaces a ⚠ cost callout on the verdict when one of these fires.
+# verdict from Enterprise to Dedicated (higher monthly cost) — the Plan
+# surfaces a ⚠ cost callout on the verdict when one of these fires.
 # Ask your Confluent account team if you're unsure.
 #
 # enforce_schemas_at_the_broker: false              # true → broker rejects records without a registered schema
@@ -36,8 +36,8 @@
 # requires_99_95_sla_within_a_single_zone: false    # true → Dedicated Single-Zone 99.95% SLA (different from sla_target)
 
 # Target cloud is implicit AWS for MSK migrations. Override only when
-# consolidating to Azure / GCP — non-AWS targets require Dedicated when the
-# source uses mTLS auth.
+# consolidating to Azure / GCP — non-AWS targets land on PrivateLink and
+# require Dedicated when the source uses mTLS auth.
 # target_cloud: aws                   # aws (default) | azure | gcp
 
 # ---------------------------------------------------------------------------
@@ -45,7 +45,16 @@
 # ---------------------------------------------------------------------------
 # If your apps already reach MSK via Transit Gateway or VPC Peering today,
 # the same pattern is the path of least resistance on Confluent Cloud — but
-# both options are Dedicated-only. On Enterprise the Plan picks PrivateLink
-# vs PNI based on peak burst.
+# both options are Dedicated-only. On Enterprise the Plan picks between
+# PrivateLink and PNI based on the triggers below.
 #
 # existing_vpc_connectivity: privatelink_or_pni  # privatelink_or_pni (default) | transit_gateway | vpc_peering
+
+# ---------------------------------------------------------------------------
+# Networking triggers — Enterprise PNI → PrivateLink flip
+# ---------------------------------------------------------------------------
+# PNI is the AWS-Enterprise default. PrivateLink fires when one of these
+# triggers is set, or when `target_cloud != aws`.
+#
+# cc_egress_required: false           # true → CC-side workloads need to push traffic back into customer VPCs (PNI doesn't natively support this)
+# projected_pni_gateway_count: 1      # ≥2 → flip to PrivateLink

--- a/docs/assets/plan.sample.json
+++ b/docs/assets/plan.sample.json
@@ -1,8 +1,8 @@
 {
   "header": {
     "source": "Amazon MSK",
-    "state_file_path": "./kcp-state.json",
-    "kcp_version": "0.7.2",
+    "state_file_path": "sample-state.json",
+    "kcp_version": "0.0.0-localdev",
     "generated_at": "2026-05-15T15:00:00Z",
     "plan_schema_version": "1-experimental"
   },
@@ -13,13 +13,14 @@
     "sla_target": "99.9",
     "sizing_percentile": "p95",
     "headroom_fraction": 0.3,
-    "privatelink_safety_threshold": 0.8,
     "spiky_workload_ratio": 2,
     "enforce_schemas_at_the_broker": false,
     "requires_high_throughput_rest_produce_api": false,
     "requires_99_95_sla_within_a_single_zone": false,
     "target_cloud": "azure",
-    "existing_vpc_connectivity": "privatelink_or_pni"
+    "existing_vpc_connectivity": "privatelink_or_pni",
+    "cc_egress_required": false,
+    "projected_pni_gateway_count": 1
   },
   "source_environment": {
     "clusters": [
@@ -244,7 +245,45 @@
         }
       ],
       "topology": "MultiZone",
-      "final_cku": 1
+      "final_cku": 1,
+      "evaluated_rules": [
+        {
+          "row_id": "eCKU_exceeds_pni_cap",
+          "description": "Sized eCKU exceeds Enterprise PNI cap",
+          "outcome": "not_fired",
+          "evidence": "sized 1 eCKU ≤ PNI cap 32 eCKU"
+        },
+        {
+          "row_id": "acl_count_exceeds_cap",
+          "description": "ACL count exceeds Enterprise cap",
+          "outcome": "fired",
+          "evidence": "4001 ACLs \u003e Enterprise cap 4000"
+        },
+        {
+          "row_id": "broker_side_schema_validation_required",
+          "description": "Broker-side schema ID validation required",
+          "outcome": "not_fired",
+          "evidence": "`enforce_schemas_at_the_broker: false`"
+        },
+        {
+          "row_id": "rest_produce_api_high_throughput",
+          "description": "High-throughput Kafka REST Produce v3 required",
+          "outcome": "not_fired",
+          "evidence": "`requires_high_throughput_rest_produce_api: false`"
+        },
+        {
+          "row_id": "sla_99_95_single_zone",
+          "description": "99.95% single-zone SLA required",
+          "outcome": "not_fired",
+          "evidence": "`requires_99_95_sla_within_a_single_zone: false`"
+        },
+        {
+          "row_id": "mtls_on_non_aws_target",
+          "description": "Source uses mTLS, target is non-AWS",
+          "outcome": "not_fired",
+          "evidence": "no mTLS source + target_cloud=\"azure\""
+        }
+      ]
     },
     {
       "cluster_id": "mtls-to-azure",
@@ -253,49 +292,163 @@
         {
           "row_id": "mtls_on_non_aws_target",
           "description": "Source uses mTLS, target is non-AWS",
-          "evidence": "target_cloud=\"azure\""
+          "evidence": "mTLS source + target_cloud=\"azure\" (mTLS on non-AWS requires Dedicated)"
         }
       ],
       "topology": "MultiZone",
-      "final_cku": 1
+      "final_cku": 1,
+      "evaluated_rules": [
+        {
+          "row_id": "eCKU_exceeds_pni_cap",
+          "description": "Sized eCKU exceeds Enterprise PNI cap",
+          "outcome": "not_fired",
+          "evidence": "sized 1 eCKU ≤ PNI cap 32 eCKU"
+        },
+        {
+          "row_id": "acl_count_exceeds_cap",
+          "description": "ACL count exceeds Enterprise cap",
+          "outcome": "not_fired",
+          "evidence": "0 ACLs ≤ Enterprise cap 4000"
+        },
+        {
+          "row_id": "broker_side_schema_validation_required",
+          "description": "Broker-side schema ID validation required",
+          "outcome": "not_fired",
+          "evidence": "`enforce_schemas_at_the_broker: false`"
+        },
+        {
+          "row_id": "rest_produce_api_high_throughput",
+          "description": "High-throughput Kafka REST Produce v3 required",
+          "outcome": "not_fired",
+          "evidence": "`requires_high_throughput_rest_produce_api: false`"
+        },
+        {
+          "row_id": "sla_99_95_single_zone",
+          "description": "99.95% single-zone SLA required",
+          "outcome": "not_fired",
+          "evidence": "`requires_99_95_sla_within_a_single_zone: false`"
+        },
+        {
+          "row_id": "mtls_on_non_aws_target",
+          "description": "Source uses mTLS, target is non-AWS",
+          "outcome": "fired",
+          "evidence": "mTLS source + target_cloud=\"azure\" (mTLS on non-AWS requires Dedicated)"
+        }
+      ]
     },
     {
       "cluster_id": "small-orders",
-      "verdict": "Enterprise"
+      "verdict": "Enterprise",
+      "evaluated_rules": [
+        {
+          "row_id": "eCKU_exceeds_pni_cap",
+          "description": "Sized eCKU exceeds Enterprise PNI cap",
+          "outcome": "not_fired",
+          "evidence": "sized 1 eCKU ≤ PNI cap 32 eCKU"
+        },
+        {
+          "row_id": "acl_count_exceeds_cap",
+          "description": "ACL count exceeds Enterprise cap",
+          "outcome": "not_fired",
+          "evidence": "0 ACLs ≤ Enterprise cap 4000"
+        },
+        {
+          "row_id": "broker_side_schema_validation_required",
+          "description": "Broker-side schema ID validation required",
+          "outcome": "not_fired",
+          "evidence": "`enforce_schemas_at_the_broker: false`"
+        },
+        {
+          "row_id": "rest_produce_api_high_throughput",
+          "description": "High-throughput Kafka REST Produce v3 required",
+          "outcome": "not_fired",
+          "evidence": "`requires_high_throughput_rest_produce_api: false`"
+        },
+        {
+          "row_id": "sla_99_95_single_zone",
+          "description": "99.95% single-zone SLA required",
+          "outcome": "not_fired",
+          "evidence": "`requires_99_95_sla_within_a_single_zone: false`"
+        },
+        {
+          "row_id": "mtls_on_non_aws_target",
+          "description": "Source uses mTLS, target is non-AWS",
+          "outcome": "not_fired",
+          "evidence": "no mTLS source + target_cloud=\"azure\""
+        }
+      ]
     },
     {
       "cluster_id": "steady-events",
-      "verdict": "Enterprise"
+      "verdict": "Enterprise",
+      "evaluated_rules": [
+        {
+          "row_id": "eCKU_exceeds_pni_cap",
+          "description": "Sized eCKU exceeds Enterprise PNI cap",
+          "outcome": "not_fired",
+          "evidence": "sized 3 eCKU ≤ PNI cap 32 eCKU"
+        },
+        {
+          "row_id": "acl_count_exceeds_cap",
+          "description": "ACL count exceeds Enterprise cap",
+          "outcome": "not_fired",
+          "evidence": "0 ACLs ≤ Enterprise cap 4000"
+        },
+        {
+          "row_id": "broker_side_schema_validation_required",
+          "description": "Broker-side schema ID validation required",
+          "outcome": "not_fired",
+          "evidence": "`enforce_schemas_at_the_broker: false`"
+        },
+        {
+          "row_id": "rest_produce_api_high_throughput",
+          "description": "High-throughput Kafka REST Produce v3 required",
+          "outcome": "not_fired",
+          "evidence": "`requires_high_throughput_rest_produce_api: false`"
+        },
+        {
+          "row_id": "sla_99_95_single_zone",
+          "description": "99.95% single-zone SLA required",
+          "outcome": "not_fired",
+          "evidence": "`requires_99_95_sla_within_a_single_zone: false`"
+        },
+        {
+          "row_id": "mtls_on_non_aws_target",
+          "description": "Source uses mTLS, target is non-AWS",
+          "outcome": "not_fired",
+          "evidence": "no mTLS source + target_cloud=\"azure\""
+        }
+      ]
     }
   ],
   "networking_decision": [
     {
       "cluster_id": "heavy-acls",
-      "verdict": "PNI",
+      "verdict": "PrivateLink",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "Dedicated cluster — PNI required (no TGW / VPC Peering override)"
+      "reason": "target_cloud=\"azure\" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
     },
     {
       "cluster_id": "mtls-to-azure",
-      "verdict": "PNI",
+      "verdict": "PrivateLink",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "Dedicated cluster — PNI required (no TGW / VPC Peering override)"
+      "reason": "target_cloud=\"azure\" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
     },
     {
       "cluster_id": "small-orders",
       "verdict": "PrivateLink",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "peak burst 1 eCKU = 10% of PrivateLink's 10 eCKU cap (safety threshold 80%)"
+      "reason": "target_cloud=\"azure\" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
     },
     {
       "cluster_id": "steady-events",
       "verdict": "PrivateLink",
       "peak_burst_ecku": 3,
       "percentage_of_cap": 30,
-      "reason": "peak burst 3 eCKU = 30% of PrivateLink's 10 eCKU cap (safety threshold 80%)"
+      "reason": "target_cloud=\"azure\" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
     }
   ],
   "sizing_appendix": [

--- a/docs/assets/plan.sample.md
+++ b/docs/assets/plan.sample.md
@@ -1,15 +1,18 @@
 # Migration Plan — Amazon MSK → Confluent Cloud
 
-_Generated 2026-05-15 15:00:00 UTC by KCP 0.7.2 from `./kcp-state.json`._
+_Generated 2026-05-15 15:00:00 UTC by KCP 0.0.0-localdev from `sample-state.json` · plan schema `1-experimental`._
 
 ## Definitions
 
+- **Enterprise / Dedicated** — Confluent Cloud cluster tiers. Enterprise has elastic billing per eCKU; Dedicated is fixed-provisioned per CKU. **MZ** (Multi-Zone) is the default Dedicated topology; **SZ** (Single-Zone) fires only when `requires_99_95_sla_within_a_single_zone: true` is set in `plan-inputs.yaml`.
 - **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. 60 MB/s ingress + 180 MB/s egress per eCKU at the per-eCKU caps used below.
 - **CKU** — Confluent Kafka Unit, the Dedicated-tier equivalent of eCKU. Sizing math is the same; only the unit name changes. Dedicated clusters always render with `CKU`.
 - **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 (override with `sizing_percentile`) so a transient spike doesn't permanently inflate the recommended cluster size.
 - **Final size** — the recommended eCKU (Enterprise) or CKU (Dedicated) count for the cluster. `(floor)` next to a value means the SLA minimum was binding (the math came in below the floor and was rounded up).
-- **PrivateLink** — single-AZ private connectivity, up to 10 eCKU. The default network when the cluster fits inside it with headroom. Enterprise only.
-- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to 32 eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst; **always required on Dedicated**.
+- **Peak burst** — short-window peak throughput observed in metrics, expressed as eCKU. Surfaces in the spiky-workload note when peak diverges from P95 by more than the configured ratio.
+- **PNI** (Private Network Interface) — AWS-to-AWS private connectivity, up to 32 eCKU on Enterprise. The default for AWS Enterprise; **always required on Dedicated** (AWS).
+- **PrivateLink** — capped at 10 eCKU on Enterprise. Fires when `target_cloud != "aws"` (PNI is AWS-only), when `cc_egress_required: true` (PNI lacks native CC→customer egress), or when `projected_pni_gateway_count >= 2`. Also the cross-cloud private path on Dedicated when `target_cloud` is Azure / GCP.
+- **ACL cap (4000)** — Enterprise supports up to 4000 ACLs; exceeding the cap forces Dedicated. Source: cluster-types.html.
 
 ## 1. Source Environment
 
@@ -26,33 +29,84 @@ _Generated 2026-05-15 15:00:00 UTC by KCP 0.7.2 from `./kcp-state.json`._
 
 | Cluster | P95 in / out (MBps) | Partitions | Final size | Cluster Type | Networking |
 |---|---|---:|---:|---|---|
-| heavy-acls | 15.0 / 25.0 | 300 | 1 CKU | Dedicated Multi-Zone (MZ) | PNI |
-| mtls-to-azure | 12.0 / 18.0 | 250 | 1 CKU | Dedicated Multi-Zone (MZ) | PNI |
+| heavy-acls | 15.0 / 25.0 | 300 | 1 CKU | Dedicated Multi-Zone (MZ) | PrivateLink |
+| mtls-to-azure | 12.0 / 18.0 | 250 | 1 CKU | Dedicated Multi-Zone (MZ) | PrivateLink |
 | small-orders | 10.0 / 20.0 | 200 | 1 eCKU | Enterprise | PrivateLink |
 | steady-events | 100.0 / 180.0 | 800 | 3 eCKU | Enterprise | PrivateLink |
 
 ### Why These Recommendations
 
-- **heavy-acls** — Cluster type **Dedicated Multi-Zone (MZ)** — ACL count exceeds Enterprise cap (4001 ACLs > Enterprise cap 4000). Networking **PNI** — Dedicated cluster — PNI required (no TGW / VPC Peering override).
-- **mtls-to-azure** — Cluster type **Dedicated Multi-Zone (MZ)** — Source uses mTLS, target is non-AWS (target_cloud="azure"). Networking **PNI** — Dedicated cluster — PNI required (no TGW / VPC Peering override).
-- **small-orders** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — peak burst 1 eCKU = 10% of PrivateLink's 10 eCKU cap (safety threshold 80%).
-- **steady-events** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — peak burst 3 eCKU = 30% of PrivateLink's 10 eCKU cap (safety threshold 80%).
+- **heavy-acls** — Cluster type **Dedicated Multi-Zone (MZ)** — ACL count exceeds Enterprise cap (4001 ACLs > Enterprise cap 4000). Networking **PrivateLink** — target_cloud="azure" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
+- **mtls-to-azure** — Cluster type **Dedicated Multi-Zone (MZ)** — Source uses mTLS, target is non-AWS (mTLS source + target_cloud="azure" (mTLS on non-AWS requires Dedicated)). Networking **PrivateLink** — target_cloud="azure" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
+- **small-orders** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — target_cloud="azure" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
+- **steady-events** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — target_cloud="azure" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
 
 ## Appendix A1 — Sizing Math
 <details><summary>Show sizing math per cluster</summary>
 
-Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.
+Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended size has spare capacity above the observed P95. Headroom for this run is `0.30` (override via `headroom_fraction` in `plan-inputs.yaml`). SLA floor binds when the math comes in below the minimum eCKU for the target SLA (1 eCKU for 99.9, 1 eCKU for 99.95, 2 eCKU for 99.99 — published in the Confluent Cloud cluster-types SLA table). The `Sized` and `Final` columns are in eCKU on Enterprise and CKU on Dedicated.
 
 Formula: `CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))`
 
-| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |
+| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized | SLA floor | Final |
 |---|---:|---:|---:|---|---:|---:|---:|
 | heavy-acls | 0.2500 | 0.1389 | 0.1000 | **0.2500** (ingress) | 1 | 1 | 1 |
 | mtls-to-azure | 0.2000 | 0.1000 | 0.0833 | **0.2000** (ingress) | 1 | 1 | 1 |
 | small-orders | 0.1667 | 0.1111 | 0.0667 | **0.1667** (ingress) | 1 | 1 | 1 |
 | steady-events | 1.6667 | 1.0000 | 0.2667 | **1.6667** (ingress) | 3 | 1 | 3 |
 
-Max-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.
+Max-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized`. `Final` is `max(Sized, SLA floor)`.
+
+</details>
+
+## Appendix A2 — Hard-Limit Rules Evaluated
+<details><summary>Show per-cluster rule-evaluation trace</summary>
+
+Every cluster runs the same hard-limit catalog; this table records each rule's outcome so a reviewer can confirm the verdict and see negative evidence (e.g. "47 ACLs ≤ 4000 cap"). `skipped` rows mean the rule couldn't be evaluated — the cluster's verdict resolves on the other rules.
+
+**heavy-acls**
+
+| Rule | Outcome | Detail |
+|---|---|---|
+| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 1 eCKU ≤ PNI cap 32 eCKU |
+| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `fired` | 4001 ACLs > Enterprise cap 4000 |
+| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
+| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
+| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
+
+**mtls-to-azure**
+
+| Rule | Outcome | Detail |
+|---|---|---|
+| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 1 eCKU ≤ PNI cap 32 eCKU |
+| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `not_fired` | 0 ACLs ≤ Enterprise cap 4000 |
+| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
+| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
+| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `fired` | mTLS source + target_cloud="azure" (mTLS on non-AWS requires Dedicated) |
+
+**small-orders**
+
+| Rule | Outcome | Detail |
+|---|---|---|
+| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 1 eCKU ≤ PNI cap 32 eCKU |
+| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `not_fired` | 0 ACLs ≤ Enterprise cap 4000 |
+| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
+| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
+| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
+
+**steady-events**
+
+| Rule | Outcome | Detail |
+|---|---|---|
+| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 3 eCKU ≤ PNI cap 32 eCKU |
+| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `not_fired` | 0 ACLs ≤ Enterprise cap 4000 |
+| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
+| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
+| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
 
 </details>
 

--- a/internal/services/kafka/kafka_service.go
+++ b/internal/services/kafka/kafka_service.go
@@ -128,7 +128,7 @@ func (ks *KafkaService) scanKafkaAcls() ([]types.Acls, error) {
 		return nil, fmt.Errorf("failed to list acls: %v", err)
 	}
 
-	// Flatten the ACLs for easier processing
+	// Flatten the ACLs for easier processing.
 	var flattenedAcls []types.Acls
 	for _, resourceAcl := range acls {
 		for _, acl := range resourceAcl.Acls {

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -1,0 +1,96 @@
+package plan
+
+import (
+	"github.com/confluentinc/kcp/internal/types"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+// defaultTargetCloud is the assumed target when `target_cloud` is unset
+// in plan-inputs.yaml. MSK is AWS-native, so AWS is the implicit default.
+const defaultTargetCloud = "aws"
+
+// targetCloud returns the customer's `target_cloud` plan-input or the
+// default ("aws") when unset. Centralizes the empty-string fallback so
+// every decision rule reads it the same way.
+func targetCloud(inputs types.PlanInputsResolved) string {
+	if inputs.TargetCloud == "" {
+		return defaultTargetCloud
+	}
+	return inputs.TargetCloud
+}
+
+// Single source of truth for "what do null / empty values mean for this
+// cluster?" Both the rule evaluator (cluster_type.go) and the
+// Open-Question detector (plan_service.go) read these primitives so the
+// SERVERLESS-vs-PROVISIONED distinction lives in exactly one place.
+
+// isServerless reports whether the cluster is MSK Serverless. Serverless
+// clusters don't have broker nodes and don't expose ACLs through the
+// admin API path used by `kcp scan clusters`, so several "looks like an
+// incomplete scan" signals are actually expected emptiness.
+func isServerless(c types.ProcessedCluster) bool {
+	return c.AWSClientInformation.MskClusterConfig.ClusterType == kafkatypes.ClusterTypeServerless
+}
+
+// aclScanRan reports whether the ACL list represents a successful scan.
+//
+// **Known limitation:** the existing scanner persists `Acls = nil` for
+// three distinct cases — "admin scan didn't run", "scan ran with 0
+// ACLs", and "scan ran with `--skip-acls`". We can't disambiguate from
+// the cluster state alone today (the scanner doesn't carry an explicit
+// scanned-marker, and the plan layer can't change scanner output
+// without breaking backward compatibility with existing state files).
+// This helper takes the conservative position that `Acls == nil` means
+// "uncertain" → callers should treat the ACL-cap rule as inconclusive
+// and surface the `acls_not_scanned` Open Question. The false-positive
+// on a legitimate 0-ACL scan is preferable to the false-negative on
+// `--skip-acls`, which would recommend Enterprise when Dedicated may
+// actually be required. Serverless clusters don't expose ACLs via this
+// API and are excluded.
+func aclScanRan(c types.ProcessedCluster) bool {
+	if isServerless(c) {
+		return false
+	}
+	return c.KafkaAdminClientInformation.Acls != nil
+}
+
+// brokerInventoryGap reports whether the broker inventory is suspect (an
+// actual scan gap rather than an expected-empty state). Serverless
+// clusters have no broker nodes by design, so emptiness on Serverless is
+// not a gap; the gap is "MSK PROVISIONED cluster with no Nodes
+// populated" — that's almost certainly a missing or incomplete discover
+// run.
+func brokerInventoryGap(c types.ProcessedCluster) bool {
+	if isServerless(c) {
+		return false
+	}
+	return len(c.AWSClientInformation.Nodes) == 0
+}
+
+// inputsMissing names load-bearing scan signals that weren't available
+// when decisions were computed for this cluster. Returned as a stable,
+// ordered list of short identifiers so downstream consumers can branch
+// (e.g. surface "sizing is best-effort while these are missing"). The
+// renderer uses this to mark affected columns provisional rather than
+// blanket-deferring the cluster — a verdict driven by a customer-
+// declared flag is still valid even when scan signals are missing.
+// Serverless clusters are evaluated against a smaller signal set —
+// `acls` and `brokers` don't apply there. The `!isServerless(c)` guard
+// on the `acls` line is intentional: aclScanRan already returns false
+// for serverless, but the explicit guard suppresses the false-positive
+// in the surfaced list (we don't want to tell the customer "acls
+// missing" for a serverless cluster that never had them).
+func inputsMissing(c types.ProcessedCluster) []string {
+	var missing []string
+	if c.KafkaAdminClientInformation.Topics == nil {
+		missing = append(missing, "topics")
+	}
+	if !aclScanRan(c) && !isServerless(c) {
+		missing = append(missing, "acls")
+	}
+	if brokerInventoryGap(c) {
+		missing = append(missing, "brokers")
+	}
+	return missing
+}

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -15,7 +15,29 @@ type hardLimit struct {
 	id               string
 	description      string
 	customerDeclared bool
-	check            func(cfg *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, sizing types.ClusterSizing) (fired bool, evidence string)
+	check            func(cfg *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, sizing types.ClusterSizing) ruleResult
+}
+
+// ruleResult is one rule's evaluation outcome. Either:
+//   - Outcome=fired  + Evidence (concrete values that fired it)
+//   - Outcome=not_fired + Evidence (e.g. "47 ACLs <= 4000 cap")
+//   - Outcome=skipped + SkipReason (e.g. "Acls == nil; ambiguous")
+type ruleResult struct {
+	Outcome    types.RuleOutcome
+	Evidence   string
+	SkipReason string
+}
+
+func fired(evidence string) ruleResult {
+	return ruleResult{Outcome: types.RuleFired, Evidence: evidence}
+}
+
+func notFired(evidence string) ruleResult {
+	return ruleResult{Outcome: types.RuleNotFired, Evidence: evidence}
+}
+
+func skipped(reason string) ruleResult {
+	return ruleResult{Outcome: types.RuleSkipped, SkipReason: reason}
 }
 
 // Rule IDs — referenced by both the catalog and the topology logic.
@@ -38,82 +60,81 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleECKUExceedsPNICap,
 		description: "Sized eCKU exceeds Enterprise PNI cap",
-		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, _ types.ProcessedCluster, sizing types.ClusterSizing) (bool, string) {
+		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, _ types.ProcessedCluster, sizing types.ClusterSizing) ruleResult {
 			pniCap := cfg.EnterpriseCaps.PNIMaxECKU
 			if sizing.FinalECKU > pniCap {
-				return true, fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, pniCap)
+				return fired(fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, pniCap))
 			}
-			return false, ""
+			return notFired(fmt.Sprintf("sized %d eCKU ≤ PNI cap %d eCKU", sizing.FinalECKU, pniCap))
 		},
 	},
 	{
 		id:          ruleACLCountExceedsCap,
 		description: "ACL count exceeds Enterprise cap",
-		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
 			aclCap := cfg.EnterpriseCaps.ACLCountCap
 			if aclCap <= 0 {
-				return false, ""
+				return skipped("acl_count_cap not configured")
 			}
-			acls := cluster.KafkaAdminClientInformation.Acls
-			// `null` (admin scan didn't run) is distinct from `0 ACLs` — skip
-			// rather than emit a wrong verdict.
-			if acls == nil {
-				return false, ""
+			if !aclScanRan(cluster) {
+				return skipped("no ACL list in state file — scan likely didn't run or used `--skip-acls`; rule resolves on the other rules")
 			}
-			if count := len(acls); count > aclCap {
-				return true, fmt.Sprintf("%d ACLs > Enterprise cap %d", count, aclCap)
+			count := len(cluster.KafkaAdminClientInformation.Acls)
+			if count > aclCap {
+				return fired(fmt.Sprintf("%d ACLs > Enterprise cap %d", count, aclCap))
 			}
-			return false, ""
+			return notFired(fmt.Sprintf("%d ACLs ≤ Enterprise cap %d", count, aclCap))
 		},
 	},
 	{
 		id:               ruleBrokerSideSchemaValidation,
 		description:      "Broker-side schema ID validation required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
 			if inputs.EnforceSchemasAtTheBroker {
-				return true, "`enforce_schemas_at_the_broker: true`"
+				return fired("`enforce_schemas_at_the_broker: true`")
 			}
-			return false, ""
+			return notFired("`enforce_schemas_at_the_broker: false`")
 		},
 	},
 	{
 		id:               ruleRESTProduceHighThroughput,
 		description:      "High-throughput Kafka REST Produce v3 required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
 			if inputs.RequiresHighThroughputRESTProduceAPI {
-				return true, "`requires_high_throughput_rest_produce_api: true`"
+				return fired("`requires_high_throughput_rest_produce_api: true`")
 			}
-			return false, ""
+			return notFired("`requires_high_throughput_rest_produce_api: false`")
 		},
 	},
 	{
 		id:               ruleSLA9995SingleZone,
 		description:      "99.95% single-zone SLA required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
 			if inputs.Requires9995SLAWithinSingleZone {
-				return true, "`requires_99_95_sla_within_a_single_zone: true`"
+				return fired("`requires_99_95_sla_within_a_single_zone: true`")
 			}
-			return false, ""
+			return notFired("`requires_99_95_sla_within_a_single_zone: false`")
 		},
 	},
 	{
 		id:          ruleMTLSOnNonAWSTarget,
 		description: "Source uses mTLS, target is non-AWS",
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) (bool, string) {
-			if !sourceUsesMTLS(cluster) {
-				return false, ""
+		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+			usesMTLS := sourceUsesMTLS(cluster)
+			target := targetCloud(inputs)
+			// Punctuation kept identical across branches so the rendered
+			// evidence line reads consistently regardless of which combo fired.
+			switch {
+			case !usesMTLS:
+				return notFired(fmt.Sprintf("no mTLS source + target_cloud=%q", target))
+			case target == defaultTargetCloud:
+				return notFired(fmt.Sprintf("mTLS source + target_cloud=%q (AWS supports mTLS on Enterprise/Freight)", target))
+			default:
+				return fired(fmt.Sprintf("mTLS source + target_cloud=%q (mTLS on non-AWS requires Dedicated)", target))
 			}
-			target := inputs.TargetCloud
-			if target == "" {
-				target = "aws"
-			}
-			if target == "aws" {
-				return false, ""
-			}
-			return true, fmt.Sprintf("target_cloud=%q", target)
 		},
 	},
 }
@@ -139,17 +160,25 @@ func sourceUsesMTLS(c types.ProcessedCluster) bool {
 // rules escalate to Dedicated when a cap is exceeded or a workload
 // constraint can't be served on Enterprise.
 func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
-	var fired []types.HardLimitTrigger
+	var firedTriggers []types.HardLimitTrigger
+	evaluated := make([]types.RuleEvaluation, 0, len(hardLimitCatalog))
 	for _, hl := range hardLimitCatalog {
 		if hl.check == nil {
 			continue
 		}
-		ok, evidence := hl.check(cfg, inputs, c, sizing)
-		if ok {
-			fired = append(fired, types.HardLimitTrigger{
+		res := hl.check(cfg, inputs, c, sizing)
+		evaluated = append(evaluated, types.RuleEvaluation{
+			RowID:       hl.id,
+			Description: hl.description,
+			Outcome:     res.Outcome,
+			Evidence:    res.Evidence,
+			SkipReason:  res.SkipReason,
+		})
+		if res.Outcome == types.RuleFired {
+			firedTriggers = append(firedTriggers, types.HardLimitTrigger{
 				RowID:            hl.id,
 				Description:      hl.description,
-				Evidence:         evidence,
+				Evidence:         res.Evidence,
 				CustomerDeclared: hl.customerDeclared,
 			})
 		}
@@ -158,12 +187,12 @@ func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg
 	verdict := types.ClusterTypeEnterprise
 	topology := types.TopologyNotApplicable
 	var finalCKU *int
-	if len(fired) > 0 {
+	if len(firedTriggers) > 0 {
 		verdict = types.ClusterTypeDedicated
 		// Single-Zone wins when the 99.95% SLA rule fires; otherwise
 		// Multi-Zone is the Dedicated default.
 		topology = types.TopologyMultiZone
-		for _, t := range fired {
+		for _, t := range firedTriggers {
 			if t.RowID == ruleSLA9995SingleZone {
 				topology = types.TopologySingleZone
 				break
@@ -174,10 +203,11 @@ func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg
 		finalCKU = &cku
 	}
 	return types.ClusterTypeDecision{
-		ClusterID: c.Name,
-		Verdict:   verdict,
-		Triggers:  fired,
-		Topology:  topology,
-		FinalCKU:  finalCKU,
+		ClusterID:      c.Name,
+		EvaluatedRules: evaluated,
+		Verdict:        verdict,
+		Triggers:       firedTriggers,
+		Topology:       topology,
+		FinalCKU:       finalCKU,
 	}
 }

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -29,12 +29,28 @@ func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 	assert.Contains(t, d.Triggers[0].Evidence, "32 eCKU")
 }
 
+// provisionedClusterWithScan returns a ProcessedCluster shaped like a
+// successful `kcp scan clusters` run against a PROVISIONED MSK cluster —
+// Topics populated, MskClusterConfig.ClusterType = PROVISIONED. The ACL
+// slice is what the caller wants the rule to evaluate against.
+// provisionedClusterWithScan builds a ProcessedCluster shaped like a
+// successful `kcp scan clusters` run against a PROVISIONED MSK cluster:
+// Topics populated and Acls set to the caller's slice (use `nil` to
+// model "scan didn't run / --skip-acls" and `[]Acls{}` to model
+// "successful scan with 0 ACLs"). Pass non-empty Acls to exercise rules
+// that need real ACL counts.
+func provisionedClusterWithScan(name string, acls []types.Acls) types.ProcessedCluster {
+	c := types.ProcessedCluster{Name: name}
+	c.KafkaAdminClientInformation.Acls = acls
+	c.KafkaAdminClientInformation.Topics = &types.Topics{}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+	return c
+}
+
 func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
 	cfg := defaultCfg(t)
-	// acl_count_cap = 4000; emit 4001 ACLs.
-	acls := make([]types.Acls, 4001)
-	c := types.ProcessedCluster{Name: "many-acls"}
-	c.KafkaAdminClientInformation.Acls = acls
+	// acl_count_cap = 4000; emit 4001 ACLs against a successful scan.
+	c := provisionedClusterWithScan("many-acls", make([]types.Acls, 4001))
 	sizing := types.ClusterSizing{ClusterID: "many-acls", FinalECKU: 5}
 
 	d := DecideClusterType(c, sizing, cfg, defaultInputs())
@@ -45,15 +61,44 @@ func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
 	assert.False(t, d.Triggers[0].CustomerDeclared, "state-derived rules must not carry the cost-callout marker")
 }
 
-func TestDecideClusterType_ACLRuleSkippedWhenNilACLs(t *testing.T) {
-	// `null` (admin scan didn't run) is distinct from `0 ACLs`.
+// Three nil-vs-empty cases for rule 2:
+//
+//  1. ACL list is non-nil (caller passes `[]Acls{}` or N entries) → rule
+//     evaluates against the count. Tests the helper logic; in practice
+//     the current scanner produces `[]` only when at least one ACL was
+//     appended, but the helper must still behave correctly if a non-nil
+//     empty slice ever lands in state.
+//  2. Acls == nil (either scan didn't run, `--skip-acls` was passed, or
+//     a successful scan returned 0 ACLs — all three indistinguishable
+//     from the current state schema) → rule skipped.
+//  3. Acls == nil on SERVERLESS → ACLs aren't exposed via this API; rule
+//     skipped (don't false-positive on serverless deployments).
+func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 	cfg := defaultCfg(t)
-	c := types.ProcessedCluster{Name: "no-admin-scan"}
-	c.KafkaAdminClientInformation.Acls = nil
-	sizing := types.ClusterSizing{ClusterID: "no-admin-scan", FinalECKU: 5}
+	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
 
-	d := DecideClusterType(c, sizing, cfg, defaultInputs())
-	assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip the rule, not fire it")
+	t.Run("non-nil ACL slice evaluates the rule (under cap)", func(t *testing.T) {
+		c := provisionedClusterWithScan("provisioned-empty-acls", []types.Acls{})
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "0 ACLs is under the 4000 cap — rule should evaluate, not fire")
+	})
+
+	t.Run("nil ACLs (scan didn't run or --skip-acls or successful 0-ACL scan) — rule skipped", func(t *testing.T) {
+		// Current scanner persists Acls=nil for all three states;
+		// without an explicit "scanned" flag we take the conservative
+		// position that nil means "uncertain" and skip the rule.
+		c := provisionedClusterWithScan("provisioned-nil-acls", nil)
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip rule 2 (count is unknown), not fire it")
+	})
+
+	t.Run("SERVERLESS cluster — rule skipped regardless of ACL slice", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "serverless"}
+		c.KafkaAdminClientInformation.Topics = &types.Topics{}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "SERVERLESS doesn't expose ACLs via this API — rule should skip")
+	})
 }
 
 func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
@@ -172,9 +217,7 @@ func TestDecideClusterType_Topology(t *testing.T) {
 	t.Run("rule 5 wins topology when combined with other rules", func(t *testing.T) {
 		// 99.95 SLA flag + ACL-cap exceeded → both rules fire; topology
 		// must escalate to Single-Zone (more restrictive).
-		acls := make([]types.Acls, 4001)
-		c2 := types.ProcessedCluster{Name: "combo"}
-		c2.KafkaAdminClientInformation.Acls = acls
+		c2 := provisionedClusterWithScan("combo", make([]types.Acls, 4001))
 		in := defaultInputs()
 		in.Requires9995SLAWithinSingleZone = true
 		d := DecideClusterType(c2, sizing, cfg, in)

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -46,11 +46,10 @@ type ClusterLinking struct {
 }
 
 type PlanInputDefaults struct {
-	SizingPercentile           string         `yaml:"sizing_percentile"`
-	HeadroomFraction           float64        `yaml:"headroom_fraction"`
-	PrivateLinkSafetyThreshold float64        `yaml:"privatelink_safety_threshold"`
-	SpikyWorkloadRatio         float64        `yaml:"spiky_workload_ratio"`
-	SLAFloorECKU               map[string]int `yaml:"sla_floor_eCKU"`
+	SizingPercentile   string         `yaml:"sizing_percentile"`
+	HeadroomFraction   float64        `yaml:"headroom_fraction"`
+	SpikyWorkloadRatio float64        `yaml:"spiky_workload_ratio"`
+	SLAFloorECKU       map[string]int `yaml:"sla_floor_eCKU"`
 
 	// Customer-declared hard requirements (all default false).
 	EnforceSchemasAtTheBroker            bool `yaml:"enforce_schemas_at_the_broker"`
@@ -60,6 +59,10 @@ type PlanInputDefaults struct {
 	// Target cloud + existing VPC connectivity (Dedicated-path networking).
 	TargetCloud             string `yaml:"target_cloud"`
 	ExistingVPCConnectivity string `yaml:"existing_vpc_connectivity"`
+
+	// Networking triggers (PNI→PrivateLink) — see PlanInputsResolved.
+	CCEgressRequired         bool `yaml:"cc_egress_required"`
+	ProjectedPNIGatewayCount int  `yaml:"projected_pni_gateway_count"`
 }
 
 // LoadPlanConfig returns the embedded plan-config.yaml, optionally
@@ -113,11 +116,11 @@ func (c *PlanConfig) Validate() error {
 	if defaults.HeadroomFraction < 0 || defaults.HeadroomFraction > 1 {
 		return fmt.Errorf("plan-config plan_input_defaults.headroom_fraction must be in [0, 1] (got %v)", defaults.HeadroomFraction)
 	}
-	if defaults.PrivateLinkSafetyThreshold <= 0 || defaults.PrivateLinkSafetyThreshold > 1 {
-		return fmt.Errorf("plan-config plan_input_defaults.privatelink_safety_threshold must be in (0, 1] (got %v)", defaults.PrivateLinkSafetyThreshold)
-	}
 	if defaults.SpikyWorkloadRatio <= 1 {
 		return fmt.Errorf("plan-config plan_input_defaults.spiky_workload_ratio must be > 1 (got %v) — a spike must be larger than the baseline", defaults.SpikyWorkloadRatio)
+	}
+	if defaults.ProjectedPNIGatewayCount < 1 {
+		return fmt.Errorf("plan-config plan_input_defaults.projected_pni_gateway_count must be >= 1 (got %v)", defaults.ProjectedPNIGatewayCount)
 	}
 	return nil
 }

--- a/internal/services/plan/config_test.go
+++ b/internal/services/plan/config_test.go
@@ -21,7 +21,8 @@ func TestLoadPlanConfigEmbedded(t *testing.T) {
 	assert.Equal(t, 32, cfg.EnterpriseCaps.PNIMaxECKU)
 	assert.Equal(t, "p95", cfg.PlanInputDefaults.SizingPercentile)
 	assert.InDelta(t, 0.30, cfg.PlanInputDefaults.HeadroomFraction, 0.0001)
-	assert.InDelta(t, 0.80, cfg.PlanInputDefaults.PrivateLinkSafetyThreshold, 0.0001)
+	assert.False(t, cfg.PlanInputDefaults.CCEgressRequired)
+	assert.Equal(t, 1, cfg.PlanInputDefaults.ProjectedPNIGatewayCount)
 }
 
 func TestLoadPlanConfigOverride(t *testing.T) {

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -40,7 +40,6 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 		Raw:                                  in,
 		SizingPercentile:                     defaults.SizingPercentile,
 		HeadroomFraction:                     defaults.HeadroomFraction,
-		PrivateLinkSafetyThreshold:           defaults.PrivateLinkSafetyThreshold,
 		SpikyWorkloadRatio:                   defaults.SpikyWorkloadRatio,
 		SLATarget:                            defaultSLATarget,
 		EnforceSchemasAtTheBroker:            defaults.EnforceSchemasAtTheBroker,
@@ -48,6 +47,8 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 		Requires9995SLAWithinSingleZone:      defaults.Requires9995SLAWithinSingleZone,
 		TargetCloud:                          defaults.TargetCloud,
 		ExistingVPCConnectivity:              defaults.ExistingVPCConnectivity,
+		CCEgressRequired:                     defaults.CCEgressRequired,
+		ProjectedPNIGatewayCount:             defaults.ProjectedPNIGatewayCount,
 	}
 	if in == nil {
 		return out
@@ -60,9 +61,6 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	}
 	if in.HeadroomFraction != nil {
 		out.HeadroomFraction = *in.HeadroomFraction
-	}
-	if in.PrivateLinkSafetyThreshold != nil {
-		out.PrivateLinkSafetyThreshold = *in.PrivateLinkSafetyThreshold
 	}
 	if in.SpikyWorkloadRatio != nil {
 		out.SpikyWorkloadRatio = *in.SpikyWorkloadRatio
@@ -81,6 +79,74 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	}
 	if in.ExistingVPCConnectivity != nil {
 		out.ExistingVPCConnectivity = *in.ExistingVPCConnectivity
+	}
+	if in.CCEgressRequired != nil {
+		out.CCEgressRequired = *in.CCEgressRequired
+	}
+	if in.ProjectedPNIGatewayCount != nil {
+		out.ProjectedPNIGatewayCount = *in.ProjectedPNIGatewayCount
+	}
+	return out
+}
+
+// ResolvePlanInputsForCluster layers a cluster-specific override on top
+// of the resolved globals. If `in.Clusters[clusterName]` is set, every
+// non-nil field in it wins over the global. Otherwise the global view
+// is returned unchanged. Caller uses this per-cluster during Plan
+// build so heterogeneous fleets get the right verdicts without one
+// global flag flipping every cluster's tier.
+//
+// **Hot path note:** when iterating many clusters, prefer
+// `applyClusterOverride` against a pre-resolved global view — this
+// function re-resolves globals on every call.
+func ResolvePlanInputsForCluster(in *types.PlanInputs, cfg *PlanConfig, clusterName string) types.PlanInputsResolved {
+	out := ResolvePlanInputs(in, cfg)
+	return applyClusterOverride(out, in, clusterName)
+}
+
+// applyClusterOverride takes an already-resolved global `PlanInputsResolved`
+// and layers any per-cluster override on top. Returns the global
+// unchanged when no override applies. Used by `PlanService.Build` to
+// avoid re-running the (cheap but non-trivial) global resolution
+// against `in.Raw` for every cluster — the global view is computed
+// once and reused.
+func applyClusterOverride(out types.PlanInputsResolved, in *types.PlanInputs, clusterName string) types.PlanInputsResolved {
+	if in == nil {
+		return out
+	}
+	override, ok := in.Clusters[clusterName]
+	if !ok {
+		return out
+	}
+	if override.SLATarget != nil {
+		out.SLATarget = *override.SLATarget
+	}
+	if override.HeadroomFraction != nil {
+		out.HeadroomFraction = *override.HeadroomFraction
+	}
+	if override.SpikyWorkloadRatio != nil {
+		out.SpikyWorkloadRatio = *override.SpikyWorkloadRatio
+	}
+	if override.EnforceSchemasAtTheBroker != nil {
+		out.EnforceSchemasAtTheBroker = *override.EnforceSchemasAtTheBroker
+	}
+	if override.RequiresHighThroughputRESTProduceAPI != nil {
+		out.RequiresHighThroughputRESTProduceAPI = *override.RequiresHighThroughputRESTProduceAPI
+	}
+	if override.Requires9995SLAWithinSingleZone != nil {
+		out.Requires9995SLAWithinSingleZone = *override.Requires9995SLAWithinSingleZone
+	}
+	if override.TargetCloud != nil {
+		out.TargetCloud = *override.TargetCloud
+	}
+	if override.ExistingVPCConnectivity != nil {
+		out.ExistingVPCConnectivity = *override.ExistingVPCConnectivity
+	}
+	if override.CCEgressRequired != nil {
+		out.CCEgressRequired = *override.CCEgressRequired
+	}
+	if override.ProjectedPNIGatewayCount != nil {
+		out.ProjectedPNIGatewayCount = *override.ProjectedPNIGatewayCount
 	}
 	return out
 }

--- a/internal/services/plan/inputs_test.go
+++ b/internal/services/plan/inputs_test.go
@@ -60,21 +60,110 @@ func TestResolvePlanInputsDefaults(t *testing.T) {
 		assert.Nil(t, resolved.Raw)
 		assert.Equal(t, "p95", resolved.SizingPercentile)
 		assert.InDelta(t, 0.30, resolved.HeadroomFraction, 0.0001)
-		assert.InDelta(t, 0.80, resolved.PrivateLinkSafetyThreshold, 0.0001)
 		assert.InDelta(t, 2.0, resolved.SpikyWorkloadRatio, 0.0001)
 		assert.Equal(t, "99.9", resolved.SLATarget)
+		assert.False(t, resolved.CCEgressRequired)
+		assert.Equal(t, 1, resolved.ProjectedPNIGatewayCount)
 	})
 
 	t.Run("customer values override defaults", func(t *testing.T) {
 		hf := 0.45
 		sla := "99.95"
-		in := &types.PlanInputs{HeadroomFraction: &hf, SLATarget: &sla}
+		egress := true
+		gateways := 3
+		in := &types.PlanInputs{
+			HeadroomFraction:         &hf,
+			SLATarget:                &sla,
+			CCEgressRequired:         &egress,
+			ProjectedPNIGatewayCount: &gateways,
+		}
 		resolved := ResolvePlanInputs(in, cfg)
 		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001)
 		assert.Equal(t, "99.95", resolved.SLATarget)
+		assert.True(t, resolved.CCEgressRequired)
+		assert.Equal(t, 3, resolved.ProjectedPNIGatewayCount)
 		// Untouched defaults persist.
 		assert.Equal(t, "p95", resolved.SizingPercentile)
 		// Raw preserves the pointer.
 		assert.Same(t, in, resolved.Raw)
 	})
+}
+
+func TestResolvePlanInputsForCluster_OverrideWins(t *testing.T) {
+	cfg, err := LoadPlanConfig("")
+	require.NoError(t, err)
+
+	hf := 0.45
+	sla := "99.95"
+	enf := true
+	in := &types.PlanInputs{
+		HeadroomFraction: &hf, // global override
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {SLATarget: &sla, EnforceSchemasAtTheBroker: &enf},
+			"beta":  {}, // empty override entry — should still fall back
+		},
+	}
+
+	t.Run("override wins over global; non-overridden fields keep global", func(t *testing.T) {
+		resolved := ResolvePlanInputsForCluster(in, cfg, "alpha")
+		assert.Equal(t, "99.95", resolved.SLATarget, "per-cluster sla_target must win")
+		assert.True(t, resolved.EnforceSchemasAtTheBroker, "per-cluster enforce_schemas_at_the_broker must win")
+		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001, "global override fields must persist when cluster doesn't override them")
+		assert.Equal(t, "p95", resolved.SizingPercentile, "untouched defaults must persist")
+	})
+
+	t.Run("empty cluster override block falls back to global resolved view", func(t *testing.T) {
+		resolved := ResolvePlanInputsForCluster(in, cfg, "beta")
+		assert.Equal(t, "99.9", resolved.SLATarget, "empty override entry must fall back to default")
+		assert.False(t, resolved.EnforceSchemasAtTheBroker)
+		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001)
+	})
+
+	t.Run("missing cluster key returns global resolved view unchanged", func(t *testing.T) {
+		resolved := ResolvePlanInputsForCluster(in, cfg, "no-such-cluster")
+		assert.Equal(t, "99.9", resolved.SLATarget)
+		assert.False(t, resolved.EnforceSchemasAtTheBroker)
+		assert.InDelta(t, 0.45, resolved.HeadroomFraction, 0.0001)
+	})
+
+	t.Run("Raw preserved across per-cluster resolve", func(t *testing.T) {
+		resolved := ResolvePlanInputsForCluster(in, cfg, "alpha")
+		assert.Same(t, in, resolved.Raw, "Raw must still point at the global PlanInputs")
+	})
+
+	t.Run("nil PlanInputs short-circuits to global defaults", func(t *testing.T) {
+		resolved := ResolvePlanInputsForCluster(nil, cfg, "alpha")
+		assert.Equal(t, "99.9", resolved.SLATarget)
+	})
+}
+
+func TestApplyClusterOverride_EquivalentToResolvePlanInputsForCluster(t *testing.T) {
+	// Lock the hot-path optimization: applying an override on top of a
+	// pre-resolved global must produce the same result as calling
+	// ResolvePlanInputsForCluster from scratch. If the two ever drift,
+	// Build's per-cluster loop will quietly diverge from the public API.
+	cfg, err := LoadPlanConfig("")
+	require.NoError(t, err)
+	hf := 0.45
+	sla := "99.95"
+	enf := true
+	in := &types.PlanInputs{
+		HeadroomFraction: &hf,
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {SLATarget: &sla, EnforceSchemasAtTheBroker: &enf},
+			"beta":  {},
+		},
+	}
+	global := ResolvePlanInputs(in, cfg)
+	for _, name := range []string{"alpha", "beta", "no-such-cluster"} {
+		fromGlobal := applyClusterOverride(global, in, name)
+		fromScratch := ResolvePlanInputsForCluster(in, cfg, name)
+		// Raw is the same pointer in both, so equality of the resolved
+		// fields is what we actually care about.
+		assert.Equal(t, fromScratch.SLATarget, fromGlobal.SLATarget, "cluster %q SLA", name)
+		assert.Equal(t, fromScratch.HeadroomFraction, fromGlobal.HeadroomFraction, "cluster %q headroom", name)
+		assert.Equal(t, fromScratch.EnforceSchemasAtTheBroker, fromGlobal.EnforceSchemasAtTheBroker, "cluster %q enforce", name)
+		assert.Equal(t, fromScratch.TargetCloud, fromGlobal.TargetCloud, "cluster %q target_cloud", name)
+		assert.Equal(t, fromScratch.CCEgressRequired, fromGlobal.CCEgressRequired, "cluster %q cc_egress", name)
+	}
 }

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -14,66 +14,95 @@ const (
 	vpcConnectivityVPCPeering     = "vpc_peering"
 )
 
+// pniGatewayBreakeven is the projected-gateway count at which the
+// recommendation flips from PNI to PrivateLink.
+const pniGatewayBreakeven = 2
+
+// netDecision constructs a NetworkingDecision from the sizing context
+// (peak burst, percentage-of-PL-cap) plus the verdict and reason. Used
+// to keep the 8 decision branches below uniform — every branch must
+// surface peak-burst data for the renderer / OQ detector to consume.
+func netDecision(sizing types.ClusterSizing, verdict types.Networking, reason string) types.NetworkingDecision {
+	return types.NetworkingDecision{
+		ClusterID:       sizing.ClusterID,
+		Verdict:         verdict,
+		PeakBurstECKU:   sizing.PeakBurstECKU,
+		PercentageOfCap: sizing.PeakBurstPctOfPLCap,
+		Reason:          reason,
+	}
+}
+
+// privateLinkSizingExceedsCap reports whether the plan ended up
+// recommending PrivateLink for an Enterprise cluster whose sizing
+// exceeds the PrivateLink eCKU cap. This combination is infeasible: the
+// PrivateLink triggers (target_cloud != "aws", cc_egress_required,
+// projected_pni_gateway_count ≥ 2) ignore sizing, so a customer with
+// the trigger AND a > 10-eCKU workload silently gets an
+// over-cap recommendation. The plan still emits PrivateLink (to keep
+// the verdict deterministic), but detectOpenQuestions surfaces an OQ so
+// the customer can move to Dedicated (which supports PrivateLink at
+// higher CKU).
+func privateLinkSizingExceedsCap(sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, cfg *PlanConfig) bool {
+	if net.Verdict != types.NetworkingPrivateLink {
+		return false
+	}
+	if ct.Verdict != types.ClusterTypeEnterprise {
+		return false
+	}
+	return sizing.FinalECKU > cfg.EnterpriseCaps.PrivateLinkMaxECKU
+}
+
 // DecideNetworking picks the Confluent Cloud networking product for one
 // cluster.
 //
+//	Dedicated + target_cloud != "aws"                        → PrivateLink (PNI / TGW / VPC Peering are AWS-only)
 //	Dedicated + existing_vpc_connectivity == transit_gateway → Transit Gateway
 //	Dedicated + existing_vpc_connectivity == vpc_peering     → VPC Peering
 //	Dedicated (otherwise)                                    → PNI
-//	Enterprise + peak_burst < threshold × privatelink_max_eCKU → PrivateLink
-//	Enterprise (otherwise)                                   → PNI
+//	Enterprise + target_cloud != "aws"                       → PrivateLink (PNI is AWS-to-AWS only)
+//	Enterprise + cc_egress_required                          → PrivateLink (PNI lacks native CC→customer egress)
+//	Enterprise + projected_pni_gateway_count ≥ 2             → PrivateLink
+//	Enterprise (otherwise)                                   → PNI (default — scales to 32 eCKU vs PrivateLink's 10)
 //
-// `existing_vpc_connectivity` is only honored on the Dedicated path —
-// Transit Gateway and VPC Peering are Dedicated-only products. On
-// Enterprise the PrivateLink-vs-PNI flip remains driven by the safety
-// threshold.
+// `existing_vpc_connectivity` is only honored on the AWS-Dedicated path —
+// Transit Gateway and VPC Peering are Dedicated-only AWS products.
 func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
-	caps := cfg.EnterpriseCaps
-	threshold := inputs.PrivateLinkSafetyThreshold
+	target := targetCloud(inputs)
 
 	if ct.Verdict == types.ClusterTypeDedicated {
+		// PNI, Transit Gateway, and VPC Peering are AWS-only networking
+		// products. Cross-cloud Dedicated lands on PrivateLink (the
+		// generic private-network option supported across clouds).
+		if target != defaultTargetCloud {
+			return netDecision(sizing, types.NetworkingPrivateLink,
+				fmt.Sprintf("target_cloud=%q — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)", target))
+		}
 		switch inputs.ExistingVPCConnectivity {
 		case vpcConnectivityTransitGateway:
-			return types.NetworkingDecision{
-				ClusterID:       sizing.ClusterID,
-				Verdict:         types.NetworkingTransitGateway,
-				PeakBurstECKU:   sizing.PeakBurstECKU,
-				PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-				Reason:          "Dedicated cluster + existing_vpc_connectivity=transit_gateway — match the customer's source topology",
-			}
+			return netDecision(sizing, types.NetworkingTransitGateway,
+				"Dedicated cluster + existing_vpc_connectivity=transit_gateway — match the customer's source topology")
 		case vpcConnectivityVPCPeering:
-			return types.NetworkingDecision{
-				ClusterID:       sizing.ClusterID,
-				Verdict:         types.NetworkingVPCPeering,
-				PeakBurstECKU:   sizing.PeakBurstECKU,
-				PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-				Reason:          "Dedicated cluster + existing_vpc_connectivity=vpc_peering — match the customer's source topology",
-			}
+			return netDecision(sizing, types.NetworkingVPCPeering,
+				"Dedicated cluster + existing_vpc_connectivity=vpc_peering — match the customer's source topology")
 		}
-		return types.NetworkingDecision{
-			ClusterID:       sizing.ClusterID,
-			Verdict:         types.NetworkingPNI,
-			PeakBurstECKU:   sizing.PeakBurstECKU,
-			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-			Reason:          "Dedicated cluster — PNI required (no TGW / VPC Peering override)",
-		}
+		return netDecision(sizing, types.NetworkingPNI,
+			"Dedicated AWS cluster — PNI required (TGW / VPC Peering are alternatives only when the customer's existing MSK topology already uses them; see `existing_vpc_connectivity` in plan-inputs.yaml)")
 	}
 
-	thresholdECKU := threshold * float64(caps.PrivateLinkMaxECKU)
-	if float64(sizing.PeakBurstECKU) < thresholdECKU {
-		return types.NetworkingDecision{
-			ClusterID:       sizing.ClusterID,
-			Verdict:         types.NetworkingPrivateLink,
-			PeakBurstECKU:   sizing.PeakBurstECKU,
-			PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-			Reason:          fmt.Sprintf("peak burst %d eCKU = %.0f%% of PrivateLink's %d eCKU cap (safety threshold %.0f%%)", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, caps.PrivateLinkMaxECKU, threshold*100),
-		}
+	// Enterprise path: PNI is the default for AWS-to-AWS workloads. The
+	// flip to PrivateLink only fires on one of three explicit triggers.
+	if target != defaultTargetCloud {
+		return netDecision(sizing, types.NetworkingPrivateLink,
+			fmt.Sprintf("target_cloud=%q — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)", target))
 	}
-	return types.NetworkingDecision{
-		ClusterID:       sizing.ClusterID,
-		Verdict:         types.NetworkingPNI,
-		PeakBurstECKU:   sizing.PeakBurstECKU,
-		PercentageOfCap: sizing.PeakBurstPctOfPLCap,
-		Reason:          fmt.Sprintf("peak burst %d eCKU = %.0f%% of PrivateLink's %d eCKU cap, over the %.0f%% safety threshold", sizing.PeakBurstECKU, sizing.PeakBurstPctOfPLCap, caps.PrivateLinkMaxECKU, threshold*100),
+	if inputs.CCEgressRequired {
+		return netDecision(sizing, types.NetworkingPrivateLink,
+			"cc_egress_required=true — PNI does not natively support egress from CC into customer infrastructure (set `cc_egress_required: false` in `plan-inputs.yaml` if this wasn't intentional)")
 	}
+	if inputs.ProjectedPNIGatewayCount >= pniGatewayBreakeven {
+		return netDecision(sizing, types.NetworkingPrivateLink,
+			fmt.Sprintf("projected_pni_gateway_count=%d (≥ %d) — flip to PrivateLink (lower `projected_pni_gateway_count` in `plan-inputs.yaml` to stay on PNI)", inputs.ProjectedPNIGatewayCount, pniGatewayBreakeven))
+	}
+	return netDecision(sizing, types.NetworkingPNI,
+		fmt.Sprintf("default for AWS Enterprise (scales to %d eCKU vs PrivateLink's %d-eCKU cap)", cfg.EnterpriseCaps.PNIMaxECKU, cfg.EnterpriseCaps.PrivateLinkMaxECKU))
 }

--- a/internal/services/plan/networking_test.go
+++ b/internal/services/plan/networking_test.go
@@ -39,43 +39,72 @@ func TestDecideNetworking_DedicatedVPCPeering(t *testing.T) {
 	assert.Contains(t, d.Reason, "vpc_peering")
 }
 
+func TestDecideNetworking_EnterpriseDefaultsToPNI(t *testing.T) {
+	// AWS Enterprise default verdict is PNI when no trigger fires.
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Contains(t, d.Reason, "default for AWS Enterprise")
+}
+
 func TestDecideNetworking_EnterpriseIgnoresVPCConnectivity(t *testing.T) {
 	// TGW / VPC Peering are Dedicated-only products. An Enterprise cluster
 	// with `existing_vpc_connectivity: transit_gateway` falls back to the
-	// PrivateLink-vs-PNI flip, not TGW.
+	// PNI-default flow, not TGW.
 	cfg := defaultCfg(t)
 	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "transit_gateway"
 	d := DecideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
-}
-
-func TestDecideNetworking_PrivateLinkBelowThreshold(t *testing.T) {
-	// PrivateLink cap = 10, threshold 0.80 → cap-7 fits, cap-8 doesn't.
-	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 7, PeakBurstPctOfPLCap: 70}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
-	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
-	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
-}
-
-func TestDecideNetworking_PNIWhenOverThreshold(t *testing.T) {
-	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 9, PeakBurstPctOfPLCap: 90}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
-	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
-	assert.Contains(t, d.Reason, "over the")
 }
 
-func TestDecideNetworking_BoundaryAt80Percent(t *testing.T) {
-	// At exactly 80% of cap (8 eCKU of 10), the rule is "less than" — flips
-	// to PNI. Lock the boundary.
+func TestDecideNetworking_EnterpriseCrossCloudFlipsToPrivateLink(t *testing.T) {
+	// PNI is AWS-to-AWS only — non-AWS target lands on PrivateLink.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 8, PeakBurstPctOfPLCap: 80}
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
-	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	in := defaultInputs()
+	in.TargetCloud = "azure"
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Contains(t, d.Reason, "AWS-to-AWS only")
+}
+
+func TestDecideNetworking_EnterpriseCCEgressRequiredFlipsToPrivateLink(t *testing.T) {
+	// CCEgressRequired=true → PrivateLink (PNI lacks native CC→customer egress).
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	in := defaultInputs()
+	in.CCEgressRequired = true
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Contains(t, d.Reason, "cc_egress_required")
+}
+
+func TestDecideNetworking_EnterpriseTwoPNIGatewaysFlipsToPrivateLink(t *testing.T) {
+	// ≥2 PNI gateways → PrivateLink (per-gateway PNI cost crosses breakeven).
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	in := defaultInputs()
+	in.ProjectedPNIGatewayCount = 2
+	d := DecideNetworking(sizing, ct, cfg, in)
+	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Contains(t, d.Reason, "projected_pni_gateway_count=2")
+}
+
+func TestDecideNetworking_EnterpriseOneGatewayStaysPNI(t *testing.T) {
+	// Single gateway is below the breakeven — PNI default.
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	in := defaultInputs()
+	in.ProjectedPNIGatewayCount = 1
+	d := DecideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 }

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -7,41 +7,39 @@
 #   1. This file (embedded in the KCP binary at build time)
 #   2. --config <path> CLI flag (admin override)
 #   3. plan-inputs.yaml (per-customer override of plan_input_defaults only)
-#
-# Unsourced constants (no canonical public doc) carry an inline TODO(verify):
-# comment naming the relevant rule for maintainers to re-check each release.
 
 schema_version: 1
-last_verified: 2026-05-15
-kcp_version_at_verification: 0.7.2
+last_verified: 2026-05-20
+kcp_version_at_verification: 0.8.0
 
 enterprise_caps:
-  per_eCKU_ingress_mbps: 60
-  per_eCKU_egress_mbps: 180
-  per_eCKU_partition_rate: 3000
-  privatelink_max_eCKU: 10
-  pni_max_eCKU: 32
-  acl_count_cap: 4000  # TODO(verify): — no canonical public doc; re-verify with CC product team each release.
+  # All values below are published in the Confluent Cloud cluster-types
+  # "Fixed limits and recommended guidelines" table (see `source` URL).
+  per_eCKU_ingress_mbps: 60        # cluster-types: Ingress (MBps) row, Enterprise column
+  per_eCKU_egress_mbps: 180        # cluster-types: Egress (MBps) row, Enterprise column
+  per_eCKU_partition_rate: 3000    # cluster-types: Partitions (pre-replication) row, Enterprise column = 3,000
+  privatelink_max_eCKU: 10         # cluster-types: "Enterprise clusters that use PrivateLink networking on AWS are limited to a maximum of 10 eCKU"
+  pni_max_eCKU: 32                 # cluster-types: "Enterprise clusters with a maximum of 32 eCKU on AWS... must use Private Network Interface (PNI)"
+  acl_count_cap: 4000              # cluster-types: ACLs row — Basic 1k / Standard 1k / Enterprise 4k / Dedicated 10k / Freight 10k
   source: https://docs.confluent.io/cloud/current/clusters/cluster-types.html
 
 cluster_linking:
-  source_min_kafka_version: "2.4.0"  # TODO(verify): — pin a permalink before shipping
+  source_min_kafka_version: "2.4.0"  # "Kafka 2.4.0 or later" — migration use cases footnote
   express_tier_supported: unknown    # verify per release
   source: https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/
 
 plan_input_defaults:
   sizing_percentile: p95           # alternatives: p99, max — lowercase to match Confluent dashboards
-  headroom_fraction: 0.30          # 0.0..1.0
-  privatelink_safety_threshold: 0.80  # TODO(verify): — internal heuristic; no peer-reviewed Confluent source
-  spiky_workload_ratio: 2.0        # peak / P95 ratio above which a workload is "spiky"
-  sla_floor_eCKU:
+  headroom_fraction: 0.30          # 0.0..1.0 — safety margin above the chosen percentile; overrideable via plan-inputs
+  spiky_workload_ratio: 2.0        # peak / P95 ratio above which a workload is flagged "spiky" (FYI-only signal)
+  sla_floor_eCKU:                  # Source: cluster-types.html SLA table — "Enterprise 1 (99.9% SLA), 2 (99.99% SLA)"; Dedicated SZ supports 99.95%
     "99.9":  1
     "99.95": 1
     "99.99": 2
 
   # Customer-declared hard requirements (all default false). A wrong `true`
-  # flips Enterprise → Dedicated (5–10× monthly); the renderer surfaces a
-  # ⚠ cost callout on the verdict when one of these is the trigger.
+  # flips Enterprise → Dedicated (higher monthly cost); the renderer surfaces
+  # a ⚠ cost callout on the verdict when one of these is the trigger.
   enforce_schemas_at_the_broker: false
   requires_high_throughput_rest_produce_api: false
   requires_99_95_sla_within_a_single_zone: false
@@ -49,3 +47,9 @@ plan_input_defaults:
   # Target cloud + existing VPC connectivity (Dedicated-path networking).
   target_cloud: aws                              # MSK is AWS-only; hidden on the MSK path
   existing_vpc_connectivity: privatelink_or_pni  # privatelink_or_pni (default) | transit_gateway | vpc_peering
+
+  # Networking triggers (PNI→PrivateLink). PNI is the AWS-Enterprise default;
+  # PrivateLink fires when one of these triggers is set, or when
+  # `target_cloud != aws`.
+  cc_egress_required: false        # CC→customer VPC egress not natively supported by PNI
+  projected_pni_gateway_count: 1   # ≥2 → flip to PrivateLink

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -62,20 +63,36 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
 			c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
 		}
-		sizing := ComputeClusterSizing(c, s.cfg, inputs)
-		ct := DecideClusterType(c, sizing, s.cfg, inputs)
-		net := DecideNetworking(sizing, ct, s.cfg, inputs)
+		// Per-cluster overrides win over globals — heterogeneous fleets
+		// need finer-grained inputs than flipping one global flag across
+		// every cluster. We start from the already-resolved global view
+		// (`inputs`) and layer any per-cluster overlay via
+		// `applyClusterOverride` — that avoids the redundant global
+		// re-resolution `ResolvePlanInputsForCluster` would do on every
+		// iteration.
+		clusterInputs := applyClusterOverride(inputs, inputs.Raw, c.Name)
+		sizing := ComputeClusterSizing(c, s.cfg, clusterInputs)
+		missing := inputsMissing(c)
+		// Each consumer gets its own slice — without Clone, a future
+		// `append` to any one InputsMissing would silently mutate the
+		// others if cap permits.
+		sizing.InputsMissing = slices.Clone(missing)
+		ct := DecideClusterType(c, sizing, s.cfg, clusterInputs)
+		net := DecideNetworking(sizing, ct, s.cfg, clusterInputs)
+		ct.InputsMissing = slices.Clone(missing)
+		net.InputsMissing = slices.Clone(missing)
 
 		plan.Sizing = append(plan.Sizing, sizing)
 		plan.ClusterTypeDecision = append(plan.ClusterTypeDecision, ct)
 		plan.NetworkingDecision = append(plan.NetworkingDecision, net)
 		plan.SourceEnvironment.Clusters = append(plan.SourceEnvironment.Clusters, types.SourceClusterSummary{
-			ClusterID:   c.Name,
-			Region:      c.Region,
-			TopicCount:  topicCount(c),
-			BrokerCount: brokerCount(c),
+			ClusterID:    c.Name,
+			Region:       c.Region,
+			TopicCount:   topicCount(c),
+			BrokerCount:  brokerCount(c),
+			IsServerless: isServerless(c),
 		})
-		plan.OpenQuestions = append(plan.OpenQuestions, detectOpenQuestions(c, sizing)...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectOpenQuestions(c, sizing, ct, net, s.cfg, clusterInputs)...)
 	}
 	plan.SourceEnvironment.TotalRegions = countRegions(state)
 	plan.SizingAppendix = buildSizingAppendix(plan.Sizing, s.cfg, inputs)
@@ -96,44 +113,59 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 // detectOpenQuestions surfaces state-file gaps and inferred-signal quirks
 // per cluster. The Plan still ships a recommendation in each case (the
 // SLA floor for degraded sizing, the verdict from the other rules when
-// Rule 2 is skipped, etc.) — the OQ tells the customer what action will
-// upgrade that recommendation.
-func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing) []types.OpenQuestion {
+// the ACL rule is skipped, etc.) — the OQ tells the customer what action
+// will upgrade that recommendation. SERVERLESS-specific suppressions for
+// "ACLs not populated" and "0 brokers" live in cluster_signals.go so the
+// same logic is shared with the rule evaluator.
+func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
 	if sizing.Degraded {
 		oqs = append(oqs, types.OpenQuestion{
-			ID:         "missing_p95_metrics",
-			ClusterID:  c.Name,
-			Title:      "No P95 throughput metrics — sizing fell back to SLA floor",
-			Body:       sizing.DegradedReason,
-			HowToClose: "Re-run `kcp scan metrics` against this cluster.",
+			ID:        "missing_p95_metrics",
+			ClusterID: c.Name,
+			Title:     fmt.Sprintf("No %s throughput metrics — sizing fell back to SLA floor", percentileHeader(inputs.SizingPercentile)),
+			Body:      sizing.DegradedReason,
+			// Metrics are collected by `kcp discover` (CloudWatch path), not a separate `scan metrics` subcommand.
+			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` without `--skip-metrics` so CloudWatch metrics get backfilled into the state file.", regionFlag(c.Region)),
 		})
 	}
-	if c.KafkaAdminClientInformation.Acls == nil {
+	if !aclScanRan(c) && !isServerless(c) {
 		oqs = append(oqs, types.OpenQuestion{
-			ID:         "acls_not_scanned",
-			ClusterID:  c.Name,
-			Title:      "Admin scan didn't populate ACLs — cap-vs-Enterprise rule was skipped",
-			Body:       "The `acl_count_exceeds_cap` hard-limit rule needs the ACL list to evaluate. With `acls == null` the rule is treated as inconclusive; the verdict resolves on the other rules.",
-			HowToClose: "Re-run `kcp scan clusters` with admin credentials to populate the ACL list.",
+			ID:        "acls_not_scanned",
+			ClusterID: c.Name,
+			Title:     "Admin scan didn't populate ACLs — cap-vs-Enterprise rule was skipped",
+			Body:      "The `acl_count_exceeds_cap` hard-limit rule needs a successful ACL scan to evaluate. Either the scan didn't run, or `--skip-acls` was passed; without the ACL list the rule is treated as inconclusive and the verdict resolves on the other rules.",
+			// `kcp scan clusters` doesn't take --region — it reads region from the state file.
+			HowToClose: "Re-run `kcp scan clusters --source-type msk --credentials-file <msk-credentials.yaml>` with admin Kafka credentials (SASL/IAM or SCRAM) and without `--skip-acls` so the ACL list populates.",
 		})
 	}
-	if brokerCount(c) == 0 {
+	if brokerInventoryGap(c) {
 		oqs = append(oqs, types.OpenQuestion{
 			ID:         "broker_inventory_empty",
 			ClusterID:  c.Name,
 			Title:      "Source environment shows 0 brokers — likely an incomplete scan",
-			Body:       "`AWSClientInformation.Nodes` is empty for this cluster. The Source Environment table reads as `Brokers: 0`, which is almost certainly wrong for a real MSK cluster.",
-			HowToClose: "Re-run `kcp discover` against the source account / region to populate the broker inventory.",
+			Body:       "`AWSClientInformation.Nodes` is empty for this cluster. The Source Environment table reads as `Brokers: 0`, which is almost certainly wrong for an MSK Provisioned cluster.",
+			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account to populate the broker inventory.", regionFlag(c.Region)),
 		})
 	}
 	if topicCount(c) == 0 {
 		oqs = append(oqs, types.OpenQuestion{
-			ID:         "topic_inventory_empty",
+			ID:        "topic_inventory_empty",
+			ClusterID: c.Name,
+			Title:     "Source environment shows 0 topics — likely an incomplete scan",
+			Body:      "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero).",
+			// `kcp scan clusters` doesn't take --region — it reads region from the state file.
+			HowToClose: "Re-run `kcp scan clusters --source-type msk --credentials-file <msk-credentials.yaml>` with admin Kafka credentials (without `--skip-topics`) to populate the topic list.",
+		})
+	}
+	if privateLinkSizingExceedsCap(sizing, ct, net, cfg) {
+		cap := cfg.EnterpriseCaps.PrivateLinkMaxECKU
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "networking_privatelink_over_cap",
 			ClusterID:  c.Name,
-			Title:      "Source environment shows 0 topics — likely an incomplete scan",
-			Body:       "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero).",
-			HowToClose: "Re-run `kcp scan clusters` with admin credentials to populate the topic list.",
+			Title:      fmt.Sprintf("PrivateLink trigger fired but cluster sizing exceeds the %d-eCKU PrivateLink cap on Enterprise", cap),
+			Body:       fmt.Sprintf("PrivateLink networking on Enterprise is capped at %d eCKU. One or more clusters sized above that cap, and a PrivateLink trigger fired (target_cloud, cc_egress_required, or projected_pni_gateway_count), so the plan still recommends PrivateLink — an infeasible combination above the %d-eCKU cap. See the Sizing & Cluster Decisions table above for each affected cluster's final eCKU.", cap, cap),
+			HowToClose: fmt.Sprintf("Raise this with your Confluent account team. Dedicated supports PrivateLink without the %d-eCKU Enterprise cap and is the most likely path to keep both the PrivateLink requirement and the throughput.", cap),
 		})
 	}
 	// Spiky workload is an informational signal, not an Open Question:
@@ -149,15 +181,18 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing) [
 // every OQ has an explicit rank — a new ID without a priority entry
 // falls through to oqPriorityUnknown and renders last.
 const (
-	oqPriorityMissingMetrics  = iota // missing P95 → sizing fell back to floor
-	oqPriorityBrokerInventory        // broker count == 0 (scan gap)
-	oqPriorityTopicInventory         // topic count == 0 (scan gap)
-	oqPriorityACLsNotScanned         // Acls == nil (admin-cred gap)
-	oqPriorityUnknown                // fallback for new IDs added without a priority entry
+	oqPriorityNetworkingOverCap = iota // infeasible PrivateLink recommendation — blocker
+	oqPriorityMissingMetrics           // missing P95 → sizing fell back to floor
+	oqPriorityBrokerInventory          // broker count == 0 (scan gap)
+	oqPriorityTopicInventory           // topic count == 0 (scan gap)
+	oqPriorityACLsNotScanned           // ACL admin scan didn't run
+	oqPriorityUnknown                  // fallback for new IDs added without a priority entry
 )
 
 func openQuestionPriority(id string) int {
 	switch id {
+	case "networking_privatelink_over_cap":
+		return oqPriorityNetworkingOverCap
 	case "missing_p95_metrics":
 		return oqPriorityMissingMetrics
 	case "broker_inventory_empty":
@@ -196,6 +231,17 @@ func countRegions(state types.ProcessedState) int {
 	return len(regions)
 }
 
+// regionFlag returns " --region <region>" when region is non-empty,
+// otherwise an empty string — so HowToClose commands rendered against a
+// hand-edited or partially-populated state file don't produce an invalid
+// `--region ` flag with a trailing empty value.
+func regionFlag(region string) string {
+	if region == "" {
+		return ""
+	}
+	return " --region " + region
+}
+
 func topicCount(c types.ProcessedCluster) int {
 	if c.KafkaAdminClientInformation.Topics == nil {
 		return 0
@@ -216,7 +262,10 @@ func buildSizingAppendix(sizings []types.ClusterSizing, cfg *PlanConfig, inputs 
 		}
 		out = append(out, types.SizingMathDetail{
 			ClusterID: s.ClusterID,
-			Formula:   fmt.Sprintf("CEIL(max(P95In/%d, P95Out/%d, partitions/%d) * (1 + %.2f headroom))", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps, caps.PerECKUPartitionRate, inputs.HeadroomFraction),
+			Formula: fmt.Sprintf("CEIL(max(%sIn/%d, %sOut/%d, partitions/%d) * (1 + %.2f headroom))",
+				percentileHeader(inputs.SizingPercentile), caps.PerECKUIngressMBps,
+				percentileHeader(inputs.SizingPercentile), caps.PerECKUEgressMBps,
+				caps.PerECKUPartitionRate, inputs.HeadroomFraction),
 			IntermediateSteps: []string{
 				fmt.Sprintf("ingress ratio = %.2f MBps / %d = %.4f", s.SizedInMBps, caps.PerECKUIngressMBps, s.IngressRatio),
 				fmt.Sprintf("egress ratio  = %.2f MBps / %d = %.4f", s.SizedOutMBps, caps.PerECKUEgressMBps, s.EgressRatio),

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -127,86 +127,128 @@ func TestPlanServiceBuild_SourceEnvironmentBrokerAndTopicCount(t *testing.T) {
 	assert.Equal(t, 42, got.TopicCount, "TopicCount must reflect KafkaAdminClientInformation.Topics.Summary.Topics")
 }
 
-// Unit-level coverage for the helpers — catches a bad rename / wrong
-// field path before the integration test does.
-func TestBrokerCountAndTopicCountReadFromState(t *testing.T) {
-	c := types.ProcessedCluster{Name: "ut"}
-	assert.Equal(t, 0, brokerCount(c))
-	assert.Equal(t, 0, topicCount(c))
-
-	c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 5)
-	c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 17}}
-	assert.Equal(t, 5, brokerCount(c))
-	assert.Equal(t, 17, topicCount(c))
-}
-
 // Each MVP open-question detector surfaces a specific state-file gap.
 // The shipping recommendation still exists for every cluster; the OQ is
 // the action that upgrades it.
 func TestDetectOpenQuestions(t *testing.T) {
-	t.Run("missing P95 metrics → missing_p95_metrics OQ", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "noMetrics"}
+	cfg := defaultCfg(t)
+	provisioned := func(name string) types.ProcessedCluster {
+		c := types.ProcessedCluster{Name: name}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
-		c.KafkaAdminClientInformation.Acls = []types.Acls{}
-		sizing := types.ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{} // non-nil means "scan ran" under aclScanRan's current heuristic
+		return c
+	}
+	ent := types.ClusterTypeDecision{Verdict: types.ClusterTypeEnterprise}
+	pniNet := func(id string) types.NetworkingDecision {
+		return types.NetworkingDecision{ClusterID: id, Verdict: types.NetworkingPNI}
+	}
 
-		oqs := detectOpenQuestions(c, sizing)
-		assertContainsOQ(t, oqs, "missing_p95_metrics", "Re-run `kcp scan metrics`")
+	t.Run("missing P95 metrics → missing_p95_metrics OQ", func(t *testing.T) {
+		c := provisioned("noMetrics")
+		sizing := types.ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("noMetrics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		// Metrics are collected by `kcp discover` (not a separate `scan metrics` subcommand).
+		assertContainsOQ(t, oqs, "missing_p95_metrics", "kcp discover")
 	})
 
-	t.Run("nil ACLs → acls_not_scanned OQ", func(t *testing.T) {
+	t.Run("scan ran with 0 ACLs (non-nil empty slice) → acls_not_scanned suppressed", func(t *testing.T) {
+		// kafka_service.go now writes `[]types.Acls{}` on a successful
+		// scan with 0 ACLs, so a non-nil-but-empty slice is the
+		// trustworthy "scan ran" signal — aclScanRan returns true and
+		// the OQ is suppressed.
+		c := provisioned("provisioned-zero-acls") // helper sets Acls = []types.Acls{}
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-zero-acls", FinalECKU: 1}, ent, pniNet("provisioned-zero-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		for _, oq := range oqs {
+			assert.NotEqual(t, "acls_not_scanned", oq.ID, "scan-ran-with-0 must NOT emit the OQ")
+		}
+	})
+
+	t.Run("nil ACLs on PROVISIONED (scan didn't run / --skip-acls / 0-ACL scan) → acls_not_scanned OQ", func(t *testing.T) {
+		// The current scanner can't distinguish these three states —
+		// they all produce Acls=nil. The OQ fires conservatively so
+		// the customer can rule out the ACL-cap risk.
+		c := provisioned("provisioned-nil-acls")
+		c.KafkaAdminClientInformation.Acls = nil
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-nil-acls", FinalECKU: 1}, ent, pniNet("provisioned-nil-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		assertContainsOQ(t, oqs, "acls_not_scanned", "--skip-acls")
+	})
+
+	t.Run("no topics scan + nil ACLs → acls_not_scanned OQ", func(t *testing.T) {
 		c := types.ProcessedCluster{Name: "noAcls"}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
-		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
-		c.KafkaAdminClientInformation.Acls = nil
-
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1})
-		assertContainsOQ(t, oqs, "acls_not_scanned", "admin credentials")
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		// Topics nil → scan didn't run; ACLs nil follows from same gap
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1}, ent, pniNet("noAcls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		assertContainsOQ(t, oqs, "acls_not_scanned", "admin Kafka credentials")
 	})
 
-	t.Run("zero brokers → broker_inventory_empty OQ", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "noBrokers"}
+	t.Run("SERVERLESS cluster suppresses acls_not_scanned and broker_inventory_empty", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "serverless"}
 		c.AWSClientInformation.Nodes = nil
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
-		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		c.KafkaAdminClientInformation.Acls = nil
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "serverless", FinalECKU: 1}, ent, pniNet("serverless"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		for _, oq := range oqs {
+			assert.NotEqual(t, "acls_not_scanned", oq.ID, "serverless does not expose ACLs via this API")
+			assert.NotEqual(t, "broker_inventory_empty", oq.ID, "serverless has no broker nodes by design")
+		}
+	})
 
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1})
+	t.Run("zero brokers on PROVISIONED → broker_inventory_empty OQ", func(t *testing.T) {
+		c := provisioned("noBrokers")
+		c.AWSClientInformation.Nodes = nil
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1}, ent, pniNet("noBrokers"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "broker_inventory_empty", "kcp discover")
 	})
 
 	t.Run("zero topics → topic_inventory_empty OQ", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "noTopics"}
-		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c := provisioned("noTopics")
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 0}}
-		c.KafkaAdminClientInformation.Acls = []types.Acls{}
-
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1}, ent, pniNet("noTopics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "topic_inventory_empty", "kcp scan clusters")
 	})
 
-	t.Run("spiky workload does NOT generate an OQ (FYI only)", func(t *testing.T) {
-		// Spiky is informational — Enterprise elasticity absorbs the
-		// spike, so there's nothing the customer MUST do. The renderer
-		// surfaces it as a one-line note in the rationale section, not
-		// as an Actions Needed item.
-		c := types.ProcessedCluster{Name: "spiky"}
-		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
-		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
-		c.KafkaAdminClientInformation.Acls = []types.Acls{}
-		sizing := types.ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
+	t.Run("PrivateLink trigger + sized > cap → networking_privatelink_over_cap OQ", func(t *testing.T) {
+		c := provisioned("overCap")
+		sizing := types.ClusterSizing{ClusterID: "overCap", FinalECKU: 15} // > 10 eCKU PL cap
+		net := types.NetworkingDecision{ClusterID: "overCap", Verdict: types.NetworkingPrivateLink}
+		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		assertContainsOQ(t, oqs, "networking_privatelink_over_cap", "account team")
+	})
 
-		oqs := detectOpenQuestions(c, sizing)
+	t.Run("PrivateLink with sized <= cap → no over-cap OQ", func(t *testing.T) {
+		c := provisioned("underCap")
+		sizing := types.ClusterSizing{ClusterID: "underCap", FinalECKU: 5}
+		net := types.NetworkingDecision{ClusterID: "underCap", Verdict: types.NetworkingPrivateLink}
+		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		for _, oq := range oqs {
+			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
+		}
+	})
+
+	t.Run("PNI with any sizing → no over-cap OQ (only fires on PrivateLink verdict)", func(t *testing.T) {
+		c := provisioned("pniBig")
+		sizing := types.ClusterSizing{ClusterID: "pniBig", FinalECKU: 25}
+		net := types.NetworkingDecision{ClusterID: "pniBig", Verdict: types.NetworkingPNI}
+		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		for _, oq := range oqs {
+			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
+		}
+	})
+
+	t.Run("spiky workload does NOT generate an OQ (FYI only)", func(t *testing.T) {
+		c := provisioned("spiky")
+		sizing := types.ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("spiky"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "spiky clusters should NOT emit an OQ — informational only")
 	})
 
 	t.Run("fully populated cluster emits no OQs", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "complete"}
-		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
-		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
-		c.KafkaAdminClientInformation.Acls = []types.Acls{}
-
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2})
+		c := provisioned("complete")
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2}, ent, pniNet("complete"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "happy-path clusters should not surface OQs")
 	})
 }
@@ -261,4 +303,133 @@ func TestPlanServiceBuild_DegradedClusterStillRenders(t *testing.T) {
 func withRegion(c types.ProcessedCluster, region string) types.ProcessedCluster {
 	c.Region = region
 	return c
+}
+
+func TestInputsMissing_AllSignalsTracked(t *testing.T) {
+	t.Run("fully-scanned PROVISIONED cluster reports no missing inputs", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "ok"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		assert.Empty(t, inputsMissing(c))
+	})
+	t.Run("Topics nil → 'topics' in the list", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "no-topics"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		assert.Contains(t, inputsMissing(c), "topics")
+	})
+	t.Run("Acls nil on PROVISIONED → 'acls' in the list", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "no-acls"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		assert.Contains(t, inputsMissing(c), "acls")
+	})
+	t.Run("Serverless suppresses 'acls' and 'brokers'", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "sl"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		missing := inputsMissing(c)
+		assert.NotContains(t, missing, "acls", "serverless: ACLs not exposed; not a gap")
+		assert.NotContains(t, missing, "brokers", "serverless: no broker nodes by design; not a gap")
+	})
+	t.Run("0 broker Nodes on PROVISIONED → 'brokers' in the list", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "no-brokers"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		assert.Contains(t, inputsMissing(c), "brokers")
+	})
+}
+
+func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
+	cfg := defaultCfg(t)
+	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
+
+	t.Run("nil-Acls PROVISIONED: skipped rule has SkipReason", func(t *testing.T) {
+		c := provisionedClusterWithScan("nil-acls", nil)
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		require.Len(t, d.EvaluatedRules, len(hardLimitCatalog), "EvaluatedRules must carry every catalog entry")
+		for _, r := range d.EvaluatedRules {
+			if r.RowID == ruleACLCountExceedsCap {
+				assert.Equal(t, types.RuleSkipped, r.Outcome)
+				assert.NotEmpty(t, r.SkipReason, "skipped rule must carry a SkipReason")
+				assert.Empty(t, r.Evidence, "skipped rule must NOT carry Evidence")
+				return
+			}
+		}
+		t.Fatalf("acl_count_exceeds_cap row missing from EvaluatedRules")
+	})
+	t.Run("non-fired rule carries negative evidence", func(t *testing.T) {
+		c := provisionedClusterWithScan("ok", []types.Acls{})
+		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		for _, r := range d.EvaluatedRules {
+			if r.RowID == ruleACLCountExceedsCap {
+				assert.Equal(t, types.RuleNotFired, r.Outcome)
+				assert.Contains(t, r.Evidence, "≤", "not_fired rule must surface negative evidence")
+				return
+			}
+		}
+		t.Fatalf("acl_count_exceeds_cap row missing")
+	})
+	t.Run("customer-declared fired rule carries Evidence + fires", func(t *testing.T) {
+		c := provisionedClusterWithScan("schema-cluster", []types.Acls{})
+		in := defaultInputs()
+		in.EnforceSchemasAtTheBroker = true
+		d := DecideClusterType(c, sizing, cfg, in)
+		var found bool
+		for _, r := range d.EvaluatedRules {
+			if r.RowID == ruleBrokerSideSchemaValidation {
+				assert.Equal(t, types.RuleFired, r.Outcome)
+				assert.NotEmpty(t, r.Evidence)
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "broker_side_schema_validation_required row missing")
+	})
+}
+
+// Per-cluster overrides win on a per-cluster basis: one cluster gets
+// Dedicated SZ from a per-cluster SLA flag; the other stays Enterprise
+// despite the global default. This is the regression guard for the
+// heterogeneous-fleet failure mode that motivated A3.
+func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T) {
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{{
+					Name: "us-east-1",
+					Clusters: []types.ProcessedCluster{
+						fixtureCluster("alpha", 100, 5.0, 5.0, 6.0, 6.0),
+						fixtureCluster("bravo", 100, 5.0, 5.0, 6.0, 6.0),
+					},
+				}},
+			},
+		}},
+	}
+	flag := true
+	rawInputs := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {Requires9995SLAWithinSingleZone: &flag}, // SZ for alpha only
+		},
+	}
+	resolved := ResolvePlanInputs(rawInputs, defaultCfg(t))
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(state, resolved, "x.json")
+	require.NoError(t, err)
+	require.Len(t, p.ClusterTypeDecision, 2)
+
+	byID := map[string]types.ClusterTypeDecision{}
+	for _, d := range p.ClusterTypeDecision {
+		byID[d.ClusterID] = d
+	}
+
+	assert.Equal(t, types.ClusterTypeDedicated, byID["alpha"].Verdict, "per-cluster override must flip alpha to Dedicated")
+	assert.Equal(t, types.TopologySingleZone, byID["alpha"].Topology, "SLA flag drives SZ topology")
+	assert.Equal(t, types.ClusterTypeEnterprise, byID["bravo"].Verdict, "non-overridden cluster must keep the global default (Enterprise)")
 }

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -3,30 +3,34 @@ package plan
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/confluentinc/kcp/internal/types"
 )
 
-// RenderMarkdown emits a human-readable Plan: Source Environment table,
-// Sizing & Cluster Decisions table with full rationale, collapsed
-// Appendix A1 with the sizing math expansion. MVP scope — no auth /
-// switchover / red flag sections (each lands with its own follow-up).
-//
-// cfg is read for product-fact numbers in the Definitions block and for
-// the partition cap rendered in the appendix; pass the same PlanConfig
-// the PlanService used to build the plan.
+// RenderMarkdown emits the human-readable Plan: Source Environment,
+// Sizing & Cluster Decisions, Actions Needed, and collapsed appendices.
+// `cfg` must be the same PlanConfig the PlanService used to build the
+// plan (product-fact numbers in the Definitions block and the partition
+// cap in the appendix read from it).
 func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	var b bytes.Buffer
 
 	fmt.Fprintf(&b, "# Migration Plan — %s → Confluent Cloud\n\n", p.Header.Source)
-	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath)
+	schemaSuffix := ""
+	if p.Header.PlanSchemaVersion != "" {
+		schemaSuffix = fmt.Sprintf(" · plan schema `%s`", p.Header.PlanSchemaVersion)
+	}
+	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`%s._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath, schemaSuffix)
 
 	writeDefinitions(&b, cfg)
 	writeSourceEnvironment(&b, p)
-	writeSizingAndDecisions(&b, p)
+	writeSizingAndDecisions(&b, p, cfg)
 	writeOpenQuestions(&b, p)
 	writeSizingAppendix(&b, p, cfg)
+	writeRulesAppendix(&b, p)
 
 	return b.Bytes(), nil
 }
@@ -37,31 +41,85 @@ func writeOpenQuestions(b *bytes.Buffer, p *types.Plan) {
 	}
 	b.WriteString("## 3. Actions Needed\n\n")
 	b.WriteString("Each item below is a concrete action that tightens the recommendation in **Sizing & Cluster Decisions**. The current recommendation stands; doing these closes a state-file or scan gap.\n\n")
-	for i, oq := range p.OpenQuestions {
-		title := oq.Title
-		if oq.ClusterID != "" {
-			title = fmt.Sprintf("`%s` — %s", oq.ClusterID, title)
+	for i, g := range groupOpenQuestions(p.OpenQuestions) {
+		fmt.Fprintf(b, "%d. **%s**\n", i+1, g.oq.Title)
+		if len(g.clusters) > 0 {
+			fmt.Fprintf(b, "   - _Affects:_ %s\n", formatClusterList(g.clusters))
 		}
-		fmt.Fprintf(b, "%d. **%s**\n", i+1, title)
-		if oq.Body != "" {
-			fmt.Fprintf(b, "   - %s\n", oq.Body)
+		if g.oq.Body != "" {
+			fmt.Fprintf(b, "   - %s\n", g.oq.Body)
 		}
-		if oq.HowToClose != "" {
-			fmt.Fprintf(b, "   - _How to close:_ %s\n", oq.HowToClose)
+		if g.oq.HowToClose != "" {
+			fmt.Fprintf(b, "   - _How to close:_ %s\n", g.oq.HowToClose)
 		}
 	}
 	b.WriteString("\n")
 }
 
+// oqGroup collapses OQs that render identically (same ID + Body +
+// HowToClose) into one entry with an `Affects:` line. Plan-level OQs
+// (empty ClusterID) never merge with per-cluster OQs; OQs whose
+// HowToClose differs (e.g. per-region commands) stay distinct.
+type oqGroup struct {
+	oq       types.OpenQuestion
+	clusters []string
+}
+
+// groupOpenQuestions returns first-seen-order groups; callers must pass
+// a priority-sorted input slice if they want priority order preserved.
+func groupOpenQuestions(oqs []types.OpenQuestion) []oqGroup {
+	groups := make([]oqGroup, 0, len(oqs))
+	byKey := make(map[string]int, len(oqs))
+	for _, oq := range oqs {
+		var key string
+		switch {
+		case oq.ClusterID == "":
+			// Plan-level — never merge with per-cluster OQs.
+			key = "plan-level\x00" + oq.ID + "\x00" + oq.Title
+		case oq.ID != "":
+			// Per-cluster grouping: include Body + HowToClose so two
+			// clusters whose rendered text differs (e.g. per-region
+			// commands) stay as separate items.
+			key = "cluster\x00" + oq.ID + "\x00" + oq.Body + "\x00" + oq.HowToClose
+		default:
+			// No ID and a ClusterID — can't safely group; keep distinct.
+			key = "cluster\x00\x00" + oq.Title + "\x00" + oq.ClusterID
+		}
+		idx, ok := byKey[key]
+		if !ok {
+			groups = append(groups, oqGroup{oq: oq})
+			idx = len(groups) - 1
+			byKey[key] = idx
+		}
+		if oq.ClusterID != "" {
+			groups[idx].clusters = append(groups[idx].clusters, oq.ClusterID)
+		}
+	}
+	return groups
+}
+
+// formatClusterList renders a list of cluster IDs as “ `a` “, “ `b` “,
+// “ `c` “ for inline display.
+func formatClusterList(ids []string) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = "`" + id + "`"
+	}
+	return strings.Join(parts, ", ")
+}
+
 func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
 	caps := cfg.EnterpriseCaps
 	b.WriteString("## Definitions\n\n")
+	b.WriteString("- **Enterprise / Dedicated** — Confluent Cloud cluster tiers. Enterprise has elastic billing per eCKU; Dedicated is fixed-provisioned per CKU. **MZ** (Multi-Zone) is the default Dedicated topology; **SZ** (Single-Zone) fires only when `requires_99_95_sla_within_a_single_zone: true` is set in `plan-inputs.yaml`.\n")
 	fmt.Fprintf(b, "- **eCKU** — Elastic Confluent Kafka Unit, the throughput unit on Enterprise clusters. %d MB/s ingress + %d MB/s egress per eCKU at the per-eCKU caps used below.\n", caps.PerECKUIngressMBps, caps.PerECKUEgressMBps)
 	b.WriteString("- **CKU** — Confluent Kafka Unit, the Dedicated-tier equivalent of eCKU. Sizing math is the same; only the unit name changes. Dedicated clusters always render with `CKU`.\n")
 	b.WriteString("- **P95** — the 95th-percentile sustained throughput observed in the metrics window. Sizing uses P95 (override with `sizing_percentile`) so a transient spike doesn't permanently inflate the recommended cluster size.\n")
 	b.WriteString("- **Final size** — the recommended eCKU (Enterprise) or CKU (Dedicated) count for the cluster. `(floor)` next to a value means the SLA minimum was binding (the math came in below the floor and was rounded up).\n")
-	fmt.Fprintf(b, "- **PrivateLink** — single-AZ private connectivity, up to %d eCKU. The default network when the cluster fits inside it with headroom. Enterprise only.\n", caps.PrivateLinkMaxECKU)
-	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — multi-AZ private connectivity, up to %d eCKU. Used when PrivateLink's cap is too close to the cluster's peak burst; **always required on Dedicated**.\n\n", caps.PNIMaxECKU)
+	b.WriteString("- **Peak burst** — short-window peak throughput observed in metrics, expressed as eCKU. Surfaces in the spiky-workload note when peak diverges from P95 by more than the configured ratio.\n")
+	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — AWS-to-AWS private connectivity, up to %d eCKU on Enterprise. The default for AWS Enterprise; **always required on Dedicated** (AWS).\n", caps.PNIMaxECKU)
+	fmt.Fprintf(b, "- **PrivateLink** — capped at %d eCKU on Enterprise. Fires when `target_cloud != \"aws\"` (PNI is AWS-only), when `cc_egress_required: true` (PNI lacks native CC→customer egress), or when `projected_pni_gateway_count >= 2`. Also the cross-cloud private path on Dedicated when `target_cloud` is Azure / GCP.\n", caps.PrivateLinkMaxECKU)
+	fmt.Fprintf(b, "- **ACL cap (%d)** — Enterprise supports up to %d ACLs; exceeding the cap forces Dedicated. Source: cluster-types.html.\n\n", caps.ACLCountCap, caps.ACLCountCap)
 }
 
 func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
@@ -72,29 +130,39 @@ func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
 	}
 	totalBrokers := 0
 	totalTopics := 0
+	serverlessCount := 0
 	for _, c := range p.SourceEnvironment.Clusters {
-		totalBrokers += c.BrokerCount
+		// Serverless clusters have no broker count by design — exclude
+		// from the total so the headline number reflects Provisioned
+		// brokers only.
+		if !c.IsServerless {
+			totalBrokers += c.BrokerCount
+		} else {
+			serverlessCount++
+		}
 		totalTopics += c.TopicCount
 	}
-	regionWord := "region"
-	if p.SourceEnvironment.TotalRegions != 1 {
-		regionWord = "regions"
+	regionWord := pluralize("region", p.SourceEnvironment.TotalRegions)
+	clusterWord := pluralize("cluster", len(p.SourceEnvironment.Clusters))
+	serverlessNote := ""
+	if serverlessCount > 0 {
+		serverlessNote = fmt.Sprintf(" (incl. %d MSK Serverless %s — no broker count by design)", serverlessCount, pluralize("cluster", serverlessCount))
 	}
-	clusterWord := "cluster"
-	if len(p.SourceEnvironment.Clusters) != 1 {
-		clusterWord = "clusters"
-	}
-	fmt.Fprintf(b, "- **%d** source %s across **%d** %s · **%d** brokers · **%d** topics\n\n",
-		len(p.SourceEnvironment.Clusters), clusterWord, p.SourceEnvironment.TotalRegions, regionWord, totalBrokers, totalTopics)
+	fmt.Fprintf(b, "- **%d** source %s across **%d** %s · **%d** brokers · **%d** topics%s\n\n",
+		len(p.SourceEnvironment.Clusters), clusterWord, p.SourceEnvironment.TotalRegions, regionWord, totalBrokers, totalTopics, serverlessNote)
 	b.WriteString("| Cluster | Region | Brokers | Topics |\n")
 	b.WriteString("|---|---|---:|---:|\n")
 	for _, c := range p.SourceEnvironment.Clusters {
-		fmt.Fprintf(b, "| %s | %s | %d | %d |\n", c.ClusterID, c.Region, c.BrokerCount, c.TopicCount)
+		brokerCell := fmt.Sprintf("%d", c.BrokerCount)
+		if c.IsServerless {
+			brokerCell = "_N/A (serverless)_"
+		}
+		fmt.Fprintf(b, "| %s | %s | %s | %d |\n", escapeMarkdownTableCell(c.ClusterID), escapeMarkdownTableCell(c.Region), brokerCell, c.TopicCount)
 	}
 	b.WriteString("\n")
 }
 
-func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan) {
+func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 	b.WriteString("## 2. Sizing & Cluster Decisions\n\n")
 	if len(p.Sizing) == 0 {
 		b.WriteString("_No clusters to size._\n\n")
@@ -122,54 +190,123 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan) {
 		net := netByID[s.ClusterID].Verdict
 		ctLabel := clusterTypeLabel(ctDecision)
 		sizeCell := formatSizeCell(s.FinalECKU, ctDecision, s.Degraded)
+		throughputCell := fmt.Sprintf("%.1f / %.1f", s.SizedInMBps, s.SizedOutMBps)
+		partitionsCell := fmt.Sprintf("%d", s.UserPartitions)
+		// Per-column provisional markers: any input in InputsMissing
+		// flips the columns it actually drives. The verdict columns
+		// (Cluster Type / Networking) still render because they're
+		// deterministic given the inputs that ARE present (customer
+		// flags, target_cloud) — only the columns whose inputs are
+		// genuinely missing get the provisional marker. A trailing
+		// note appears in the Why line so the reader sees what's
+		// missing.
 		if s.Degraded {
-			fmt.Fprintf(b, "| %s | _metrics missing_ | %d | %s | %s | %s |\n",
-				s.ClusterID, s.UserPartitions, sizeCell, ctLabel, net)
-			continue
+			throughputCell = "_metrics missing_"
+			sizeCell = formatSizeCell(s.FinalECKU, ctDecision, true)
 		}
-		fmt.Fprintf(b, "| %s | %.1f / %.1f | %d | %s | %s | %s |\n",
-			s.ClusterID, s.SizedInMBps, s.SizedOutMBps, s.UserPartitions, sizeCell, ctLabel, net)
+		// Partitions column reflects topics specifically (the only
+		// signal that drives partition count). The `*` marker is
+		// broader — ANY missing input flips the sizing cell so a
+		// table-only reader sees every cluster with a provisional
+		// verdict, not just the topics-missing ones.
+		if slices.Contains(s.InputsMissing, "topics") {
+			partitionsCell = "_unknown_"
+		}
+		if len(s.InputsMissing) > 0 {
+			sizeCell += " *"
+		}
+		fmt.Fprintf(b, "| %s | %s | %s | %s | %s | %s |\n",
+			escapeMarkdownTableCell(s.ClusterID), throughputCell, partitionsCell, sizeCell, ctLabel, net)
 	}
 	b.WriteString("\n")
+	if hasProvisional(p.Sizing) {
+		b.WriteString("`*` = sizing is provisional — some scan inputs were missing; see each cluster's Why line for the specifics.\n\n")
+	}
 
 	// Per-cluster rationale: each line cites the cluster-type decision and
 	// the networking decision. Reads cleanly even for 30+ clusters because
 	// each entry is one or two lines.
 	b.WriteString("### Why These Recommendations\n\n")
+	srcByID := make(map[string]types.SourceClusterSummary, len(p.SourceEnvironment.Clusters))
+	for _, sc := range p.SourceEnvironment.Clusters {
+		srcByID[sc.ClusterID] = sc
+	}
+	// Triggers that fire on every cluster (e.g. a global flag in plan-
+	// inputs.yaml) get one top-of-section cost callout instead of the
+	// same warning repeated per cluster. Per-cluster overrides where
+	// only some clusters fire keep the inline cost callout — the noise
+	// signal there is real.
+	globalCustomerTriggers := detectGlobalCustomerTriggers(p.ClusterTypeDecision)
+	if len(globalCustomerTriggers) > 0 {
+		writeCostCallout(b, globalCustomerTriggers, calloutGlobal)
+		if szIsGlobal(globalCustomerTriggers) {
+			writeSZTradeoff(b, cfg, calloutGlobal)
+		}
+	}
 	for _, s := range p.Sizing {
+		ct := ctByID[s.ClusterID]
+		unit := finalSizeUnit(ct)
+		src := srcByID[s.ClusterID]
 		if s.Degraded {
-			// Symptom-only here; the action lives in Actions Needed
-			// (so it isn't duplicated across two surfaces).
-			fmt.Fprintf(b, "- **%s** — metrics missing (%s). Final eCKU defaults to the SLA floor (%d). See Actions Needed below.\n", s.ClusterID, s.DegradedReason, s.FinalECKU)
+			// Metrics-degraded clusters get a symptom-only line here;
+			// the action lives in Actions Needed (so the symptom isn't
+			// duplicated across two surfaces).
+			if src.IsServerless {
+				fmt.Fprintf(b, "- **%s** — **MSK Serverless source**; broker count is N/A by design and the CloudWatch metrics path differs from Provisioned. Final %s defaults to the SLA floor (%d) until throughput is supplied. See Actions Needed below.\n", s.ClusterID, unit, s.FinalECKU)
+			} else {
+				fmt.Fprintf(b, "- **%s** — metrics missing (%s). Final %s defaults to the SLA floor (%d). See Actions Needed below.\n", s.ClusterID, s.DegradedReason, unit, s.FinalECKU)
+			}
 			continue
 		}
 		var pieces []string
-		var customerDeclaredTriggers []string
-		if ct, ok := ctByID[s.ClusterID]; ok {
-			ctLabel := clusterTypeLabel(ct)
-			if len(ct.Triggers) == 0 {
-				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", ctLabel))
-			} else {
-				rules := make([]string, 0, len(ct.Triggers))
-				for _, t := range ct.Triggers {
-					rules = append(rules, fmt.Sprintf("%s (%s)", t.Description, t.Evidence))
-					if t.CustomerDeclared {
-						customerDeclaredTriggers = append(customerDeclaredTriggers, t.RowID)
-					}
-				}
-				pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — %s", ctLabel, strings.Join(rules, "; ")))
+		var customerDeclaredTriggers []types.HardLimitTrigger
+		skippedRuleCount := countSkippedRules(ct.EvaluatedRules)
+		if len(ct.Triggers) == 0 {
+			noFire := fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", clusterTypeLabel(ct))
+			if skippedRuleCount > 0 {
+				noFire += fmt.Sprintf(" (%d %s skipped pending missing inputs — see Appendix A2)", skippedRuleCount, pluralize("rule", skippedRuleCount))
 			}
+			pieces = append(pieces, noFire)
+		} else {
+			rules := make([]string, 0, len(ct.Triggers))
+			for _, t := range ct.Triggers {
+				rules = append(rules, fmt.Sprintf("%s (%s)", t.Description, t.Evidence))
+				if t.CustomerDeclared {
+					customerDeclaredTriggers = append(customerDeclaredTriggers, t)
+				}
+			}
+			pieces = append(pieces, fmt.Sprintf("Cluster type **%s** — %s", clusterTypeLabel(ct), strings.Join(rules, "; ")))
 		}
 		if n, ok := netByID[s.ClusterID]; ok {
 			pieces = append(pieces, fmt.Sprintf("Networking **%s** — %s", n.Verdict, n.Reason))
 		}
 		fmt.Fprintf(b, "- **%s** — %s.\n", s.ClusterID, strings.Join(pieces, ". "))
-		if len(customerDeclaredTriggers) > 0 {
-			fmt.Fprintf(b, costCalloutTemplate, strings.Join(customerDeclaredTriggers, ", "))
+		if len(s.InputsMissing) > 0 {
+			fmt.Fprintf(b, "  - _Inputs missing: %s — sizing math is provisional until the scan is re-run; the verdict above resolves on the rules that could still evaluate. See Actions Needed below for the next command._\n", strings.Join(s.InputsMissing, ", "))
+		}
+		// Per-cluster cost callout: only render triggers that didn't
+		// already fire as global (those got the one-time banner up top).
+		perClusterTriggers := filterNonGlobalTriggers(customerDeclaredTriggers, globalCustomerTriggers)
+		if len(perClusterTriggers) > 0 {
+			writeCostCallout(b, perClusterTriggers, calloutPerCluster)
+		}
+		// Single-Zone resilience tradeoff: skipped when the SZ trigger
+		// fired globally (banner already covered it); otherwise emit
+		// inline so the per-cluster reader sees the failure-domain
+		// note next to the verdict.
+		if ct.Verdict == types.ClusterTypeDedicated && ct.Topology == types.TopologySingleZone && !szIsGlobal(globalCustomerTriggers) {
+			writeSZTradeoff(b, cfg, calloutPerCluster)
 		}
 		// Spiky-workload note (FYI only — sizing already absorbs the spike).
-		if s.SpikyIngress || s.SpikyEgress {
-			fmt.Fprintf(b, "  - _Note: %s. Sizing is P95-based and Enterprise elasticity absorbs the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s))
+		// Suppress when sizing landed on the SLA floor: the spike couldn't
+		// have pushed the cluster larger anyway (floor binds first), so
+		// the hint to flip `sizing_percentile: p99` would be misleading.
+		if (s.SpikyIngress || s.SpikyEgress) && s.FinalECKU > s.SLAFloorECKU {
+			absorbed := "Enterprise elasticity absorbs"
+			if ct.Verdict == types.ClusterTypeDedicated {
+				absorbed = "the sized Dedicated capacity absorbs"
+			}
+			fmt.Fprintf(b, "  - _Note: %s. Sizing is P95-based and %s the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s), absorbed)
 		}
 	}
 	b.WriteString("\n")
@@ -192,9 +329,101 @@ func spikyDescription(s types.ClusterSizing) string {
 
 func formatSpikeRatio(dir string, peak, p95 float64) string {
 	if p95 <= 0 {
-		return fmt.Sprintf("%s peak %.0f MB/s (no P95 baseline)", dir, peak)
+		return fmt.Sprintf("%s peak %s MB/s (no P95 baseline)", dir, formatMBps(peak))
 	}
-	return fmt.Sprintf("%s peak %.0f MB/s vs P95 %.0f MB/s (%.1fx)", dir, peak, p95, peak/p95)
+	return fmt.Sprintf("%s peak %s MB/s vs P95 %s MB/s (%.1fx)", dir, formatMBps(peak), formatMBps(p95), peak/p95)
+}
+
+// formatMBps renders a MB/s value with precision scaled to the value's
+// magnitude, so a 0.27 MB/s peak vs 0.002 MB/s P95 reads as "0.27 vs
+// 0.002" rather than "0 vs 0" (which makes a 136x ratio look like
+// nonsense).
+func formatMBps(v float64) string {
+	switch {
+	case v >= 10:
+		return fmt.Sprintf("%.0f", v)
+	case v >= 1:
+		return fmt.Sprintf("%.1f", v)
+	case v >= 0.01:
+		return fmt.Sprintf("%.3f", v)
+	default:
+		return fmt.Sprintf("%.4f", v)
+	}
+}
+
+// escapeMarkdownTableCell escapes the column-separator character so an
+// evidence string like "auth ⊥ a|b" doesn't break the table layout.
+// Backslash is also escaped to keep the result unambiguous on re-render.
+func escapeMarkdownTableCell(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
+}
+
+// pluralize returns `singular` when n == 1, else `singular + "s"`.
+// Trivial but used in multiple places ("cluster"/"clusters",
+// "rule"/"rules") so the call sites read naturally without inline
+// if-statements or programmatic `(s)` hacks.
+func pluralize(singular string, n int) string {
+	if n == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+// hasProvisional reports whether any cluster has at least one
+// load-bearing scan signal missing — used to decide whether to emit
+// the `*` legend after the Sizing & Cluster Decisions table.
+func hasProvisional(sizings []types.ClusterSizing) bool {
+	for _, s := range sizings {
+		if len(s.InputsMissing) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// countSkippedRules returns how many evaluated rules were `skipped`
+// (i.e. could not be evaluated because their inputs were missing). The
+// renderer uses this to append a one-liner note to "no hard-limit rule
+// fired" verdicts so the reader doesn't mistake the silence for
+// certainty.
+func countSkippedRules(rules []types.RuleEvaluation) int {
+	n := 0
+	for _, r := range rules {
+		if r.Outcome == types.RuleSkipped {
+			n++
+		}
+	}
+	return n
+}
+
+// slaFloorList renders the SLA-floor table as an inline phrase, e.g.
+// "1 eCKU for 99.9, 1 eCKU for 99.95, 2 eCKU for 99.99". Sorted by SLA
+// key for determinism. Lexicographic sort coincides with numeric
+// ascending for the current tier shape; revisit if a tier like "100"
+// is ever added.
+func slaFloorList(cfg *PlanConfig) string {
+	keys := make([]string, 0, len(cfg.PlanInputDefaults.SLAFloorECKU))
+	for k := range cfg.PlanInputDefaults.SLAFloorECKU {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%d eCKU for %s", cfg.PlanInputDefaults.SLAFloorECKU[k], k)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// finalSizeUnit returns "eCKU" or "CKU" for the given cluster-type
+// verdict so rendered prose matches the unit in the Sizing & Cluster
+// Decisions table.
+func finalSizeUnit(ct types.ClusterTypeDecision) string {
+	if ct.Verdict == types.ClusterTypeDedicated {
+		return "CKU"
+	}
+	return "eCKU"
 }
 
 func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
@@ -204,30 +433,211 @@ func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 	partitionCap := cfg.EnterpriseCaps.PerECKUPartitionRate
 	b.WriteString("## Appendix A1 — Sizing Math\n")
 	b.WriteString("<details><summary>Show sizing math per cluster</summary>\n\n")
-	b.WriteString("Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended eCKU has spare capacity above the observed P95. SLA floor binds when the math comes in below the minimum eCKU for the target SLA.\n\n")
+	fmt.Fprintf(b, "Each cluster is sized by taking the largest of its three throughput-vs-cap ratios (ingress, egress, partitions) and scaling that by `(1 + headroom)`, so the recommended size has spare capacity above the observed %s. Headroom for this run is `%.2f` (override via `headroom_fraction` in `plan-inputs.yaml`). SLA floor binds when the math comes in below the minimum eCKU for the target SLA (%s — published in the Confluent Cloud cluster-types SLA table). The `Sized` and `Final` columns are in eCKU on Enterprise and CKU on Dedicated.\n\n", percentileHeader(p.Inputs.SizingPercentile), p.Inputs.HeadroomFraction, slaFloorList(cfg))
 	// The formula is identical for every cluster (caps + headroom are
 	// constants, not per-cluster). Print it once, then a single audit
 	// table covers every cluster in a row.
 	fmt.Fprintf(b, "Formula: `%s`\n\n", p.SizingAppendix[0].Formula)
-	b.WriteString("| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized eCKU | SLA floor | Final eCKU |\n")
+	b.WriteString("| Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized | SLA floor | Final |\n")
 	b.WriteString("|---|---:|---:|---:|---|---:|---:|---:|\n")
 	for _, s := range p.Sizing {
+		// Topics missing → partition input is `_unknown_`, sizing math
+		// can't be computed; show the SLA-floor fallback alongside the
+		// note. Other "missing inputs" don't affect sizing math itself.
+		if slices.Contains(s.InputsMissing, "topics") {
+			fmt.Fprintf(b, "| %s | _unknown_ | _unknown_ | _unknown_ / %d | _n/a_ | _n/a_ | %d | %d (floor) |\n",
+				escapeMarkdownTableCell(s.ClusterID), partitionCap, s.SLAFloorECKU, s.FinalECKU)
+			continue
+		}
 		if s.Degraded {
 			fmt.Fprintf(b, "| %s | _degraded_ | _degraded_ | %d / %d | _n/a_ | _n/a_ | %d | %d |\n",
-				s.ClusterID, s.UserPartitions, partitionCap, s.SLAFloorECKU, s.FinalECKU)
+				escapeMarkdownTableCell(s.ClusterID), s.UserPartitions, partitionCap, s.SLAFloorECKU, s.FinalECKU)
 			continue
 		}
 		fmt.Fprintf(b, "| %s | %.4f | %.4f | %.4f | **%.4f** (%s) | %d | %d | %d |\n",
-			s.ClusterID, s.IngressRatio, s.EgressRatio, s.PartitionRatio, s.MaxRatio, s.MaxRatioDriver, s.SizedECKU, s.SLAFloorECKU, s.FinalECKU)
+			escapeMarkdownTableCell(s.ClusterID), s.IngressRatio, s.EgressRatio, s.PartitionRatio, s.MaxRatio, s.MaxRatioDriver, s.SizedECKU, s.SLAFloorECKU, s.FinalECKU)
 	}
-	b.WriteString("\nMax-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized eCKU`. `Final eCKU` is `max(Sized, SLA floor)`.\n\n")
+	b.WriteString("\nMax-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized`. `Final` is `max(Sized, SLA floor)`.\n\n")
 	b.WriteString("</details>\n\n")
 }
 
-// costCalloutTemplate surfaces a ⚠ warning when a customer-declared
-// flag flipped the cluster to Dedicated — a wrong `true` costs 5–10×
-// monthly, so the callout names the rules and the recovery path.
-const costCalloutTemplate = "  - > ⚠ **Cost callout:** Dedicated was forced by customer-declared `plan-inputs.yaml` flag(s) — %s. Dedicated costs ~5–10× Enterprise per month for an equivalent footprint. If a flag was set in error, flip it to `false` and re-run; confirm with your Confluent account team if unsure.\n"
+// writeRulesAppendix surfaces the full hard-limit-rule evaluation trace
+// per cluster: every rule's outcome (fired / not_fired / skipped) with
+// evidence or skip-reason. Lets a reviewer audit "what would the rules
+// engine have said given this state" without re-running the tool.
+// Collapsed by default since most readers don't need it.
+func writeRulesAppendix(b *bytes.Buffer, p *types.Plan) {
+	hasAny := false
+	for _, ct := range p.ClusterTypeDecision {
+		if len(ct.EvaluatedRules) > 0 {
+			hasAny = true
+			break
+		}
+	}
+	if !hasAny {
+		return
+	}
+	b.WriteString("## Appendix A2 — Hard-Limit Rules Evaluated\n")
+	b.WriteString("<details><summary>Show per-cluster rule-evaluation trace</summary>\n\n")
+	b.WriteString("Every cluster runs the same hard-limit catalog; this table records each rule's outcome so a reviewer can confirm the verdict and see negative evidence (e.g. \"47 ACLs ≤ 4000 cap\"). `skipped` rows mean the rule couldn't be evaluated — the cluster's verdict resolves on the other rules.\n\n")
+	for _, ct := range p.ClusterTypeDecision {
+		if len(ct.EvaluatedRules) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, "**%s**\n\n", escapeMarkdownTableCell(ct.ClusterID))
+		b.WriteString("| Rule | Outcome | Detail |\n|---|---|---|\n")
+		for _, r := range ct.EvaluatedRules {
+			detail := r.Evidence
+			if r.Outcome == types.RuleSkipped {
+				detail = r.SkipReason
+			}
+			fmt.Fprintf(b, "| `%s` (%s) | `%s` | %s |\n",
+				escapeMarkdownTableCell(r.RowID),
+				escapeMarkdownTableCell(r.Description),
+				r.Outcome,
+				escapeMarkdownTableCell(detail))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("</details>\n\n")
+}
+
+// --- cost callout & Single-Zone resilience tradeoff -----------------
+//
+// When a customer-declared trigger fires on every cluster (a global
+// plan-input flag), the N inline callouts collapse into one banner
+// above the Why list. Partial fires keep the per-cluster callout. The
+// SZ resilience tradeoff piggybacks on the same scope rule.
+
+// szTriggerRowID is the RowID of the SZ-SLA customer trigger that, in
+// addition to the cost callout, gets a paired Single-Zone resilience
+// tradeoff banner. Constant-named here so the two emit sites (global
+// banner + per-cluster suppression) can't drift.
+const szTriggerRowID = "sla_99_95_single_zone"
+
+// calloutScope selects between the one-time banner at the top of the
+// Why section (calloutGlobal) and the inline nested-list-item attached
+// to one cluster's bullet (calloutPerCluster). The body text is the
+// same; only the lead phrase and indent differ.
+type calloutScope int
+
+const (
+	calloutGlobal calloutScope = iota
+	calloutPerCluster
+)
+
+const costCalloutBody = "Dedicated was forced by customer-declared `plan-inputs.yaml` flag(s) — %s. Dedicated has a higher monthly cost than Enterprise. If a flag was set in error, flip it to `false` and re-run; confirm with your Confluent account team if unsure."
+
+const szTradeoffBody = "**Single-Zone resilience tradeoff:** the 99.95%% SLA selected here is a same-AZ failure-domain choice. An AZ-wide outage takes the cluster offline. Multi-Zone (99.99%% SLA, ≥%d CKU) is the resilience-first alternative."
+
+// writeCostCallout emits the cost-callout block. Global scope renders
+// the top-of-section banner once; per-cluster scope renders the inline
+// nested-list-item version attached to one cluster's bullet.
+func writeCostCallout(b *bytes.Buffer, triggers []types.HardLimitTrigger, scope calloutScope) {
+	labels := formatCustomerTriggerLabels(triggers)
+	switch scope {
+	case calloutGlobal:
+		fmt.Fprintf(b, "> ⚠ **Cost callout (applies to every cluster below):** "+costCalloutBody+"\n\n", labels)
+	case calloutPerCluster:
+		fmt.Fprintf(b, "  - > ⚠ **Cost callout:** "+costCalloutBody+"\n", labels)
+	}
+}
+
+// writeSZTradeoff emits the Single-Zone resilience-tradeoff block. The
+// MZ floor comes from PlanConfig so renaming a tier in YAML doesn't
+// desync from prose.
+func writeSZTradeoff(b *bytes.Buffer, cfg *PlanConfig, scope calloutScope) {
+	mzFloor := cfg.PlanInputDefaults.SLAFloorECKU["99.99"]
+	switch scope {
+	case calloutGlobal:
+		fmt.Fprintf(b, "> ℹ "+szTradeoffBody+"\n\n", mzFloor)
+	case calloutPerCluster:
+		fmt.Fprintf(b, "  - > ℹ "+szTradeoffBody+"\n", mzFloor)
+	}
+}
+
+// szIsGlobal reports whether the SZ-SLA customer trigger appears in
+// the global-banner set — if it does, per-cluster sites must suppress
+// their inline SZ tradeoff to avoid duplicating the message.
+func szIsGlobal(global []types.HardLimitTrigger) bool {
+	return slices.ContainsFunc(global, func(t types.HardLimitTrigger) bool { return t.RowID == szTriggerRowID })
+}
+
+// detectGlobalCustomerTriggers finds customer-declared triggers that
+// fire on *every* cluster — those are global flags (one plan-input
+// flipped, no per-cluster scoping) and deserve one top-of-section
+// banner instead of N repeated per-cluster callouts. Per-cluster
+// overrides (where the same trigger fires on a subset) keep their
+// inline cost callout because the noise signal there is real.
+func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types.HardLimitTrigger {
+	if len(decisions) == 0 {
+		return nil
+	}
+	// Count occurrences per customer-declared RowID across all clusters.
+	// Use a per-cluster `seen` set so a duplicate RowID inside one
+	// cluster's Triggers (defensive — DecideClusterType today emits at
+	// most once) doesn't inflate the count past `len(decisions)` and
+	// fool the "fires on every cluster" check.
+	count := make(map[string]int)
+	firstSeen := make(map[string]types.HardLimitTrigger)
+	for _, d := range decisions {
+		seen := make(map[string]bool, len(d.Triggers))
+		for _, t := range d.Triggers {
+			if !t.CustomerDeclared || seen[t.RowID] {
+				continue
+			}
+			seen[t.RowID] = true
+			count[t.RowID]++
+			if _, ok := firstSeen[t.RowID]; !ok {
+				firstSeen[t.RowID] = t
+			}
+		}
+	}
+	var global []types.HardLimitTrigger
+	for rowID, n := range count {
+		if n == len(decisions) {
+			global = append(global, firstSeen[rowID])
+		}
+	}
+	// Stable order by RowID so the rendered banner doesn't reshuffle
+	// across runs (determinism contract).
+	sort.Slice(global, func(i, j int) bool { return global[i].RowID < global[j].RowID })
+	return global
+}
+
+// filterNonGlobalTriggers returns the subset of `cluster` that does
+// NOT appear in `global`. Used at the per-cluster cost-callout site
+// so a trigger that already got the top-of-section banner isn't
+// repeated inline.
+func filterNonGlobalTriggers(cluster, global []types.HardLimitTrigger) []types.HardLimitTrigger {
+	if len(global) == 0 {
+		return cluster
+	}
+	globalIDs := make(map[string]struct{}, len(global))
+	for _, t := range global {
+		globalIDs[t.RowID] = struct{}{}
+	}
+	var out []types.HardLimitTrigger
+	for _, t := range cluster {
+		if _, isGlobal := globalIDs[t.RowID]; !isGlobal {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// formatCustomerTriggerLabels renders the comma-separated trigger labels
+// used inside the cost callout. Uses the human-readable Description
+// (e.g. "99.95% single-zone SLA required") rather than the raw RowID
+// (e.g. "sla_99_95_single_zone") so a customer sees something they
+// recognise from the YAML comments.
+func formatCustomerTriggerLabels(triggers []types.HardLimitTrigger) string {
+	labels := make([]string, len(triggers))
+	for i, t := range triggers {
+		labels[i] = fmt.Sprintf("%s (`%s`)", t.Description, t.RowID)
+	}
+	return strings.Join(labels, "; ")
+}
 
 // percentileHeader returns the uppercase label rendered in the throughput
 // column header so the customer can see which percentile produced the

--- a/internal/services/plan/render_markdown_test.go
+++ b/internal/services/plan/render_markdown_test.go
@@ -11,8 +11,8 @@ import (
 
 // Renderer must surface a ⚠ cost callout when a customer-declared flag
 // is the reason a cluster was escalated to Dedicated — a wrong `true`
-// costs 5–10× monthly and the customer needs to see it inline with the
-// verdict, not buried in an appendix.
+// raises the monthly cost and the customer needs to see it inline with
+// the verdict, not buried in an appendix.
 func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
 	cfg := defaultCfg(t)
 	p := &types.Plan{
@@ -43,7 +43,7 @@ func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
 	body := string(out)
 
 	assert.Contains(t, body, "⚠", "cost callout must be surfaced for customer-declared Dedicated escalations")
-	assert.Contains(t, body, "5–10×", "must communicate the order-of-magnitude cost delta")
+	assert.Contains(t, body, "higher monthly cost", "must communicate the cost-direction signal without naming a multiplier")
 	assert.Contains(t, body, "sla_99_95_single_zone", "must name the rule that fired so the customer can find the flag")
 }
 
@@ -167,5 +167,226 @@ func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
 	body := string(out)
 
 	assert.NotContains(t, body, "⚠", "state-derived Dedicated escalations must not surface the wrong-click callout")
-	assert.NotContains(t, body, "5–10×")
+	assert.NotContains(t, body, "higher monthly cost")
+}
+
+// Clusters whose source scan didn't populate the load-bearing signals
+// still render their cluster-type + networking verdicts (those are
+// deterministic given the inputs that ARE present), but the sizing
+// column flips to provisional (`*` marker + `_unknown_` partitions)
+// and the Why line carries an "Inputs missing:" note so the reader
+// sees what to fix.
+func TestRenderMarkdown_InputsMissingMarksProvisional(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "ok", FinalECKU: 1, SizedInMBps: 5, SizedOutMBps: 8, MaxRatioDriver: "ingress"},
+			{ClusterID: "gap", FinalECKU: 1, SLAFloorECKU: 1, MaxRatioDriver: "ingress", InputsMissing: []string{"topics", "acls"}},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{ClusterID: "ok", Verdict: types.ClusterTypeEnterprise},
+			{ClusterID: "gap", Verdict: types.ClusterTypeEnterprise, InputsMissing: []string{"topics", "acls"}},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "ok", Verdict: types.NetworkingPNI, Reason: "PNI default"},
+			{ClusterID: "gap", Verdict: types.NetworkingPNI, Reason: "PNI default"},
+		},
+		SizingAppendix: []types.SizingMathDetail{
+			{ClusterID: "ok", Formula: "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))"},
+		},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+
+	// Verdict columns still render for the gap cluster — Enterprise + PNI are computable
+	// even without scan signals (no rule could have fired anyway).
+	assert.Contains(t, body, "| gap | 0.0 / 0.0 | _unknown_ | 1 eCKU * | Enterprise | PNI |",
+		"inputs-missing cluster must still render its verdict, just with a provisional marker on sizing")
+	// Why line carries the Inputs missing note.
+	assert.Contains(t, body, "_Inputs missing: topics, acls",
+		"inputs-missing cluster must surface the missing signals inline so the reader knows what to fix")
+	// `*` legend appears once when any cluster is provisional.
+	assert.Contains(t, body, "`*` = sizing is provisional",
+		"the `*` marker legend must appear after the table when any cluster is provisional")
+	// The healthy cluster renders unchanged.
+	assert.Contains(t, body, "| ok | 5.0 / 8.0 | 0 | 1 eCKU | Enterprise | PNI |",
+		"fully-scanned cluster must render its numeric verdict unchanged")
+
+	// Negative checks: the old `_deferred_` shape should not appear anywhere now.
+	for _, badPattern := range []string{"_deferred_", "_scan incomplete_"} {
+		assert.False(t, strings.Contains(body, badPattern),
+			"old deferral shape %q must not appear after refactor — verdicts now render with InputsMissing", badPattern)
+	}
+}
+
+// Pipe character in a cluster name or evidence string must not break
+// the rendered Appendix A2 table — `escapeMarkdownTableCell` is what
+// keeps the table parseable. Regression guard for the markdown-
+// injection vector the code reviewer flagged.
+func TestRenderMarkdown_AppendixA2EscapesPipeInTableCells(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "weird|name", FinalECKU: 1, SizedInMBps: 1, SizedOutMBps: 1, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{
+				ClusterID: "weird|name",
+				Verdict:   types.ClusterTypeEnterprise,
+				EvaluatedRules: []types.RuleEvaluation{
+					{RowID: "demo", Description: "Demo rule", Outcome: types.RuleNotFired, Evidence: "value a|b"},
+				},
+			},
+		},
+		NetworkingDecision: []types.NetworkingDecision{{ClusterID: "weird|name", Verdict: types.NetworkingPNI, Reason: "x"}},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, `weird\|name`, "cluster name with | must be escaped in the appendix cell")
+	assert.Contains(t, body, `value a\|b`, "evidence with | must be escaped")
+	assert.False(t, strings.Contains(body, "| weird|name |"), "raw unescaped | must not appear inside a table row")
+}
+
+// Cost callout aggregates multiple customer-declared triggers into a
+// single warning when more than one fires on the same cluster — verify
+// the labels are joined by `;` not duplicated, and the human Description
+// appears for each.
+func TestRenderMarkdown_CostCalloutMultipleTriggers(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "combo", FinalECKU: 2, SizedInMBps: 10, SizedOutMBps: 10, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{{
+			ClusterID: "combo",
+			Verdict:   types.ClusterTypeDedicated,
+			Triggers: []types.HardLimitTrigger{
+				{RowID: "sla_99_95_single_zone", Description: "99.95% single-zone SLA required", CustomerDeclared: true},
+				{RowID: "broker_side_schema_validation_required", Description: "Broker-side schema ID validation required", CustomerDeclared: true},
+			},
+		}},
+		NetworkingDecision: []types.NetworkingDecision{{ClusterID: "combo", Verdict: types.NetworkingPNI, Reason: "Dedicated"}},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, "99.95% single-zone SLA required")
+	assert.Contains(t, body, "Broker-side schema ID validation required")
+	// Both labels appear in a single cost-callout line, separated by `;`.
+	assert.True(t, strings.Contains(body, "99.95% single-zone SLA required (`sla_99_95_single_zone`); Broker-side schema ID validation required (`broker_side_schema_validation_required`)") ||
+		strings.Contains(body, "Broker-side schema ID validation required (`broker_side_schema_validation_required`); 99.95% single-zone SLA required (`sla_99_95_single_zone`)"),
+		"cost callout must join multiple trigger labels with `;`")
+}
+
+// Negative assertion: a fully-scanned healthy cluster must NOT carry
+// the `_Inputs missing_` Why-line note or a `*` provisional marker.
+func TestRenderMarkdown_HealthyClusterHasNoProvisionalMarker(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "ok", FinalECKU: 1, SizedInMBps: 5, SizedOutMBps: 8, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{{ClusterID: "ok", Verdict: types.ClusterTypeEnterprise}},
+		NetworkingDecision:  []types.NetworkingDecision{{ClusterID: "ok", Verdict: types.NetworkingPNI, Reason: "default"}},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	assert.NotContains(t, body, "_Inputs missing", "healthy cluster must not surface the provisional note")
+	assert.NotContains(t, body, "1 eCKU *", "healthy cluster's Final size must not carry the provisional `*` marker")
+	assert.NotContains(t, body, "`*` = sizing is provisional", "legend must not appear when no cluster is provisional")
+}
+
+// Plan C-shape regression: a customer-declared trigger that fires on
+// every cluster gets one banner up top, not N repeated per-cluster
+// callouts.
+func TestRenderMarkdown_GlobalTriggerCollapsesToBanner(t *testing.T) {
+	cfg := defaultCfg(t)
+	mkTrigger := func(id, desc string) []types.HardLimitTrigger {
+		return []types.HardLimitTrigger{{RowID: id, Description: desc, CustomerDeclared: true}}
+	}
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "a", FinalECKU: 1, MaxRatioDriver: "ingress"},
+			{ClusterID: "b", FinalECKU: 1, MaxRatioDriver: "ingress"},
+			{ClusterID: "c", FinalECKU: 1, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			{ClusterID: "a", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+			{ClusterID: "b", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+			{ClusterID: "c", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "a", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "b", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "c", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+		},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	bannerCount := strings.Count(body, "applies to every cluster below")
+	// Per-cluster callouts use the prefix `  - > ⚠ **Cost callout:**`
+	// (note the leading `  - `); the banner uses `> ⚠ **Cost callout
+	// (applies to every cluster below):**`. Count only the per-cluster
+	// shape to verify it didn't ALSO fire when the global banner did.
+	perClusterCount := strings.Count(body, "  - > ⚠ **Cost callout:**")
+	szTradeoffCount := strings.Count(body, "Single-Zone resilience tradeoff")
+	assert.Equal(t, 1, bannerCount, "global trigger must collapse to exactly one banner up top")
+	assert.Equal(t, 0, perClusterCount, "the per-cluster cost callout must NOT fire when the banner already did")
+	assert.Equal(t, 1, szTradeoffCount, "SZ resilience tradeoff must collapse to one banner when the SZ trigger is global")
+}
+
+// slaFloorList renders the SLA-floor table inline; verify it's
+// deterministic (sorted by key) and pulls values from cfg.
+func TestSlaFloorList_SortedDeterministic(t *testing.T) {
+	cfg := defaultCfg(t)
+	out := slaFloorList(cfg)
+	// Default config: 99.9 → 1, 99.95 → 1, 99.99 → 2
+	assert.Contains(t, out, "1 eCKU for 99.9")
+	assert.Contains(t, out, "1 eCKU for 99.95")
+	assert.Contains(t, out, "2 eCKU for 99.99")
+	// Deterministic order — 99.9 sorts before 99.95 sorts before 99.99.
+	assert.True(t, strings.Index(out, "99.9") < strings.Index(out, "99.95") &&
+		strings.Index(out, "99.95") < strings.Index(out, "99.99"),
+		"slaFloorList must be sorted by SLA key for deterministic output")
+}
+
+// Partial-fire: trigger fires on 2 of 3 clusters → it is NOT global,
+// so the per-cluster cost callout must still appear inline on each
+// firing cluster (the global banner must NOT appear).
+func TestDetectGlobalCustomerTriggers_PartialFireKeepsInline(t *testing.T) {
+	cfg := defaultCfg(t)
+	mkTrigger := func() []types.HardLimitTrigger {
+		return []types.HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95% single-zone SLA required", CustomerDeclared: true}}
+	}
+	p := &types.Plan{
+		Sizing: []types.ClusterSizing{
+			{ClusterID: "a", FinalECKU: 1, MaxRatioDriver: "ingress"},
+			{ClusterID: "b", FinalECKU: 1, MaxRatioDriver: "ingress"},
+			{ClusterID: "c", FinalECKU: 1, MaxRatioDriver: "ingress"},
+		},
+		ClusterTypeDecision: []types.ClusterTypeDecision{
+			// a + b fire; c doesn't (Enterprise default)
+			{ClusterID: "a", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger()},
+			{ClusterID: "b", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger()},
+			{ClusterID: "c", Verdict: types.ClusterTypeEnterprise},
+		},
+		NetworkingDecision: []types.NetworkingDecision{
+			{ClusterID: "a", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "b", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "c", Verdict: types.NetworkingPNI, Reason: "default for AWS Enterprise"},
+		},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	bannerCount := strings.Count(body, "applies to every cluster below")
+	perClusterCount := strings.Count(body, "  - > ⚠ **Cost callout:**")
+	szTradeoffCount := strings.Count(body, "Single-Zone resilience tradeoff")
+	assert.Equal(t, 0, bannerCount, "partial fire (2 of 3) must NOT collapse to a global banner")
+	assert.Equal(t, 2, perClusterCount, "each firing cluster must keep its inline cost callout when scope is partial")
+	assert.Equal(t, 2, szTradeoffCount, "each SZ cluster must keep its inline resilience tradeoff when scope is partial")
 }

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -32,11 +32,12 @@ func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMB
 
 func defaultInputs() types.PlanInputsResolved {
 	return types.PlanInputsResolved{
-		SLATarget:                  "99.9",
-		SizingPercentile:           "p95",
-		HeadroomFraction:           0.30,
-		PrivateLinkSafetyThreshold: 0.80,
-		SpikyWorkloadRatio:         2.0,
+		SLATarget:                "99.9",
+		SizingPercentile:         "p95",
+		HeadroomFraction:         0.30,
+		SpikyWorkloadRatio:       2.0,
+		TargetCloud:              "aws",
+		ProjectedPNIGatewayCount: 1,
 	}
 }
 

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -56,6 +56,11 @@ type SourceClusterSummary struct {
 	BrokerCount  int    `json:"broker_count"`
 	TopicCount   int    `json:"topic_count"`
 	KafkaVersion string `json:"kafka_version,omitempty"`
+	// IsServerless flags MSK Serverless source clusters. Set to true
+	// when MskClusterConfig.ClusterType == "SERVERLESS"; the renderer
+	// uses it to suppress Provisioned-only framing (broker counts,
+	// "incomplete scan" guidance) that doesn't apply to Serverless.
+	IsServerless bool `json:"is_serverless,omitempty"`
 }
 
 // ----- sizing & decisions -----
@@ -95,6 +100,14 @@ type ClusterSizing struct {
 	// the gap rather than silently asserting a sized eCKU.
 	Degraded       bool   `json:"degraded,omitempty"`
 	DegradedReason string `json:"degraded_reason,omitempty"`
+
+	// InputsMissing names load-bearing scan signals that weren't
+	// available when sizing was computed (e.g. `"topics"`, `"acls"`,
+	// `"brokers"`). The verdict from downstream decisions may still be
+	// solid if driven by customer-declared flags; the renderer reads
+	// this list to mark sizing as provisional rather than blanket-
+	// deferring the cluster.
+	InputsMissing []string `json:"inputs_missing,omitempty"`
 }
 
 // ClusterType represents the Confluent Cloud cluster verdict.
@@ -137,6 +150,49 @@ type ClusterTypeDecision struct {
 	// FinalCKU mirrors the sizing's FinalECKU under the Dedicated unit
 	// (Confluent Kafka Unit). Set only when Verdict == Dedicated.
 	FinalCKU *int `json:"final_cku,omitempty"`
+	// InputsMissing names load-bearing scan / plan-input signals that
+	// weren't available when this decision was computed (e.g. `"topics"`,
+	// `"acls"`). **Observational only** — set post-hoc in
+	// `PlanService.Build` after `DecideClusterType` has already run; the
+	// Verdict itself was computed against whatever inputs WERE present.
+	// Markdown reads this to flag the sizing column as provisional;
+	// JSON consumers can branch on the list.
+	InputsMissing []string `json:"inputs_missing,omitempty"`
+	// EvaluatedRules is the full audit trail for the hard-limit catalog
+	// against this cluster — every rule's outcome (fired / not_fired /
+	// skipped) with evidence. Read-only audit shape; the renderer
+	// surfaces it as a collapsed appendix.
+	EvaluatedRules []RuleEvaluation `json:"evaluated_rules,omitempty"`
+}
+
+// RuleOutcome enumerates the possible outcomes of evaluating one
+// hard-limit rule against a cluster. Persisted in the audit trail so a
+// reviewer can replay "what would the rules engine have said given
+// this state" without re-running the tool.
+//
+// The string values below ("fired" / "not_fired" / "skipped") are
+// **stable** and intended for downstream consumers to match on by
+// equality. Don't rename without a coordinated migration of consumers
+// + a plan_schema_version bump.
+type RuleOutcome string
+
+const (
+	RuleFired    RuleOutcome = "fired"     // rule fired — its evidence is recorded
+	RuleNotFired RuleOutcome = "not_fired" // rule evaluated and explicitly didn't fire
+	RuleSkipped  RuleOutcome = "skipped"   // rule was not evaluated (missing inputs)
+)
+
+// RuleEvaluation is one row of the per-cluster hard-limit audit trail.
+// Triggers (above) carries only the fired rules — this carries every
+// evaluation including not-fired and skipped, so the rendered appendix
+// can show negative evidence ("ACL cap not exceeded: 47 < 4000") and
+// skip rationales ("AclsScanned == false; rule inconclusive").
+type RuleEvaluation struct {
+	RowID       string      `json:"row_id"`
+	Description string      `json:"description"`
+	Outcome     RuleOutcome `json:"outcome"`
+	Evidence    string      `json:"evidence,omitempty"`
+	SkipReason  string      `json:"skip_reason,omitempty"`
 }
 
 type HardLimitTrigger struct {
@@ -146,7 +202,7 @@ type HardLimitTrigger struct {
 	// CustomerDeclared marks rules whose only signal is a customer-set
 	// `plan-inputs.yaml` flag. Renderer surfaces a cost callout on these
 	// so a wrong `true` doesn't quietly flip the verdict from Enterprise
-	// to Dedicated (Dedicated runs 5–10× monthly).
+	// to Dedicated (Dedicated has a higher monthly cost).
 	CustomerDeclared bool `json:"customer_declared,omitempty"`
 }
 
@@ -175,6 +231,13 @@ type NetworkingDecision struct {
 	PeakBurstECKU   int        `json:"peak_burst_ecku"`
 	PercentageOfCap float64    `json:"percentage_of_cap"`
 	Reason          string     `json:"reason"`
+	// InputsMissing — see ClusterTypeDecision.InputsMissing. Populated
+	// in lockstep so JSON consumers see the same gating signal on both
+	// decisions for an affected cluster. **JSON-consumer-only**: the
+	// markdown renderer reads the sister field on `ClusterTypeDecision`
+	// (and the same list on `ClusterSizing`) — this copy is here so
+	// downstream JSON branching doesn't need a cross-reference lookup.
+	InputsMissing []string `json:"inputs_missing,omitempty"`
 }
 
 // ----- citations & appendix -----
@@ -196,13 +259,18 @@ type SizingMathDetail struct {
 // input (nil pointers for fields they didn't set); the flat fields below
 // are the merged values PlanService computes against.
 type PlanInputsResolved struct {
+	// Raw preserves the original customer-supplied `PlanInputs`. **Note:**
+	// the flat fields below carry the *global* resolved view; per-cluster
+	// overrides (`Raw.Clusters[<name>]`) are layered on top per cluster
+	// inside `PlanService.Build` via `ResolvePlanInputsForCluster` — they
+	// are NOT applied to the values stored here. JSON consumers wanting
+	// the per-cluster view should re-run the resolver against `Raw`.
 	Raw *PlanInputs `json:"raw,omitempty"`
 
-	SLATarget                  string  `json:"sla_target"`
-	SizingPercentile           string  `json:"sizing_percentile"`
-	HeadroomFraction           float64 `json:"headroom_fraction"`
-	PrivateLinkSafetyThreshold float64 `json:"privatelink_safety_threshold"`
-	SpikyWorkloadRatio         float64 `json:"spiky_workload_ratio"`
+	SLATarget          string  `json:"sla_target"`
+	SizingPercentile   string  `json:"sizing_percentile"`
+	HeadroomFraction   float64 `json:"headroom_fraction"`
+	SpikyWorkloadRatio float64 `json:"spiky_workload_ratio"`
 
 	// Customer-declared hard requirements. Booleans (not *bool) — defaults
 	// resolve to false, which is the safe verdict (no escalation to Dedicated).
@@ -213,4 +281,10 @@ type PlanInputsResolved struct {
 	// Target cloud + existing VPC connectivity (Dedicated-path networking).
 	TargetCloud             string `json:"target_cloud"`
 	ExistingVPCConnectivity string `json:"existing_vpc_connectivity"`
+
+	// Networking triggers that flip the AWS-Enterprise default from PNI
+	// to PrivateLink. CCEgressRequired and ProjectedPNIGatewayCount are
+	// workload properties, not state-derived.
+	CCEgressRequired         bool `json:"cc_egress_required"`
+	ProjectedPNIGatewayCount int  `json:"projected_pni_gateway_count"`
 }

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -11,15 +11,15 @@ package types
 // Customer-declared flags that flip the cluster-type verdict
 // (`EnforceSchemasAtTheBroker`, `RequiresHighThroughputRESTProduceAPI`,
 // `Requires9995SLAWithinSingleZone`) are wrong-click sensitive — a
-// misfired `true` costs 5–10× monthly. The renderer surfaces a ⚠ cost
-// callout on the Dedicated verdict when any of them is the reason.
+// misfired `true` quietly raises the monthly cost. The renderer
+// surfaces a ⚠ cost callout on the Dedicated verdict when any of them
+// is the reason.
 type PlanInputs struct {
 	// Sizing overrides (defaults live in plan-config.yaml).
-	SLATarget                  *string  `yaml:"sla_target,omitempty"                    json:"sla_target,omitempty"`
-	SizingPercentile           *string  `yaml:"sizing_percentile,omitempty"             json:"sizing_percentile,omitempty"`
-	HeadroomFraction           *float64 `yaml:"headroom_fraction,omitempty"             json:"headroom_fraction,omitempty"`
-	PrivateLinkSafetyThreshold *float64 `yaml:"privatelink_safety_threshold,omitempty"  json:"privatelink_safety_threshold,omitempty"`
-	SpikyWorkloadRatio         *float64 `yaml:"spiky_workload_ratio,omitempty"          json:"spiky_workload_ratio,omitempty"`
+	SLATarget          *string  `yaml:"sla_target,omitempty"          json:"sla_target,omitempty"`
+	SizingPercentile   *string  `yaml:"sizing_percentile,omitempty"   json:"sizing_percentile,omitempty"`
+	HeadroomFraction   *float64 `yaml:"headroom_fraction,omitempty"   json:"headroom_fraction,omitempty"`
+	SpikyWorkloadRatio *float64 `yaml:"spiky_workload_ratio,omitempty" json:"spiky_workload_ratio,omitempty"`
 
 	// Customer-declared hard requirements that force Dedicated.
 	// Default `false`; only the customer (or an SE on their behalf) sets these.
@@ -35,7 +35,52 @@ type PlanInputs struct {
 	// Existing VPC connectivity to MSK. When set to `transit_gateway`
 	// or `vpc_peering` and the cluster is Dedicated, the same pattern
 	// is recommended for Confluent Cloud. `privatelink_or_pni` (default)
-	// lets the Plan pick between PrivateLink and PNI based on the
-	// safety threshold.
+	// keeps the AWS-to-AWS Enterprise default (PNI) unless one of the
+	// PrivateLink triggers fires (see CCEgressRequired,
+	// ProjectedPNIGatewayCount, non-AWS target_cloud).
 	ExistingVPCConnectivity *string `yaml:"existing_vpc_connectivity,omitempty" json:"existing_vpc_connectivity,omitempty"`
+
+	// CCEgressRequired = "Do CC-side workloads need to push traffic
+	// back into your customer VPC?" PNI does not natively support
+	// egress from CC into customer infrastructure; when true the
+	// networking default flips from PNI to PrivateLink.
+	CCEgressRequired *bool `yaml:"cc_egress_required,omitempty" json:"cc_egress_required,omitempty"`
+
+	// ProjectedPNIGatewayCount — projected PNI gateway count for the
+	// deployment. When ≥ 2, the recommendation flips from PNI to
+	// PrivateLink. Default 1 (single gateway).
+	ProjectedPNIGatewayCount *int `yaml:"projected_pni_gateway_count,omitempty" json:"projected_pni_gateway_count,omitempty"`
+
+	// Clusters — per-cluster overrides keyed by source cluster name.
+	// Heterogeneous fleets (mixed-SLA, mixed-tier) need finer-grained
+	// inputs than the global flags above; without this, flipping a
+	// single global flag like `requires_99_95_sla_within_a_single_zone:
+	// true` would force Dedicated SZ on every cluster including
+	// idle / Zookeeper / Serverless ones. Resolution: per-cluster
+	// override wins; fall back to global default. Only the subset of
+	// fields that makes sense per-cluster lives here.
+	Clusters map[string]ClusterPlanInputs `yaml:"clusters,omitempty" json:"clusters,omitempty"`
+}
+
+// ClusterPlanInputs is the per-cluster override slice of PlanInputs.
+// All fields are optional pointers so the resolver can detect "not set
+// for this cluster" and fall back to the global default.
+//
+// **Intentionally global-only** (not in this struct):
+//   - `sizing_percentile` — the Appendix A1 preamble names a single
+//     percentile for the whole plan; mixing P95 + P99 in one run would
+//     desync the prose. If a customer genuinely needs different
+//     percentiles per cluster, run the plan twice with different
+//     inputs and merge — explicit beats invisible.
+type ClusterPlanInputs struct {
+	SLATarget                            *string  `yaml:"sla_target,omitempty"                                 json:"sla_target,omitempty"`
+	HeadroomFraction                     *float64 `yaml:"headroom_fraction,omitempty"                          json:"headroom_fraction,omitempty"`
+	SpikyWorkloadRatio                   *float64 `yaml:"spiky_workload_ratio,omitempty"                       json:"spiky_workload_ratio,omitempty"`
+	EnforceSchemasAtTheBroker            *bool    `yaml:"enforce_schemas_at_the_broker,omitempty"              json:"enforce_schemas_at_the_broker,omitempty"`
+	RequiresHighThroughputRESTProduceAPI *bool    `yaml:"requires_high_throughput_rest_produce_api,omitempty"  json:"requires_high_throughput_rest_produce_api,omitempty"`
+	Requires9995SLAWithinSingleZone      *bool    `yaml:"requires_99_95_sla_within_a_single_zone,omitempty"    json:"requires_99_95_sla_within_a_single_zone,omitempty"`
+	TargetCloud                          *string  `yaml:"target_cloud,omitempty"                               json:"target_cloud,omitempty"`
+	ExistingVPCConnectivity              *string  `yaml:"existing_vpc_connectivity,omitempty"                  json:"existing_vpc_connectivity,omitempty"`
+	CCEgressRequired                     *bool    `yaml:"cc_egress_required,omitempty"                         json:"cc_egress_required,omitempty"`
+	ProjectedPNIGatewayCount             *int     `yaml:"projected_pni_gateway_count,omitempty"                json:"projected_pni_gateway_count,omitempty"`
 }


### PR DESCRIPTION
## Summary

Updated based on feedback. Follow-up to PR #292.

- **Networking** — PNI is now the AWS-Enterprise default; PrivateLink fires only when `target_cloud != "aws"`, `cc_egress_required: true`, or `projected_pni_gateway_count >= 2`.
- **ACL rule** — distinguishes "scan ran with 0 ACLs" from "scan didn't run" via Topics presence + MSK cluster type.
- **Open Questions** — grouped by `(ID, Body, HowToClose)` with an `Affects:` cluster list; commands include `--region <region>`.
- **Deferred verdicts** — incomplete-scan PROVISIONED clusters now render `_deferred_` instead of a confident-looking sized recommendation.

## Test plan

- [x] `go test ./...` clean
- [x] `golangci-lint` + `gofmt` clean
- [x] End-to-end run against a real MSK state file
- [x] Determinism preserved (byte-identical output modulo `generated_at`)