### PR TITLE
chore: detect legacy state file format and surface actionable error

### DIFF
--- a/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
+++ b/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
@@ -29,6 +29,7 @@
         "ec2:DescribeVpcs",
         "ec2:RevokeSecurityGroupEgress",
         "route53:AssociateVPCWithHostedZone",
+        "route53:ChangeResourceRecordSets",
         "route53:ChangeTagsForResource",
         "route53:CreateHostedZone",
         "route53:DeleteHostedZone",

--- a/cmd/discover/cmd_discover.go
+++ b/cmd/discover/cmd_discover.go
@@ -182,11 +182,12 @@ func parseDiscoverOpts() (*DiscovererOpts, error) {
 		return nil, fmt.Errorf("failed to check state file: %v", err)
 	} else {
 		// State file exists - load it
+		slog.Info("Found existing state file, attempting to load it", "file", stateFileName)
 		state, err = types.NewStateFromFile(stateFileName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load existing state file: %v", err)
 		}
-		slog.Debug("using existing state file", "file", stateFileName)
+		slog.Debug("Loaded existing state file", "file", stateFileName)
 	}
 
 	// Check if existing credentials file exists

--- a/cmd/scan/schema_registry/glue_schema_registry_scanner_test.go
+++ b/cmd/scan/schema_registry/glue_schema_registry_scanner_test.go
@@ -30,7 +30,7 @@ func TestGlueSchemaRegistryScanner_Run(t *testing.T) {
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Write initial state
-	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":null,"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
+	_, err = tmpFile.WriteString(`{"msk_sources":{"regions":[]},"schema_registries":null,"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 
@@ -86,7 +86,7 @@ func TestGlueSchemaRegistryScanner_Run_UpsertExisting(t *testing.T) {
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Write state with existing Glue registry
-	_, err = tmpFile.WriteString(`{"regions":[],"schema_registries":{"aws_glue":[{"registry_name":"my-registry","region":"us-east-1","registry_arn":"old-arn","schemas":[]}]},"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
+	_, err = tmpFile.WriteString(`{"msk_sources":{"regions":[]},"schema_registries":{"aws_glue":[{"registry_name":"my-registry","region":"us-east-1","registry_arn":"old-arn","schemas":[]}]},"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 
@@ -125,7 +125,7 @@ func TestGlueSchemaRegistryScanner_Run_RegistryNotFound(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	_, err = tmpFile.WriteString(`{"regions":[],"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
+	_, err = tmpFile.WriteString(`{"msk_sources":{"regions":[]},"kcp_build_info":{"version":"0.0.0-localdev","commit":"unknown","date":"unknown"}}`)
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 

--- a/cmd/ui/frontend/tests/e2e/state-validation.spec.ts
+++ b/cmd/ui/frontend/tests/e2e/state-validation.spec.ts
@@ -90,7 +90,7 @@ test.describe('State File Validation', () => {
       osk_sources: { clusters: [] },
       schema_registries: {
         confluent_schema_registry: [
-          { url: 'http://localhost:8081', schemas: [] },
+          { type: 'confluent', url: 'http://localhost:8081', subjects: [] },
         ],
       },
     }

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -131,11 +131,11 @@ func NewStateFromBytes(data []byte) (*State, error) {
 		}
 		if jsonErr := json.Unmarshal(data, &raw); jsonErr == nil {
 			if raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
-				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q). Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err, raw.KcpBuildInfo.Version, build_info.Version)
+				return nil, fmt.Errorf("%v (file was created with KCP version %q, you are running %q). Please recreate the state file with kcp discover (MSK) or kcp scan clusters (OSK) using the latest KCP release, or use KCP version %s to load this file", err, raw.KcpBuildInfo.Version, build_info.Version, raw.KcpBuildInfo.Version)
 			}
-			return nil, fmt.Errorf("state file could not be loaded: %v. Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err)
+			return nil, fmt.Errorf("%v. Please recreate the state file with kcp discover (MSK) or kcp scan clusters (OSK) using the latest KCP release", err)
 		}
-		return nil, fmt.Errorf("failed to unmarshal state file: %v. Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err)
+		return nil, fmt.Errorf("%v. Please recreate the state file with kcp discover (MSK) or kcp scan clusters (OSK) using the latest KCP release", err)
 	}
 
 	if state.KcpBuildInfo.Version == "" {

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -116,8 +117,11 @@ func NewStateFromFile(stateFile string) (*State, error) {
 
 func NewStateFromBytes(data []byte) (*State, error) {
 	var state State
-	if err := json.Unmarshal(data, &state); err != nil {
-		// Unmarshal failed — the schema may have changed between versions.
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		// Decode failed — the schema may have changed between versions,
+		// or the file contains unknown fields from a different KCP version.
 		// Try to extract just the version from the raw bytes to give a more
 		// actionable error than a raw JSON type error.
 		var raw struct {
@@ -127,15 +131,15 @@ func NewStateFromBytes(data []byte) (*State, error) {
 		}
 		if jsonErr := json.Unmarshal(data, &raw); jsonErr == nil {
 			if raw.KcpBuildInfo.Version != "" && raw.KcpBuildInfo.Version != build_info.Version {
-				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q — please try loading the state file with KCP version %q or recreating the state file with KCP version %q)", err, raw.KcpBuildInfo.Version, build_info.Version, raw.KcpBuildInfo.Version, build_info.Version)
+				return nil, fmt.Errorf("state file could not be loaded: %v (file was created with KCP version %q, you are running %q). Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err, raw.KcpBuildInfo.Version, build_info.Version)
 			}
-			return nil, fmt.Errorf("state file could not be loaded: %v — please recreate the state file using kcp discover or kcp scan clusters", err)
+			return nil, fmt.Errorf("state file could not be loaded: %v. Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err)
 		}
-		return nil, fmt.Errorf("failed to unmarshal state file: %v — please recreate the state file using kcp discover or kcp scan clusters", err)
+		return nil, fmt.Errorf("failed to unmarshal state file: %v. Please recreate the state file with kcp discover or kcp scan clusters using the latest KCP release", err)
 	}
 
 	if state.KcpBuildInfo.Version == "" {
-		slog.Warn("state file has no kcp_build_info.version — this may not be a valid KCP state file")
+		slog.Warn("state file has no kcp_build_info.version, this may not be a valid KCP state file")
 	}
 
 	return &state, nil

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1049,7 +1049,7 @@ func TestNewStateFromFile_SchemaMismatch_SurfacesVersionError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "state file could not be loaded") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected load error from fallback, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "0.5.0") {
@@ -1073,7 +1073,7 @@ func TestNewStateFromFile_InvalidJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to unmarshal state file") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected unmarshal error, got: %v", err)
 	}
 }
@@ -1096,7 +1096,7 @@ func TestNewStateFromFile_SchemaMismatch_NoVersion_SurfacesFriendlyError(t *test
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "state file could not be loaded") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected friendly error for versionless schema mismatch, got: %v", err)
 	}
 }
@@ -1153,7 +1153,7 @@ func TestNewStateFromBytes_SchemaMismatch_NoVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "state file could not be loaded") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected friendly error, got: %v", err)
 	}
 }
@@ -1164,7 +1164,7 @@ func TestNewStateFromBytes_InvalidJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to unmarshal state file") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected unmarshal error, got: %v", err)
 	}
 }
@@ -1200,7 +1200,7 @@ func TestNewStateFromBytes_UnknownFields_NoVersion_Rejects(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown fields, got nil")
 	}
-	if !strings.Contains(err.Error(), "state file could not be loaded") {
+	if !strings.Contains(err.Error(), "Please recreate the state file") {
 		t.Errorf("expected load error, got: %v", err)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1180,6 +1180,39 @@ func TestNewStateFromBytes_EmptyVersion(t *testing.T) {
 	}
 }
 
+func TestNewStateFromBytes_UnknownFields_WithVersion_RejectsWithVersionContext(t *testing.T) {
+	data := []byte(`{"kcp_build_info":{"version":"0.7.2"},"regions":[{"region_name":"us-east-1"}]}`)
+	_, err := NewStateFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error for unknown fields, got nil")
+	}
+	if !strings.Contains(err.Error(), "0.7.2") {
+		t.Errorf("expected error to contain file version, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), build_info.Version) {
+		t.Errorf("expected error to contain running version, got: %v", err)
+	}
+}
+
+func TestNewStateFromBytes_UnknownFields_NoVersion_Rejects(t *testing.T) {
+	data := []byte(`{"regions":[{"region_name":"us-east-1"}]}`)
+	_, err := NewStateFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error for unknown fields, got nil")
+	}
+	if !strings.Contains(err.Error(), "state file could not be loaded") {
+		t.Errorf("expected load error, got: %v", err)
+	}
+}
+
+func TestNewStateFromBytes_UnknownFields_AnyExtraField_Rejects(t *testing.T) {
+	data := []byte(`{"kcp_build_info":{"version":"` + build_info.Version + `"},"unexpected_field":"value"}`)
+	_, err := NewStateFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+}
+
 func TestFormatQueryDuration(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

State files from older KCP versions can contain JSON fields that don't exist in the current struct (e.g. top-level `"regions"` from v0.7.2 which moved to `"msk_sources.regions"`). Previously, `json.Unmarshal` silently ignored unknown fields, causing data to load with zero clusters despite the file containing real data.

This PR replaces `json.Unmarshal` with `json.NewDecoder` + `DisallowUnknownFields()` in `NewStateFromBytes`. Any state file with fields that don't map to the current `State` struct is now rejected with a clear error advising the user to recreate the file or use the matching KCP version.

## What changed

**`internal/types/state.go`**
- `NewStateFromBytes` now uses `json.NewDecoder` with `DisallowUnknownFields()` instead of `json.Unmarshal`
- Removed redundant error prefixes that caused triple-wrapping when callers added their own context
- Error messages now specify `kcp discover (MSK)` or `kcp scan clusters (OSK)` and advise using the latest KCP release
- When a version mismatch is detected, also suggests using the matching KCP version as an alternative

**`internal/types/state_test.go`**
- Replaced legacy-specific tests with generic unknown field rejection tests
- `TestNewStateFromBytes_UnknownFields_WithVersion_RejectsWithVersionContext` — unknown field with version mismatch shows both versions
- `TestNewStateFromBytes_UnknownFields_NoVersion_Rejects` — unknown field without version shows generic error
- `TestNewStateFromBytes_UnknownFields_AnyExtraField_Rejects` — any extra field is rejected even with matching version
- Updated existing test assertions to match simplified error message format

**`cmd/discover/cmd_discover.go`**
- Added `slog.Info` when an existing state file is found before attempting to load it, giving users context if loading fails

**`cmd/scan/schema_registry/glue_schema_registry_scanner_test.go`**
- Updated 3 test fixtures from legacy `"regions":[]` to current `"msk_sources":{"regions":[]}`

**`cmd/ui/frontend/tests/e2e/state-validation.spec.ts`**
- Fixed schema-registries-only test fixture to use correct struct field names (`type`, `url`, `subjects` instead of `schemas`)

**`cmd/create_asset/target_infra/testdata/iam_annotation.golden.md`**
- Updated to include `route53:ChangeResourceRecordSets` added in PR #297 (pre-existing golden file mismatch on main)

## Example error output

With version mismatch:
```
$ kcp ui --state-file old-state.json
ERROR failed to load state file "old-state.json": json: unknown field "regions"
(file was created with KCP version "0.7.2", you are running "0.0.0-localdev").
Please recreate the state file with kcp discover (MSK) or kcp scan clusters (OSK)
using the latest KCP release, or use KCP version 0.7.2 to load this file
```

Without version context:
```
$ kcp ui --state-file broken.json
ERROR failed to load state file "broken.json": json: unknown field "foo".
Please recreate the state file with kcp discover (MSK) or kcp scan clusters (OSK)
using the latest KCP release
```

## Follow-up

The 8 inline `os.ReadFile` + `json.Unmarshal` sites in `create-asset` commands still bypass `NewStateFromBytes` and won't get strict field checking or version-aware errors. This will be addressed in a separate consolidation PR.

## Test plan

- [x] `make test-go` — all tests pass (zero failures)
- [x] `go vet ./...` — clean
- [x] `make test-playwright` — all 6 state-validation E2E tests pass
- [x] 3 new unit tests for unknown field rejection
- [x] Manual: verified with real v0.7.2 state file (41 clusters, top-level regions)
- [x] Manual: verified current-format state files load normally
- [x] Manual: verified `kcp discover` with old state file shows clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)