### PR TITLE
feat(lib): add pkg/lib bytes-in / bytes-out façade for external callers

### DIFF
--- a/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
+++ b/cmd/create_asset/target_infra/testdata/iam_annotation.golden.md
@@ -29,6 +29,7 @@
         "ec2:DescribeVpcs",
         "ec2:RevokeSecurityGroupEgress",
         "route53:AssociateVPCWithHostedZone",
+        "route53:ChangeResourceRecordSets",
         "route53:ChangeTagsForResource",
         "route53:CreateHostedZone",
         "route53:DeleteHostedZone",

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -20,7 +20,14 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	var b bytes.Buffer
 
 	fmt.Fprintf(&b, "# Migration Plan — %s → Confluent Cloud\n\n", p.Header.Source)
-	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath)
+	// `from <path>` clause is omitted when the path is empty — library
+	// callers (pkg/lib) pass bytes, not a file path; only the CLI
+	// `kcp report plan --state-file ...` populates this field.
+	fromClause := ""
+	if p.Header.StateFilePath != "" {
+		fromClause = fmt.Sprintf(" from `%s`", p.Header.StateFilePath)
+	}
+	fmt.Fprintf(&b, "_Generated %s by KCP %s%s._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, fromClause)
 
 	writeDefinitions(&b, cfg)
 	writeSourceEnvironment(&b, p)

--- a/pkg/lib/doc.go
+++ b/pkg/lib/doc.go
@@ -5,9 +5,7 @@
 //
 // Formats:
 //   - state bytes must be JSON (kcp-state.json — what `kcp scan` writes).
-//   - plan_inputs bytes may be JSON or YAML (goccy/go-yaml accepts both
-//     since JSON is a YAML 1.2 subset), so an HTTP caller can pass an
-//     incoming request body through without a YAML dependency.
+//   - plan_inputs bytes must be YAML (plan-inputs.yaml shape).
 //   - Plan output is JSON + Markdown. Resolved plan_inputs are echoed
 //     back as YAML so callers preserve the plan-inputs.yaml shape their
 //     users edit.
@@ -15,7 +13,7 @@
 // API surface:
 //
 //	func ScanSummary(stateJSON []byte) ([]byte, error)
-//	func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error)
+//	func GeneratePlan(stateJSON, planInputsYAML []byte) (*PlanResult, error)
 //
 //	type PlanResult struct { JSON, Markdown, PlanInputs []byte }
 //

--- a/pkg/lib/doc.go
+++ b/pkg/lib/doc.go
@@ -1,12 +1,17 @@
-// Package lib is the stable JSON-in / JSON-out façade over kcp's
+// Package lib is the stable bytes-in / bytes-out façade over kcp's
 // state-processing and plan-generation pipelines. External Go modules
 // (cc-growth-service, etc.) import this package; it wraps the
 // internal/* implementations so they stay private.
 //
-// EXPERIMENTAL: signatures and JSON shapes may change while
+// Formats: state and plan_inputs go in as raw bytes — JSON or YAML
+// (JSON is a YAML 1.2 subset, so goccy/go-yaml accepts either). Plan
+// output is JSON + Markdown; resolved plan_inputs come back as YAML
+// so callers preserve the plan-inputs.yaml format their users edit.
+//
+// EXPERIMENTAL: signatures and payload shapes may change while
 // `plan_schema_version` is `"1-experimental"`. Pin to a specific kcp
 // version in your go.mod and bump deliberately. The function names and
 // `(stateJSON, planInputs []byte) → ([]byte, error)` shape are
-// expected to remain stable; the JSON payload schema is the only
+// expected to remain stable; the JSON / YAML payload schema is the
 // surface intended to evolve.
 package lib

--- a/pkg/lib/doc.go
+++ b/pkg/lib/doc.go
@@ -3,15 +3,25 @@
 // (cc-growth-service, etc.) import this package; it wraps the
 // internal/* implementations so they stay private.
 //
-// Formats: state and plan_inputs go in as raw bytes — JSON or YAML
-// (JSON is a YAML 1.2 subset, so goccy/go-yaml accepts either). Plan
-// output is JSON + Markdown; resolved plan_inputs come back as YAML
-// so callers preserve the plan-inputs.yaml format their users edit.
+// Formats:
+//   - state bytes must be JSON (kcp-state.json — what `kcp scan` writes).
+//   - plan_inputs bytes may be JSON or YAML (goccy/go-yaml accepts both
+//     since JSON is a YAML 1.2 subset), so an HTTP caller can pass an
+//     incoming request body through without a YAML dependency.
+//   - Plan output is JSON + Markdown. Resolved plan_inputs are echoed
+//     back as YAML so callers preserve the plan-inputs.yaml shape their
+//     users edit.
+//
+// API surface:
+//
+//	func ScanSummary(stateJSON []byte) ([]byte, error)
+//	func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error)
+//
+//	type PlanResult struct { JSON, Markdown, PlanInputs []byte }
 //
 // EXPERIMENTAL: signatures and payload shapes may change while
 // `plan_schema_version` is `"1-experimental"`. Pin to a specific kcp
-// version in your go.mod and bump deliberately. The function names and
-// `(stateJSON, planInputs []byte) → ([]byte, error)` shape are
-// expected to remain stable; the JSON / YAML payload schema is the
-// surface intended to evolve.
+// version in your go.mod and bump deliberately. Function names and
+// argument shapes are expected to remain stable; the JSON / YAML
+// payload schema is the surface intended to evolve.
 package lib

--- a/pkg/lib/doc.go
+++ b/pkg/lib/doc.go
@@ -1,0 +1,12 @@
+// Package lib is the stable JSON-in / JSON-out façade over kcp's
+// state-processing and plan-generation pipelines. External Go modules
+// (cc-growth-service, etc.) import this package; it wraps the
+// internal/* implementations so they stay private.
+//
+// EXPERIMENTAL: signatures and JSON shapes may change while
+// `plan_schema_version` is `"1-experimental"`. Pin to a specific kcp
+// version in your go.mod and bump deliberately. The function names and
+// `(stateJSON, planInputs []byte) → ([]byte, error)` shape are
+// expected to remain stable; the JSON payload schema is the only
+// surface intended to evolve.
+package lib

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -40,11 +40,9 @@ func ScanSummary(stateJSON []byte) ([]byte, error) {
 }
 
 // GeneratePlan builds a migration plan from a state file and optional
-// plan-inputs. Pass nil planInputs for defaults. planInputs may be JSON
-// or YAML bytes — JSON is a YAML 1.2 subset, so goccy/go-yaml accepts
-// either content type, which lets HTTP callers pass an incoming
-// request body straight through without a YAML dependency on their side.
-func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
+// plan-inputs YAML. Pass nil planInputsYAML for defaults. planInputsYAML
+// must follow the plan-inputs.yaml shape; see docs/assets/plan-inputs.example.yaml.
+func GeneratePlan(stateJSON, planInputsYAML []byte) (*PlanResult, error) {
 	state, err := types.NewStateFromBytes(stateJSON)
 	if err != nil {
 		return nil, fmt.Errorf("parse state: %w", err)
@@ -54,9 +52,9 @@ func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
 		return nil, fmt.Errorf("load plan-config: %w", err)
 	}
 	var pi *types.PlanInputs
-	if len(planInputs) > 0 {
+	if len(planInputsYAML) > 0 {
 		var parsed types.PlanInputs
-		if err := yaml.Unmarshal(planInputs, &parsed); err != nil {
+		if err := yaml.Unmarshal(planInputsYAML, &parsed); err != nil {
 			return nil, fmt.Errorf("parse plan-inputs: %w", err)
 		}
 		pi = &parsed

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -1,0 +1,77 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/plan"
+	"github.com/confluentinc/kcp/internal/services/report"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/goccy/go-yaml"
+)
+
+// PlanResult is the dual-format output of GeneratePlan. Both renderings
+// come from a single Build pass — calling GeneratePlan once is strictly
+// cheaper than calling two separate functions when the caller wants
+// both formats, and the marginal cost of rendering the unused format
+// is negligible compared to Build itself.
+type PlanResult struct {
+	JSON     []byte // same schema as `kcp report plan --output json`
+	Markdown []byte // same rendering as `kcp report plan --output md`
+}
+
+// ScanSummary parses a kcp-state.json byte slice and returns the
+// ProcessedState as JSON bytes — the flattened, aggregated view the
+// kcp UI serves at GET /state. Stateless; safe for concurrent use.
+func ScanSummary(stateJSON []byte) ([]byte, error) {
+	state, err := types.NewStateFromBytes(stateJSON)
+	if err != nil {
+		return nil, fmt.Errorf("parse state: %w", err)
+	}
+	processed := report.NewReportService().ProcessState(*state)
+	out, err := json.Marshal(processed)
+	if err != nil {
+		return nil, fmt.Errorf("marshal processed state: %w", err)
+	}
+	return out, nil
+}
+
+// GeneratePlan builds a migration plan from a state file and optional
+// plan-inputs. Pass nil planInputs for defaults. planInputs may be JSON
+// or YAML bytes — JSON is a YAML 1.2 subset, so goccy/go-yaml accepts
+// either content type, which lets HTTP callers pass an incoming
+// request body straight through without a YAML dependency on their side.
+func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
+	state, err := types.NewStateFromBytes(stateJSON)
+	if err != nil {
+		return nil, fmt.Errorf("parse state: %w", err)
+	}
+	cfg, err := plan.LoadPlanConfig("")
+	if err != nil {
+		return nil, fmt.Errorf("load plan-config: %w", err)
+	}
+	var pi *types.PlanInputs
+	if len(planInputs) > 0 {
+		var parsed types.PlanInputs
+		if err := yaml.Unmarshal(planInputs, &parsed); err != nil {
+			return nil, fmt.Errorf("parse plan-inputs: %w", err)
+		}
+		pi = &parsed
+	}
+	resolved := plan.ResolvePlanInputs(pi, cfg)
+	processed := report.NewReportService().ProcessState(*state)
+	p, err := plan.NewPlanService(cfg, time.Now).Build(processed, resolved, "lib")
+	if err != nil {
+		return nil, fmt.Errorf("build plan: %w", err)
+	}
+	js, err := plan.RenderJSON(p)
+	if err != nil {
+		return nil, fmt.Errorf("render plan json: %w", err)
+	}
+	md, err := plan.RenderMarkdown(p, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("render plan markdown: %w", err)
+	}
+	return &PlanResult{JSON: js, Markdown: md}, nil
+}

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -11,14 +11,16 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-// PlanResult is the dual-format output of GeneratePlan. Both renderings
-// come from a single Build pass — calling GeneratePlan once is strictly
-// cheaper than calling two separate functions when the caller wants
-// both formats, and the marginal cost of rendering the unused format
-// is negligible compared to Build itself.
+// PlanResult is the output of GeneratePlan. JSON and Markdown are two
+// renderings of the same Plan from a single Build pass. PlanInputs is
+// the resolved input set (caller-supplied fields merged with kcp
+// defaults) serialised as YAML — same shape as a plan-inputs.yaml file,
+// so a UI can show it as an editable text block (with room for future
+// commented-out optional knobs that a JSON echo would strip).
 type PlanResult struct {
-	JSON     []byte // same schema as `kcp report plan --output json`
-	Markdown []byte // same rendering as `kcp report plan --output md`
+	JSON       []byte // same schema as `kcp report plan --output json`
+	Markdown   []byte // same rendering as `kcp report plan --output md`
+	PlanInputs []byte // resolved plan-inputs (request merged with kcp defaults), as YAML
 }
 
 // ScanSummary parses a kcp-state.json byte slice and returns the
@@ -73,5 +75,9 @@ func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("render plan markdown: %w", err)
 	}
-	return &PlanResult{JSON: js, Markdown: md}, nil
+	piYAML, err := yaml.Marshal(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resolved plan-inputs: %w", err)
+	}
+	return &PlanResult{JSON: js, Markdown: md, PlanInputs: piYAML}, nil
 }

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -63,7 +63,10 @@ func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
 	}
 	resolved := plan.ResolvePlanInputs(pi, cfg)
 	processed := report.NewReportService().ProcessState(*state)
-	p, err := plan.NewPlanService(cfg, time.Now).Build(processed, resolved, "lib")
+	// Empty state-file path: library callers passed bytes, not a file.
+	// The renderer omits the "from <path>" header clause when this is
+	// empty; JSON consumers get `"state_file_path": ""`.
+	p, err := plan.NewPlanService(cfg, time.Now).Build(processed, resolved, "")
 	if err != nil {
 		return nil, fmt.Errorf("build plan: %w", err)
 	}
@@ -75,7 +78,13 @@ func GeneratePlan(stateJSON, planInputs []byte) (*PlanResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("render plan markdown: %w", err)
 	}
-	piYAML, err := yaml.Marshal(resolved)
+	// Strip the Raw pointer before YAML marshalling so the echoed
+	// plan-inputs match the flat plan-inputs.yaml shape — Raw is a
+	// runtime helper that surfaces customer-set vs default fields and
+	// has no place in user-facing YAML output.
+	echo := resolved
+	echo.Raw = nil
+	piYAML, err := yaml.Marshal(echo)
 	if err != nil {
 		return nil, fmt.Errorf("marshal resolved plan-inputs: %w", err)
 	}

--- a/pkg/lib/lib_test.go
+++ b/pkg/lib/lib_test.go
@@ -2,10 +2,12 @@ package lib_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/confluentinc/kcp/pkg/lib"
+	"github.com/goccy/go-yaml"
 )
 
 // minimal but valid kcp-state.json with one MSK Provisioned cluster.
@@ -48,7 +50,11 @@ func TestScanSummary_RejectsMalformedJSON(t *testing.T) {
 	}
 }
 
-func TestGeneratePlan_ReturnsBothRenderings(t *testing.T) {
+// With nil planInputs, PlanInputs in the reply must still be populated
+// with the full default set — it's the same `resolved` struct that
+// Build consumed, so a follow-up call echoing it back produces an
+// identical plan and a UI can use the first call to discover defaults.
+func TestGeneratePlan_NilInputsEchoesDefaults(t *testing.T) {
 	res, err := lib.GeneratePlan([]byte(sampleStateJSON), nil)
 	if err != nil {
 		t.Fatalf("GeneratePlan: %v", err)
@@ -59,6 +65,9 @@ func TestGeneratePlan_ReturnsBothRenderings(t *testing.T) {
 	if len(res.Markdown) == 0 {
 		t.Fatal("GeneratePlan.Markdown is empty")
 	}
+	if len(res.PlanInputs) == 0 {
+		t.Fatal("GeneratePlan.PlanInputs is empty")
+	}
 	var plan map[string]any
 	if err := json.Unmarshal(res.JSON, &plan); err != nil {
 		t.Fatalf("GeneratePlan.JSON is not valid JSON: %v", err)
@@ -66,20 +75,79 @@ func TestGeneratePlan_ReturnsBothRenderings(t *testing.T) {
 	if !strings.Contains(string(res.Markdown), "Migration Plan") {
 		t.Fatalf("GeneratePlan.Markdown missing expected header; got first 200 bytes: %s", truncate(res.Markdown, 200))
 	}
+	var inputs map[string]any
+	if err := yaml.Unmarshal(res.PlanInputs, &inputs); err != nil {
+		t.Fatalf("GeneratePlan.PlanInputs is not valid YAML: %v", err)
+	}
+	// Spot-check three independent default keys; if any is missing the
+	// resolver is leaking nil pointers and the UI can't render its form.
+	for _, k := range []string{"sizing_percentile", "headroom_fraction", "target_cloud"} {
+		if _, ok := inputs[k]; !ok {
+			t.Fatalf("PlanInputs missing default key %q; keys: %v", k, keys(inputs))
+		}
+	}
+	// The echo must match what Build consumed: the inputs in the plan
+	// JSON's header must equal the standalone PlanInputs field. (json
+	// and yaml decoders both produce map[string]any; numeric types may
+	// differ — compare via fmt.Sprint to dodge int64/float64 noise.)
+	planInputs, ok := plan["inputs"].(map[string]any)
+	if !ok {
+		t.Fatalf("plan.inputs missing from plan JSON; top-level keys: %v", keys(plan))
+	}
+	for _, k := range []string{"sizing_percentile", "headroom_fraction", "target_cloud"} {
+		gotPlan, gotInputs := fmt.Sprint(planInputs[k]), fmt.Sprint(inputs[k])
+		if gotPlan != gotInputs {
+			t.Fatalf("plan.inputs[%q] = %s, PlanInputs[%q] = %s (must match)", k, gotPlan, k, gotInputs)
+		}
+	}
+}
+
+// PlanInputs in the reply must echo back the caller's overrides AND
+// include the default keys they didn't set, so a UI can use an empty
+// initial call to discover the full input shape.
+func TestGeneratePlan_PlanInputsEchoesOverridesAndDefaults(t *testing.T) {
+	inputs := []byte(`{"target_cloud":"azure"}`)
+	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
+	if err != nil {
+		t.Fatalf("GeneratePlan: %v", err)
+	}
+	var got map[string]any
+	if err := yaml.Unmarshal(res.PlanInputs, &got); err != nil {
+		t.Fatalf("PlanInputs is not valid YAML: %v", err)
+	}
+	if got["target_cloud"] != "azure" {
+		t.Fatalf("PlanInputs.target_cloud = %v, want azure", got["target_cloud"])
+	}
+	// At least one default key the caller didn't set must be present —
+	// the whole point of the echo is to surface defaults to the UI.
+	if _, ok := got["sizing_percentile"]; !ok {
+		t.Fatalf("PlanInputs missing default key sizing_percentile; keys: %v", keys(got))
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // Plan-inputs as JSON: goccy/go-yaml accepts JSON (subset of YAML 1.2),
 // so HTTP callers can pass an incoming request body straight through
-// without a YAML dependency.
+// without a YAML dependency. Assertion targets PlanInputs (the resolved
+// echo) rather than markdown so it's independent of the renderer's
+// current surface area.
 func TestGeneratePlan_AcceptsJSONPlanInputs(t *testing.T) {
 	inputs := []byte(`{"target_cloud":"azure","headroom_fraction":0.4}`)
 	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
 	if err != nil {
 		t.Fatalf("GeneratePlan with JSON inputs: %v", err)
 	}
-	if !strings.Contains(string(res.Markdown), "azure") {
-		t.Fatal("plan markdown should mention azure target_cloud from the JSON inputs")
-	}
+	assertPlanInputsContains(t, res.PlanInputs, map[string]any{
+		"target_cloud":      "azure",
+		"headroom_fraction": 0.4,
+	})
 }
 
 func TestGeneratePlan_AcceptsYAMLPlanInputs(t *testing.T) {
@@ -88,8 +156,22 @@ func TestGeneratePlan_AcceptsYAMLPlanInputs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlan with YAML inputs: %v", err)
 	}
-	if !strings.Contains(string(res.Markdown), "azure") {
-		t.Fatal("plan markdown should mention azure target_cloud from the YAML inputs")
+	assertPlanInputsContains(t, res.PlanInputs, map[string]any{
+		"target_cloud":      "azure",
+		"headroom_fraction": 0.4,
+	})
+}
+
+func assertPlanInputsContains(t *testing.T, planInputs []byte, want map[string]any) {
+	t.Helper()
+	var got map[string]any
+	if err := yaml.Unmarshal(planInputs, &got); err != nil {
+		t.Fatalf("PlanInputs is not valid YAML: %v", err)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("PlanInputs[%q] = %v, want %v", k, got[k], v)
+		}
 	}
 }
 

--- a/pkg/lib/lib_test.go
+++ b/pkg/lib/lib_test.go
@@ -123,6 +123,13 @@ func TestGeneratePlan_PlanInputsEchoesOverridesAndDefaults(t *testing.T) {
 	if _, ok := got["sizing_percentile"]; !ok {
 		t.Fatalf("PlanInputs missing default key sizing_percentile; keys: %v", keys(got))
 	}
+	// PlanInputsResolved carries a `Raw *PlanInputs` runtime helper. It
+	// must not surface in the YAML echo — the echo is supposed to match
+	// the flat plan-inputs.yaml shape a user edits, not the internal
+	// resolved struct.
+	if _, ok := got["raw"]; ok {
+		t.Fatalf("PlanInputs YAML must not contain `raw` wrapper; keys: %v", keys(got))
+	}
 }
 
 func keys(m map[string]any) []string {

--- a/pkg/lib/lib_test.go
+++ b/pkg/lib/lib_test.go
@@ -106,7 +106,7 @@ func TestGeneratePlan_NilInputsEchoesDefaults(t *testing.T) {
 // include the default keys they didn't set, so a UI can use an empty
 // initial call to discover the full input shape.
 func TestGeneratePlan_PlanInputsEchoesOverridesAndDefaults(t *testing.T) {
-	inputs := []byte(`{"target_cloud":"azure"}`)
+	inputs := []byte("target_cloud: azure\n")
 	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
 	if err != nil {
 		t.Fatalf("GeneratePlan: %v", err)
@@ -138,23 +138,6 @@ func keys(m map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
-}
-
-// Plan-inputs as JSON: goccy/go-yaml accepts JSON (subset of YAML 1.2),
-// so HTTP callers can pass an incoming request body straight through
-// without a YAML dependency. Assertion targets PlanInputs (the resolved
-// echo) rather than markdown so it's independent of the renderer's
-// current surface area.
-func TestGeneratePlan_AcceptsJSONPlanInputs(t *testing.T) {
-	inputs := []byte(`{"target_cloud":"azure","headroom_fraction":0.4}`)
-	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
-	if err != nil {
-		t.Fatalf("GeneratePlan with JSON inputs: %v", err)
-	}
-	assertPlanInputsContains(t, res.PlanInputs, map[string]any{
-		"target_cloud":      "azure",
-		"headroom_fraction": 0.4,
-	})
 }
 
 func TestGeneratePlan_AcceptsYAMLPlanInputs(t *testing.T) {

--- a/pkg/lib/lib_test.go
+++ b/pkg/lib/lib_test.go
@@ -1,0 +1,107 @@
+package lib_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/pkg/lib"
+)
+
+// minimal but valid kcp-state.json with one MSK Provisioned cluster.
+// Kept tiny on purpose — the underlying processing/sizing/plan logic
+// has detailed coverage in internal/*; this suite asserts only that
+// the façade wires inputs to outputs and produces parseable JSON +
+// non-empty markdown.
+const sampleStateJSON = `{
+  "timestamp": "2026-05-01T00:00:00Z",
+  "kcp_build_info": {"version": "", "commit": "", "date": ""},
+  "msk_sources": {
+    "regions": [{
+      "name": "us-east-1",
+      "clusters": [{
+        "name": "demo-cluster",
+        "arn": "arn:aws:kafka:us-east-1:111:cluster/demo/uuid",
+        "region": "us-east-1"
+      }]
+    }]
+  }
+}`
+
+func TestScanSummary_RoundTripsValidJSON(t *testing.T) {
+	out, err := lib.ScanSummary([]byte(sampleStateJSON))
+	if err != nil {
+		t.Fatalf("ScanSummary: %v", err)
+	}
+	var processed map[string]any
+	if err := json.Unmarshal(out, &processed); err != nil {
+		t.Fatalf("ScanSummary returned invalid JSON: %v\nbody=%s", err, out)
+	}
+	if len(processed) == 0 {
+		t.Fatal("ScanSummary returned empty object")
+	}
+}
+
+func TestScanSummary_RejectsMalformedJSON(t *testing.T) {
+	if _, err := lib.ScanSummary([]byte("{not-json")); err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestGeneratePlan_ReturnsBothRenderings(t *testing.T) {
+	res, err := lib.GeneratePlan([]byte(sampleStateJSON), nil)
+	if err != nil {
+		t.Fatalf("GeneratePlan: %v", err)
+	}
+	if len(res.JSON) == 0 {
+		t.Fatal("GeneratePlan.JSON is empty")
+	}
+	if len(res.Markdown) == 0 {
+		t.Fatal("GeneratePlan.Markdown is empty")
+	}
+	var plan map[string]any
+	if err := json.Unmarshal(res.JSON, &plan); err != nil {
+		t.Fatalf("GeneratePlan.JSON is not valid JSON: %v", err)
+	}
+	if !strings.Contains(string(res.Markdown), "Migration Plan") {
+		t.Fatalf("GeneratePlan.Markdown missing expected header; got first 200 bytes: %s", truncate(res.Markdown, 200))
+	}
+}
+
+// Plan-inputs as JSON: goccy/go-yaml accepts JSON (subset of YAML 1.2),
+// so HTTP callers can pass an incoming request body straight through
+// without a YAML dependency.
+func TestGeneratePlan_AcceptsJSONPlanInputs(t *testing.T) {
+	inputs := []byte(`{"target_cloud":"azure","headroom_fraction":0.4}`)
+	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
+	if err != nil {
+		t.Fatalf("GeneratePlan with JSON inputs: %v", err)
+	}
+	if !strings.Contains(string(res.Markdown), "azure") {
+		t.Fatal("plan markdown should mention azure target_cloud from the JSON inputs")
+	}
+}
+
+func TestGeneratePlan_AcceptsYAMLPlanInputs(t *testing.T) {
+	inputs := []byte("target_cloud: azure\nheadroom_fraction: 0.4\n")
+	res, err := lib.GeneratePlan([]byte(sampleStateJSON), inputs)
+	if err != nil {
+		t.Fatalf("GeneratePlan with YAML inputs: %v", err)
+	}
+	if !strings.Contains(string(res.Markdown), "azure") {
+		t.Fatal("plan markdown should mention azure target_cloud from the YAML inputs")
+	}
+}
+
+func TestGeneratePlan_RejectsMalformedPlanInputs(t *testing.T) {
+	if _, err := lib.GeneratePlan([]byte(sampleStateJSON), []byte(":\n  - not")); err == nil {
+		t.Fatal("expected error for malformed plan-inputs")
+	}
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "..."
+}


### PR DESCRIPTION
Adds `pkg/lib` — a public façade so external Go modules can call kcp's state-processing and plan-generation programmatically without reaching into `internal/*`.

```go
func ScanSummary(stateJSON []byte) ([]byte, error)
func GeneratePlan(stateJSON, planInputsYAML []byte) (*PlanResult, error)

type PlanResult struct {
    JSON       []byte // same as `kcp report plan --output json`
    Markdown   []byte // same as `kcp report plan --output md`
    PlanInputs []byte // resolved plan-inputs (request merged with kcp defaults), as YAML
}
```

- **Bytes in, bytes out.** `stateJSON` must be JSON (`kcp-state.json` shape). `planInputsYAML` must be YAML (`plan-inputs.yaml` shape) — pass `nil` to use defaults.
- **YAML echo.** `PlanInputs` comes back in `plan-inputs.yaml` shape so a UI can pre-populate an editable form from an empty initial call.
- **Stateless, concurrent-safe.** Each call constructs its own services.

## Calling from a service

```go
res, err := lib.GeneratePlan(stateBytes, planInputsYAML)
// res.JSON, res.Markdown, res.PlanInputs are all []byte — pass through to the client.
```

## Test plan

- [x] `go test ./pkg/lib/...` — covers happy path, malformed input rejection, default-echo on nil input, YAML plan-inputs parsing, and `plan.inputs` ↔ `PlanInputs` consistency (including a regression guard that the resolved `Raw` wrapper never appears in the YAML echo).

Marked **experimental** in `doc.go`; pin a specific kcp version in your `go.mod` until `plan_schema_version` leaves `"1-experimental"`.