### PR TITLE
feat(plan): add cutover, client-auth, and schema-migration decisions to report plan

### DIFF
--- a/docs/assets/plan-inputs.example.yaml
+++ b/docs/assets/plan-inputs.example.yaml
@@ -3,11 +3,14 @@
 # All fields are optional. Pinned defaults live in plan-config.yaml
 # (embedded in the KCP binary). A missing field falls back to its default.
 #
-# MVP scope:
+# Field groups:
 #   - sizing knobs
 #   - customer-declared hard requirements that force Dedicated
 #   - existing VPC connectivity for the Dedicated networking path
 #   - networking triggers that flip the AWS-Enterprise default from PNI to PrivateLink
+#   - cutover approach + gateway prereqs
+#   - client auth migration (target auth, per-cluster overrides)
+#   - schema migration (strategy + CP/edition/reachability for Schema Linking)
 #
 # Usage:
 #   kcp report plan \
@@ -60,7 +63,7 @@
 # projected_pni_gateway_count: 1      # ≥2 → flip to PrivateLink
 
 # ---------------------------------------------------------------------------
-# Cutover approach (V1)
+# Cutover approach
 # ---------------------------------------------------------------------------
 # downtime_tolerance drives the cutover style. Pick the value that matches
 # your operational constraint; the Plan maps it 1:1 to a recommended style.
@@ -89,7 +92,7 @@
 # iam_pre_migration_status: not_started          # not_started | in_progress | complete
 
 # ---------------------------------------------------------------------------
-# Client auth migration (V1)
+# Client auth migration
 # ---------------------------------------------------------------------------
 # Target auth for ALL source auths detected on every cluster. Leave unset
 # to use the per-source default from the embedded auth_mapping table

--- a/docs/assets/plan-inputs.example.yaml
+++ b/docs/assets/plan-inputs.example.yaml
@@ -58,3 +58,43 @@
 #
 # cc_egress_required: false           # true → CC-side workloads need to push traffic back into customer VPCs (PNI doesn't natively support this)
 # projected_pni_gateway_count: 1      # ≥2 → flip to PrivateLink
+
+# ---------------------------------------------------------------------------
+# Cutover approach (V1)
+# ---------------------------------------------------------------------------
+# downtime_tolerance drives the cutover style. Pick the value that matches
+# your operational constraint; the Plan maps it 1:1 to a recommended style.
+#   zero                          → Blue/Green (parallel run via Cluster Linking)
+#   seconds_per_service           → Stop-Restart-Repeat — REQUIRES the CC Gateway
+#   minutes_per_service           → Stop-Restart-Repeat — gateway optional
+#   scheduled_window_sequential   → Stop-Wait-Restart (one window, services rolled in sequence)
+#   scheduled_window_all_at_once  → Restart-All-At-Once (one window, every client flips at once)
+#   let_confluent_choose          → Stop-Restart-Repeat (Confluent's recommended default)
+#
+# downtime_tolerance: let_confluent_choose
+# sub_pattern: app-by-app             # app-by-app (default) | topic-by-topic — only used with Stop-Restart-Repeat
+
+# CC Gateway opt-out. Default true follows Confluent's canonical
+# recommendation; set false to use plain Cluster Linking even when eligible.
+# prefer_gateway: true
+
+# Gateway prereq statuses. All three default to `not_started`. Move to
+# `in_progress` to declare intent, `complete` once the prereq is satisfied.
+# The Plan can recommend the canonical gateway-mediated path only when all
+# applicable prereqs are at `in_progress` or `complete` (the IAM prereq is
+# only consulted if IAM is detected on any source cluster).
+#
+# confluent_for_kubernetes_status: not_started   # not_started | in_progress | complete
+# cc_gateway_license_status: not_started         # not_started | in_progress | complete
+# iam_pre_migration_status: not_started          # not_started | in_progress | complete
+
+# ---------------------------------------------------------------------------
+# Client auth migration (V1)
+# ---------------------------------------------------------------------------
+# Target auth for ALL source auths detected on every cluster. Leave unset
+# to use the per-source default from the embedded auth_mapping table
+# (SCRAM → API Keys, IAM → API Keys, mTLS → mTLS, Unauth → API Keys).
+# Set when you want a single target enforced across every detected source
+# auth — e.g. consolidating onto OAuth.
+#
+# target_auth_method: ""              # "" (default; per-source mapping) | confluent_cloud_api_keys | mtls | oauth

--- a/docs/assets/plan.sample.json
+++ b/docs/assets/plan.sample.json
@@ -4,12 +4,11 @@
     "state_file_path": "sample-state.json",
     "kcp_version": "0.0.0-localdev",
     "generated_at": "2026-05-15T15:00:00Z",
+    "state_generated_at": "2026-05-15T15:00:00Z",
     "plan_schema_version": "1-experimental"
   },
   "inputs": {
-    "raw": {
-      "target_cloud": "azure"
-    },
+    "raw": {},
     "sla_target": "99.9",
     "sizing_percentile": "p95",
     "headroom_fraction": 0.3,
@@ -17,10 +16,17 @@
     "enforce_schemas_at_the_broker": false,
     "requires_high_throughput_rest_produce_api": false,
     "requires_99_95_sla_within_a_single_zone": false,
-    "target_cloud": "azure",
+    "target_cloud": "aws",
     "existing_vpc_connectivity": "privatelink_or_pni",
     "cc_egress_required": false,
-    "projected_pni_gateway_count": 1
+    "projected_pni_gateway_count": 1,
+    "downtime_tolerance": "let_confluent_choose",
+    "sub_pattern": "app-by-app",
+    "prefer_gateway": true,
+    "confluent_for_kubernetes_status": "not_started",
+    "cc_gateway_license_status": "not_started",
+    "iam_pre_migration_status": "not_started",
+    "target_auth_method": ""
   },
   "source_environment": {
     "clusters": [
@@ -28,25 +34,37 @@
         "cluster_id": "heavy-acls",
         "region": "us-east-1",
         "broker_count": 3,
-        "topic_count": 65
+        "topic_count": 65,
+        "source_auths": [
+          "scram"
+        ]
       },
       {
-        "cluster_id": "mtls-to-azure",
+        "cluster_id": "mtls-cluster",
         "region": "us-east-1",
         "broker_count": 3,
-        "topic_count": 38
+        "topic_count": 38,
+        "source_auths": [
+          "mtls"
+        ]
       },
       {
         "cluster_id": "small-orders",
         "region": "us-east-1",
         "broker_count": 3,
-        "topic_count": 42
+        "topic_count": 42,
+        "source_auths": [
+          "scram"
+        ]
       },
       {
         "cluster_id": "steady-events",
         "region": "us-east-1",
         "broker_count": 6,
-        "topic_count": 120
+        "topic_count": 120,
+        "source_auths": [
+          "scram"
+        ]
       }
     ],
     "total_regions": 1
@@ -98,7 +116,7 @@
       ]
     },
     {
-      "cluster_id": "mtls-to-azure",
+      "cluster_id": "mtls-cluster",
       "sized_in_mbps": 12,
       "sized_out_mbps": 18,
       "peak_in_mbps": 15,
@@ -121,23 +139,23 @@
       "spiky_egress": false,
       "citations": [
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.p95",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesInPerSec.p95",
           "value": 12582912
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.p95",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesOutPerSec.p95",
           "value": 18874368
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.max",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesInPerSec.max",
           "value": 15728640
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.max",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesOutPerSec.max",
           "value": 23068672
         },
         {
-          "path": "cluster[mtls-to-azure].kafka_admin_client_information.topics.summary.total_partitions",
+          "path": "cluster[mtls-cluster].kafka_admin_client_information.topics.summary.total_partitions",
           "value": 250
         }
       ]
@@ -281,22 +299,13 @@
           "row_id": "mtls_on_non_aws_target",
           "description": "Source uses mTLS, target is non-AWS",
           "outcome": "not_fired",
-          "evidence": "no mTLS source + target_cloud=\"azure\""
+          "evidence": "no mTLS source + target_cloud=\"aws\""
         }
       ]
     },
     {
-      "cluster_id": "mtls-to-azure",
-      "verdict": "Dedicated",
-      "triggers": [
-        {
-          "row_id": "mtls_on_non_aws_target",
-          "description": "Source uses mTLS, target is non-AWS",
-          "evidence": "mTLS source + target_cloud=\"azure\" (mTLS on non-AWS requires Dedicated)"
-        }
-      ],
-      "topology": "MultiZone",
-      "final_cku": 1,
+      "cluster_id": "mtls-cluster",
+      "verdict": "Enterprise",
       "evaluated_rules": [
         {
           "row_id": "eCKU_exceeds_pni_cap",
@@ -331,8 +340,8 @@
         {
           "row_id": "mtls_on_non_aws_target",
           "description": "Source uses mTLS, target is non-AWS",
-          "outcome": "fired",
-          "evidence": "mTLS source + target_cloud=\"azure\" (mTLS on non-AWS requires Dedicated)"
+          "outcome": "not_fired",
+          "evidence": "mTLS source + target_cloud=\"aws\" (AWS supports mTLS on Enterprise/Freight)"
         }
       ]
     },
@@ -374,7 +383,7 @@
           "row_id": "mtls_on_non_aws_target",
           "description": "Source uses mTLS, target is non-AWS",
           "outcome": "not_fired",
-          "evidence": "no mTLS source + target_cloud=\"azure\""
+          "evidence": "no mTLS source + target_cloud=\"aws\""
         }
       ]
     },
@@ -416,7 +425,7 @@
           "row_id": "mtls_on_non_aws_target",
           "description": "Source uses mTLS, target is non-AWS",
           "outcome": "not_fired",
-          "evidence": "no mTLS source + target_cloud=\"azure\""
+          "evidence": "no mTLS source + target_cloud=\"aws\""
         }
       ]
     }
@@ -424,31 +433,119 @@
   "networking_decision": [
     {
       "cluster_id": "heavy-acls",
-      "verdict": "PrivateLink",
+      "verdict": "PNI",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "target_cloud=\"azure\" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
+      "reason": "Dedicated AWS cluster — PNI required (TGW / VPC Peering are alternatives only when the customer's existing MSK topology already uses them; see `existing_vpc_connectivity` in plan-inputs.yaml)"
     },
     {
-      "cluster_id": "mtls-to-azure",
-      "verdict": "PrivateLink",
+      "cluster_id": "mtls-cluster",
+      "verdict": "PNI",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "target_cloud=\"azure\" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
+      "reason": "default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap)"
     },
     {
       "cluster_id": "small-orders",
-      "verdict": "PrivateLink",
+      "verdict": "PNI",
       "peak_burst_ecku": 1,
       "percentage_of_cap": 10,
-      "reason": "target_cloud=\"azure\" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
+      "reason": "default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap)"
     },
     {
       "cluster_id": "steady-events",
-      "verdict": "PrivateLink",
+      "verdict": "PNI",
       "peak_burst_ecku": 3,
       "percentage_of_cap": 30,
-      "reason": "target_cloud=\"azure\" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)"
+      "reason": "default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap)"
+    }
+  ],
+  "cutover": {
+    "style": "Stop-Restart-Repeat",
+    "sub_pattern": "app-by-app",
+    "gateway_mediated": "false",
+    "recommendation_status": "degraded_awaiting_oq",
+    "alternatives_shown_for_trust": [
+      "Stop-Wait-Restart",
+      "Restart-All-At-Once",
+      "Blue/Green"
+    ],
+    "prereqs": [
+      {
+        "description": "Confluent for Kubernetes (CFK) cluster",
+        "status": "blocked"
+      },
+      {
+        "description": "Confluent Cloud Gateway Add-On license",
+        "status": "blocked"
+      }
+    ]
+  },
+  "auth": [
+    {
+      "cluster_id": "heavy-acls",
+      "source_auths_detected": [
+        "scram"
+      ],
+      "target_mappings": [
+        {
+          "source_auth": "scram",
+          "effective_target": "confluent_cloud_api_keys",
+          "gateway_compatible": true,
+          "transparent_swap": true,
+          "source": "https://docs.confluent.io/cloud/current/security/authenticate/overview.html",
+          "last_verified": "2026-05-20"
+        }
+      ]
+    },
+    {
+      "cluster_id": "mtls-cluster",
+      "source_auths_detected": [
+        "mtls"
+      ],
+      "target_mappings": [
+        {
+          "source_auth": "mtls",
+          "effective_target": "mtls",
+          "gateway_compatible": true,
+          "transparent_swap": false,
+          "note": "Gateway terminates TLS and re-issues an ACM-PCA cert source-side (auth-swap mode).",
+          "source": "https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/mtls/configure.html",
+          "last_verified": "2026-05-20"
+        }
+      ]
+    },
+    {
+      "cluster_id": "small-orders",
+      "source_auths_detected": [
+        "scram"
+      ],
+      "target_mappings": [
+        {
+          "source_auth": "scram",
+          "effective_target": "confluent_cloud_api_keys",
+          "gateway_compatible": true,
+          "transparent_swap": true,
+          "source": "https://docs.confluent.io/cloud/current/security/authenticate/overview.html",
+          "last_verified": "2026-05-20"
+        }
+      ]
+    },
+    {
+      "cluster_id": "steady-events",
+      "source_auths_detected": [
+        "scram"
+      ],
+      "target_mappings": [
+        {
+          "source_auth": "scram",
+          "effective_target": "confluent_cloud_api_keys",
+          "gateway_compatible": true,
+          "transparent_swap": true,
+          "source": "https://docs.confluent.io/cloud/current/security/authenticate/overview.html",
+          "last_verified": "2026-05-20"
+        }
+      ]
     }
   ],
   "sizing_appendix": [
@@ -487,7 +584,7 @@
       ]
     },
     {
-      "cluster_id": "mtls-to-azure",
+      "cluster_id": "mtls-cluster",
       "formula": "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))",
       "intermediate_steps": [
         "ingress ratio = 12.00 MBps / 60 = 0.2000",
@@ -499,23 +596,23 @@
       ],
       "citations": [
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.p95",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesInPerSec.p95",
           "value": 12582912
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.p95",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesOutPerSec.p95",
           "value": 18874368
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesInPerSec.max",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesInPerSec.max",
           "value": 15728640
         },
         {
-          "path": "cluster[mtls-to-azure].metrics.aggregates.BytesOutPerSec.max",
+          "path": "cluster[mtls-cluster].metrics.aggregates.BytesOutPerSec.max",
           "value": 23068672
         },
         {
-          "path": "cluster[mtls-to-azure].kafka_admin_client_information.topics.summary.total_partitions",
+          "path": "cluster[mtls-cluster].kafka_admin_client_information.topics.summary.total_partitions",
           "value": 250
         }
       ]
@@ -587,6 +684,14 @@
           "value": 800
         }
       ]
+    }
+  ],
+  "open_questions": [
+    {
+      "id": "gateway_intent_unconfirmed",
+      "title": "Gateway intent — pick CC Gateway or plain Cluster Linking",
+      "body": "`prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open.",
+      "how_to_close": "In `plan-inputs.yaml`, either (a) set `prefer_gateway: false` to commit to plain Cluster Linking, OR (b) move at least one gateway prereq to `in_progress` to commit to the gateway path. Re-run `kcp report plan` to clear the OQ."
     }
   ]
 }

--- a/docs/assets/plan.sample.json
+++ b/docs/assets/plan.sample.json
@@ -8,7 +8,9 @@
     "plan_schema_version": "1-experimental"
   },
   "inputs": {
-    "raw": {},
+    "raw": {
+      "schema_strategy": "no_schemas"
+    },
     "sla_target": "99.9",
     "sizing_percentile": "p95",
     "headroom_fraction": 0.3,
@@ -26,7 +28,8 @@
     "confluent_for_kubernetes_status": "not_started",
     "cc_gateway_license_status": "not_started",
     "iam_pre_migration_status": "not_started",
-    "target_auth_method": ""
+    "target_auth_method": "",
+    "schema_strategy": "no_schemas"
   },
   "source_environment": {
     "clusters": [

--- a/docs/assets/plan.sample.md
+++ b/docs/assets/plan.sample.md
@@ -12,34 +12,92 @@ _Generated 2026-05-15 15:00:00 UTC by KCP 0.0.0-localdev from `sample-state.json
 - **Peak burst** — short-window peak throughput observed in metrics, expressed as eCKU. Surfaces in the spiky-workload note when peak diverges from P95 by more than the configured ratio.
 - **PNI** (Private Network Interface) — AWS-to-AWS private connectivity, up to 32 eCKU on Enterprise. The default for AWS Enterprise; **always required on Dedicated** (AWS).
 - **PrivateLink** — capped at 10 eCKU on Enterprise. Fires when `target_cloud != "aws"` (PNI is AWS-only), when `cc_egress_required: true` (PNI lacks native CC→customer egress), or when `projected_pni_gateway_count >= 2`. Also the cross-cloud private path on Dedicated when `target_cloud` is Azure / GCP.
-- **ACL cap (4000)** — Enterprise supports up to 4000 ACLs; exceeding the cap forces Dedicated. Source: cluster-types.html.
+- **ACL cap (4000)** — Enterprise supports up to 4000 ACLs; exceeding the cap forces Dedicated. Source: [https://docs.confluent.io/cloud/current/clusters/cluster-types.html](https://docs.confluent.io/cloud/current/clusters/cluster-types.html).
+
+<details><summary>Cutover-related terms (Stop-Restart-Repeat, Blue/Green, CC Gateway-mediated, etc.)</summary>
+
+- **Stop-Restart-Repeat** — phased per-service cutover. Each application (or topic) is stopped on MSK, mirrored to CC, and resumed at the CC endpoint, one at a time. Recoverable per step; longer elapsed time.
+- **Stop-Wait-Restart** — single coordinated maintenance window. Producers stop, the mirror catches up, services resume in sequence inside the window.
+- **Restart-All-At-Once** — single window where every client reconfigures and reconnects at the same instant. Largest blast radius; one rollback point for the whole fleet.
+- **Blue/Green** — parallel run on both sides via Cluster Linking. Zero downtime, highest operational complexity; customer-designed orchestration.
+- **CC Gateway-mediated** — a sidecar component that absorbs the cutover with a 30–90 s `BROKER_NOT_AVAILABLE` window per service, after which clients auto-retry against CC. Removes the per-service producer restart; requires Confluent for Kubernetes + a Gateway Add-On license.
+- **Plain Cluster Linking** — Cluster Linking without the CC Gateway; the simpler op model. Each service stops, mirror drains, restarts against the CC endpoint (minutes per service). Fully supported; chosen via `prefer_gateway: false`.
+
+</details>
 
 ## 1. Source Environment
 
 - **4** source clusters across **1** region · **15** brokers · **265** topics
 
-| Cluster | Region | Brokers | Topics |
-|---|---|---:|---:|
-| heavy-acls | us-east-1 | 3 | 65 |
-| mtls-to-azure | us-east-1 | 3 | 38 |
-| small-orders | us-east-1 | 3 | 42 |
-| steady-events | us-east-1 | 6 | 120 |
+| Cluster | Region | Brokers | Topics | Source auth |
+|---|---|---:|---:|---|
+| heavy-acls | us-east-1 | 3 | 65 | `scram` |
+| mtls-cluster | us-east-1 | 3 | 38 | `mtls` |
+| small-orders | us-east-1 | 3 | 42 | `scram` |
+| steady-events | us-east-1 | 6 | 120 | `scram` |
 
 ## 2. Sizing & Cluster Decisions
 
+This section combines three per-cluster decisions: the **sizing** (how many eCKU each cluster needs to absorb its workload at the chosen percentile + headroom), the **cluster type** (Enterprise, Dedicated, or Freight — driven by hard limits like ACL count and customer-declared flags), and the **networking** topology (PNI, PrivateLink, Transit Gateway, or VPC Peering — driven by `target_cloud`, egress requirements, and projected PNI gateway count). They render together because each row's verdict in one column constrains the others: e.g. a Dedicated cluster opens up PrivateLink networking patterns that Enterprise caps.
+
 | Cluster | P95 in / out (MBps) | Partitions | Final size | Cluster Type | Networking |
 |---|---|---:|---:|---|---|
-| heavy-acls | 15.0 / 25.0 | 300 | 1 CKU | Dedicated Multi-Zone (MZ) | PrivateLink |
-| mtls-to-azure | 12.0 / 18.0 | 250 | 1 CKU | Dedicated Multi-Zone (MZ) | PrivateLink |
-| small-orders | 10.0 / 20.0 | 200 | 1 eCKU | Enterprise | PrivateLink |
-| steady-events | 100.0 / 180.0 | 800 | 3 eCKU | Enterprise | PrivateLink |
+| heavy-acls | 15.0 / 25.0 | 300 | 1 CKU | Dedicated Multi-Zone (MZ) | PNI |
+| mtls-cluster | 12.0 / 18.0 | 250 | 1 eCKU | Enterprise | PNI |
+| small-orders | 10.0 / 20.0 | 200 | 1 eCKU | Enterprise | PNI |
+| steady-events | 100.0 / 180.0 | 800 | 3 eCKU | Enterprise | PNI |
 
 ### Why These Recommendations
 
-- **heavy-acls** — Cluster type **Dedicated Multi-Zone (MZ)** — ACL count exceeds Enterprise cap (4001 ACLs > Enterprise cap 4000). Networking **PrivateLink** — target_cloud="azure" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
-- **mtls-to-azure** — Cluster type **Dedicated Multi-Zone (MZ)** — Source uses mTLS, target is non-AWS (mTLS source + target_cloud="azure" (mTLS on non-AWS requires Dedicated)). Networking **PrivateLink** — target_cloud="azure" — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
-- **small-orders** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — target_cloud="azure" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
-- **steady-events** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PrivateLink** — target_cloud="azure" — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo).
+- **heavy-acls** — Cluster type **Dedicated Multi-Zone (MZ)** — ACL count exceeds Enterprise cap (4001 ACLs > Enterprise cap 4000). Networking **PNI** — Dedicated AWS cluster — PNI required (TGW / VPC Peering are alternatives only when the customer's existing MSK topology already uses them; see `existing_vpc_connectivity` in plan-inputs.yaml).
+  - ℹ **Cost direction:** Dedicated has a higher monthly cost than Enterprise. This verdict is state-derived (a hard-limit rule fired on the cluster as scanned), so the escalation isn't recoverable by editing `plan-inputs.yaml`. Confirm with your Confluent account team that the cluster's capacity reflects your actual workload before committing.
+- **mtls-cluster** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PNI** — default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap).
+- **small-orders** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PNI** — default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap).
+- **steady-events** — Cluster type **Enterprise** — no hard-limit rule fired. Networking **PNI** — default for AWS Enterprise (scales to 32 eCKU vs PrivateLink's 10-eCKU cap).
+
+## 3. Cutover Approach
+
+_The cutover style below applies to the **entire fleet**. Per-cluster cutover overrides aren't supported in this kcp version (planned for a follow-up). Heterogeneous fleets can run kcp against a state-file subset that contains only the clusters sharing a style — re-run for each subset and combine the recommendations manually._
+
+- **Style:** Stop-Restart-Repeat (app-by-app)
+- **Gateway mediation:** Plain Cluster Linking
+  - ℹ **Awaiting gateway intent** — no preference declared yet; the Plan uses plain Cluster Linking until you confirm. See **Actions Needed** for how to choose.
+- **Alternatives considered:**
+  - **Stop-Wait-Restart** — single coordinated window; needs the window to be long enough for re-mirroring + validation. Pick via `downtime_tolerance: scheduled_window_sequential`.
+  - **Restart-All-At-Once** — single window; every client reconfigures at the same instant. Highest blast radius. Pick via `downtime_tolerance: scheduled_window_all_at_once`.
+  - **Blue/Green** — parallel run via Cluster Linking; zero downtime, highest operational complexity. Pick via `downtime_tolerance: zero`.
+- **Prerequisites:**
+
+  | Prereq | Status |
+  |---|---|
+  | Confluent for Kubernetes (CFK) cluster | ⛔ not started |
+  | Confluent Cloud Gateway Add-On license | ⛔ not started |
+
+  _IAM pre-migration prereq omitted — no IAM source detected in this fleet._
+
+
+## 4. Client Auth Migration
+
+Per-cluster source→target mapping. Each source-auth method on every cluster maps to a recommended Confluent Cloud auth — the recommendation can be overridden globally via `target_auth_method` or per-cluster via `clusters[<name>].target_auth_method`. The **Works via CC Gateway** column describes whether this auth method *could* flow through the CC Gateway when the gateway path is in use — it's a property of the auth mapping, not a statement about which path §3 picked.
+
+| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway | Notes |
+|---|---|---|---|---|
+| heavy-acls | `scram` | `confluent_cloud_api_keys` | ✅ yes (transparent swap) | — |
+| mtls-cluster | `mtls` | `mtls` | ✅ yes (auth-swap mode) | Gateway terminates TLS and re-issues an ACM-PCA cert source-side (auth-swap mode). |
+| small-orders | `scram` | `confluent_cloud_api_keys` | ✅ yes (transparent swap) | — |
+| steady-events | `scram` | `confluent_cloud_api_keys` | ✅ yes (transparent swap) | — |
+
+_Mapping provenance:_
+- `mtls` mapping → https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/mtls/configure.html (last verified 2026-05-20)
+- `scram` mapping → https://docs.confluent.io/cloud/current/security/authenticate/overview.html (last verified 2026-05-20)
+
+## 5. Actions Needed
+
+Each item below is a concrete action that tightens the recommendation. The current recommendation stands; these close state-file gaps, fix invalid inputs, or resolve preference questions. **Severity prefix:** 🟢 preference (pick one).
+
+1. 🟢 **Gateway intent — pick CC Gateway or plain Cluster Linking**
+   - `prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open.
+   - _How to close:_ In `plan-inputs.yaml`, either (a) set `prefer_gateway: false` to commit to plain Cluster Linking, OR (b) move at least one gateway prereq to `in_progress` to commit to the gateway path. Re-run `kcp report plan` to clear the OQ.
 
 ## Appendix A1 — Sizing Math
 <details><summary>Show sizing math per cluster</summary>
@@ -51,7 +109,7 @@ Formula: `CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))
 | Cluster | Ingress ratio | Egress ratio | Partition ratio | Max (driver) | Sized | SLA floor | Final |
 |---|---:|---:|---:|---|---:|---:|---:|
 | heavy-acls | 0.2500 | 0.1389 | 0.1000 | **0.2500** (ingress) | 1 | 1 | 1 |
-| mtls-to-azure | 0.2000 | 0.1000 | 0.0833 | **0.2000** (ingress) | 1 | 1 | 1 |
+| mtls-cluster | 0.2000 | 0.1000 | 0.0833 | **0.2000** (ingress) | 1 | 1 | 1 |
 | small-orders | 0.1667 | 0.1111 | 0.0667 | **0.1667** (ingress) | 1 | 1 | 1 |
 | steady-events | 1.6667 | 1.0000 | 0.2667 | **1.6667** (ingress) | 3 | 1 | 3 |
 
@@ -64,7 +122,9 @@ Max-ratio is multiplied by `(1 + headroom)` and rounded up to get `Sized`. `Fina
 
 Every cluster runs the same hard-limit catalog; this table records each rule's outcome so a reviewer can confirm the verdict and see negative evidence (e.g. "47 ACLs ≤ 4000 cap"). `skipped` rows mean the rule couldn't be evaluated — the cluster's verdict resolves on the other rules.
 
-**heavy-acls**
+_Evidence below reflects the source state file as of 2026-05-15 15:00:00 UTC. Re-run `kcp discover` / `kcp scan ...` if the source environment has changed materially since._
+
+**Cluster** `heavy-acls`
 
 | Rule | Outcome | Detail |
 |---|---|---|
@@ -73,20 +133,9 @@ Every cluster runs the same hard-limit catalog; this table records each rule's o
 | `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
 | `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
 | `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
-| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="aws" |
 
-**mtls-to-azure**
-
-| Rule | Outcome | Detail |
-|---|---|---|
-| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 1 eCKU ≤ PNI cap 32 eCKU |
-| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `not_fired` | 0 ACLs ≤ Enterprise cap 4000 |
-| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
-| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
-| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
-| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `fired` | mTLS source + target_cloud="azure" (mTLS on non-AWS requires Dedicated) |
-
-**small-orders**
+**Cluster** `mtls-cluster`
 
 | Rule | Outcome | Detail |
 |---|---|---|
@@ -95,9 +144,20 @@ Every cluster runs the same hard-limit catalog; this table records each rule's o
 | `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
 | `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
 | `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
-| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | mTLS source + target_cloud="aws" (AWS supports mTLS on Enterprise/Freight) |
 
-**steady-events**
+**Cluster** `small-orders`
+
+| Rule | Outcome | Detail |
+|---|---|---|
+| `eCKU_exceeds_pni_cap` (Sized eCKU exceeds Enterprise PNI cap) | `not_fired` | sized 1 eCKU ≤ PNI cap 32 eCKU |
+| `acl_count_exceeds_cap` (ACL count exceeds Enterprise cap) | `not_fired` | 0 ACLs ≤ Enterprise cap 4000 |
+| `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
+| `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
+| `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="aws" |
+
+**Cluster** `steady-events`
 
 | Rule | Outcome | Detail |
 |---|---|---|
@@ -106,7 +166,7 @@ Every cluster runs the same hard-limit catalog; this table records each rule's o
 | `broker_side_schema_validation_required` (Broker-side schema ID validation required) | `not_fired` | `enforce_schemas_at_the_broker: false` |
 | `rest_produce_api_high_throughput` (High-throughput Kafka REST Produce v3 required) | `not_fired` | `requires_high_throughput_rest_produce_api: false` |
 | `sla_99_95_single_zone` (99.95% single-zone SLA required) | `not_fired` | `requires_99_95_sla_within_a_single_zone: false` |
-| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="azure" |
+| `mtls_on_non_aws_target` (Source uses mTLS, target is non-AWS) | `not_fired` | no mTLS source + target_cloud="aws" |
 
 </details>
 

--- a/internal/services/plan/auth.go
+++ b/internal/services/plan/auth.go
@@ -1,0 +1,82 @@
+package plan
+
+import (
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// Target auth method tokens. Customer-facing values written into
+// `plan-inputs.yaml` and rendered back in the AuthDecision JSON.
+const (
+	TargetAuthAPIKeys = "confluent_cloud_api_keys"
+	TargetAuthMTLS    = "mtls"
+	TargetAuthOAuth   = "oauth"
+)
+
+// knownTargetAuthMethod reports whether `t` is one of the recognised
+// enum values. Empty string counts as known (resolver leaves the
+// per-source default in place). Used by the OQ detector to surface
+// typos in `plan-inputs.yaml`.
+func knownTargetAuthMethod(t string) bool {
+	return knownEnum(t, TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth)
+}
+
+// DecideAuth produces the per-cluster source→target auth mapping.
+// Sources come from the MSK ClientAuthentication detection in
+// cluster_signals.go; per-source target defaults come from
+// `auth_mapping` in plan-config.yaml.
+//
+// The customer's `target_auth_method` override (global or per-cluster
+// via `clusters[name].target_auth_method`) replaces the default
+// target across all source rows for that cluster — the renderer
+// surfaces the source/target pair and a `Note` so the customer can
+// see the trade-off.
+func DecideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.AuthDecision {
+	sources := sourceAuthsDetected(c)
+	out := types.AuthDecision{
+		ClusterID:   c.Name,
+		SourceAuths: sources,
+	}
+	if len(sources) == 0 {
+		return out
+	}
+	override := inputs.TargetAuthMethod
+	for _, src := range sources {
+		mapping, ok := cfg.AuthMapping[src]
+		if !ok {
+			// Unknown source token (shouldn't happen given the closed enum
+			// in cluster_signals.go); emit a row with empty target rather
+			// than dropping it silently.
+			out.TargetMappings = append(out.TargetMappings, types.AuthMappingRow{SourceAuth: src})
+			continue
+		}
+		row := types.AuthMappingRow{
+			SourceAuth:        src,
+			EffectiveTarget:   effectiveTarget(mapping, override),
+			GatewayCompatible: mapping.GatewayCompatible,
+			TransparentSwap:   mapping.TransparentSwap,
+			Note:              mapping.Note,
+			Source:            mapping.Source,
+			LastVerified:      mapping.LastVerified,
+		}
+		out.TargetMappings = append(out.TargetMappings, row)
+	}
+	return out
+}
+
+// effectiveTarget returns the customer-overridden target when set
+// AND recognised. Empty string means the customer didn't explicitly
+// set `target_auth_method` — the per-source default applies. An
+// unknown enum value falls back to the per-source default too (the
+// target_auth_method_unknown OQ surfaces the typo separately); without
+// this guard the §4 Auth table would render the typo as the
+// "effective target" while the OQ says "per-source defaults applied"
+// — two surfaces disagreeing.
+func effectiveTarget(mapping AuthMapping, override string) string {
+	if !knownTargetAuthMethod(override) {
+		return mapping.Target
+	}
+	if override == "" {
+		return mapping.Target
+	}
+	return override
+}

--- a/internal/services/plan/auth_test.go
+++ b/internal/services/plan/auth_test.go
@@ -1,0 +1,87 @@
+package plan
+
+import (
+	"testing"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// authInputs builds a PlanInputsResolved with the default target_auth
+// unset — DecideAuth falls back to the per-source default from
+// auth_mapping. Tests that want an override-everywhere behavior set
+// inputs.TargetAuthMethod explicitly.
+func authInputs() types.PlanInputsResolved {
+	return types.PlanInputsResolved{}
+}
+
+func TestDecideAuth_NoSourceAuthsDetected(t *testing.T) {
+	c := types.ProcessedCluster{Name: "blank"}
+	d := DecideAuth(c, defaultCfg(t), authInputs())
+	assert.Equal(t, "blank", d.ClusterID)
+	assert.Empty(t, d.SourceAuths, "no auth flags enabled → empty SourceAuths")
+	assert.Empty(t, d.TargetMappings, "empty SourceAuths → no mapping rows")
+}
+
+func TestDecideAuth_SCRAMMapsToAPIKeysAndIsGatewayCompatible(t *testing.T) {
+	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
+	d := DecideAuth(c, defaultCfg(t), authInputs())
+	assert.Equal(t, []string{SourceAuthSCRAM}, d.SourceAuths)
+	require := requireRow(t, d, SourceAuthSCRAM)
+	assert.Equal(t, TargetAuthAPIKeys, require.EffectiveTarget)
+	assert.True(t, require.GatewayCompatible, "SCRAM is gateway-compatible (credential swap)")
+	assert.True(t, require.TransparentSwap, "SCRAM → API Keys is a transparent swap")
+}
+
+func TestDecideAuth_IAMTargetsAPIKeysButGatewayIncompatible(t *testing.T) {
+	c := withSourceAuth("iam-cluster", SourceAuthIAM)
+	d := DecideAuth(c, defaultCfg(t), authInputs())
+	row := requireRow(t, d, SourceAuthIAM)
+	assert.Equal(t, TargetAuthAPIKeys, row.EffectiveTarget)
+	assert.False(t, row.GatewayCompatible, "IAM clients cannot connect to the CC Gateway")
+}
+
+func TestDecideAuth_MTLSStaysMTLS(t *testing.T) {
+	c := withSourceAuth("mtls-cluster", SourceAuthMTLS)
+	d := DecideAuth(c, defaultCfg(t), authInputs())
+	row := requireRow(t, d, SourceAuthMTLS)
+	assert.Equal(t, TargetAuthMTLS, row.EffectiveTarget)
+	assert.True(t, row.GatewayCompatible, "mTLS gateway path uses auth-swap mode")
+	assert.False(t, row.TransparentSwap, "mTLS swap is not transparent — gateway re-issues certs")
+}
+
+// Customer override replaces the auth_mapping default. Verified end-to-end
+// through PlanService.Build's per-cluster resolution in
+// plan_service_test.go; here we exercise DecideAuth directly.
+func TestDecideAuth_TargetAuthMethodOverrideWins(t *testing.T) {
+	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
+	inputs := authInputs()
+	inputs.TargetAuthMethod = TargetAuthOAuth
+	d := DecideAuth(c, defaultCfg(t), inputs)
+	row := requireRow(t, d, SourceAuthSCRAM)
+	assert.Equal(t, TargetAuthOAuth, row.EffectiveTarget, "customer override must beat the auth_mapping default")
+}
+
+// Multiple source auths on one cluster (e.g. SCRAM + mTLS both on) is
+// a real MSK shape; the plan must surface ALL options rather than
+// picking one.
+func TestDecideAuth_MultipleSourceAuthsAllRendered(t *testing.T) {
+	c := withSourceAuth("multi-cluster", SourceAuthSCRAM)
+	enabled := true
+	c.AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication.Tls = &kafkatypes.Tls{Enabled: &enabled}
+	d := DecideAuth(c, defaultCfg(t), authInputs())
+	assert.Len(t, d.SourceAuths, 2, "both SCRAM and mTLS should appear")
+	assert.Len(t, d.TargetMappings, 2, "one row per source auth — plan never picks one")
+}
+
+func requireRow(t *testing.T, d types.AuthDecision, sourceAuth string) types.AuthMappingRow {
+	t.Helper()
+	for _, row := range d.TargetMappings {
+		if row.SourceAuth == sourceAuth {
+			return row
+		}
+	}
+	t.Fatalf("AuthDecision missing row for source auth %q; got: %+v", sourceAuth, d.TargetMappings)
+	return types.AuthMappingRow{}
+}

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -68,6 +68,121 @@ func brokerInventoryGap(c types.ProcessedCluster) bool {
 	return len(c.AWSClientInformation.Nodes) == 0
 }
 
+// knownEnum reports whether `value` is one of `valid` (empty value
+// always counts as known — it means "default applies"). Used by enum
+// validators across decisions (downtime_tolerance, target_auth_method)
+// to surface typos as OQs.
+func knownEnum(value string, valid ...string) bool {
+	if value == "" {
+		return true
+	}
+	for _, v := range valid {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Source-auth tokens. Stable strings — these appear in the rendered
+// Plan (AuthDecision.SourceAuths) and key the auth_mapping table in
+// plan-config.yaml. Don't rename without bumping a schema doc.
+const (
+	SourceAuthSCRAM  = "scram"
+	SourceAuthIAM    = "iam"
+	SourceAuthMTLS   = "mtls"
+	SourceAuthUnauth = "unauth"
+)
+
+// sourceAuthsDetected returns the set of auth methods enabled on the
+// source MSK cluster, as a deterministic insertion-order list (IAM,
+// SCRAM, mTLS, Unauth — never alphabetical). Reads pointers from the
+// AWS SDK Cluster struct; a nil pointer or false `Enabled` is treated
+// as "off". Serverless clusters expose a smaller ClientAuthentication
+// shape — handled in a separate branch.
+//
+// Fallback: when the MSK ClientAuthentication block is empty (partial
+// admin scan), consults `KafkaAdminClientInformation.SaslMechanism`
+// from the Kafka Admin probe — a last-resort signal so a discover-side
+// gap doesn't silently leave source auths empty.
+//
+// Multiple auths can be enabled simultaneously; the plan renders all
+// detected source auths and never picks one when more than one is on.
+func sourceAuthsDetected(c types.ProcessedCluster) []string {
+	if isServerless(c) {
+		return serverlessSourceAuths(c)
+	}
+	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
+	var out []string
+	if prov != nil && prov.ClientAuthentication != nil {
+		auth := prov.ClientAuthentication
+		if auth.Sasl != nil {
+			if auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled != nil && *auth.Sasl.Iam.Enabled {
+				out = append(out, SourceAuthIAM)
+			}
+			if auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled != nil && *auth.Sasl.Scram.Enabled {
+				out = append(out, SourceAuthSCRAM)
+			}
+		}
+		if auth.Tls != nil && auth.Tls.Enabled != nil && *auth.Tls.Enabled {
+			out = append(out, SourceAuthMTLS)
+		}
+		if auth.Unauthenticated != nil && auth.Unauthenticated.Enabled != nil && *auth.Unauthenticated.Enabled {
+			out = append(out, SourceAuthUnauth)
+		}
+	}
+	if len(out) == 0 {
+		if fallback := authFromSaslMechanism(c.KafkaAdminClientInformation.SaslMechanism); fallback != "" {
+			out = append(out, fallback)
+		}
+	}
+	return out
+}
+
+// authFromSaslMechanism maps the Kafka Admin probe's `sasl_mechanism`
+// field to a source-auth token. Used as a discover-gap fallback when
+// the MSK ClientAuthentication block is empty. Returns "" for
+// unrecognised mechanisms — the caller leaves SourceAuths empty so the
+// auth_posture_unknown OQ still fires.
+func authFromSaslMechanism(mech string) string {
+	switch types.NormalizeSaslMechanism(mech) {
+	case "SCRAM-SHA-256", "SCRAM-SHA-512":
+		return SourceAuthSCRAM
+	case "AWS_MSK_IAM":
+		return SourceAuthIAM
+	case "PLAIN":
+		return SourceAuthUnauth
+	default:
+		return ""
+	}
+}
+
+func serverlessSourceAuths(c types.ProcessedCluster) []string {
+	srv := c.AWSClientInformation.MskClusterConfig.Serverless
+	if srv == nil || srv.ClientAuthentication == nil || srv.ClientAuthentication.Sasl == nil {
+		return nil
+	}
+	if iam := srv.ClientAuthentication.Sasl.Iam; iam != nil && iam.Enabled != nil && *iam.Enabled {
+		return []string{SourceAuthIAM}
+	}
+	return nil
+}
+
+// fleetUsesIAM reports whether any cluster in the processed fleet has
+// IAM enabled on the source side. Drives gateway eligibility —
+// IAM clients cannot connect to the CC Gateway and must pre-migrate
+// to SCRAM or mTLS first.
+func fleetUsesIAM(clusters []types.ProcessedCluster) bool {
+	for _, c := range clusters {
+		for _, auth := range sourceAuthsDetected(c) {
+			if auth == SourceAuthIAM {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // inputsMissing names load-bearing scan signals that weren't available
 // when decisions were computed for this cluster. Returned as a stable,
 // ordered list of short identifiers so downstream consumers can branch
@@ -76,17 +191,16 @@ func brokerInventoryGap(c types.ProcessedCluster) bool {
 // blanket-deferring the cluster — a verdict driven by a customer-
 // declared flag is still valid even when scan signals are missing.
 // Serverless clusters are evaluated against a smaller signal set —
-// `acls` and `brokers` don't apply there. The `!isServerless(c)` guard
-// on the `acls` line is intentional: aclScanRan already returns false
-// for serverless, but the explicit guard suppresses the false-positive
-// in the surfaced list (we don't want to tell the customer "acls
-// missing" for a serverless cluster that never had them).
+// `acls` and `brokers` don't apply there, so the serverless check
+// inlines directly rather than going through aclScanRan (which
+// returns false for serverless AND for nil-on-provisioned, an
+// ambiguity the caller would have to re-disambiguate).
 func inputsMissing(c types.ProcessedCluster) []string {
 	var missing []string
 	if c.KafkaAdminClientInformation.Topics == nil {
 		missing = append(missing, "topics")
 	}
-	if !aclScanRan(c) && !isServerless(c) {
+	if !isServerless(c) && c.KafkaAdminClientInformation.Acls == nil {
 		missing = append(missing, "acls")
 	}
 	if brokerInventoryGap(c) {

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -77,6 +77,9 @@ var hardLimitCatalog = []hardLimit{
 				return skipped("acl_count_cap not configured")
 			}
 			if !aclScanRan(cluster) {
+				if isServerless(cluster) {
+					return skipped("MSK Serverless does not expose ACLs via the admin API path kcp scans; this rule is N/A for Serverless clusters")
+				}
 				return skipped("no ACL list in state file — scan likely didn't run or used `--skip-acls`; rule resolves on the other rules")
 			}
 			count := len(cluster.KafkaAdminClientInformation.Acls)

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -26,6 +26,7 @@ type PlanConfig struct {
 
 	EnterpriseCaps    EnterpriseCaps         `yaml:"enterprise_caps"`
 	ClusterLinking    ClusterLinking         `yaml:"cluster_linking"`
+	SchemaLinking     SchemaLinking          `yaml:"schema_linking"`
 	PlanInputDefaults PlanInputDefaults      `yaml:"plan_input_defaults"`
 	AuthMapping       map[string]AuthMapping `yaml:"auth_mapping"`
 	Thresholds        Thresholds             `yaml:"thresholds"`
@@ -104,6 +105,27 @@ type PlanInputDefaults struct {
 
 	// Auth defaults.
 	TargetAuthMethod string `yaml:"target_auth_method"`
+
+	// Schema-migration defaults. Defaults below resolve to
+	// `unknown` so first-run plans always ask the customer to declare
+	// strategy + reachability + CP version/edition rather than silently
+	// picking a path.
+	SchemaStrategy       string `yaml:"schema_strategy"`
+	ConfluentSRCPVersion string `yaml:"confluent_sr_cp_version,omitempty"`
+	ConfluentSRCPEdition string `yaml:"confluent_sr_cp_edition,omitempty"`
+}
+
+// SchemaLinking pins the version + edition floor that source Confluent
+// SR must clear for the Schema Linking path. Customers below these
+// floors get the `defer_to_account_team` verdict (REST API export /
+// import is technically possible but kcp doesn't drive it). The values
+// come from the [Schema Linking on CP docs](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html);
+// last-verified date below tracks when an engineer cross-checked them.
+type SchemaLinking struct {
+	MinCPVersion      string `yaml:"min_cp_version"`
+	RequiresCPEdition string `yaml:"requires_cp_edition"`
+	Source            string `yaml:"source"`
+	LastVerified      string `yaml:"last_verified"`
 }
 
 // LoadPlanConfig returns the embedded plan-config.yaml, optionally
@@ -162,6 +184,18 @@ func (c *PlanConfig) Validate() error {
 	}
 	if defaults.ProjectedPNIGatewayCount < 1 {
 		return fmt.Errorf("plan-config plan_input_defaults.projected_pni_gateway_count must be >= 1 (got %v)", defaults.ProjectedPNIGatewayCount)
+	}
+	if c.SchemaLinking.MinCPVersion == "" {
+		return fmt.Errorf("plan-config schema_linking.min_cp_version must be non-empty")
+	}
+	if c.SchemaLinking.RequiresCPEdition == "" {
+		return fmt.Errorf("plan-config schema_linking.requires_cp_edition must be non-empty")
+	}
+	if c.SchemaLinking.Source == "" {
+		return fmt.Errorf("plan-config schema_linking.source must be non-empty (provenance is mandatory)")
+	}
+	if c.SchemaLinking.LastVerified == "" {
+		return fmt.Errorf("plan-config schema_linking.last_verified must be non-empty (provenance is mandatory)")
 	}
 	if c.Thresholds.StaleStateDays < 1 {
 		return fmt.Errorf("plan-config thresholds.stale_state_days must be >= 1 (got %v)", c.Thresholds.StaleStateDays)

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -24,9 +24,39 @@ type PlanConfig struct {
 	LastVerified             string `yaml:"last_verified"`
 	KCPVersionAtVerification string `yaml:"kcp_version_at_verification"`
 
-	EnterpriseCaps    EnterpriseCaps    `yaml:"enterprise_caps"`
-	ClusterLinking    ClusterLinking    `yaml:"cluster_linking"`
-	PlanInputDefaults PlanInputDefaults `yaml:"plan_input_defaults"`
+	EnterpriseCaps    EnterpriseCaps         `yaml:"enterprise_caps"`
+	ClusterLinking    ClusterLinking         `yaml:"cluster_linking"`
+	PlanInputDefaults PlanInputDefaults      `yaml:"plan_input_defaults"`
+	AuthMapping       map[string]AuthMapping `yaml:"auth_mapping"`
+	Thresholds        Thresholds             `yaml:"thresholds"`
+}
+
+// Thresholds collects numeric cutoffs that the rule engine and the
+// renderer need but that aren't customer-facing knobs — pulled out
+// so an admin can tune them without code edits if a tenant has a
+// genuinely different operating envelope.
+type Thresholds struct {
+	// StaleStateDays — emit the state-file-stale OQ when the state
+	// snapshot is older than this many days.
+	StaleStateDays int `yaml:"stale_state_days"`
+	// PNIGatewayBreakeven — projected PNI gateway count at or above
+	// which the recommendation flips from PNI to PrivateLink.
+	PNIGatewayBreakeven int `yaml:"pni_gateway_breakeven"`
+}
+
+// AuthMapping is one row in the source→target auth lookup table
+// keyed by source-auth token (scram / iam / mtls / unauth). Defaults
+// resolve via this table when the customer doesn't override via
+// `target_auth_method`. Source + LastVerified carry the row's
+// provenance (which Confluent doc the values come from, and when an
+// engineer last checked it).
+type AuthMapping struct {
+	Target            string `yaml:"target"`
+	GatewayCompatible bool   `yaml:"gateway_compatible"`
+	TransparentSwap   bool   `yaml:"transparent_swap"`
+	Note              string `yaml:"note"`
+	Source            string `yaml:"source"`
+	LastVerified      string `yaml:"last_verified"`
 }
 
 type EnterpriseCaps struct {
@@ -63,6 +93,17 @@ type PlanInputDefaults struct {
 	// Networking triggers (PNI→PrivateLink) — see PlanInputsResolved.
 	CCEgressRequired         bool `yaml:"cc_egress_required"`
 	ProjectedPNIGatewayCount int  `yaml:"projected_pni_gateway_count"`
+
+	// Cutover defaults.
+	DowntimeTolerance            string `yaml:"downtime_tolerance"`
+	SubPattern                   string `yaml:"sub_pattern"`
+	PreferGateway                bool   `yaml:"prefer_gateway"`
+	ConfluentForKubernetesStatus string `yaml:"confluent_for_kubernetes_status"`
+	CCGatewayLicenseStatus       string `yaml:"cc_gateway_license_status"`
+	IAMPreMigrationStatus        string `yaml:"iam_pre_migration_status"`
+
+	// Auth defaults.
+	TargetAuthMethod string `yaml:"target_auth_method"`
 }
 
 // LoadPlanConfig returns the embedded plan-config.yaml, optionally
@@ -121,6 +162,32 @@ func (c *PlanConfig) Validate() error {
 	}
 	if defaults.ProjectedPNIGatewayCount < 1 {
 		return fmt.Errorf("plan-config plan_input_defaults.projected_pni_gateway_count must be >= 1 (got %v)", defaults.ProjectedPNIGatewayCount)
+	}
+	if c.Thresholds.StaleStateDays < 1 {
+		return fmt.Errorf("plan-config thresholds.stale_state_days must be >= 1 (got %v)", c.Thresholds.StaleStateDays)
+	}
+	if c.Thresholds.PNIGatewayBreakeven < 1 {
+		return fmt.Errorf("plan-config thresholds.pni_gateway_breakeven must be >= 1 (got %v)", c.Thresholds.PNIGatewayBreakeven)
+	}
+	// Every auth_mapping entry MUST carry Target + provenance (Source +
+	// LastVerified). The fields exist so the rendered Plan can audit
+	// where each recommendation came from — a silently-empty mapping
+	// row would propagate as a blank Plan footnote.
+	requiredSources := []string{"scram", "iam", "mtls", "unauth"}
+	for _, s := range requiredSources {
+		row, ok := c.AuthMapping[s]
+		if !ok {
+			return fmt.Errorf("plan-config auth_mapping is missing required entry %q", s)
+		}
+		if row.Target == "" {
+			return fmt.Errorf("plan-config auth_mapping[%s].target must be non-empty", s)
+		}
+		if row.Source == "" {
+			return fmt.Errorf("plan-config auth_mapping[%s].source must be non-empty (provenance is mandatory)", s)
+		}
+		if row.LastVerified == "" {
+			return fmt.Errorf("plan-config auth_mapping[%s].last_verified must be non-empty (provenance is mandatory)", s)
+		}
 	}
 	return nil
 }

--- a/internal/services/plan/cutover.go
+++ b/internal/services/plan/cutover.go
@@ -58,7 +58,7 @@ func DecideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsRes
 
 	iamInUse := fleetUsesIAM(clusters)
 	eligible := gatewayEligible(inputs, iamInUse)
-	ambiguous := ambiguousGatewayIntent(inputs)
+	ambiguous := ambiguousGatewayIntent(inputs, iamInUse)
 
 	var mediated types.GatewayMediated
 	var status types.RecommendationStatus
@@ -175,16 +175,26 @@ func prereqAdvanced(status string) bool {
 
 // ambiguousGatewayIntent reports whether the customer hasn't expressed
 // any preference about the gateway — `prefer_gateway: true` (default)
-// AND all three prereqs at `not_started`. Distinguishes "I deliberately
-// want plain CL" (`prefer_gateway: false`) from "I haven't thought
-// about the gateway yet".
-func ambiguousGatewayIntent(inputs types.PlanInputsResolved) bool {
+// AND every *applicable* prereq is at `not_started`. The IAM prereq
+// only counts when the fleet actually uses IAM, mirroring
+// gatewayEligible — otherwise a non-IAM fleet that accidentally sets
+// `iam_pre_migration_status: in_progress` would flip the status from
+// `degraded_awaiting_oq` to `degraded_prereqs_pending` even though the
+// IAM prereq doesn't apply to this fleet.
+func ambiguousGatewayIntent(inputs types.PlanInputsResolved, iamInUse bool) bool {
 	if !inputs.PreferGateway {
 		return false
 	}
-	return inputs.ConfluentForKubernetesStatus == PrereqNotStarted &&
-		inputs.CCGatewayLicenseStatus == PrereqNotStarted &&
-		inputs.IAMPreMigrationStatus == PrereqNotStarted
+	if inputs.ConfluentForKubernetesStatus != PrereqNotStarted {
+		return false
+	}
+	if inputs.CCGatewayLicenseStatus != PrereqNotStarted {
+		return false
+	}
+	if iamInUse && inputs.IAMPreMigrationStatus != PrereqNotStarted {
+		return false
+	}
+	return true
 }
 
 // alternativesShown returns the cutover styles that the renderer

--- a/internal/services/plan/cutover.go
+++ b/internal/services/plan/cutover.go
@@ -1,0 +1,244 @@
+package plan
+
+import (
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// downtime_tolerance enum values. Stable identifiers — used as YAML
+// input tokens AND as keys in the style mapping.
+const (
+	DowntimeZero                      = "zero"
+	DowntimeSecondsPerService         = "seconds_per_service"
+	DowntimeMinutesPerService         = "minutes_per_service"
+	DowntimeScheduledWindowSequential = "scheduled_window_sequential"
+	DowntimeScheduledWindowAllAtOnce  = "scheduled_window_all_at_once"
+	DowntimeLetConfluentChoose        = "let_confluent_choose"
+	DowntimeUnsetFallback             = DowntimeLetConfluentChoose
+)
+
+// Gateway prereq status enum values.
+const (
+	PrereqNotStarted            = "not_started"
+	PrereqStatusInProgressInput = "in_progress"
+	PrereqStatusCompleteInput   = "complete"
+)
+
+// DecideCutover produces the fleet-wide cutover decision.
+// Reads:
+//   - inputs.DowntimeTolerance → CutoverStyle (1:1 mapping)
+//   - gateway eligibility (3 prereqs + fleet-wide IAM cross-reference)
+//   - inputs.PreferGateway opt-out
+//
+// Emits CutoverDecision with all four recommendation_status branches
+// modelled. Open Questions are emitted separately by the caller; this
+// function only produces the decision, not the OQs.
+//
+// **Input contract:** `inputs` MUST come from `ResolvePlanInputs` (or
+// `applyClusterOverride` on top of it). The function reads
+// `PreferGateway` as a bool, so a Go zero-value `PlanInputsResolved{}`
+// would silently land on the customer-choice / plain-CL branch —
+// distinct from "the customer set `prefer_gateway: false`" but
+// indistinguishable at this layer. Callers from tests should construct
+// inputs via the resolver, not by struct literal.
+func DecideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.CutoverDecision {
+	style, sub := resolveStyle(inputs)
+
+	// Blue/Green sidesteps the gateway question entirely — the gateway
+	// doesn't sit on a parallel-run cutover step.
+	if style == types.CutoverBlueGreen {
+		return types.CutoverDecision{
+			Style:                style,
+			SubPattern:           sub,
+			GatewayMediated:      types.GatewayMediatedNotApplicable,
+			RecommendationStatus: types.RecommendationCustomerChoice,
+			AlternativesShown:    alternativesShown(style),
+			Prereqs:              prereqsForStyle(style, inputs, fleetUsesIAM(clusters)),
+		}
+	}
+
+	iamInUse := fleetUsesIAM(clusters)
+	eligible := gatewayEligible(inputs, iamInUse)
+	ambiguous := ambiguousGatewayIntent(inputs)
+
+	var mediated types.GatewayMediated
+	var status types.RecommendationStatus
+	switch {
+	case !inputs.PreferGateway:
+		mediated = types.GatewayMediatedFalse
+		status = types.RecommendationCustomerChoice
+	case eligible:
+		mediated = types.GatewayMediatedTrue
+		status = types.RecommendationCanonical
+	case ambiguous:
+		mediated = types.GatewayMediatedFalse
+		status = types.RecommendationDegradedAwaitingOQ
+	default:
+		// `prefer_gateway: true` but at least one prereq is still
+		// `not_started`. Customer has engaged but not finished.
+		mediated = types.GatewayMediatedFalse
+		status = types.RecommendationDegradedPrereqsPending
+	}
+
+	// Suppress the gateway prereq table when the customer opted out of
+	// the gateway — those prereqs aren't needed for plain Cluster
+	// Linking, so showing "not started" against them is misleading.
+	var prereqs []types.Prereq
+	if mediated != types.GatewayMediatedFalse || status != types.RecommendationCustomerChoice {
+		prereqs = prereqsForStyle(style, inputs, iamInUse)
+	}
+	return types.CutoverDecision{
+		Style:                style,
+		SubPattern:           sub,
+		GatewayMediated:      mediated,
+		RecommendationStatus: status,
+		AlternativesShown:    alternativesShown(style),
+		Prereqs:              prereqs,
+	}
+}
+
+// resolveStyle maps downtime_tolerance to a CutoverStyle plus optional
+// sub-pattern. sub-pattern is only populated when style is
+// Stop-Restart-Repeat; for everything else it's empty.
+func resolveStyle(inputs types.PlanInputsResolved) (types.CutoverStyle, types.CutoverSubPattern) {
+	tolerance := inputs.DowntimeTolerance
+	if tolerance == "" {
+		tolerance = DowntimeUnsetFallback
+	}
+	var style types.CutoverStyle
+	switch tolerance {
+	case DowntimeZero:
+		style = types.CutoverBlueGreen
+	case DowntimeSecondsPerService, DowntimeMinutesPerService, DowntimeLetConfluentChoose:
+		style = types.CutoverStopRestartRepeat
+	case DowntimeScheduledWindowSequential:
+		style = types.CutoverStopWaitRestart
+	case DowntimeScheduledWindowAllAtOnce:
+		style = types.CutoverRestartAllAtOnce
+	default:
+		// Unknown value: degrade to the Confluent default rather than
+		// erroring. `detectCutoverOpenQuestions` surfaces an OQ
+		// (`downtime_tolerance_unknown`) so the customer sees the
+		// typo / unrecognised value rather than silently inheriting
+		// the default.
+		style = types.CutoverStopRestartRepeat
+	}
+
+	var sub types.CutoverSubPattern
+	if style == types.CutoverStopRestartRepeat {
+		switch inputs.SubPattern {
+		case string(types.SubPatternTopicByTopic):
+			sub = types.SubPatternTopicByTopic
+		default:
+			sub = types.SubPatternAppByApp
+		}
+	}
+	return style, sub
+}
+
+// knownDowntimeTolerance reports whether `tolerance` is one of the
+// recognised enum values. Empty string counts as known (resolves to
+// the default). Used by the OQ detector to surface typos rather than
+// silently mapping unknown values to Stop-Restart-Repeat.
+func knownDowntimeTolerance(tolerance string) bool {
+	return knownEnum(tolerance,
+		DowntimeZero,
+		DowntimeSecondsPerService,
+		DowntimeMinutesPerService,
+		DowntimeScheduledWindowSequential,
+		DowntimeScheduledWindowAllAtOnce,
+		DowntimeLetConfluentChoose,
+	)
+}
+
+// gatewayEligible reports whether all gateway prereqs are at
+// `in_progress` or `complete`. IAM prereq only counts when the fleet
+// actually has IAM enabled (otherwise the IAM-pre-migration constraint
+// is vacuous — there's nothing to pre-migrate).
+func gatewayEligible(inputs types.PlanInputsResolved, iamInUse bool) bool {
+	if !prereqAdvanced(inputs.ConfluentForKubernetesStatus) {
+		return false
+	}
+	if !prereqAdvanced(inputs.CCGatewayLicenseStatus) {
+		return false
+	}
+	if iamInUse && !prereqAdvanced(inputs.IAMPreMigrationStatus) {
+		return false
+	}
+	return true
+}
+
+// prereqAdvanced returns true for `in_progress` or `complete`.
+// `not_started` (or anything unrecognised) returns false.
+func prereqAdvanced(status string) bool {
+	return status == PrereqStatusInProgressInput || status == PrereqStatusCompleteInput
+}
+
+// ambiguousGatewayIntent reports whether the customer hasn't expressed
+// any preference about the gateway — `prefer_gateway: true` (default)
+// AND all three prereqs at `not_started`. Distinguishes "I deliberately
+// want plain CL" (`prefer_gateway: false`) from "I haven't thought
+// about the gateway yet".
+func ambiguousGatewayIntent(inputs types.PlanInputsResolved) bool {
+	if !inputs.PreferGateway {
+		return false
+	}
+	return inputs.ConfluentForKubernetesStatus == PrereqNotStarted &&
+		inputs.CCGatewayLicenseStatus == PrereqNotStarted &&
+		inputs.IAMPreMigrationStatus == PrereqNotStarted
+}
+
+// alternativesShown returns the cutover styles that the renderer
+// should explain for trust ("we considered these and didn't pick
+// them") — every style EXCEPT the recommended one.
+func alternativesShown(recommended types.CutoverStyle) []types.CutoverStyle {
+	all := []types.CutoverStyle{
+		types.CutoverStopRestartRepeat,
+		types.CutoverStopWaitRestart,
+		types.CutoverRestartAllAtOnce,
+		types.CutoverBlueGreen,
+	}
+	var out []types.CutoverStyle
+	for _, s := range all {
+		if s != recommended {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// prereqsForStyle renders the Prerequisites table rows. The Cluster
+// Linking floor (`source_min_kafka_version: 2.4.0`) and Express tier
+// compatibility are state-derived prereqs surfaced by the renderer
+// based on plan-config; this function only emits the customer-driven
+// gateway prereqs. Blue/Green has no kcp-emitted prereqs.
+func prereqsForStyle(style types.CutoverStyle, inputs types.PlanInputsResolved, iamInUse bool) []types.Prereq {
+	if style == types.CutoverBlueGreen {
+		return nil
+	}
+	out := []types.Prereq{
+		{Description: "Confluent for Kubernetes (CFK) cluster", Status: prereqStatusFromInput(inputs.ConfluentForKubernetesStatus)},
+		{Description: "Confluent Cloud Gateway Add-On license", Status: prereqStatusFromInput(inputs.CCGatewayLicenseStatus)},
+	}
+	if iamInUse {
+		out = append(out, types.Prereq{
+			Description: "IAM clients pre-migrated to SCRAM / mTLS",
+			Status:      prereqStatusFromInput(inputs.IAMPreMigrationStatus),
+		})
+	}
+	return out
+}
+
+// prereqStatusFromInput maps plan-input status tokens to the rendered
+// PrereqStatus enum. Unknown values fall through to `unconfirmed`.
+func prereqStatusFromInput(status string) types.PrereqStatus {
+	switch status {
+	case PrereqStatusCompleteInput:
+		return types.PrereqMet
+	case PrereqStatusInProgressInput:
+		return types.PrereqInProgress
+	case PrereqNotStarted:
+		return types.PrereqBlocked
+	default:
+		return types.PrereqUnconfirmed
+	}
+}

--- a/internal/services/plan/cutover_test.go
+++ b/internal/services/plan/cutover_test.go
@@ -1,0 +1,257 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// styleInputs returns a base PlanInputsResolved with the given
+// downtime_tolerance plus sensible defaults (eligible gateway, no IAM).
+// Each test layers its own modifications on top.
+func styleInputs(tolerance string) types.PlanInputsResolved {
+	return types.PlanInputsResolved{
+		DowntimeTolerance:            tolerance,
+		SubPattern:                   string(types.SubPatternAppByApp),
+		PreferGateway:                true,
+		ConfluentForKubernetesStatus: PrereqStatusCompleteInput,
+		CCGatewayLicenseStatus:       PrereqStatusCompleteInput,
+		IAMPreMigrationStatus:        PrereqNotStarted, // irrelevant when no IAM in fleet
+	}
+}
+
+func TestDecideCutover_StyleMapping(t *testing.T) {
+	cases := []struct {
+		tolerance string
+		want      types.CutoverStyle
+	}{
+		{DowntimeZero, types.CutoverBlueGreen},
+		{DowntimeSecondsPerService, types.CutoverStopRestartRepeat},
+		{DowntimeMinutesPerService, types.CutoverStopRestartRepeat},
+		{DowntimeScheduledWindowSequential, types.CutoverStopWaitRestart},
+		{DowntimeScheduledWindowAllAtOnce, types.CutoverRestartAllAtOnce},
+		{DowntimeLetConfluentChoose, types.CutoverStopRestartRepeat},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tolerance, func(t *testing.T) {
+			d := DecideCutover(nil, styleInputs(tc.tolerance))
+			assert.Equal(t, tc.want, d.Style)
+		})
+	}
+}
+
+func TestDecideCutover_SubPatternOnlyForSRR(t *testing.T) {
+	srr := styleInputs(DowntimeMinutesPerService)
+	srr.SubPattern = string(types.SubPatternTopicByTopic)
+	d := DecideCutover(nil, srr)
+	assert.Equal(t, types.SubPatternTopicByTopic, d.SubPattern, "SRR should carry the sub-pattern")
+
+	bg := styleInputs(DowntimeZero)
+	bg.SubPattern = string(types.SubPatternTopicByTopic)
+	d = DecideCutover(nil, bg)
+	assert.Empty(t, d.SubPattern, "non-SRR styles must not surface a sub-pattern")
+}
+
+func TestDecideCutover_Canonical(t *testing.T) {
+	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus)
+	assert.Equal(t, types.GatewayMediatedTrue, d.GatewayMediated)
+}
+
+func TestDecideCutover_CustomerChoiceOptOut(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.PreferGateway = false
+	d := DecideCutover(nil, inputs)
+	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
+	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+}
+
+func TestDecideCutover_BlueGreenIsCustomerChoice(t *testing.T) {
+	d := DecideCutover(nil, styleInputs(DowntimeZero))
+	assert.Equal(t, types.CutoverBlueGreen, d.Style)
+	assert.Equal(t, types.GatewayMediatedNotApplicable, d.GatewayMediated)
+	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
+}
+
+// Ambiguous = prefer_gateway default true + all three prereqs at
+// not_started. Customer hasn't engaged with the gateway question.
+func TestDecideCutover_DegradedAwaitingOQ(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
+	inputs.CCGatewayLicenseStatus = PrereqNotStarted
+	inputs.IAMPreMigrationStatus = PrereqNotStarted
+	d := DecideCutover(nil, inputs)
+	assert.Equal(t, types.RecommendationDegradedAwaitingOQ, d.RecommendationStatus)
+	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+}
+
+// Pending = prefer_gateway true + at least one prereq advanced but
+// at least one still at not_started.
+func TestDecideCutover_DegradedPrereqsPending(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.ConfluentForKubernetesStatus = PrereqStatusInProgressInput
+	inputs.CCGatewayLicenseStatus = PrereqNotStarted
+	d := DecideCutover(nil, inputs)
+	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus)
+	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+}
+
+// IAM prereq is only consulted when the fleet actually has IAM enabled.
+func TestDecideCutover_IAMPrereqOnlyMattersWhenIAMInFleet(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	// IAM prereq at not_started; the other two complete.
+	inputs.IAMPreMigrationStatus = PrereqNotStarted
+
+	// Without IAM in the fleet, still eligible / canonical.
+	d := DecideCutover([]types.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
+	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus, "no IAM in fleet → IAM prereq irrelevant")
+
+	// With IAM in the fleet, the IAM-not-started prereq now blocks eligibility.
+	d = DecideCutover([]types.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
+	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus, "IAM in fleet → IAM prereq required")
+}
+
+func TestDecideCutover_AlternativesShown(t *testing.T) {
+	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	assert.Equal(t, types.CutoverStopRestartRepeat, d.Style)
+	assert.Len(t, d.AlternativesShown, 3, "alternatives = all styles except the recommended one")
+	assert.NotContains(t, d.AlternativesShown, types.CutoverStopRestartRepeat)
+	assert.Contains(t, d.AlternativesShown, types.CutoverBlueGreen)
+}
+
+// IAM prereq row only appears in the rendered prereq table when IAM is
+// in the fleet — otherwise it's irrelevant noise.
+func TestDecideCutover_IAMPrereqRowOnlyWhenIAMInFleet(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+
+	noIAM := DecideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthSCRAM)}, inputs)
+	for _, p := range noIAM.Prereqs {
+		assert.False(t, strings.Contains(p.Description, "IAM"), "IAM prereq must NOT appear when fleet has no IAM")
+	}
+
+	iam := DecideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthIAM)}, inputs)
+	var sawIAM bool
+	for _, p := range iam.Prereqs {
+		if strings.Contains(p.Description, "IAM") {
+			sawIAM = true
+		}
+	}
+	assert.True(t, sawIAM, "IAM prereq row must appear when fleet has IAM")
+}
+
+// withSourceAuth returns a minimal ProcessedCluster with the named
+// source auth enabled on the AWS-side ClientAuthentication. Used to
+// drive fleetUsesIAM() through DecideCutover.
+func withSourceAuth(name, auth string) types.ProcessedCluster {
+	c := types.ProcessedCluster{Name: name}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+	enabled := true
+	clientAuth := &kafkatypes.ClientAuthentication{}
+	switch auth {
+	case SourceAuthIAM:
+		clientAuth.Sasl = &kafkatypes.Sasl{Iam: &kafkatypes.Iam{Enabled: &enabled}}
+	case SourceAuthSCRAM:
+		clientAuth.Sasl = &kafkatypes.Sasl{Scram: &kafkatypes.Scram{Enabled: &enabled}}
+	case SourceAuthMTLS:
+		clientAuth.Tls = &kafkatypes.Tls{Enabled: &enabled}
+	case SourceAuthUnauth:
+		clientAuth.Unauthenticated = &kafkatypes.Unauthenticated{Enabled: &enabled}
+	}
+	c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{ClientAuthentication: clientAuth}
+	return c
+}
+
+// ----- detectCutoverOpenQuestions -----
+
+// hasOQ returns whether any OQ matches the given ID.
+func hasOQ(oqs []types.OpenQuestion, id string) bool {
+	for _, oq := range oqs {
+		if oq.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDetectCutoverOpenQuestions_AmbiguousIntent(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
+	inputs.CCGatewayLicenseStatus = PrereqNotStarted
+	inputs.IAMPreMigrationStatus = PrereqNotStarted
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.True(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
+	assert.False(t, hasOQ(oqs, "gateway_prereqs_pending"))
+}
+
+func TestDetectCutoverOpenQuestions_PrereqsPending(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.ConfluentForKubernetesStatus = PrereqStatusInProgressInput
+	inputs.CCGatewayLicenseStatus = PrereqNotStarted
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.True(t, hasOQ(oqs, "gateway_prereqs_pending"))
+	assert.False(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
+}
+
+// seconds_per_service + prefer_gateway:false → cross-check OQ fires
+// with the "prefer_gateway: false" message.
+func TestDetectCutoverOpenQuestions_SecondsPerServiceOptOut(t *testing.T) {
+	inputs := styleInputs(DowntimeSecondsPerService)
+	inputs.PreferGateway = false
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.True(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
+}
+
+// seconds_per_service + ambiguous intent → cross-check OQ fires AND
+// gateway_intent_unconfirmed also fires (separate concerns).
+func TestDetectCutoverOpenQuestions_SecondsPerServiceAmbiguous(t *testing.T) {
+	inputs := styleInputs(DowntimeSecondsPerService)
+	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
+	inputs.CCGatewayLicenseStatus = PrereqNotStarted
+	inputs.IAMPreMigrationStatus = PrereqNotStarted
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.True(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
+	assert.True(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
+}
+
+// Blue/Green sidesteps the gateway question entirely; seconds_per_service
+// can't combine with Blue/Green (different style), so the cross-check
+// OQ should NOT fire on a Blue/Green resolved style.
+func TestDetectCutoverOpenQuestions_BlueGreenSkipsCrossCheck(t *testing.T) {
+	inputs := styleInputs(DowntimeZero)
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.False(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
+}
+
+func TestDetectCutoverOpenQuestions_UnknownTolerance(t *testing.T) {
+	inputs := styleInputs("scheduled_window_quarterly") // typo
+	d := DecideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	assert.True(t, hasOQ(oqs, "downtime_tolerance_unknown"))
+}
+
+func TestDetectCutoverOpenQuestions_CanonicalEmits_NoOQs(t *testing.T) {
+	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	oqs := detectCutoverOpenQuestions(d, styleInputs(DowntimeLetConfluentChoose), false)
+	assert.Empty(t, oqs, "canonical recommendation has nothing to ask")
+}
+
+// Customer opted out + gateway prereqs absent: prereq table is empty
+// (S5 fix). When opted in (default), prereqs surface.
+func TestDecideCutover_PrereqsSuppressedOnOptOut(t *testing.T) {
+	inputs := styleInputs(DowntimeMinutesPerService)
+	inputs.PreferGateway = false
+	d := DecideCutover(nil, inputs)
+	assert.Empty(t, d.Prereqs, "opt-out hides the gateway prereq table — they don't apply")
+
+	inputs.PreferGateway = true
+	d = DecideCutover(nil, inputs)
+	assert.NotEmpty(t, d.Prereqs, "opt-in keeps the prereq table visible")
+}

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -56,6 +56,9 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 		CCGatewayLicenseStatus:               defaults.CCGatewayLicenseStatus,
 		IAMPreMigrationStatus:                defaults.IAMPreMigrationStatus,
 		TargetAuthMethod:                     defaults.TargetAuthMethod,
+		SchemaStrategy:                       defaults.SchemaStrategy,
+		ConfluentSRCPVersion:                 defaults.ConfluentSRCPVersion,
+		ConfluentSRCPEdition:                 defaults.ConfluentSRCPEdition,
 	}
 	if in == nil {
 		return out
@@ -113,6 +116,21 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	}
 	if in.TargetAuthMethod != nil {
 		out.TargetAuthMethod = *in.TargetAuthMethod
+	}
+	if in.SchemaStrategy != nil {
+		out.SchemaStrategy = *in.SchemaStrategy
+	}
+	if in.SourceSROutboundReachableToCC != nil {
+		// Copy the value (not the pointer) so a later mutation of the
+		// caller-owned PlanInputs doesn't bleed into Resolved.
+		v := *in.SourceSROutboundReachableToCC
+		out.SourceSROutboundReachableToCC = &v
+	}
+	if in.ConfluentSRCPVersion != nil {
+		out.ConfluentSRCPVersion = *in.ConfluentSRCPVersion
+	}
+	if in.ConfluentSRCPEdition != nil {
+		out.ConfluentSRCPEdition = *in.ConfluentSRCPEdition
 	}
 	return out
 }

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -49,6 +49,13 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 		ExistingVPCConnectivity:              defaults.ExistingVPCConnectivity,
 		CCEgressRequired:                     defaults.CCEgressRequired,
 		ProjectedPNIGatewayCount:             defaults.ProjectedPNIGatewayCount,
+		DowntimeTolerance:                    defaults.DowntimeTolerance,
+		SubPattern:                           defaults.SubPattern,
+		PreferGateway:                        defaults.PreferGateway,
+		ConfluentForKubernetesStatus:         defaults.ConfluentForKubernetesStatus,
+		CCGatewayLicenseStatus:               defaults.CCGatewayLicenseStatus,
+		IAMPreMigrationStatus:                defaults.IAMPreMigrationStatus,
+		TargetAuthMethod:                     defaults.TargetAuthMethod,
 	}
 	if in == nil {
 		return out
@@ -85,6 +92,27 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	}
 	if in.ProjectedPNIGatewayCount != nil {
 		out.ProjectedPNIGatewayCount = *in.ProjectedPNIGatewayCount
+	}
+	if in.DowntimeTolerance != nil {
+		out.DowntimeTolerance = *in.DowntimeTolerance
+	}
+	if in.SubPattern != nil {
+		out.SubPattern = *in.SubPattern
+	}
+	if in.PreferGateway != nil {
+		out.PreferGateway = *in.PreferGateway
+	}
+	if in.ConfluentForKubernetesStatus != nil {
+		out.ConfluentForKubernetesStatus = *in.ConfluentForKubernetesStatus
+	}
+	if in.CCGatewayLicenseStatus != nil {
+		out.CCGatewayLicenseStatus = *in.CCGatewayLicenseStatus
+	}
+	if in.IAMPreMigrationStatus != nil {
+		out.IAMPreMigrationStatus = *in.IAMPreMigrationStatus
+	}
+	if in.TargetAuthMethod != nil {
+		out.TargetAuthMethod = *in.TargetAuthMethod
 	}
 	return out
 }
@@ -147,6 +175,9 @@ func applyClusterOverride(out types.PlanInputsResolved, in *types.PlanInputs, cl
 	}
 	if override.ProjectedPNIGatewayCount != nil {
 		out.ProjectedPNIGatewayCount = *override.ProjectedPNIGatewayCount
+	}
+	if override.TargetAuthMethod != nil {
+		out.TargetAuthMethod = *override.TargetAuthMethod
 	}
 	return out
 }

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -14,10 +14,6 @@ const (
 	vpcConnectivityVPCPeering     = "vpc_peering"
 )
 
-// pniGatewayBreakeven is the projected-gateway count at which the
-// recommendation flips from PNI to PrivateLink.
-const pniGatewayBreakeven = 2
-
 // netDecision constructs a NetworkingDecision from the sizing context
 // (peak burst, percentage-of-PL-cap) plus the verdict and reason. Used
 // to keep the 8 decision branches below uniform — every branch must
@@ -99,9 +95,9 @@ func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, 
 		return netDecision(sizing, types.NetworkingPrivateLink,
 			"cc_egress_required=true — PNI does not natively support egress from CC into customer infrastructure (set `cc_egress_required: false` in `plan-inputs.yaml` if this wasn't intentional)")
 	}
-	if inputs.ProjectedPNIGatewayCount >= pniGatewayBreakeven {
+	if inputs.ProjectedPNIGatewayCount >= cfg.Thresholds.PNIGatewayBreakeven {
 		return netDecision(sizing, types.NetworkingPrivateLink,
-			fmt.Sprintf("projected_pni_gateway_count=%d (≥ %d) — flip to PrivateLink (lower `projected_pni_gateway_count` in `plan-inputs.yaml` to stay on PNI)", inputs.ProjectedPNIGatewayCount, pniGatewayBreakeven))
+			fmt.Sprintf("projected_pni_gateway_count=%d (≥ %d) — flip to PrivateLink (lower `projected_pni_gateway_count` in `plan-inputs.yaml` to stay on PNI)", inputs.ProjectedPNIGatewayCount, cfg.Thresholds.PNIGatewayBreakeven))
 	}
 	return netDecision(sizing, types.NetworkingPNI,
 		fmt.Sprintf("default for AWS Enterprise (scales to %d eCKU vs PrivateLink's %d-eCKU cap)", cfg.EnterpriseCaps.PNIMaxECKU, cfg.EnterpriseCaps.PrivateLinkMaxECKU))

--- a/internal/services/plan/oq_registry.go
+++ b/internal/services/plan/oq_registry.go
@@ -1,0 +1,142 @@
+package plan
+
+// OQMeta describes how one Open-Question ID should render: its
+// priority for sort-order, its base severity prefix, and an optional
+// promoted severity + title when a sibling OQ co-fires.
+//
+// Putting these three concerns in one struct collapses what was
+// previously 5 parallel structures keyed by OQ ID (the detector
+// emitting the ID, an iota priority constant, a priority-lookup
+// switch, a severity-lookup switch, and a sibling-aware promotion
+// override). New OQ = one new entry in `oqRegistry`.
+type OQMeta struct {
+	// Priority controls the §5 Actions Needed sort order — lower
+	// priority renders first. IDs missing from the registry fall
+	// through to PriorityUnknown and sort last.
+	Priority int
+
+	// Severity is the 🔴 / 🟡 / 🟢 prefix when no promotion applies.
+	// Classes:
+	//   🔴 blocker — fix before cutover
+	//   🟡 affects accuracy — fix before relying on the plan
+	//   🟢 preference — pick one
+	Severity string
+
+	// PromoteWhen lists sibling OQ IDs that, when also present on
+	// the same Plan, promote this OQ's severity (and optionally
+	// rewrite its title). Empty = no promotion ever fires.
+	PromoteWhen []string
+
+	// PromotedSeverity replaces Severity when any PromoteWhen sibling
+	// is present. Empty falls back to Severity.
+	PromotedSeverity string
+
+	// PromotedTitle replaces the OQ's rendered title when promoted.
+	// Empty falls back to the OQ's natural Title field — but for
+	// "preference"-shaped titles being promoted to blocker (a 🟢→🔴
+	// promotion), keeping the original title creates a contradictory
+	// signal ("pick" + 🔴), so promotion entries should always
+	// supply a replacement.
+	PromotedTitle string
+}
+
+// PriorityUnknown is the sort-last fallback. Anchor at a high value
+// so adding a new low-priority OQ doesn't accidentally outrank it.
+const PriorityUnknown = 1000
+
+// oqRegistry holds every OQ ID emitted by the detectors. Adding a
+// new OQ requires exactly one entry here and one detector emit; the
+// renderer and the priority sort both read from this map.
+var oqRegistry = map[string]OQMeta{
+	"networking_privatelink_over_cap": {
+		Priority: 10,
+		Severity: "🔴",
+	},
+	"downtime_tolerance_requires_gateway": {
+		Priority: 20,
+		Severity: "🔴",
+	},
+	"downtime_tolerance_unknown": {
+		Priority: 30,
+		Severity: "🔴",
+	},
+	"target_auth_method_unknown": {
+		Priority: 40,
+		Severity: "🔴",
+	},
+	"auth_target_gateway_incompatible": {
+		Priority: 50,
+		Severity: "🔴",
+	},
+	"gateway_prereqs_pending": {
+		Priority:         60,
+		Severity:         "🟢",
+		PromoteWhen:      []string{"auth_target_gateway_incompatible"},
+		PromotedSeverity: "🔴",
+		PromotedTitle:    "Gateway prereqs — moot until the auth conflict above is resolved",
+	},
+	"gateway_intent_unconfirmed": {
+		Priority:         70,
+		Severity:         "🟢",
+		PromoteWhen:      []string{"auth_target_gateway_incompatible"},
+		PromotedSeverity: "🔴",
+		PromotedTitle:    "Gateway intent — moot until the auth conflict above is resolved",
+	},
+	"state_file_stale": {
+		Priority: 80,
+		Severity: "🟡",
+	},
+	"missing_p95_metrics": {
+		Priority: 90,
+		Severity: "🟡",
+	},
+	"broker_inventory_empty": {
+		Priority: 100,
+		Severity: "🟡",
+	},
+	"topic_inventory_empty": {
+		Priority: 110,
+		Severity: "🟡",
+	},
+	"auth_posture_unknown": {
+		Priority: 120,
+		Severity: "🟡",
+	},
+	"acls_not_scanned": {
+		Priority: 130,
+		Severity: "🟡",
+	},
+}
+
+// oqMetaFor returns the registry entry for an OQ ID, or a sentinel
+// (Priority: PriorityUnknown, Severity: 🟡) when the ID is unknown.
+// 🟡 is the safe default for accuracy-class signals; an unknown ID
+// indicates a missed registry entry — surfacing it as 🟡 keeps it
+// visible without falsely claiming blocker status.
+func oqMetaFor(id string) OQMeta {
+	if m, ok := oqRegistry[id]; ok {
+		return m
+	}
+	return OQMeta{Priority: PriorityUnknown, Severity: "🟡"}
+}
+
+// promoteSeverity applies the sibling-aware promotion rule: if any
+// of `meta.PromoteWhen` is in `siblings`, returns the promoted
+// severity + title; otherwise returns the base severity + the
+// original title.
+func promoteSeverity(meta OQMeta, originalTitle string, siblings map[string]bool) (severity, title string) {
+	for _, trigger := range meta.PromoteWhen {
+		if siblings[trigger] {
+			sev := meta.PromotedSeverity
+			if sev == "" {
+				sev = meta.Severity
+			}
+			t := meta.PromotedTitle
+			if t == "" {
+				t = originalTitle
+			}
+			return sev, t
+		}
+	}
+	return meta.Severity, originalTitle
+}

--- a/internal/services/plan/oq_registry.go
+++ b/internal/services/plan/oq_registry.go
@@ -10,9 +10,12 @@ package plan
 // switch, a severity-lookup switch, and a sibling-aware promotion
 // override). New OQ = one new entry in `oqRegistry`.
 type OQMeta struct {
-	// Priority controls the §5 Actions Needed sort order — lower
+	// Priority controls the Actions Needed sort order — lower
 	// priority renders first. IDs missing from the registry fall
-	// through to PriorityUnknown and sort last.
+	// through to PriorityUnknown and sort last. (Actions Needed's
+	// section number is computed dynamically by RenderMarkdown
+	// based on which sections fired; the registry only orders the
+	// items within it.)
 	Priority int
 
 	// Severity is the 🔴 / 🟡 / 🟢 prefix when no promotion applies.
@@ -44,66 +47,106 @@ type OQMeta struct {
 // so adding a new low-priority OQ doesn't accidentally outrank it.
 const PriorityUnknown = 1000
 
-// oqRegistry holds every OQ ID emitted by the detectors. Adding a
-// new OQ requires exactly one entry here and one detector emit; the
-// renderer and the priority sort both read from this map.
+// oqRegistry holds every OQ ID emitted by the detectors. Priority is
+// sparse + grouped by concern so new IDs land between siblings
+// without renumbering. The concern bands are:
+//
+//	100s  — Sizing
+//	200s  — Cluster Type
+//	300s  — Networking
+//	400s  — Cutover
+//	500s  — Auth
+//	600s  — Schema
+//	900s  — Fleet / state-file (cross-cutting)
+//
+// Within a band, 10-unit spacing leaves room for an inserted OQ to
+// slot between existing entries without a shuffle.
 var oqRegistry = map[string]OQMeta{
+	// Networking
 	"networking_privatelink_over_cap": {
-		Priority: 10,
+		Priority: 310,
 		Severity: "🔴",
 	},
+
+	// Cutover
 	"downtime_tolerance_requires_gateway": {
-		Priority: 20,
+		Priority: 410,
 		Severity: "🔴",
 	},
 	"downtime_tolerance_unknown": {
-		Priority: 30,
-		Severity: "🔴",
-	},
-	"target_auth_method_unknown": {
-		Priority: 40,
-		Severity: "🔴",
-	},
-	"auth_target_gateway_incompatible": {
-		Priority: 50,
+		Priority: 420,
 		Severity: "🔴",
 	},
 	"gateway_prereqs_pending": {
-		Priority:         60,
+		Priority:         430,
 		Severity:         "🟢",
 		PromoteWhen:      []string{"auth_target_gateway_incompatible"},
 		PromotedSeverity: "🔴",
 		PromotedTitle:    "Gateway prereqs — moot until the auth conflict above is resolved",
 	},
 	"gateway_intent_unconfirmed": {
-		Priority:         70,
+		Priority:         440,
 		Severity:         "🟢",
 		PromoteWhen:      []string{"auth_target_gateway_incompatible"},
 		PromotedSeverity: "🔴",
 		PromotedTitle:    "Gateway intent — moot until the auth conflict above is resolved",
 	},
+
+	// Auth
+	"target_auth_method_unknown": {
+		Priority: 510,
+		Severity: "🔴",
+	},
+	"auth_target_gateway_incompatible": {
+		Priority: 520,
+		Severity: "🔴",
+	},
+	"auth_posture_unknown": {
+		Priority: 530,
+		Severity: "🟡",
+	},
+
+	// Schema migration
+	"schema_strategy_invalid": {
+		Priority: 610,
+		Severity: "🔴",
+	},
+	"schema_linking_ineligible": {
+		Priority: 620,
+		Severity: "🔴",
+	},
+	"schema_strategy_unknown": {
+		Priority: 630,
+		Severity: "🟡",
+	},
+	"schema_linking_eligibility_unknown": {
+		Priority: 640,
+		Severity: "🟡",
+	},
+	"schema_state_strategy_mismatch": {
+		Priority: 650,
+		Severity: "🟡",
+	},
+
+	// Cross-cutting fleet / state-file signals
 	"state_file_stale": {
-		Priority: 80,
+		Priority: 910,
 		Severity: "🟡",
 	},
 	"missing_p95_metrics": {
-		Priority: 90,
+		Priority: 920,
 		Severity: "🟡",
 	},
 	"broker_inventory_empty": {
-		Priority: 100,
+		Priority: 930,
 		Severity: "🟡",
 	},
 	"topic_inventory_empty": {
-		Priority: 110,
-		Severity: "🟡",
-	},
-	"auth_posture_unknown": {
-		Priority: 120,
+		Priority: 940,
 		Severity: "🟡",
 	},
 	"acls_not_scanned": {
-		Priority: 130,
+		Priority: 950,
 		Severity: "🟡",
 	},
 }

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -53,3 +53,71 @@ plan_input_defaults:
   # `target_cloud != aws`.
   cc_egress_required: false        # CC→customer VPC egress not natively supported by PNI
   projected_pni_gateway_count: 1   # ≥2 → flip to PrivateLink
+
+  # Cutover defaults. `let_confluent_choose` resolves to
+  # Stop-Restart-Repeat — Confluent's canonical recommendation. The
+  # gateway prereq statuses default to `not_started`; a customer who
+  # hasn't engaged with the gateway question stays in the "ambiguous
+  # intent" branch (degraded_awaiting_oq) until they answer.
+  downtime_tolerance: let_confluent_choose
+  sub_pattern: app-by-app
+  prefer_gateway: true
+  confluent_for_kubernetes_status: not_started
+  cc_gateway_license_status: not_started
+  iam_pre_migration_status: not_started
+
+  # Auth default target. Intentionally empty — the per-source
+  # default lives in `auth_mapping` below. Only set via plan-inputs.yaml
+  # when the customer wants to force a single target across all source
+  # auths detected on a cluster.
+  target_auth_method: ""
+
+# Source → target auth lookup. Keyed by source-auth token. The
+# plan renders all detected source auths and the recommended target
+# for each — it doesn't pick one when a cluster has multiple enabled.
+auth_mapping:
+  scram:
+    target: confluent_cloud_api_keys
+    gateway_compatible: true
+    transparent_swap: true   # gateway swaps credentials transparently
+    # Note left empty — the "transparent swap" label in the Gateway
+    # column already conveys this row's behavior; repeating it as a
+    # Note on every SCRAM cluster adds noise without information.
+    note: ""
+    source: https://docs.confluent.io/cloud/current/security/authenticate/overview.html
+    last_verified: "2026-05-20"
+  iam:
+    target: confluent_cloud_api_keys
+    gateway_compatible: false   # IAM clients cannot connect to the gateway
+    transparent_swap: false
+    note: "IAM clients cannot connect to the CC Gateway. Pre-migrate to SCRAM or mTLS first."
+    source: https://github.com/confluentinc/kcp/blob/main/docs/assets/getting-started-with-zero-cut-migrations.md
+    last_verified: "2026-05-20"
+  mtls:
+    target: mtls
+    gateway_compatible: true
+    transparent_swap: false   # gateway terminates TLS and re-issues an ACM-PCA cert source-side
+    note: "Gateway terminates TLS and re-issues an ACM-PCA cert source-side (auth-swap mode)."
+    source: https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/mtls/configure.html
+    last_verified: "2026-05-20"
+  unauth:
+    target: confluent_cloud_api_keys
+    gateway_compatible: true
+    transparent_swap: false
+    note: "Plaintext on production is unusual; review with the customer."
+    source: https://docs.confluent.io/cloud/current/security/authenticate/overview.html
+    last_verified: "2026-05-20"
+
+# Threshold cutoffs — numeric levers the rule engine and renderer need
+# but that aren't customer-facing knobs. Tune here if a tenant has a
+# genuinely different operating envelope (older state files acceptable,
+# different PNI/PrivateLink breakeven, etc.).
+thresholds:
+  # Emit a 🟡 state-file-stale OQ when the source state.json is older
+  # than this many days. Conservative default: 7. Anything younger is
+  # silent; anything older surfaces a re-discover prompt.
+  stale_state_days: 7
+  # Projected PNI gateway count at or above which the networking
+  # recommendation flips from PNI to PrivateLink. 2 = first additional
+  # gateway crosses the cost line.
+  pni_gateway_breakeven: 2

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -1,7 +1,7 @@
 # plan-config.yaml — Embedded defaults for `kcp report plan`.
 #
 # Single source of truth for Confluent product facts and the customer-tunable
-# sizing defaults. MVP scope: sizing + cluster-type (rules 1–6) + networking.
+# sizing defaults.
 #
 # Override precedence (lowest → highest):
 #   1. This file (embedded in the KCP binary at build time)
@@ -27,6 +27,16 @@ cluster_linking:
   source_min_kafka_version: "2.4.0"  # "Kafka 2.4.0 or later" — migration use cases footnote
   express_tier_supported: unknown    # verify per release
   source: https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/
+
+# Schema Linking eligibility floor. Source Confluent SR clusters below
+# any of these floors fall to `defer_to_account_team` rather than the
+# Schema Linking path — the REST API export/import alternative is real
+# but its rollout sequencing is workload-specific and not deterministic.
+schema_linking:
+  min_cp_version: "7.0"
+  requires_cp_edition: enterprise
+  source: https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html
+  last_verified: "2026-05-27"
 
 plan_input_defaults:
   sizing_percentile: p95           # alternatives: p99, max — lowercase to match Confluent dashboards
@@ -71,6 +81,14 @@ plan_input_defaults:
   # when the customer wants to force a single target across all source
   # auths detected on a cluster.
   target_auth_method: ""
+
+  # Schema-migration defaults. `unknown` keeps first-run plans honest:
+  # the customer answers the strategy OQ once and the verdict pins.
+  # CP version/edition stay empty (= unknown) for the same reason —
+  # the scanner doesn't backfill them today.
+  schema_strategy: unknown
+  confluent_sr_cp_version: ""
+  confluent_sr_cp_edition: ""
 
 # Source → target auth lookup. Keyed by source-auth token. The
 # plan renders all detected source auths and the recommended target

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/build_info"
@@ -51,6 +52,7 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 			StateFilePath:     stateFilePath,
 			KCPVersion:        build_info.Version,
 			GeneratedAt:       s.now().UTC(),
+			StateGeneratedAt:  state.Timestamp.UTC(),
 			PlanSchemaVersion: "1-experimental",
 		},
 		Inputs: inputs,
@@ -82,20 +84,40 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		ct.InputsMissing = slices.Clone(missing)
 		net.InputsMissing = slices.Clone(missing)
 
+		auth := DecideAuth(c, s.cfg, clusterInputs)
+
 		plan.Sizing = append(plan.Sizing, sizing)
 		plan.ClusterTypeDecision = append(plan.ClusterTypeDecision, ct)
 		plan.NetworkingDecision = append(plan.NetworkingDecision, net)
+		plan.Auth = append(plan.Auth, auth)
 		plan.SourceEnvironment.Clusters = append(plan.SourceEnvironment.Clusters, types.SourceClusterSummary{
 			ClusterID:    c.Name,
 			Region:       c.Region,
 			TopicCount:   topicCount(c),
 			BrokerCount:  brokerCount(c),
 			IsServerless: isServerless(c),
+			SourceAuths:  auth.SourceAuths,
 		})
-		plan.OpenQuestions = append(plan.OpenQuestions, detectOpenQuestions(c, sizing, ct, net, s.cfg, clusterInputs)...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectOpenQuestions(c, sizing, ct, net, auth, s.cfg, clusterInputs)...)
 	}
 	plan.SourceEnvironment.TotalRegions = countRegions(state)
 	plan.SizingAppendix = buildSizingAppendix(plan.Sizing, s.cfg, inputs)
+
+	// Cutover is fleet-wide (one Plan = one cutover style). Only emit
+	// when there are clusters to migrate; an empty fleet has nothing
+	// to cut over.
+	if len(clusters) > 0 {
+		cutover := DecideCutover(clusters, inputs)
+		plan.Cutover = &cutover
+		plan.OpenQuestions = append(plan.OpenQuestions, detectCutoverOpenQuestions(cutover, inputs, fleetUsesIAM(clusters))...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectAuthFleetOpenQuestions(inputs)...)
+	}
+	// Stale-state OQ: surface a fleet-wide accuracy warning when the
+	// source state file is older than the freshness window. The Plan
+	// still renders against whatever's in state.json — but a 14-day-old
+	// snapshot could miss ACL drift, new brokers, etc. that would
+	// change the verdicts.
+	plan.OpenQuestions = append(plan.OpenQuestions, detectStaleStateOQ(state.Timestamp, s.now(), s.cfg.Thresholds.StaleStateDays)...)
 
 	// Stable order: blocker OQs first, acknowledgement OQs last; tie-break
 	// on cluster ID so two clusters of equal priority sort alphabetically.
@@ -117,8 +139,46 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 // will upgrade that recommendation. SERVERLESS-specific suppressions for
 // "ACLs not populated" and "0 brokers" live in cluster_signals.go so the
 // same logic is shared with the rule evaluator.
-func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
+func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, auth types.AuthDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
+	// Auth posture undetectable. Fires whenever the source has no
+	// detected auth methods on a non-serverless cluster — auth is its
+	// own concern, surfaced independently of topic / ACL inventory gaps
+	// (those have their own OQs and don't suppress this one).
+	// Serverless clusters legitimately produce no detected methods
+	// when IAM isn't enabled; suppress only for them.
+	if len(auth.SourceAuths) == 0 && !isServerless(c) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "auth_posture_unknown",
+			ClusterID:  c.Name,
+			Title:      "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
+			Body:       "Neither `AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication` nor `kafka_admin_client_information.sasl_mechanism` reports an enabled auth method. A real MSK Provisioned cluster always has at least one. Likely cause: discover ran without admin credentials (or the state file pre-dates the auth scan).",
+			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account, OR provide admin Kafka credentials to `kcp scan clusters` so the Admin probe can backfill `sasl_mechanism`.", regionFlag(c.Region)),
+		})
+	}
+	// Customer-set target_auth_method conflicts with a source whose
+	// auth_mapping is gateway_compatible: false (today: IAM). The plan
+	// emits the override mapping but the gateway path itself remains
+	// incompatible — surface the conflict so the customer sees the gap.
+	// Skip the conflict OQ when the customer opted out of the gateway
+	// — gateway compatibility is moot on the plain-CL path, so the
+	// conflict isn't real. Also skip on unknown target (the
+	// target_auth_method_unknown OQ already fires for that; pairing the
+	// two would double-report a single typo).
+	if inputs.TargetAuthMethod != "" && inputs.PreferGateway && knownTargetAuthMethod(inputs.TargetAuthMethod) {
+		for _, row := range auth.TargetMappings {
+			if !row.GatewayCompatible {
+				oqs = append(oqs, types.OpenQuestion{
+					ID:         "auth_target_gateway_incompatible",
+					ClusterID:  c.Name,
+					Title:      fmt.Sprintf("`target_auth_method: %s` set but source auth `%s` is gateway-incompatible", inputs.TargetAuthMethod, row.SourceAuth),
+					Body:       fmt.Sprintf("You've overridden the target auth to `%s`, but the source uses `%s` — the CC Gateway can't accept `%s` clients at all (regardless of where they land on the CC side). The target-side override changes the credential clients present to CC; it does not change which auth scheme CC accepts at the gateway. Source clients need to pre-migrate to a gateway-compatible auth (SCRAM or mTLS) on MSK before the gateway path is viable.", inputs.TargetAuthMethod, row.SourceAuth, row.SourceAuth),
+					HowToClose: fmt.Sprintf("Two paths: (a) pre-migrate source clients off `%s` on MSK — typical replacement is SASL/SCRAM (see [MSK SASL/SCRAM docs](https://docs.aws.amazon.com/msk/latest/developerguide/msk-password.html)); flip the matching pre-migration prereq to `complete` and re-run the plan. OR (b) unset `target_auth_method` and let the per-source default apply — the override doesn't help here because the gateway barrier is on the source side.", row.SourceAuth),
+				})
+				break // one OQ per cluster, not one per gateway-incompatible row
+			}
+		}
+	}
 	if sizing.Degraded {
 		oqs = append(oqs, types.OpenQuestion{
 			ID:        "missing_p95_metrics",
@@ -136,7 +196,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 			Title:     "Admin scan didn't populate ACLs — cap-vs-Enterprise rule was skipped",
 			Body:      "The `acl_count_exceeds_cap` hard-limit rule needs a successful ACL scan to evaluate. Either the scan didn't run, or `--skip-acls` was passed; without the ACL list the rule is treated as inconclusive and the verdict resolves on the other rules.",
 			// `kcp scan clusters` doesn't take --region — it reads region from the state file.
-			HowToClose: "Re-run `kcp scan clusters --source-type msk --credentials-file <msk-credentials.yaml>` with admin Kafka credentials (SASL/IAM or SCRAM) and without `--skip-acls` so the ACL list populates.",
+			HowToClose: "Re-run `kcp scan clusters --source-type msk --credentials-file msk-credentials.yaml` without `--skip-acls`. The credentials file is a YAML with the admin Kafka credentials (SASL/IAM or SCRAM) — see `kcp scan clusters --help` for the schema, or [the kcp docs](https://confluentinc.github.io/kcp/command-reference/scan/clusters/) for a sample.\n\nSample `msk-credentials.yaml`:\n```yaml\nclusters:\n  - cluster_arn: <arn>\n    authentication_type: SASL_SCRAM        # or AWS_MSK_IAM\n    sasl_scram_username: <username>        # for SASL/SCRAM\n    sasl_scram_password: <password>\n```",
 		})
 	}
 	if brokerInventoryGap(c) {
@@ -177,33 +237,129 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	return oqs
 }
 
-// Priority order for OQs. Lower number renders first. Constants here so
-// every OQ has an explicit rank — a new ID without a priority entry
-// falls through to oqPriorityUnknown and renders last.
-const (
-	oqPriorityNetworkingOverCap = iota // infeasible PrivateLink recommendation — blocker
-	oqPriorityMissingMetrics           // missing P95 → sizing fell back to floor
-	oqPriorityBrokerInventory          // broker count == 0 (scan gap)
-	oqPriorityTopicInventory           // topic count == 0 (scan gap)
-	oqPriorityACLsNotScanned           // ACL admin scan didn't run
-	oqPriorityUnknown                  // fallback for new IDs added without a priority entry
-)
-
-func openQuestionPriority(id string) int {
-	switch id {
-	case "networking_privatelink_over_cap":
-		return oqPriorityNetworkingOverCap
-	case "missing_p95_metrics":
-		return oqPriorityMissingMetrics
-	case "broker_inventory_empty":
-		return oqPriorityBrokerInventory
-	case "topic_inventory_empty":
-		return oqPriorityTopicInventory
-	case "acls_not_scanned":
-		return oqPriorityACLsNotScanned
-	default:
-		return oqPriorityUnknown
+// detectCutoverOpenQuestions surfaces fleet-wide gateway-intent / prereq
+// gaps. Emitted once per Plan (no ClusterID — these aren't per-cluster).
+// Three independent OQs can fire:
+//   - gateway intent ambiguous (degraded_awaiting_oq)
+//   - gateway prereqs pending (degraded_prereqs_pending)
+//   - seconds_per_service tolerance requires the gateway, but it isn't
+//     mediated for some reason (cross-check; message varies by cause).
+//
+// detectStaleStateOQ surfaces a fleet-wide OQ when the source state
+// file is older than `staleDays`. Compares state.Timestamp against the
+// Plan's GeneratedAt time; if the state was empty (zero timestamp) the
+// OQ is suppressed because there's nothing to compare against.
+// `staleDays` comes from plan-config.yaml `thresholds.stale_state_days`.
+func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDays int) []types.OpenQuestion {
+	if stateTimestamp.IsZero() {
+		return nil
 	}
+	threshold := time.Duration(staleDays) * 24 * time.Hour
+	age := generatedAt.UTC().Sub(stateTimestamp.UTC())
+	if age < threshold {
+		return nil
+	}
+	days := int(age.Hours() / 24)
+	return []types.OpenQuestion{{
+		ID:         "state_file_stale",
+		Title:      fmt.Sprintf("State file is %d days old — verdicts may not reflect current source state", days),
+		Body:       fmt.Sprintf("The source state file is dated `%s`; this Plan was generated `%s` (%d days later). Verdicts above (ACL-cap, broker counts, throughput sizing) are computed against the state file as-is, but the source environment may have drifted since.", stateTimestamp.UTC().Format("2006-01-02 15:04:05 UTC"), generatedAt.UTC().Format("2006-01-02 15:04:05 UTC"), days),
+		HowToClose: "Re-run `kcp discover` (and `kcp scan clusters` if you have admin creds) to refresh the state file, then re-run `kcp report plan`. If the source environment hasn't changed materially, you can ignore this OQ.",
+	}}
+}
+
+func detectCutoverOpenQuestions(cutover types.CutoverDecision, inputs types.PlanInputsResolved, iamInUse bool) []types.OpenQuestion {
+	var oqs []types.OpenQuestion
+	if !knownDowntimeTolerance(inputs.DowntimeTolerance) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "downtime_tolerance_unknown",
+			Title:      fmt.Sprintf("`downtime_tolerance: %s` is not a recognised value — defaulted to Stop-Restart-Repeat", inputs.DowntimeTolerance),
+			Body:       "The Plan only recognises `zero | seconds_per_service | minutes_per_service | scheduled_window_sequential | scheduled_window_all_at_once | let_confluent_choose`. The current value falls outside the enum, so the Plan inherits the Confluent default (Stop-Restart-Repeat) silently — which is probably not what you intended.",
+			HowToClose: "Set `downtime_tolerance` in `plan-inputs.yaml` to one of the recognised values, then re-run `kcp report plan`.",
+		})
+	}
+	switch cutover.RecommendationStatus {
+	case types.RecommendationDegradedAwaitingOQ:
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "gateway_intent_unconfirmed",
+			Title:      "Gateway intent — pick CC Gateway or plain Cluster Linking",
+			Body:       "`prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open.",
+			HowToClose: "In `plan-inputs.yaml`, either (a) set `prefer_gateway: false` to commit to plain Cluster Linking, OR (b) move at least one gateway prereq to `in_progress` to commit to the gateway path. Re-run `kcp report plan` to clear the OQ.",
+		})
+	case types.RecommendationDegradedPrereqsPending:
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "gateway_prereqs_pending",
+			Title:      "Gateway prereqs — pending items before the gateway path can be recommended",
+			Body:       fmt.Sprintf("`prefer_gateway: true` and at least one gateway prereq is still at `not_started`: %s. The gateway-mediated path needs all applicable prereqs at `in_progress` or `complete`. Plain Cluster Linking applies until they advance.", pendingPrereqList(inputs, iamInUse)),
+			HowToClose: "Move each pending prereq above to `in_progress` (intent declared) or `complete` (done). Re-run `kcp report plan` once the prereqs advance.",
+		})
+	}
+	// Cross-check: `seconds_per_service` is only achievable through the
+	// gateway. If the customer asks for it but mediation isn't possible
+	// (opt-out OR ambiguous OR prereqs pending), surface a cause-specific
+	// OQ. Blue/Green sidesteps the gateway entirely and never trips this.
+	if inputs.DowntimeTolerance == DowntimeSecondsPerService && cutover.GatewayMediated != types.GatewayMediatedTrue && cutover.Style != types.CutoverBlueGreen {
+		body := "seconds_per_service downtime tolerance requires CC-Gateway mediation (the gateway's 30–90s `BROKER_NOT_AVAILABLE` window is what makes sub-minute cutovers possible). The current Plan doesn't mediate via the gateway because: "
+		switch {
+		case !inputs.PreferGateway:
+			body += "`prefer_gateway: false`. Set `prefer_gateway: true` OR relax `downtime_tolerance` to `minutes_per_service` (plain Cluster Linking)."
+		case cutover.RecommendationStatus == types.RecommendationDegradedAwaitingOQ:
+			body += "gateway intent is unconfirmed (see the related Open Question above). Commit to the gateway path or relax `downtime_tolerance`."
+		default:
+			body += "one or more gateway prereqs are still at `not_started`. Move pending prereqs to `in_progress`/`complete`, OR relax `downtime_tolerance` to `minutes_per_service`."
+		}
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "downtime_tolerance_requires_gateway",
+			Title:      "`downtime_tolerance: seconds_per_service` requires the gateway but the recommendation is plain Cluster Linking",
+			Body:       body,
+			HowToClose: "Adjust either `prefer_gateway` / the gateway prereq statuses, or `downtime_tolerance`, in `plan-inputs.yaml`.",
+		})
+	}
+	return oqs
+}
+
+// detectAuthFleetOpenQuestions surfaces fleet-wide auth OQs that aren't
+// tied to a particular cluster — currently just the `target_auth_method`
+// typo signal (a global field, so emitting it per-cluster would produce
+// N identical OQs from one typo).
+func detectAuthFleetOpenQuestions(inputs types.PlanInputsResolved) []types.OpenQuestion {
+	var oqs []types.OpenQuestion
+	if !knownTargetAuthMethod(inputs.TargetAuthMethod) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "target_auth_method_unknown",
+			Title:      fmt.Sprintf("`target_auth_method: %s` is not a recognised value — per-source defaults applied instead", inputs.TargetAuthMethod),
+			Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The current value falls outside the enum; the per-source `auth_mapping` default is used silently for every cluster.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth),
+			HowToClose: "Set `target_auth_method` in `plan-inputs.yaml` (or `clusters[<name>].target_auth_method` for a per-cluster override) to one of the recognised values, OR unset it to keep the per-source default.",
+		})
+	}
+	return oqs
+}
+
+// pendingPrereqList renders the list of gateway prereqs still at
+// `not_started`, for inclusion in an OQ body. Inline rather than a
+// helper-with-cases because the body string is one-shot per Plan.
+func pendingPrereqList(inputs types.PlanInputsResolved, iamInUse bool) string {
+	var pending []string
+	if inputs.ConfluentForKubernetesStatus == PrereqNotStarted {
+		pending = append(pending, "`confluent_for_kubernetes_status`")
+	}
+	if inputs.CCGatewayLicenseStatus == PrereqNotStarted {
+		pending = append(pending, "`cc_gateway_license_status`")
+	}
+	if iamInUse && inputs.IAMPreMigrationStatus == PrereqNotStarted {
+		pending = append(pending, "`iam_pre_migration_status`")
+	}
+	if len(pending) == 0 {
+		return "(none — but eligibility check failed for another reason)"
+	}
+	return strings.Join(pending, ", ")
+}
+
+// openQuestionPriority is a thin shim over the OQ registry — keeps the
+// sort callsite in Build readable without a direct map lookup. New OQ
+// IDs land in `oqRegistry` (see oq_registry.go), not here.
+func openQuestionPriority(id string) int {
+	return oqMetaFor(id).Priority
 }
 
 func collectClusters(state types.ProcessedState) []types.ProcessedCluster {

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -259,7 +260,11 @@ func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDa
 	if age < threshold {
 		return nil
 	}
-	days := int(age.Hours() / 24)
+	// Round to nearest full day so the rendered title isn't off by a
+	// long fractional remainder (a 7d 23h-old file rendering as
+	// "7 days old" reads as wrong-by-a-day). Math.Round avoids
+	// truncation toward zero.
+	days := int(math.Round(age.Hours() / 24))
 	return []types.OpenQuestion{{
 		ID:         "state_file_stale",
 		Title:      fmt.Sprintf("State file is %d days old — verdicts may not reflect current source state", days),
@@ -318,10 +323,13 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, inputs types.Plan
 	return oqs
 }
 
-// detectAuthFleetOpenQuestions surfaces fleet-wide auth OQs that aren't
-// tied to a particular cluster — currently just the `target_auth_method`
-// typo signal (a global field, so emitting it per-cluster would produce
-// N identical OQs from one typo).
+// detectAuthFleetOpenQuestions surfaces auth OQs that come from
+// invalid customer input — the global `target_auth_method` typo
+// (fleet-level OQ, single emit) and any per-cluster
+// `clusters[<name>].target_auth_method` typos (per-cluster OQs so the
+// affected cluster is obvious). Per-cluster typos silently fall back
+// to the per-source default in DecideAuth via effectiveTarget, so
+// without this detector they're invisible to the customer.
 func detectAuthFleetOpenQuestions(inputs types.PlanInputsResolved) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
 	if !knownTargetAuthMethod(inputs.TargetAuthMethod) {
@@ -331,6 +339,30 @@ func detectAuthFleetOpenQuestions(inputs types.PlanInputsResolved) []types.OpenQ
 			Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The current value falls outside the enum; the per-source `auth_mapping` default is used silently for every cluster.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth),
 			HowToClose: "Set `target_auth_method` in `plan-inputs.yaml` (or `clusters[<name>].target_auth_method` for a per-cluster override) to one of the recognised values, OR unset it to keep the per-source default.",
 		})
+	}
+	if inputs.Raw != nil {
+		clusterNames := make([]string, 0, len(inputs.Raw.Clusters))
+		for name := range inputs.Raw.Clusters {
+			clusterNames = append(clusterNames, name)
+		}
+		sort.Strings(clusterNames)
+		for _, name := range clusterNames {
+			cluster := inputs.Raw.Clusters[name]
+			if cluster.TargetAuthMethod == nil {
+				continue
+			}
+			value := *cluster.TargetAuthMethod
+			if knownTargetAuthMethod(value) {
+				continue
+			}
+			oqs = append(oqs, types.OpenQuestion{
+				ID:         "target_auth_method_unknown",
+				ClusterID:  name,
+				Title:      fmt.Sprintf("`clusters[%s].target_auth_method: %s` is not a recognised value — per-source default applied for this cluster", name, value),
+				Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The override falls outside the enum; the per-source `auth_mapping` default is used silently for `%s`.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth, name),
+				HowToClose: fmt.Sprintf("Set `clusters[%s].target_auth_method` in `plan-inputs.yaml` to one of the recognised values, OR remove the override to keep the per-source default.", name),
+			})
+		}
 	}
 	return oqs
 }

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -14,8 +14,8 @@ import (
 )
 
 // PlanService orchestrates the deterministic plan-generation pipeline.
-// MVP scope: source-environment summary, sizing, cluster-type, networking.
-// Auth approach, switchover, red flags, etc. land in follow-up PRs.
+// Each Build step is a pure function so the test surface is the
+// orchestration, not its parts.
 type PlanService struct {
 	cfg *PlanConfig
 	now func() time.Time
@@ -113,6 +113,16 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		plan.OpenQuestions = append(plan.OpenQuestions, detectCutoverOpenQuestions(cutover, inputs, fleetUsesIAM(clusters))...)
 		plan.OpenQuestions = append(plan.OpenQuestions, detectAuthFleetOpenQuestions(inputs)...)
 	}
+	// Schema migration — fleet-wide; one Plan, one verdict. The
+	// `schemaless` branch returns nil so the renderer can omit the
+	// whole section cleanly. We still run the OQ detector either way:
+	// the strategy-typo / strategy-unknown signals are valuable even
+	// when the verdict resolves to no recommendation.
+	schema := DecideSchema(state, s.cfg, inputs)
+	if schema != nil && !HasPath(schema, types.SchemaPathSchemaless) {
+		plan.Schema = schema
+	}
+	plan.OpenQuestions = append(plan.OpenQuestions, detectSchemaOpenQuestions(schema, s.cfg, inputs)...)
 	// Stale-state OQ: surface a fleet-wide accuracy warning when the
 	// source state file is older than the freshness window. The Plan
 	// still renders against whatever's in state.json — but a 14-day-old

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -517,6 +517,42 @@ func TestDetectAuthFleetOpenQuestions_TargetAuthMethodTypo(t *testing.T) {
 	assert.Empty(t, detectAuthFleetOpenQuestions(resolved))
 }
 
+// Per-cluster target_auth_method typos surface as cluster-scoped OQs
+// so the affected cluster is obvious; without this the override
+// silently falls back to the per-source default.
+func TestDetectAuthFleetOpenQuestions_PerClusterTargetAuthTypo(t *testing.T) {
+	typo := "oauthhh"
+	good := TargetAuthOAuth
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {TargetAuthMethod: &typo},
+			"bravo": {TargetAuthMethod: &good},
+		},
+	}
+	resolved := types.PlanInputsResolved{Raw: raw}
+	oqs := detectAuthFleetOpenQuestions(resolved)
+	require.Len(t, oqs, 1, "only the typo cluster should emit an OQ")
+	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
+	assert.Equal(t, "alpha", oqs[0].ClusterID)
+	assert.Contains(t, oqs[0].Title, "oauthhh")
+}
+
+// ambiguousGatewayIntent ignores `iam_pre_migration_status` for fleets
+// that don't use IAM — otherwise a non-IAM fleet that accidentally
+// flipped that prereq would lose the `gateway_intent_unconfirmed` OQ.
+func TestAmbiguousGatewayIntent_IgnoresIAMPrereqWhenNoIAM(t *testing.T) {
+	inputs := types.PlanInputsResolved{
+		PreferGateway:                true,
+		ConfluentForKubernetesStatus: PrereqNotStarted,
+		CCGatewayLicenseStatus:       PrereqNotStarted,
+		IAMPreMigrationStatus:        PrereqStatusInProgressInput,
+	}
+	assert.True(t, ambiguousGatewayIntent(inputs, false),
+		"non-IAM fleet: stray iam_pre_migration_status must not disqualify the ambiguous state")
+	assert.False(t, ambiguousGatewayIntent(inputs, true),
+		"IAM fleet: an advanced iam_pre_migration_status moves past ambiguity")
+}
+
 // promoteSeverity flips gateway_intent_unconfirmed and
 // gateway_prereqs_pending from 🟢 to 🔴 — and rewrites the title — when
 // auth_target_gateway_incompatible is present in the same Plan. Without

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -144,11 +144,18 @@ func TestDetectOpenQuestions(t *testing.T) {
 	pniNet := func(id string) types.NetworkingDecision {
 		return types.NetworkingDecision{ClusterID: id, Verdict: types.NetworkingPNI}
 	}
+	// scramAuth is the default test fixture for AuthDecision — a single
+	// SCRAM source. Non-empty SourceAuths suppresses the
+	// `auth_posture_unknown` OQ, which is what every test here cares
+	// about (those tests assert on other OQ IDs).
+	scramAuth := func(id string) types.AuthDecision {
+		return types.AuthDecision{ClusterID: id, SourceAuths: []string{SourceAuthSCRAM}}
+	}
 
 	t.Run("missing P95 metrics → missing_p95_metrics OQ", func(t *testing.T) {
 		c := provisioned("noMetrics")
 		sizing := types.ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
-		oqs := detectOpenQuestions(c, sizing, ent, pniNet("noMetrics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("noMetrics"), scramAuth("noMetrics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		// Metrics are collected by `kcp discover` (not a separate `scan metrics` subcommand).
 		assertContainsOQ(t, oqs, "missing_p95_metrics", "kcp discover")
 	})
@@ -159,7 +166,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		// trustworthy "scan ran" signal — aclScanRan returns true and
 		// the OQ is suppressed.
 		c := provisioned("provisioned-zero-acls") // helper sets Acls = []types.Acls{}
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-zero-acls", FinalECKU: 1}, ent, pniNet("provisioned-zero-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-zero-acls", FinalECKU: 1}, ent, pniNet("provisioned-zero-acls"), scramAuth("provisioned-zero-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "acls_not_scanned", oq.ID, "scan-ran-with-0 must NOT emit the OQ")
 		}
@@ -171,7 +178,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		// the customer can rule out the ACL-cap risk.
 		c := provisioned("provisioned-nil-acls")
 		c.KafkaAdminClientInformation.Acls = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-nil-acls", FinalECKU: 1}, ent, pniNet("provisioned-nil-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-nil-acls", FinalECKU: 1}, ent, pniNet("provisioned-nil-acls"), scramAuth("provisioned-nil-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "acls_not_scanned", "--skip-acls")
 	})
 
@@ -180,7 +187,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		// Topics nil → scan didn't run; ACLs nil follows from same gap
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1}, ent, pniNet("noAcls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1}, ent, pniNet("noAcls"), scramAuth("noAcls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "acls_not_scanned", "admin Kafka credentials")
 	})
 
@@ -190,7 +197,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		c.KafkaAdminClientInformation.Acls = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "serverless", FinalECKU: 1}, ent, pniNet("serverless"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "serverless", FinalECKU: 1}, ent, pniNet("serverless"), scramAuth("serverless"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "acls_not_scanned", oq.ID, "serverless does not expose ACLs via this API")
 			assert.NotEqual(t, "broker_inventory_empty", oq.ID, "serverless has no broker nodes by design")
@@ -200,14 +207,14 @@ func TestDetectOpenQuestions(t *testing.T) {
 	t.Run("zero brokers on PROVISIONED → broker_inventory_empty OQ", func(t *testing.T) {
 		c := provisioned("noBrokers")
 		c.AWSClientInformation.Nodes = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1}, ent, pniNet("noBrokers"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1}, ent, pniNet("noBrokers"), scramAuth("noBrokers"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "broker_inventory_empty", "kcp discover")
 	})
 
 	t.Run("zero topics → topic_inventory_empty OQ", func(t *testing.T) {
 		c := provisioned("noTopics")
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 0}}
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1}, ent, pniNet("noTopics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1}, ent, pniNet("noTopics"), scramAuth("noTopics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "topic_inventory_empty", "kcp scan clusters")
 	})
 
@@ -215,7 +222,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c := provisioned("overCap")
 		sizing := types.ClusterSizing{ClusterID: "overCap", FinalECKU: 15} // > 10 eCKU PL cap
 		net := types.NetworkingDecision{ClusterID: "overCap", Verdict: types.NetworkingPrivateLink}
-		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "networking_privatelink_over_cap", "account team")
 	})
 
@@ -223,7 +230,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c := provisioned("underCap")
 		sizing := types.ClusterSizing{ClusterID: "underCap", FinalECKU: 5}
 		net := types.NetworkingDecision{ClusterID: "underCap", Verdict: types.NetworkingPrivateLink}
-		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
 		}
@@ -233,7 +240,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c := provisioned("pniBig")
 		sizing := types.ClusterSizing{ClusterID: "pniBig", FinalECKU: 25}
 		net := types.NetworkingDecision{ClusterID: "pniBig", Verdict: types.NetworkingPNI}
-		oqs := detectOpenQuestions(c, sizing, ent, net, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
 		}
@@ -242,13 +249,13 @@ func TestDetectOpenQuestions(t *testing.T) {
 	t.Run("spiky workload does NOT generate an OQ (FYI only)", func(t *testing.T) {
 		c := provisioned("spiky")
 		sizing := types.ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
-		oqs := detectOpenQuestions(c, sizing, ent, pniNet("spiky"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("spiky"), scramAuth("spiky"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "spiky clusters should NOT emit an OQ — informational only")
 	})
 
 	t.Run("fully populated cluster emits no OQs", func(t *testing.T) {
 		c := provisioned("complete")
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2}, ent, pniNet("complete"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2}, ent, pniNet("complete"), scramAuth("complete"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "happy-path clusters should not surface OQs")
 	})
 }
@@ -432,4 +439,133 @@ func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T
 	assert.Equal(t, types.ClusterTypeDedicated, byID["alpha"].Verdict, "per-cluster override must flip alpha to Dedicated")
 	assert.Equal(t, types.TopologySingleZone, byID["alpha"].Topology, "SLA flag drives SZ topology")
 	assert.Equal(t, types.ClusterTypeEnterprise, byID["bravo"].Verdict, "non-overridden cluster must keep the global default (Enterprise)")
+}
+
+// Per-cluster target_auth_method override flips the effective target
+// only for the named cluster; everything else stays on the per-source
+// auth_mapping default.
+func TestPlanServiceBuild_PerClusterTargetAuthOverride(t *testing.T) {
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{{
+					Name: "us-east-1",
+					Clusters: []types.ProcessedCluster{
+						attachAuth(fixtureCluster("alpha", 100, 5.0, 5.0, 6.0, 6.0), SourceAuthSCRAM),
+						attachAuth(fixtureCluster("bravo", 100, 5.0, 5.0, 6.0, 6.0), SourceAuthSCRAM),
+					},
+				}},
+			},
+		}},
+	}
+	oauth := TargetAuthOAuth
+	rawInputs := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {TargetAuthMethod: &oauth},
+		},
+	}
+	resolved := ResolvePlanInputs(rawInputs, defaultCfg(t))
+	svc := NewPlanService(defaultCfg(t), fixedNow)
+	p, err := svc.Build(state, resolved, "x.json")
+	require.NoError(t, err)
+	require.Len(t, p.Auth, 2)
+
+	byID := map[string]types.AuthDecision{}
+	for _, a := range p.Auth {
+		byID[a.ClusterID] = a
+	}
+	require.Len(t, byID["alpha"].TargetMappings, 1)
+	require.Len(t, byID["bravo"].TargetMappings, 1)
+	assert.Equal(t, TargetAuthOAuth, byID["alpha"].TargetMappings[0].EffectiveTarget, "alpha override must replace the default API-Keys target")
+	assert.Equal(t, TargetAuthAPIKeys, byID["bravo"].TargetMappings[0].EffectiveTarget, "bravo must keep the per-source default (SCRAM → API Keys)")
+}
+
+// detectStaleStateOQ fires only when the source state file is older
+// than the configured threshold. Threshold-1 day is silent; threshold
+// + 1 day surfaces a 🟡 OQ with the day delta in the title.
+func TestDetectStaleStateOQ_HonorsThreshold(t *testing.T) {
+	gen := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Boundary: exactly threshold-days old → silent.
+	stamp := gen.AddDate(0, 0, -7).Add(time.Hour) // 6d 23h
+	require.Empty(t, detectStaleStateOQ(stamp, gen, 7))
+	// 8 days old → fires.
+	stamp = gen.AddDate(0, 0, -8)
+	oqs := detectStaleStateOQ(stamp, gen, 7)
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "state_file_stale", oqs[0].ID)
+	assert.Contains(t, oqs[0].Title, "8 days old")
+	// Zero timestamp → suppressed (no state-file stamp recorded).
+	require.Empty(t, detectStaleStateOQ(time.Time{}, gen, 7))
+}
+
+// detectAuthFleetOpenQuestions emits target_auth_method_unknown when
+// the global override is a typo, and stays silent for the recognised
+// values + the empty default.
+func TestDetectAuthFleetOpenQuestions_TargetAuthMethodTypo(t *testing.T) {
+	resolved := types.PlanInputsResolved{TargetAuthMethod: "oauthhh"}
+	oqs := detectAuthFleetOpenQuestions(resolved)
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
+	assert.Contains(t, oqs[0].Title, "oauthhh")
+
+	// Recognised value → silent.
+	resolved.TargetAuthMethod = TargetAuthOAuth
+	assert.Empty(t, detectAuthFleetOpenQuestions(resolved))
+	// Empty (default) → silent.
+	resolved.TargetAuthMethod = ""
+	assert.Empty(t, detectAuthFleetOpenQuestions(resolved))
+}
+
+// promoteSeverity flips gateway_intent_unconfirmed and
+// gateway_prereqs_pending from 🟢 to 🔴 — and rewrites the title — when
+// auth_target_gateway_incompatible is present in the same Plan. Without
+// the sibling the base severity + original title pass through.
+func TestPromoteSeverity_SiblingTriggersBlockerForGatewayOQs(t *testing.T) {
+	siblings := map[string]bool{"auth_target_gateway_incompatible": true}
+	emptySiblings := map[string]bool{}
+
+	for _, id := range []string{"gateway_intent_unconfirmed", "gateway_prereqs_pending"} {
+		meta := oqMetaFor(id)
+		sev, title := promoteSeverity(meta, "original title", siblings)
+		assert.Equal(t, "🔴", sev, id+" must promote to 🔴 when auth sibling fires")
+		assert.NotEqual(t, "original title", title, id+" must rewrite its title when promoted")
+
+		sev, title = promoteSeverity(meta, "original title", emptySiblings)
+		assert.Equal(t, "🟢", sev, id+" must stay 🟢 without the sibling")
+		assert.Equal(t, "original title", title, id+" must keep original title without promotion")
+	}
+}
+
+// severityLegend renders only the severities present in this Plan —
+// no 🔴 entry when nothing surfaces as blocker, etc.
+func TestSeverityLegend_OnlyPresent(t *testing.T) {
+	assert.Empty(t, severityLegend(map[string]bool{}))
+
+	yellowOnly := severityLegend(map[string]bool{"🟡": true})
+	assert.Contains(t, yellowOnly, "🟡")
+	assert.NotContains(t, yellowOnly, "🔴")
+	assert.NotContains(t, yellowOnly, "🟢")
+
+	all := severityLegend(map[string]bool{"🔴": true, "🟡": true, "🟢": true})
+	assert.Contains(t, all, "🔴")
+	assert.Contains(t, all, "🟡")
+	assert.Contains(t, all, "🟢")
+}
+
+// attachAuth gives a fixture cluster a SCRAM (or other) source auth so
+// it surfaces in DecideAuth output. Mirrors withSourceAuth in
+// cutover_test.go but layers on top of an existing fixtureCluster.
+func attachAuth(c types.ProcessedCluster, sourceAuth string) types.ProcessedCluster {
+	enabled := true
+	clientAuth := &kafkatypes.ClientAuthentication{}
+	switch sourceAuth {
+	case SourceAuthSCRAM:
+		clientAuth.Sasl = &kafkatypes.Sasl{Scram: &kafkatypes.Scram{Enabled: &enabled}}
+	case SourceAuthIAM:
+		clientAuth.Sasl = &kafkatypes.Sasl{Iam: &kafkatypes.Iam{Enabled: &enabled}}
+	}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+	c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{ClientAuthentication: clientAuth}
+	return c
 }

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -42,6 +42,10 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 		writeAuth(&b, p.Auth, p.Cutover, p.Inputs, section)
 		section++
 	}
+	if p.Schema != nil {
+		writeSchema(&b, p.Schema, p.Inputs, cfg, section)
+		section++
+	}
 	writeOpenQuestions(&b, p, section)
 	writeSizingAppendix(&b, p, cfg)
 	writeRulesAppendix(&b, p)
@@ -511,13 +515,18 @@ func escapeMarkdownTableCell(s string) string {
 	return s
 }
 
-// pluralize returns `singular` when n == 1, else `singular + "s"`.
+// pluralize returns `singular` when n == 1, else the plural form.
+// Handles the regular `+ s` rule by default; pass a `y → ies` word
+// (e.g. "registry") and the helper rewrites the suffix accordingly.
 // Trivial but used in multiple places ("cluster"/"clusters",
-// "rule"/"rules") so the call sites read naturally without inline
-// if-statements or programmatic `(s)` hacks.
+// "rule"/"rules", "registry"/"registries") so the call sites read
+// naturally without inline if-statements or programmatic `(s)` hacks.
 func pluralize(singular string, n int) string {
 	if n == 1 {
 		return singular
+	}
+	if strings.HasSuffix(singular, "y") {
+		return strings.TrimSuffix(singular, "y") + "ies"
 	}
 	return singular + "s"
 }
@@ -1184,4 +1193,215 @@ func gatewayCompatibleLabel(compatible, transparent bool) string {
 	default:
 		return "❌ no"
 	}
+}
+
+// ----- §schema -----
+
+// writeSchema renders the fleet-wide Schema Migration section. Skips
+// rendering entirely on the schemaless path (caller already nils
+// p.Schema in that branch). For mixed Confluent+Glue deployments
+// both verdicts render — Glue Terraform command and a Schema-Linking
+// eligibility table.
+func writeSchema(b *bytes.Buffer, dec *types.SchemaDecision, inputs types.PlanInputsResolved, cfg *PlanConfig, section int) {
+	if dec == nil {
+		return
+	}
+	fmt.Fprintf(b, "## %d. Schema Migration\n\n", section)
+	b.WriteString("Schemas are a fleet-wide concern (one Schema Registry per source, not one per cluster).\n\n")
+	// The Schema-Linking glossary only applies to paths that use it
+	// (Confluent SR — solo or dual). Pure-Glue paths don't, so the
+	// definition would just confuse a Glue-only customer.
+	if sourceTouchesConfluent(dec.Source) {
+		b.WriteString("_**Schema Linking** is Confluent's source-pushes, CC-receives mirror — the source SR runs a one-directional exporter that streams schema updates to your CC SR endpoint, no manual export/import needed._\n\n")
+	}
+	b.WriteString("The verdict below combines:\n")
+	b.WriteString("- what `kcp scan schema-registry` / `kcp scan glue-schema-registry` found on the source, and\n")
+	b.WriteString("- the customer-declared `schema_strategy` / CP version / edition / network-reachability inputs in `plan-inputs.yaml`.\n\n")
+
+	fmt.Fprintf(b, "- **Source detected:** %s\n", schemaSourceLabel(dec.Source, dec.ConfluentSRURLs, dec.GlueRegistries))
+	fmt.Fprintf(b, "- **Recommended path%s:** %s\n", pluralize("", len(dec.Paths)), schemaPathsLabelForContext(dec.Paths, inputs.SchemaStrategy, dec.Source))
+	fmt.Fprintf(b, "- **Strategy declared:** %s\n\n", schemaStrategyDeclaredLabel(inputs.SchemaStrategy, dec))
+
+	// The eligibility table renders only when the customer's strategy
+	// actually engages Schema Linking. Suppress on the `no_schemas`
+	// strategy even if a Confluent SR was scanned — the table would
+	// otherwise show all-❔ unknown to a reader who explicitly said
+	// they're not migrating schemas. The mismatch OQ carries the
+	// reconciliation prompt. Normalize "" → unknown here so the
+	// comparison matches DecideSchema's own normalization (schema.go).
+	strategy := inputs.SchemaStrategy
+	if strategy == "" {
+		strategy = SchemaStrategyUnknown
+	}
+	suppressEligibilityTable := strategy == SchemaStrategyNoSchemas
+
+	switch dec.Source {
+	case types.SchemaSourceGlue:
+		writeGluePathCommand(b, dec.GlueRegistries)
+	case types.SchemaSourceConfluent:
+		if !suppressEligibilityTable {
+			writeSchemaLinkingEligibility(b, dec, cfg)
+		}
+	case types.SchemaSourceConfluentAndGlue:
+		// Both registries present: render each path side-by-side so the
+		// customer sees both recommendations without having to re-run
+		// the Plan against a narrowed scan.
+		writeGluePathCommand(b, dec.GlueRegistries)
+		if !suppressEligibilityTable {
+			writeSchemaLinkingEligibility(b, dec, cfg)
+		}
+	}
+
+	writeSchemaProvenance(b, dec, cfg)
+}
+
+// writeSchemaProvenance emits a citation line whose content depends on
+// the source. Glue-only paths cite the `kcp create-asset migrate-schemas`
+// docs (the active recommendation); Confluent paths cite the Schema
+// Linking docs (the eligibility floor); dual-source cites both.
+func writeSchemaProvenance(b *bytes.Buffer, dec *types.SchemaDecision, cfg *PlanConfig) {
+	const glueRef = "https://confluentinc.github.io/kcp/command-reference/create-asset/migrate-schemas/"
+	switch dec.Source {
+	case types.SchemaSourceGlue:
+		fmt.Fprintf(b, "\n_Mapping provenance: Glue migration command → %s._\n\n", glueRef)
+	case types.SchemaSourceConfluent:
+		fmt.Fprintf(b, "\n_Mapping provenance: Schema Linking eligibility (CP %s+ %s + outbound reachable) → %s (last verified %s)._\n\n",
+			cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition, cfg.SchemaLinking.Source, cfg.SchemaLinking.LastVerified)
+	case types.SchemaSourceConfluentAndGlue:
+		fmt.Fprintf(b, "\n_Mapping provenance: Glue migration → %s; Schema Linking eligibility (CP %s+ %s + outbound reachable) → %s (last verified %s)._\n\n",
+			glueRef, cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition, cfg.SchemaLinking.Source, cfg.SchemaLinking.LastVerified)
+	default:
+		// Source==None case: no provenance citation applies — the
+		// recommendation is purely strategy-driven and the OQ
+		// explains the next step.
+	}
+}
+
+// schemaPathsLabel formats one or more paths in rendering order. Used
+// by the "Recommended path(s)" bullet to handle both single- and
+// dual-source decisions uniformly. Joiner is " — **also:** " to keep
+// the inline-bold labels readable (each label already ends with `**`,
+// so a `**also**` joiner would collide asterisks).
+func schemaPathsLabel(paths []types.SchemaPath) string {
+	if len(paths) == 0 {
+		return schemaPathLabel(types.SchemaPathUnknown)
+	}
+	if len(paths) == 1 {
+		return schemaPathLabel(paths[0])
+	}
+	labels := make([]string, 0, len(paths))
+	for _, p := range paths {
+		labels = append(labels, schemaPathLabel(p))
+	}
+	return strings.Join(labels, " — **also:** ")
+}
+
+// schemaPathsLabelForContext is the entrypoint used by writeSchema.
+// Overrides the generic schemaPathsLabel rendering for context-specific
+// cases where the path enum's default text would mislead — currently:
+//   - `no_schemas` declared while a SR was scanned: the verdict path
+//     is Unknown but the underlying issue is the mismatch, not a
+//     missing input. Surface "Conflict" so the reader's eye lands on
+//     the contradiction rather than chasing a phantom missing field.
+func schemaPathsLabelForContext(paths []types.SchemaPath, strategy string, source types.SchemaSource) string {
+	if strategy == SchemaStrategyNoSchemas && source != types.SchemaSourceNone {
+		return "**Conflict** — strategy declares `no_schemas` but the scan found a Schema Registry; see §Actions Needed for reconciliation"
+	}
+	return schemaPathsLabel(paths)
+}
+
+// schemaStrategyDeclaredLabel renders the strategy bullet with a
+// status glyph when the declared value conflicts with what the scan
+// found, so a reader doesn't have to cross-reference §Schema with
+// §Actions Needed to spot the contradiction.
+func schemaStrategyDeclaredLabel(strategy string, dec *types.SchemaDecision) string {
+	if strategy == "" {
+		strategy = SchemaStrategyUnknown
+	}
+	if strategy == SchemaStrategyNoSchemas && dec.Source != types.SchemaSourceNone {
+		return fmt.Sprintf("`%s` ⚠ (scan found a Schema Registry)", strategy)
+	}
+	return fmt.Sprintf("`%s`", strategy)
+}
+
+func schemaSourceLabel(src types.SchemaSource, confluentURLs, glueNames []string) string {
+	switch src {
+	case types.SchemaSourceConfluent:
+		return fmt.Sprintf("Confluent Schema Registry (%d URL%s: %s)",
+			len(confluentURLs), pluralize("", len(confluentURLs)), strings.Join(quoteAll(confluentURLs), ", "))
+	case types.SchemaSourceGlue:
+		return fmt.Sprintf("AWS Glue Schema Registry (%d %s: %s)",
+			len(glueNames), pluralize("registry", len(glueNames)), strings.Join(quoteAll(glueNames), ", "))
+	case types.SchemaSourceConfluentAndGlue:
+		return "Confluent Schema Registry AND AWS Glue Schema Registry (each handled independently below)"
+	default:
+		return "_none detected_ — neither `kcp scan schema-registry` nor `kcp scan glue-schema-registry` found a registry on the source"
+	}
+}
+
+func schemaPathLabel(p types.SchemaPath) string {
+	switch p {
+	case types.SchemaPathSchemaLinking:
+		return "**Schema Linking** — source SR pushes schema updates to CC SR over TCP; alternative is manual REST export/import"
+	case types.SchemaPathMigrateGlue:
+		return "**`kcp create-asset migrate-schemas --glue-registry`** — one Terraform apply imports every schema in the Glue registry into CC SR"
+	case types.SchemaPathDeferToAccount:
+		return "**Defer to your Confluent account team** — REST API export/import is possible but not deterministic; see §Actions Needed for the failing constraint"
+	case types.SchemaPathSchemaless:
+		return "**Schemaless** — `schema_strategy: no_schemas` and no source SR was scanned; this section will not render"
+	default:
+		return "**Pending** — declare the missing input in `plan-inputs.yaml`; see §Actions Needed for the specific field"
+	}
+}
+
+// writeGluePathCommand emits one canonical `kcp create-asset
+// migrate-schemas` invocation with placeholder substitution hints,
+// then lists the detected registries (one apply per registry, run
+// the same command N times with `--glue-registry` varied).
+func writeGluePathCommand(b *bytes.Buffer, glueNames []string) {
+	b.WriteString("\n**Glue path — generates Terraform that imports every schema in a registry into CC SR as a `confluent_schema` resource. Run the command once per registry:**\n\n")
+	b.WriteString("```bash\nkcp create-asset migrate-schemas \\\n  --glue-registry <registry-name> \\\n  --region <aws-region> \\\n  --cc-sr-rest-endpoint <cc-sr-url>\n```\n\n")
+	b.WriteString("Find each placeholder:\n")
+	b.WriteString("- `<registry-name>` — one of the detected registries below.\n")
+	b.WriteString("- `<aws-region>` — the AWS region the Glue registry lives in (e.g. `us-east-1`).\n")
+	b.WriteString("- `<cc-sr-url>` — your CC Schema Registry REST endpoint, e.g. `https://psrc-xxxxx.us-east-1.aws.confluent.cloud`; find on CC Console → Environment → Schema Registry.\n\n")
+	fmt.Fprintf(b, "Detected %s: %s.\n\n", pluralize("registry", len(glueNames)), strings.Join(quoteAll(glueNames), ", "))
+	b.WriteString("Applying the generated Terraform imports every schema in that registry into CC SR in one apply. **Client-side work remains yours:** swap `AWSKafkaAvroSerializer` for `KafkaAvroSerializer` in producers / consumers, and reconcile any subject-name overlaps with topics that already exist on CC.\n")
+}
+
+// writeSchemaLinkingEligibility renders the three-row eligibility
+// table for the Confluent SR path. Verdict comes first so the
+// reader's eye lands on ✅/❌/❔ before the constraint text — at a
+// glance you see whether to read further or fix YAML.
+func writeSchemaLinkingEligibility(b *bytes.Buffer, dec *types.SchemaDecision, cfg *PlanConfig) {
+	b.WriteString("\n**Schema Linking eligibility (Confluent SR path):** all three rows must be **✅ yes** for the Schema Linking path to apply. Any **❌ no** falls to `defer_to_account_team`; any **❔ unknown** keeps the path at `unknown` until you declare the missing input.\n\n")
+	b.WriteString("| Verdict | Constraint | Input |\n")
+	b.WriteString("|---|---|---|\n")
+	fmt.Fprintf(b, "| %s | Source CP version ≥ %s | `plan-inputs.confluent_sr_cp_version` |\n",
+		eligibilityCell(dec.MeetsCPVersionFloor), cfg.SchemaLinking.MinCPVersion)
+	fmt.Fprintf(b, "| %s | Source CP edition is `%s` | `plan-inputs.confluent_sr_cp_edition` |\n",
+		eligibilityCell(dec.MeetsCPEditionRequirement), cfg.SchemaLinking.RequiresCPEdition)
+	fmt.Fprintf(b, "| %s | Source SR can reach CC SR outbound | `plan-inputs.source_sr_outbound_reachable_to_cc` |\n",
+		eligibilityCell(dec.SourceSROutboundReachable))
+}
+
+// eligibilityCell renders the verdict cell for a tri-state flag (nil
+// = unknown, *true = yes, *false = no).
+func eligibilityCell(flag *bool) string {
+	if flag == nil {
+		return "❔ unknown"
+	}
+	if *flag {
+		return "✅ yes"
+	}
+	return "❌ no"
+}
+
+// quoteAll wraps each string in backticks for inline code rendering.
+func quoteAll(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, "`"+v+"`")
+	}
+	return out
 }

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -28,6 +28,8 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	writeDefinitions(&b, cfg)
 	writeSourceEnvironment(&b, p)
 	writeSizingAndDecisions(&b, p, cfg)
+	writeCutover(&b, p.Cutover, cfg)
+	writeAuth(&b, p.Auth, p.Cutover, p.Inputs)
 	writeOpenQuestions(&b, p)
 	writeSizingAppendix(&b, p, cfg)
 	writeRulesAppendix(&b, p)
@@ -37,23 +39,79 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 
 func writeOpenQuestions(b *bytes.Buffer, p *types.Plan) {
 	if len(p.OpenQuestions) == 0 {
+		b.WriteString("## 5. Actions Needed\n\n")
+		b.WriteString("_No actions outstanding — the Plan above renders without unresolved questions._\n\n")
 		return
 	}
-	b.WriteString("## 3. Actions Needed\n\n")
-	b.WriteString("Each item below is a concrete action that tightens the recommendation in **Sizing & Cluster Decisions**. The current recommendation stands; doing these closes a state-file or scan gap.\n\n")
-	for i, g := range groupOpenQuestions(p.OpenQuestions) {
-		fmt.Fprintf(b, "%d. **%s**\n", i+1, g.oq.Title)
+	b.WriteString("## 5. Actions Needed\n\n")
+	groups := groupOpenQuestions(p.OpenQuestions)
+	siblingIDs := oqIDSet(p.OpenQuestions)
+	// Build per-group rendered severity + title up front so the legend
+	// can mention only severities that actually appear in this Plan.
+	rendered := make([]struct {
+		severity string
+		title    string
+	}, len(groups))
+	present := map[string]bool{}
+	for i, g := range groups {
+		meta := oqMetaFor(g.oq.ID)
+		sev, title := promoteSeverity(meta, g.oq.Title, siblingIDs)
+		rendered[i].severity = sev
+		rendered[i].title = title
+		present[sev] = true
+	}
+	b.WriteString("Each item below is a concrete action that tightens the recommendation. The current recommendation stands; these close state-file gaps, fix invalid inputs, or resolve preference questions.")
+	if legend := severityLegend(present); legend != "" {
+		fmt.Fprintf(b, " %s", legend)
+	}
+	b.WriteString("\n\n")
+	for i, g := range groups {
+		fmt.Fprintf(b, "%d. %s **%s**\n", i+1, rendered[i].severity, rendered[i].title)
 		if len(g.clusters) > 0 {
-			fmt.Fprintf(b, "   - _Affects:_ %s\n", formatClusterList(g.clusters))
+			fmt.Fprintf(b, "   - **Affects:** %s\n", formatClusterList(g.clusters))
 		}
 		if g.oq.Body != "" {
-			fmt.Fprintf(b, "   - %s\n", g.oq.Body)
+			fmt.Fprintf(b, "   - %s\n", indentMultiline(g.oq.Body, "     "))
 		}
 		if g.oq.HowToClose != "" {
-			fmt.Fprintf(b, "   - _How to close:_ %s\n", g.oq.HowToClose)
+			fmt.Fprintf(b, "   - _How to close:_ %s\n", indentMultiline(g.oq.HowToClose, "     "))
 		}
 	}
 	b.WriteString("\n")
+}
+
+// severityLegend renders only the severities that appear in this Plan.
+// Suppresses the legend entirely when nothing is present (no OQs path
+// short-circuits earlier; this guards an all-promoted edge case).
+func severityLegend(present map[string]bool) string {
+	if len(present) == 0 {
+		return ""
+	}
+	parts := []string{}
+	if present["🔴"] {
+		parts = append(parts, "🔴 blocker (fix before cutover)")
+	}
+	if present["🟡"] {
+		parts = append(parts, "🟡 affects accuracy (fix before relying on the plan)")
+	}
+	if present["🟢"] {
+		parts = append(parts, "🟢 preference (pick one)")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "**Severity prefix:** " + strings.Join(parts, " · ") + "."
+}
+
+// oqIDSet returns a lookup of OQ IDs present in this Plan. Used to
+// drive sibling-aware severity promotions through the OQ registry
+// (see oq_registry.go — `promoteSeverity`).
+func oqIDSet(oqs []types.OpenQuestion) map[string]bool {
+	out := make(map[string]bool, len(oqs))
+	for _, oq := range oqs {
+		out[oq.ID] = true
+	}
+	return out
 }
 
 // oqGroup collapses OQs that render identically (same ID + Body +
@@ -98,6 +156,18 @@ func groupOpenQuestions(oqs []types.OpenQuestion) []oqGroup {
 	return groups
 }
 
+// indentMultiline prefixes every newline-separated continuation line
+// in `s` with `indent` so the line stays nested under its parent
+// ordered-list / bullet item. Without this, an embedded fenced code
+// block in an OQ Body or HowToClose terminates the enclosing list
+// item because the ``` lands at column 0.
+func indentMultiline(s, indent string) string {
+	if !strings.Contains(s, "\n") {
+		return s
+	}
+	return strings.ReplaceAll(s, "\n", "\n"+indent)
+}
+
 // formatClusterList renders a list of cluster IDs as “ `a` “, “ `b` “,
 // “ `c` “ for inline display.
 func formatClusterList(ids []string) string {
@@ -119,7 +189,18 @@ func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
 	b.WriteString("- **Peak burst** — short-window peak throughput observed in metrics, expressed as eCKU. Surfaces in the spiky-workload note when peak diverges from P95 by more than the configured ratio.\n")
 	fmt.Fprintf(b, "- **PNI** (Private Network Interface) — AWS-to-AWS private connectivity, up to %d eCKU on Enterprise. The default for AWS Enterprise; **always required on Dedicated** (AWS).\n", caps.PNIMaxECKU)
 	fmt.Fprintf(b, "- **PrivateLink** — capped at %d eCKU on Enterprise. Fires when `target_cloud != \"aws\"` (PNI is AWS-only), when `cc_egress_required: true` (PNI lacks native CC→customer egress), or when `projected_pni_gateway_count >= 2`. Also the cross-cloud private path on Dedicated when `target_cloud` is Azure / GCP.\n", caps.PrivateLinkMaxECKU)
-	fmt.Fprintf(b, "- **ACL cap (%d)** — Enterprise supports up to %d ACLs; exceeding the cap forces Dedicated. Source: cluster-types.html.\n\n", caps.ACLCountCap, caps.ACLCountCap)
+	fmt.Fprintf(b, "- **ACL cap (%d)** — Enterprise supports up to %d ACLs; exceeding the cap forces Dedicated. Source: [%s](%s).\n\n", caps.ACLCountCap, caps.ACLCountCap, caps.Source, caps.Source)
+	// Cutover-style + plain-CL definitions live in a collapsible block —
+	// they're load-bearing context for §3 but expanding inline triples
+	// the Definitions wall before the reader has any context.
+	b.WriteString("<details><summary>Cutover-related terms (Stop-Restart-Repeat, Blue/Green, CC Gateway-mediated, etc.)</summary>\n\n")
+	b.WriteString("- **Stop-Restart-Repeat** — phased per-service cutover. Each application (or topic) is stopped on MSK, mirrored to CC, and resumed at the CC endpoint, one at a time. Recoverable per step; longer elapsed time.\n")
+	b.WriteString("- **Stop-Wait-Restart** — single coordinated maintenance window. Producers stop, the mirror catches up, services resume in sequence inside the window.\n")
+	b.WriteString("- **Restart-All-At-Once** — single window where every client reconfigures and reconnects at the same instant. Largest blast radius; one rollback point for the whole fleet.\n")
+	b.WriteString("- **Blue/Green** — parallel run on both sides via Cluster Linking. Zero downtime, highest operational complexity; customer-designed orchestration.\n")
+	b.WriteString("- **CC Gateway-mediated** — a sidecar component that absorbs the cutover with a 30–90 s `BROKER_NOT_AVAILABLE` window per service, after which clients auto-retry against CC. Removes the per-service producer restart; requires Confluent for Kubernetes + a Gateway Add-On license.\n")
+	b.WriteString("- **Plain Cluster Linking** — Cluster Linking without the CC Gateway; the simpler op model. Each service stops, mirror drains, restarts against the CC endpoint (minutes per service). Fully supported; chosen via `prefer_gateway: false`.\n")
+	b.WriteString("\n</details>\n\n")
 }
 
 func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
@@ -150,16 +231,44 @@ func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
 	}
 	fmt.Fprintf(b, "- **%d** source %s across **%d** %s · **%d** brokers · **%d** topics%s\n\n",
 		len(p.SourceEnvironment.Clusters), clusterWord, p.SourceEnvironment.TotalRegions, regionWord, totalBrokers, totalTopics, serverlessNote)
-	b.WriteString("| Cluster | Region | Brokers | Topics |\n")
-	b.WriteString("|---|---|---:|---:|\n")
+	b.WriteString("| Cluster | Region | Brokers | Topics | Source auth |\n")
+	b.WriteString("|---|---|---:|---:|---|\n")
 	for _, c := range p.SourceEnvironment.Clusters {
 		brokerCell := fmt.Sprintf("%d", c.BrokerCount)
 		if c.IsServerless {
 			brokerCell = "_N/A (serverless)_"
 		}
-		fmt.Fprintf(b, "| %s | %s | %s | %d |\n", escapeMarkdownTableCell(c.ClusterID), escapeMarkdownTableCell(c.Region), brokerCell, c.TopicCount)
+		fmt.Fprintf(b, "| %s | %s | %s | %d | %s |\n",
+			escapeMarkdownTableCell(c.ClusterID),
+			escapeMarkdownTableCell(c.Region),
+			brokerCell,
+			c.TopicCount,
+			sourceAuthCell(c.SourceAuths),
+		)
 	}
 	b.WriteString("\n")
+	if serverlessCount > 0 {
+		b.WriteString("**MSK Serverless caveats** — the fleet includes one or more Serverless source clusters. These differ from Provisioned MSK in ways that affect the migration plan:\n")
+		b.WriteString("- **No broker inventory.** Serverless is a pay-per-throughput managed service; the broker count column reads `N/A`.\n")
+		b.WriteString("- **ACL semantics differ.** Serverless does not expose ACLs via the admin API path kcp scans; the `acl_count_exceeds_cap` rule cannot evaluate on Serverless clusters.\n")
+		b.WriteString("- **Auth surface is smaller.** Only SASL/IAM is supported on Serverless; SCRAM / mTLS / unauthenticated paths don't apply.\n")
+		b.WriteString("- **Workload shape changes at the migration boundary.** Serverless billing is throughput-based; CC destination clusters are eCKU / CKU sized. Confirm sizing against actual rate metrics with your Confluent account team.\n\n")
+	}
+}
+
+// sourceAuthCell renders the Source-auth column: comma-separated
+// `code`-formatted tokens, or "_none detected_" italic when empty.
+// Multiple auths on one cluster (e.g. SCRAM + mTLS both enabled on
+// MSK) are surfaced together; the plan never picks one.
+func sourceAuthCell(auths []string) string {
+	if len(auths) == 0 {
+		return "_none detected_"
+	}
+	parts := make([]string, len(auths))
+	for i, a := range auths {
+		parts[i] = "`" + a + "`"
+	}
+	return strings.Join(parts, ", ")
 }
 
 func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
@@ -168,6 +277,7 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 		b.WriteString("_No clusters to size._\n\n")
 		return
 	}
+	b.WriteString("This section combines three per-cluster decisions: the **sizing** (how many eCKU each cluster needs to absorb its workload at the chosen percentile + headroom), the **cluster type** (Enterprise, Dedicated, or Freight — driven by hard limits like ACL count and customer-declared flags), and the **networking** topology (PNI, PrivateLink, Transit Gateway, or VPC Peering — driven by `target_cloud`, egress requirements, and projected PNI gateway count). They render together because each row's verdict in one column constrains the others: e.g. a Dedicated cluster opens up PrivateLink networking patterns that Enterprise caps.\n\n")
 
 	// Build cluster_id-keyed lookups so the rendered table can't silently
 	// mis-pair a cluster's sizing with another cluster's verdict — earlier
@@ -202,7 +312,9 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 		// missing.
 		if s.Degraded {
 			throughputCell = "_metrics missing_"
-			sizeCell = formatSizeCell(s.FinalECKU, ctDecision, true)
+			// sizeCell already carries the (floor) suffix via the
+			// earlier formatSizeCell call (degraded flag was already
+			// true). No re-format needed.
 		}
 		// Partitions column reflects topics specifically (the only
 		// signal that drives partition count). The `*` marker is
@@ -212,7 +324,13 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 		if slices.Contains(s.InputsMissing, "topics") {
 			partitionsCell = "_unknown_"
 		}
-		if len(s.InputsMissing) > 0 {
+		// Provisional `*` marker fires for ANY signal that makes the
+		// size cell less than fully trusted: missing scan inputs OR a
+		// degraded (metrics-missing) sizing fallback to the SLA floor.
+		// Without the second branch, a metrics-degraded cluster shows
+		// `1 eCKU (floor)` without the asterisk that explicitly means
+		// "provisional" — three notations for the same condition.
+		if len(s.InputsMissing) > 0 || s.Degraded {
 			sizeCell += " *"
 		}
 		fmt.Fprintf(b, "| %s | %s | %s | %s | %s | %s |\n",
@@ -220,7 +338,7 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 	}
 	b.WriteString("\n")
 	if hasProvisional(p.Sizing) {
-		b.WriteString("`*` = sizing is provisional — some scan inputs were missing; see each cluster's Why line for the specifics.\n\n")
+		b.WriteString("`*` = sizing is provisional — some scan inputs were missing or metrics were degraded; see each cluster's Why line. `(floor)` next to a size means the SLA minimum bound it; both can apply to the same cluster.\n\n")
 	}
 
 	// Per-cluster rationale: each line cites the cluster-type decision and
@@ -242,6 +360,17 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 		if szIsGlobal(globalCustomerTriggers) {
 			writeSZTradeoff(b, cfg, calloutGlobal)
 		}
+	}
+	// Fleet-level state-derived Dedicated banner: emit once at the top
+	// of the section when ≥ 2 clusters land on Dedicated because of a
+	// state-driven rule (no customer-declared trigger). Below the
+	// threshold the per-cluster note is still readable; above it we
+	// were repeating the same paragraph 30 times.
+	stateDerivedDedicatedCount := countStateDerivedDedicated(p.ClusterTypeDecision)
+	hoistStateDerivedBanner := stateDerivedDedicatedCount >= 2
+	if hoistStateDerivedBanner {
+		fmt.Fprintf(b, "> ℹ **Cost direction (fleet):** %d clusters land on Dedicated because of state-derived hard-limit rules — i.e. the cluster as scanned hit a cap that Enterprise can't carry. The escalation isn't recoverable by editing `plan-inputs.yaml`; confirm with your Confluent account team that the scanned capacity reflects each cluster's actual workload before committing. Dedicated has a higher monthly cost than Enterprise.\n\n",
+			stateDerivedDedicatedCount)
 	}
 	for _, s := range p.Sizing {
 		ct := ctByID[s.ClusterID]
@@ -289,6 +418,16 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 		perClusterTriggers := filterNonGlobalTriggers(customerDeclaredTriggers, globalCustomerTriggers)
 		if len(perClusterTriggers) > 0 {
 			writeCostCallout(b, perClusterTriggers, calloutPerCluster)
+		}
+		// State-derived Dedicated cost note: when the verdict is
+		// Dedicated and none of the firing rules are customer-declared
+		// (so the customer-callout above didn't fire), surface a
+		// shorter note so the cost direction is visible. Recovery isn't
+		// "flip a flag" here — the fleet's state forced the escalation
+		// — but the cost-direction signal is the same. Suppressed when
+		// the fleet-level banner above already covers it.
+		if !hoistStateDerivedBanner && ct.Verdict == types.ClusterTypeDedicated && len(customerDeclaredTriggers) == 0 && len(ct.Triggers) > 0 {
+			b.WriteString("  - ℹ **Cost direction:** Dedicated has a higher monthly cost than Enterprise. This verdict is state-derived (a hard-limit rule fired on the cluster as scanned), so the escalation isn't recoverable by editing `plan-inputs.yaml`. Confirm with your Confluent account team that the cluster's capacity reflects your actual workload before committing.\n")
 		}
 		// Single-Zone resilience tradeoff: skipped when the SZ trigger
 		// fired globally (banner already covered it); otherwise emit
@@ -376,7 +515,7 @@ func pluralize(singular string, n int) string {
 // the `*` legend after the Sizing & Cluster Decisions table.
 func hasProvisional(sizings []types.ClusterSizing) bool {
 	for _, s := range sizings {
-		if len(s.InputsMissing) > 0 {
+		if len(s.InputsMissing) > 0 || s.Degraded {
 			return true
 		}
 	}
@@ -480,11 +619,14 @@ func writeRulesAppendix(b *bytes.Buffer, p *types.Plan) {
 	b.WriteString("## Appendix A2 — Hard-Limit Rules Evaluated\n")
 	b.WriteString("<details><summary>Show per-cluster rule-evaluation trace</summary>\n\n")
 	b.WriteString("Every cluster runs the same hard-limit catalog; this table records each rule's outcome so a reviewer can confirm the verdict and see negative evidence (e.g. \"47 ACLs ≤ 4000 cap\"). `skipped` rows mean the rule couldn't be evaluated — the cluster's verdict resolves on the other rules.\n\n")
+	if !p.Header.StateGeneratedAt.IsZero() {
+		fmt.Fprintf(b, "_Evidence below reflects the source state file as of %s. Re-run `kcp discover` / `kcp scan ...` if the source environment has changed materially since._\n\n", p.Header.StateGeneratedAt.Format("2006-01-02 15:04:05 UTC"))
+	}
 	for _, ct := range p.ClusterTypeDecision {
 		if len(ct.EvaluatedRules) == 0 {
 			continue
 		}
-		fmt.Fprintf(b, "**%s**\n\n", escapeMarkdownTableCell(ct.ClusterID))
+		fmt.Fprintf(b, "**Cluster** `%s`\n\n", escapeMarkdownTableCell(ct.ClusterID))
 		b.WriteString("| Rule | Outcome | Detail |\n|---|---|---|\n")
 		for _, r := range ct.EvaluatedRules {
 			detail := r.Evidence
@@ -539,7 +681,7 @@ func writeCostCallout(b *bytes.Buffer, triggers []types.HardLimitTrigger, scope 
 	case calloutGlobal:
 		fmt.Fprintf(b, "> ⚠ **Cost callout (applies to every cluster below):** "+costCalloutBody+"\n\n", labels)
 	case calloutPerCluster:
-		fmt.Fprintf(b, "  - > ⚠ **Cost callout:** "+costCalloutBody+"\n", labels)
+		fmt.Fprintf(b, "  - ⚠ **Cost callout:** "+costCalloutBody+"\n", labels)
 	}
 }
 
@@ -552,7 +694,7 @@ func writeSZTradeoff(b *bytes.Buffer, cfg *PlanConfig, scope calloutScope) {
 	case calloutGlobal:
 		fmt.Fprintf(b, "> ℹ "+szTradeoffBody+"\n\n", mzFloor)
 	case calloutPerCluster:
-		fmt.Fprintf(b, "  - > ℹ "+szTradeoffBody+"\n", mzFloor)
+		fmt.Fprintf(b, "  - ℹ "+szTradeoffBody+"\n", mzFloor)
 	}
 }
 
@@ -569,6 +711,32 @@ func szIsGlobal(global []types.HardLimitTrigger) bool {
 // banner instead of N repeated per-cluster callouts. Per-cluster
 // overrides (where the same trigger fires on a subset) keep their
 // inline cost callout because the noise signal there is real.
+// countStateDerivedDedicated returns the number of clusters whose
+// verdict is Dedicated AND every firing trigger was state-derived
+// (no customer-declared flag in the trigger set). Drives the
+// fleet-level "Cost direction" banner when many clusters share the
+// state-forced escalation — at small N the per-cluster inline note
+// is fine; at fleet scale it becomes noise.
+func countStateDerivedDedicated(decisions []types.ClusterTypeDecision) int {
+	n := 0
+	for _, ct := range decisions {
+		if ct.Verdict != types.ClusterTypeDedicated || len(ct.Triggers) == 0 {
+			continue
+		}
+		anyCustomer := false
+		for _, t := range ct.Triggers {
+			if t.CustomerDeclared {
+				anyCustomer = true
+				break
+			}
+		}
+		if !anyCustomer {
+			n++
+		}
+	}
+	return n
+}
+
 func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types.HardLimitTrigger {
 	if len(decisions) == 0 {
 		return nil
@@ -685,4 +853,323 @@ func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) 
 		return fmt.Sprintf("%d %s (floor)", value, suffix)
 	}
 	return fmt.Sprintf("%d %s", value, suffix)
+}
+
+// ----- §3 cutover -----
+
+// writeCutover renders the fleet-wide cutover recommendation: chosen
+// style, gateway mediation status with degraded markers, alternatives
+// shown for trust, and the gateway prereq table. Skips the section
+// entirely when there's no cutover decision (empty fleet).
+func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, cfg *PlanConfig) {
+	if c == nil {
+		return
+	}
+	b.WriteString("## 3. Cutover Approach\n\n")
+	b.WriteString("_The cutover style below applies to the **entire fleet**. Per-cluster cutover overrides aren't supported in this kcp version (planned for a follow-up). Heterogeneous fleets can run kcp against a state-file subset that contains only the clusters sharing a style — re-run for each subset and combine the recommendations manually._\n\n")
+	fmt.Fprintf(b, "- **Style:** %s\n", cutoverStyleLabel(c.Style, c.SubPattern))
+	fmt.Fprintf(b, "- **Gateway mediation:** %s\n", cutoverGatewayLabel(c.GatewayMediated, c.RecommendationStatus))
+	if marker := recommendationStatusMarker(c.RecommendationStatus); marker != "" {
+		fmt.Fprintf(b, "  - %s\n", marker)
+	}
+	writeCutoverAlternatives(b, c.AlternativesShown)
+	writeCutoverPrereqs(b, c.Prereqs)
+	b.WriteString("\n")
+	// Blue/Green is customer-designed — kcp doesn't generate the
+	// orchestration. Promote the runbook hint to its own sub-heading
+	// so the multi-sentence content reads as a separate concern, not
+	// a comically heavy list item.
+	if c.Style == types.CutoverBlueGreen {
+		linkingURL := "https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/index.html"
+		if cfg != nil && cfg.ClusterLinking.Source != "" {
+			linkingURL = cfg.ClusterLinking.Source
+		}
+		b.WriteString("### Runbook (Blue/Green)\n\n")
+		fmt.Fprintf(b, "kcp does not generate Blue/Green orchestration. See [Confluent Cloud Cluster Linking guide](%s) for the parallel-run pattern; the customer designs cutover gating, consumer-offset handoff, and rollback.\n\n", linkingURL)
+		b.WriteString("**Scope check** — three items to confirm with your account team before committing:\n")
+		b.WriteString("- Dual-ingest cost on the source side\n")
+		b.WriteString("- Consumer-coordinator change window\n")
+		b.WriteString("- Consumer-offset translation strategy\n\n")
+	}
+}
+
+// cutoverStyleLabel renders the style + sub-pattern label. Stop-Restart-Repeat
+// carries the sub-pattern suffix (app-by-app vs topic-by-topic); other
+// styles render as-is.
+func cutoverStyleLabel(style types.CutoverStyle, sub types.CutoverSubPattern) string {
+	base := cutoverStyleName(style)
+	if style == types.CutoverStopRestartRepeat && sub != "" {
+		return fmt.Sprintf("%s (%s)", base, sub)
+	}
+	return base
+}
+
+func cutoverStyleName(style types.CutoverStyle) string {
+	switch style {
+	case types.CutoverStopRestartRepeat:
+		return "Stop-Restart-Repeat"
+	case types.CutoverStopWaitRestart:
+		return "Stop-Wait-Restart"
+	case types.CutoverRestartAllAtOnce:
+		return "Restart-All-At-Once"
+	case types.CutoverBlueGreen:
+		return "Blue/Green"
+	default:
+		return string(style)
+	}
+}
+
+// cutoverGatewayLabel returns the "CC Gateway / plain Cluster Linking /
+// not applicable" phrasing for the rendered Gateway mediation line.
+// Plain Cluster Linking gets a tradeoff hint so it doesn't read as
+// second-class — it's a fully supported path that some customers
+// deliberately pick.
+func cutoverGatewayLabel(m types.GatewayMediated, status types.RecommendationStatus) string {
+	switch m {
+	case types.GatewayMediatedTrue:
+		return "CC Gateway-mediated (transparent per-service cutover, 30–90 s `BROKER_NOT_AVAILABLE` window)"
+	case types.GatewayMediatedFalse:
+		if status == types.RecommendationCustomerChoice {
+			return "Plain Cluster Linking (gateway opted out via `prefer_gateway: false`). Simpler ops; requires per-service producer restart at cutover. Pick this when the CFK + Gateway Add-On license aren't justifiable for the fleet's downtime budget."
+		}
+		return "Plain Cluster Linking"
+	case types.GatewayMediatedNotApplicable:
+		return "Not applicable — Blue/Green doesn't sit on a single cutover step"
+	default:
+		return string(m)
+	}
+}
+
+// recommendationStatusMarker returns the inline ℹ note shown beneath
+// the Gateway mediation line for unresolved-decision paths, or empty
+// for the canonical / customer-choice paths (those don't need a callout).
+// "Awaiting" framing, not "Degraded" — plain Cluster Linking is a fully
+// supported path; the marker just signals an open decision, not a
+// broken state.
+func recommendationStatusMarker(status types.RecommendationStatus) string {
+	switch status {
+	case types.RecommendationDegradedAwaitingOQ:
+		return "ℹ **Awaiting gateway intent** — no preference declared yet; the Plan uses plain Cluster Linking until you confirm. See **Actions Needed** for how to choose."
+	case types.RecommendationDegradedPrereqsPending:
+		return "ℹ **Awaiting gateway prereqs** — gateway path requested but one or more prereqs are still at `not_started`. See **Actions Needed** for the list. Plain Cluster Linking applies in the meantime."
+	default:
+		return ""
+	}
+}
+
+// writeCutoverAlternatives renders a short bullet list explaining the
+// styles the plan considered and didn't pick. Keeps the reader's trust
+// without forcing them to walk the full decision tree.
+func writeCutoverAlternatives(b *bytes.Buffer, alts []types.CutoverStyle) {
+	if len(alts) == 0 {
+		return
+	}
+	b.WriteString("- **Alternatives considered:**\n")
+	for _, s := range alts {
+		fmt.Fprintf(b, "  - **%s** — %s\n", cutoverStyleName(s), cutoverAlternativeWhy(s))
+	}
+}
+
+// cutoverAlternativeWhy returns the one-line "why this isn't the
+// recommendation" string for each style.
+func cutoverAlternativeWhy(s types.CutoverStyle) string {
+	switch s {
+	case types.CutoverStopRestartRepeat:
+		return "phased per-service rollout; recoverable steps, longer elapsed time. Pick via `downtime_tolerance: seconds_per_service | minutes_per_service | let_confluent_choose`."
+	case types.CutoverStopWaitRestart:
+		return "single coordinated window; needs the window to be long enough for re-mirroring + validation. Pick via `downtime_tolerance: scheduled_window_sequential`."
+	case types.CutoverRestartAllAtOnce:
+		return "single window; every client reconfigures at the same instant. Highest blast radius. Pick via `downtime_tolerance: scheduled_window_all_at_once`."
+	case types.CutoverBlueGreen:
+		return "parallel run via Cluster Linking; zero downtime, highest operational complexity. Pick via `downtime_tolerance: zero`."
+	default:
+		return ""
+	}
+}
+
+// writeCutoverPrereqs renders the prereq status table. When the
+// prereq list is empty (Blue/Green OR customer opted out), emits a
+// symmetric "no prereqs required" stub so both paths visually
+// balance — without it, a reader scanning multiple plans wonders
+// whether a row went missing. When IAM prereq is absent from a
+// non-empty list, adds a one-line note clarifying it was suppressed
+// because no IAM source was detected.
+func writeCutoverPrereqs(b *bytes.Buffer, prereqs []types.Prereq) {
+	if len(prereqs) == 0 {
+		b.WriteString("- **Prerequisites:** _none required for this path._\n")
+		return
+	}
+	b.WriteString("- **Prerequisites:**\n\n")
+	b.WriteString("  | Prereq | Status |\n")
+	b.WriteString("  |---|---|\n")
+	var hasIAM bool
+	for _, p := range prereqs {
+		fmt.Fprintf(b, "  | %s | %s |\n", escapeMarkdownTableCell(p.Description), prereqStatusLabel(p.Status))
+		if strings.Contains(p.Description, "IAM") {
+			hasIAM = true
+		}
+	}
+	if !hasIAM {
+		b.WriteString("\n  _IAM pre-migration prereq omitted — no IAM source detected in this fleet._\n")
+	}
+	b.WriteString("\n")
+}
+
+func prereqStatusLabel(s types.PrereqStatus) string {
+	switch s {
+	case types.PrereqMet:
+		return "✅ met"
+	case types.PrereqInProgress:
+		return "🚧 in progress"
+	case types.PrereqBlocked:
+		return "⛔ not started"
+	case types.PrereqUnconfirmed:
+		return "❓ unconfirmed"
+	default:
+		return string(s)
+	}
+}
+
+// ----- §4 auth -----
+
+// writeAuth renders the per-cluster source→target auth mapping table.
+// One row per source auth detected on each cluster.
+//
+// `cutover` and `inputs` are read for the IAM-transition footnote
+// when source-detected auth is IAM AND `iam_pre_migration_status:
+// complete` AND the gateway is mediated, the §4 source row is a
+// pre-migration snapshot and the prereq says clients have already
+// moved off IAM — surface that so §3 and §4 don't read as contradictory.
+func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.CutoverDecision, inputs types.PlanInputsResolved) {
+	if len(auths) == 0 {
+		return
+	}
+	b.WriteString("## 4. Client Auth Migration\n\n")
+	b.WriteString("Per-cluster source→target mapping. Each source-auth method on every cluster maps to a recommended Confluent Cloud auth — the recommendation can be overridden globally via `target_auth_method` or per-cluster via `clusters[<name>].target_auth_method`. The **Works via CC Gateway** column describes whether this auth method *could* flow through the CC Gateway when the gateway path is in use — it's a property of the auth mapping, not a statement about which path §3 picked.\n\n")
+	// Notes column carries non-empty values only on rows where the
+	// auth_mapping row has something specific to say (IAM blocker,
+	// mTLS auth-swap detail, unauth review hint). All-empty notes
+	// across the entire table drop the column entirely.
+	notesUseful := anyNotesPresent(auths)
+	if notesUseful {
+		b.WriteString("| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway | Notes |\n")
+		b.WriteString("|---|---|---|---|---|\n")
+	} else {
+		b.WriteString("| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway |\n")
+		b.WriteString("|---|---|---|---|\n")
+	}
+	for _, a := range auths {
+		if len(a.TargetMappings) == 0 {
+			if notesUseful {
+				fmt.Fprintf(b, "| %s | _none detected_ | _n/a_ | _n/a_ | _Source auth posture unknown — see Actions Needed._ |\n",
+					escapeMarkdownTableCell(a.ClusterID))
+			} else {
+				fmt.Fprintf(b, "| %s | _none detected_ | _n/a_ | _n/a_ |\n",
+					escapeMarkdownTableCell(a.ClusterID))
+			}
+			continue
+		}
+		for i, row := range a.TargetMappings {
+			cluster := escapeMarkdownTableCell(a.ClusterID)
+			if i > 0 {
+				cluster = ""
+			}
+			noteCell := strings.TrimSpace(row.Note)
+			if noteCell == "" {
+				noteCell = "—"
+			}
+			if notesUseful {
+				fmt.Fprintf(b, "| %s | `%s` | `%s` | %s | %s |\n",
+					cluster, row.SourceAuth, row.EffectiveTarget,
+					gatewayCompatibleLabel(row.GatewayCompatible, row.TransparentSwap),
+					escapeMarkdownTableCell(noteCell))
+			} else {
+				fmt.Fprintf(b, "| %s | `%s` | `%s` | %s |\n",
+					cluster, row.SourceAuth, row.EffectiveTarget,
+					gatewayCompatibleLabel(row.GatewayCompatible, row.TransparentSwap))
+			}
+		}
+	}
+	// IAM-transition footnote — when prereq is `complete` and
+	// gateway is in play, the IAM rows above are a pre-migration
+	// snapshot, not the post-migration auth.
+	if cutover != nil && inputs.IAMPreMigrationStatus == PrereqStatusCompleteInput && cutover.GatewayMediated == types.GatewayMediatedTrue {
+		anyIAM := false
+		for _, a := range auths {
+			for _, row := range a.TargetMappings {
+				if row.SourceAuth == SourceAuthIAM {
+					anyIAM = true
+					break
+				}
+			}
+		}
+		if anyIAM {
+			b.WriteString("\n_The IAM rows above reflect the **pre-migration** auth recorded by `kcp discover`. With `iam_pre_migration_status: complete`, clients have moved off IAM (to SCRAM or mTLS) — re-run `kcp discover` / `kcp scan clusters` to refresh §4 against post-migration state._\n")
+		}
+	}
+	writeAuthMappingProvenance(b, auths)
+	b.WriteString("\n")
+}
+
+// writeAuthMappingProvenance surfaces the per-row source URL +
+// last_verified date so a reviewer can audit where each auth-mapping
+// recommendation came from. Walks the unique (SourceAuth, Source,
+// LastVerified) tuples and emits one bullet per source row.
+func writeAuthMappingProvenance(b *bytes.Buffer, auths []types.AuthDecision) {
+	type provKey struct{ source, lastVerified, sourceAuth string }
+	seen := map[provKey]bool{}
+	var rows []provKey
+	for _, a := range auths {
+		for _, r := range a.TargetMappings {
+			if r.Source == "" && r.LastVerified == "" {
+				continue
+			}
+			k := provKey{source: r.Source, lastVerified: r.LastVerified, sourceAuth: r.SourceAuth}
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			rows = append(rows, k)
+		}
+	}
+	if len(rows) == 0 {
+		return
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].sourceAuth < rows[j].sourceAuth })
+	b.WriteString("\n_Mapping provenance:_\n")
+	for _, r := range rows {
+		fmt.Fprintf(b, "- `%s` mapping → %s (last verified %s)\n",
+			r.sourceAuth, r.source, r.lastVerified)
+	}
+}
+
+// anyNotesPresent reports whether any auth-mapping row across the
+// fleet has a non-empty Note. Drives the §4 Notes-column drop when
+// nothing in the column would carry information.
+func anyNotesPresent(auths []types.AuthDecision) bool {
+	for _, a := range auths {
+		for _, row := range a.TargetMappings {
+			if strings.TrimSpace(row.Note) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// gatewayCompatibleLabel renders the Gateway-compatible cell.
+// Transparent swap means clients don't restart at cutover (gateway
+// handles credential exchange in flight); non-transparent gateway
+// paths still work but require auth-side coordination (e.g. mTLS cert
+// re-issue). Both are spelled out so readers don't infer "transparent"
+// means "the only good option".
+func gatewayCompatibleLabel(compatible, transparent bool) string {
+	switch {
+	case compatible && transparent:
+		return "✅ yes (transparent swap)"
+	case compatible:
+		return "✅ yes (auth-swap mode)"
+	default:
+		return "❌ no"
+	}
 }

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -26,24 +26,36 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	fmt.Fprintf(&b, "_Generated %s by KCP %s from `%s`%s._\n\n", p.Header.GeneratedAt.Format("2006-01-02 15:04:05 UTC"), p.Header.KCPVersion, p.Header.StateFilePath, schemaSuffix)
 
 	writeDefinitions(&b, cfg)
-	writeSourceEnvironment(&b, p)
-	writeSizingAndDecisions(&b, p, cfg)
-	writeCutover(&b, p.Cutover, cfg)
-	writeAuth(&b, p.Auth, p.Cutover, p.Inputs)
-	writeOpenQuestions(&b, p)
+	// Section numbering is dynamic: empty Cutover or empty Auth slices
+	// drop their section, and Actions Needed claims the next available
+	// number. Avoids "jumps from §2 to §5" when an empty fleet skips §3/§4.
+	section := 1
+	writeSourceEnvironment(&b, p, section)
+	section++
+	writeSizingAndDecisions(&b, p, cfg, section)
+	section++
+	if p.Cutover != nil {
+		writeCutover(&b, p.Cutover, cfg, section)
+		section++
+	}
+	if len(p.Auth) > 0 {
+		writeAuth(&b, p.Auth, p.Cutover, p.Inputs, section)
+		section++
+	}
+	writeOpenQuestions(&b, p, section)
 	writeSizingAppendix(&b, p, cfg)
 	writeRulesAppendix(&b, p)
 
 	return b.Bytes(), nil
 }
 
-func writeOpenQuestions(b *bytes.Buffer, p *types.Plan) {
+func writeOpenQuestions(b *bytes.Buffer, p *types.Plan, section int) {
 	if len(p.OpenQuestions) == 0 {
-		b.WriteString("## 5. Actions Needed\n\n")
+		fmt.Fprintf(b, "## %d. Actions Needed\n\n", section)
 		b.WriteString("_No actions outstanding — the Plan above renders without unresolved questions._\n\n")
 		return
 	}
-	b.WriteString("## 5. Actions Needed\n\n")
+	fmt.Fprintf(b, "## %d. Actions Needed\n\n", section)
 	groups := groupOpenQuestions(p.OpenQuestions)
 	siblingIDs := oqIDSet(p.OpenQuestions)
 	// Build per-group rendered severity + title up front so the legend
@@ -203,8 +215,8 @@ func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
 	b.WriteString("\n</details>\n\n")
 }
 
-func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan) {
-	b.WriteString("## 1. Source Environment\n\n")
+func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan, section int) {
+	fmt.Fprintf(b, "## %d. Source Environment\n\n", section)
 	if len(p.SourceEnvironment.Clusters) == 0 {
 		b.WriteString("_No clusters found in the state file. Re-run `kcp discover` / `kcp scan ...` and try again._\n\n")
 		return
@@ -271,8 +283,8 @@ func sourceAuthCell(auths []string) string {
 	return strings.Join(parts, ", ")
 }
 
-func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
-	b.WriteString("## 2. Sizing & Cluster Decisions\n\n")
+func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, section int) {
+	fmt.Fprintf(b, "## %d. Sizing & Cluster Decisions\n\n", section)
 	if len(p.Sizing) == 0 {
 		b.WriteString("_No clusters to size._\n\n")
 		return
@@ -861,11 +873,11 @@ func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) 
 // style, gateway mediation status with degraded markers, alternatives
 // shown for trust, and the gateway prereq table. Skips the section
 // entirely when there's no cutover decision (empty fleet).
-func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, cfg *PlanConfig) {
+func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, cfg *PlanConfig, section int) {
 	if c == nil {
 		return
 	}
-	b.WriteString("## 3. Cutover Approach\n\n")
+	fmt.Fprintf(b, "## %d. Cutover Approach\n\n", section)
 	b.WriteString("_The cutover style below applies to the **entire fleet**. Per-cluster cutover overrides aren't supported in this kcp version (planned for a follow-up). Heterogeneous fleets can run kcp against a state-file subset that contains only the clusters sharing a style — re-run for each subset and combine the recommendations manually._\n\n")
 	fmt.Fprintf(b, "- **Style:** %s\n", cutoverStyleLabel(c.Style, c.SubPattern))
 	fmt.Fprintf(b, "- **Gateway mediation:** %s\n", cutoverGatewayLabel(c.GatewayMediated, c.RecommendationStatus))
@@ -1040,11 +1052,11 @@ func prereqStatusLabel(s types.PrereqStatus) string {
 // complete` AND the gateway is mediated, the §4 source row is a
 // pre-migration snapshot and the prereq says clients have already
 // moved off IAM — surface that so §3 and §4 don't read as contradictory.
-func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.CutoverDecision, inputs types.PlanInputsResolved) {
+func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.CutoverDecision, inputs types.PlanInputsResolved, section int) {
 	if len(auths) == 0 {
 		return
 	}
-	b.WriteString("## 4. Client Auth Migration\n\n")
+	fmt.Fprintf(b, "## %d. Client Auth Migration\n\n", section)
 	b.WriteString("Per-cluster source→target mapping. Each source-auth method on every cluster maps to a recommended Confluent Cloud auth — the recommendation can be overridden globally via `target_auth_method` or per-cluster via `clusters[<name>].target_auth_method`. The **Works via CC Gateway** column describes whether this auth method *could* flow through the CC Gateway when the gateway path is in use — it's a property of the auth mapping, not a statement about which path §3 picked.\n\n")
 	// Notes column carries non-empty values only on rows where the
 	// auth_mapping row has something specific to say (IAM blocker,

--- a/internal/services/plan/render_markdown_test.go
+++ b/internal/services/plan/render_markdown_test.go
@@ -166,8 +166,13 @@ func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
 	require.NoError(t, err)
 	body := string(out)
 
-	assert.NotContains(t, body, "⚠", "state-derived Dedicated escalations must not surface the wrong-click callout")
-	assert.NotContains(t, body, "higher monthly cost")
+	assert.NotContains(t, body, "⚠ **Cost callout:**", "state-derived Dedicated must not surface the customer-declared wrong-click callout")
+	// State-derived Dedicated DOES get a separate ℹ cost-direction note
+	// (round-3 feedback: bigger cost decisions than SLA-SZ shouldn't be
+	// silent). It uses ℹ not ⚠ and frames recovery as "not recoverable
+	// by editing plan-inputs.yaml" — semantically distinct from the
+	// wrong-click flow.
+	assert.Contains(t, body, "ℹ **Cost direction:**", "state-derived Dedicated must surface the cost-direction note")
 }
 
 // Clusters whose source scan didn't populate the load-bearing signals
@@ -332,7 +337,7 @@ func TestRenderMarkdown_GlobalTriggerCollapsesToBanner(t *testing.T) {
 	// (note the leading `  - `); the banner uses `> ⚠ **Cost callout
 	// (applies to every cluster below):**`. Count only the per-cluster
 	// shape to verify it didn't ALSO fire when the global banner did.
-	perClusterCount := strings.Count(body, "  - > ⚠ **Cost callout:**")
+	perClusterCount := strings.Count(body, "  - ⚠ **Cost callout:**")
 	szTradeoffCount := strings.Count(body, "Single-Zone resilience tradeoff")
 	assert.Equal(t, 1, bannerCount, "global trigger must collapse to exactly one banner up top")
 	assert.Equal(t, 0, perClusterCount, "the per-cluster cost callout must NOT fire when the banner already did")
@@ -384,7 +389,7 @@ func TestDetectGlobalCustomerTriggers_PartialFireKeepsInline(t *testing.T) {
 	require.NoError(t, err)
 	body := string(out)
 	bannerCount := strings.Count(body, "applies to every cluster below")
-	perClusterCount := strings.Count(body, "  - > ⚠ **Cost callout:**")
+	perClusterCount := strings.Count(body, "  - ⚠ **Cost callout:**")
 	szTradeoffCount := strings.Count(body, "Single-Zone resilience tradeoff")
 	assert.Equal(t, 0, bannerCount, "partial fire (2 of 3) must NOT collapse to a global banner")
 	assert.Equal(t, 2, perClusterCount, "each firing cluster must keep its inline cost callout when scope is partial")

--- a/internal/services/plan/schema.go
+++ b/internal/services/plan/schema.go
@@ -1,0 +1,377 @@
+package plan
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// Plan-input enum tokens for schema migration. Stable customer-facing
+// strings — surfaced in plan-inputs.yaml and the rendered Plan.
+const (
+	SchemaStrategyUnknown                       = "unknown"
+	SchemaStrategyNoSchemas                     = "no_schemas"
+	SchemaStrategyAdoptSchemasDuringMigration   = "adopt_schemas_during_migration"
+	SchemaStrategyMigrateExistingSchemaRegistry = "migrate_existing_schema_registry"
+
+	SchemaCPEditionEnterprise = "enterprise"
+	SchemaCPEditionCommunity  = "community"
+)
+
+// knownSchemaStrategy reports whether `value` is a recognised
+// schema_strategy token (empty value resolves to the configured
+// default in the resolver, so empty is treated as known here).
+func knownSchemaStrategy(value string) bool {
+	return knownEnum(value, SchemaStrategyUnknown,
+		SchemaStrategyNoSchemas,
+		SchemaStrategyAdoptSchemasDuringMigration,
+		SchemaStrategyMigrateExistingSchemaRegistry)
+}
+
+// knownSchemaCPEdition reports whether `value` is a recognised
+// confluent_sr_cp_edition token. Empty (default) is known.
+func knownSchemaCPEdition(value string) bool {
+	return knownEnum(value, SchemaCPEditionEnterprise, SchemaCPEditionCommunity)
+}
+
+// DecideSchema produces the fleet-wide schema migration recommendation.
+// The branches:
+//   - Glue detected                    → kcp_migrate_schemas_glue
+//   - Confluent + eligible             → schema_linking
+//   - Confluent + ineligible           → defer_to_account_team
+//   - Confluent + eligibility unknown  → unknown (OQ asks customer)
+//   - Confluent + Glue (rare)          → migrate Glue AND confluent verdict
+//   - None + no_schemas                → schemaless (section omitted)
+//   - SR scanned + no_schemas          → unknown + mismatch OQ
+//   - Strategy unknown                 → unknown (OQ asks to declare)
+//   - Strategy typo'd                  → unknown (OQ flags the invalid value)
+//
+// The result's `Paths` slice carries every verdict that applies —
+// usually one entry, two for the dual-source case so JSON consumers
+// branching on a single slot don't miss the second arm.
+func DecideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.SchemaDecision {
+	source, confluentURLs, glueNames := detectSchemaSource(state)
+	strategy := inputs.SchemaStrategy
+	if strategy == "" {
+		strategy = SchemaStrategyUnknown
+	}
+
+	dec := &types.SchemaDecision{
+		Source:          source,
+		ConfluentSRURLs: confluentURLs,
+		GlueRegistries:  glueNames,
+	}
+
+	// Strategy typo / unknown: surface the OQ before any other branch
+	// (typo wins — emitting a verdict against an unrecognised strategy
+	// would silently override the customer's intent).
+	if !knownSchemaStrategy(strategy) || strategy == SchemaStrategyUnknown {
+		dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+		return dec
+	}
+
+	// Customer declared no_schemas. Two outcomes:
+	//   (a) source==None → schemaless (section will be omitted by Build).
+	//   (b) source has an SR → contradiction. Don't populate eligibility
+	//       flags (the table would render as "❔ unknown" across the
+	//       board, which is misleading when the customer's intent is to
+	//       skip schemas entirely). The 🟡 schema_state_strategy_mismatch
+	//       OQ carries the message.
+	if strategy == SchemaStrategyNoSchemas {
+		if source == types.SchemaSourceNone {
+			dec.Paths = []types.SchemaPath{types.SchemaPathSchemaless}
+		} else {
+			dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+		}
+		return dec
+	}
+
+	switch source {
+	case types.SchemaSourceGlue:
+		dec.Paths = []types.SchemaPath{types.SchemaPathMigrateGlue}
+		return dec
+	case types.SchemaSourceConfluent:
+		fillConfluentEligibility(dec, cfg, inputs)
+		dec.Paths = []types.SchemaPath{confluentEligibilityPath(dec)}
+		return dec
+	case types.SchemaSourceConfluentAndGlue:
+		// Two arms apply concurrently. Glue first (it's the
+		// automatable path) so the renderer leads with the actionable
+		// command; Confluent verdict second so the customer sees both
+		// without re-running the Plan.
+		//
+		// We only append the Confluent arm when it RESOLVED to a
+		// real verdict (Schema Linking or defer-to-account). If the
+		// Confluent arm is still pending (eligibility flags
+		// undeclared), don't put `unknown` in the Paths slice — a
+		// JSON consumer can't distinguish "Confluent arm pending OQ"
+		// from "verdict undecidable" by looking at the slice. The
+		// `schema_linking_eligibility_unknown` OQ carries the gap.
+		fillConfluentEligibility(dec, cfg, inputs)
+		dec.Paths = []types.SchemaPath{types.SchemaPathMigrateGlue}
+		if confluent := confluentEligibilityPath(dec); confluent != types.SchemaPathUnknown {
+			dec.Paths = append(dec.Paths, confluent)
+		}
+		return dec
+	}
+
+	// Source = none AND strategy is one of the schemas-on-the-roadmap
+	// values (`adopt_schemas_during_migration` or
+	// `migrate_existing_schema_registry`). The customer has declared
+	// intent but no source SR was scanned — the path is unknown until
+	// they either rerun the scan or confirm "no existing SR".
+	dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+	return dec
+}
+
+// confluentEligibilityPath maps the three-flag eligibility verdict
+// onto the corresponding SchemaPath. Extracted from DecideSchema so
+// both the pure-Confluent and the dual ConfluentAndGlue branches share
+// one rule.
+func confluentEligibilityPath(dec *types.SchemaDecision) types.SchemaPath {
+	switch schemaLinkingEligibilityVerdict(dec) {
+	case eligibilityVerdictEligible:
+		return types.SchemaPathSchemaLinking
+	case eligibilityVerdictIneligible:
+		return types.SchemaPathDeferToAccount
+	default:
+		return types.SchemaPathUnknown
+	}
+}
+
+// primaryPath returns the first Path on a SchemaDecision, or
+// SchemaPathUnknown if Paths is empty. Package-private — only test
+// assertions care about the leading verdict; production code uses
+// HasPath or reads `dec.Paths` directly.
+func primaryPath(dec *types.SchemaDecision) types.SchemaPath {
+	if dec == nil || len(dec.Paths) == 0 {
+		return types.SchemaPathUnknown
+	}
+	return dec.Paths[0]
+}
+
+// sourceTouchesConfluent reports whether the detected source includes
+// a Confluent Schema Registry (solo or alongside Glue). Used by the
+// eligibility-OQ detectors and the renderer's preamble gate so the
+// predicate doesn't drift across callsites.
+func sourceTouchesConfluent(s types.SchemaSource) bool {
+	return s == types.SchemaSourceConfluent || s == types.SchemaSourceConfluentAndGlue
+}
+
+// HasPath reports whether a SchemaDecision's Paths slice contains `p`.
+// Used by Build to decide whether to suppress the §Schema section
+// (schemaless) and by the renderer for path-specific rendering.
+func HasPath(dec *types.SchemaDecision, p types.SchemaPath) bool {
+	if dec == nil {
+		return false
+	}
+	for _, dp := range dec.Paths {
+		if dp == p {
+			return true
+		}
+	}
+	return false
+}
+
+// detectSchemaSource collapses the scanner's two-bucket state shape
+// (state.SchemaRegistries.ConfluentSchemaRegistry +
+// state.SchemaRegistries.AWSGlue) into a single enum + the lookups the
+// renderer needs (URLs + registry names).
+func detectSchemaSource(state types.ProcessedState) (types.SchemaSource, []string, []string) {
+	srs := state.SchemaRegistries
+	if srs == nil {
+		return types.SchemaSourceNone, nil, nil
+	}
+	confluentURLs := make([]string, 0, len(srs.ConfluentSchemaRegistry))
+	for _, sr := range srs.ConfluentSchemaRegistry {
+		confluentURLs = append(confluentURLs, sr.URL)
+	}
+	glueNames := make([]string, 0, len(srs.AWSGlue))
+	for _, gr := range srs.AWSGlue {
+		glueNames = append(glueNames, gr.RegistryName)
+	}
+	switch {
+	case len(confluentURLs) > 0 && len(glueNames) > 0:
+		return types.SchemaSourceConfluentAndGlue, confluentURLs, glueNames
+	case len(confluentURLs) > 0:
+		return types.SchemaSourceConfluent, confluentURLs, nil
+	case len(glueNames) > 0:
+		return types.SchemaSourceGlue, nil, glueNames
+	default:
+		return types.SchemaSourceNone, nil, nil
+	}
+}
+
+// fillConfluentEligibility populates the three Schema-Linking flags
+// on `dec` from the customer-declared CP version + edition +
+// reachability inputs. Tri-state (nil = unknown) so the verdict can
+// distinguish "verified false" from "not declared yet" downstream.
+func fillConfluentEligibility(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) {
+	if inputs.ConfluentSRCPVersion != "" {
+		v := versionAtLeast(inputs.ConfluentSRCPVersion, cfg.SchemaLinking.MinCPVersion)
+		dec.MeetsCPVersionFloor = &v
+	}
+	if inputs.ConfluentSRCPEdition != "" && knownSchemaCPEdition(inputs.ConfluentSRCPEdition) {
+		v := inputs.ConfluentSRCPEdition == cfg.SchemaLinking.RequiresCPEdition
+		dec.MeetsCPEditionRequirement = &v
+	}
+	if inputs.SourceSROutboundReachableToCC != nil {
+		v := *inputs.SourceSROutboundReachableToCC
+		dec.SourceSROutboundReachable = &v
+	}
+}
+
+type eligibilityVerdict int
+
+const (
+	eligibilityVerdictUnknown eligibilityVerdict = iota
+	eligibilityVerdictEligible
+	eligibilityVerdictIneligible
+)
+
+// schemaLinkingEligibilityVerdict folds the three tri-state flags into
+// one verdict: any "verified false" → ineligible, any nil → unknown,
+// all "verified true" → eligible.
+func schemaLinkingEligibilityVerdict(dec *types.SchemaDecision) eligibilityVerdict {
+	flags := []*bool{dec.MeetsCPVersionFloor, dec.MeetsCPEditionRequirement, dec.SourceSROutboundReachable}
+	anyUnknown := false
+	for _, f := range flags {
+		if f == nil {
+			anyUnknown = true
+			continue
+		}
+		if !*f {
+			return eligibilityVerdictIneligible
+		}
+	}
+	if anyUnknown {
+		return eligibilityVerdictUnknown
+	}
+	return eligibilityVerdictEligible
+}
+
+// detectSchemaOpenQuestions surfaces what the customer must close
+// before the schema-migration verdict above is fully reliable. Called
+// after DecideSchema so the detector can read the verdict directly
+// rather than recomputing eligibility flags. Takes `cfg` so the OQ
+// body can quote the configured CP-version floor + edition the same
+// way the rendered eligibility table does — keeps the two surfaces
+// in lockstep if an admin tunes `plan-config.yaml`.
+func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
+	if dec == nil {
+		return nil
+	}
+	var oqs []types.OpenQuestion
+
+	strategy := inputs.SchemaStrategy
+	if strategy == "" {
+		strategy = SchemaStrategyUnknown
+	}
+
+	// Strategy typo (recognised values + the explicit `unknown` token
+	// keep this silent; anything else fires).
+	if !knownSchemaStrategy(strategy) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "schema_strategy_invalid",
+			Title:      "`schema_strategy` is not a recognised value — set to one of the four enum tokens",
+			Body:       "Recognised values: `unknown` | `no_schemas` | `adopt_schemas_during_migration` | `migrate_existing_schema_registry`. The current value falls outside the enum, so the Plan treats it as `unknown` and emits this OQ.",
+			HowToClose: "Set `schema_strategy` in `plan-inputs.yaml` to one of the recognised values, then re-run `kcp report plan`.",
+		})
+		return oqs
+	}
+
+	// Strategy explicitly unknown — the customer hasn't declared
+	// intent. Suppress on the pure-Glue branch: the kcp-automated
+	// migration command decides itself, no strategy declaration
+	// needed. The dual `ConfluentAndGlue` case still fires the OQ
+	// because the Confluent arm requires the strategy.
+	if strategy == SchemaStrategyUnknown && dec.Source != types.SchemaSourceGlue {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "schema_strategy_unknown",
+			Title:      "Schema migration strategy not declared — set `schema_strategy` in `plan-inputs.yaml`",
+			Body:       "First-run Plans default `schema_strategy: unknown` so we don't silently emit a schemaless verdict (which would suppress the Red Flag for shops that genuinely have a Schema Registry). Pick the strategy that matches your migration: `no_schemas` (workloads carry no schemas), `adopt_schemas_during_migration` (you want CC Schema Registry but don't have one on-prem), or `migrate_existing_schema_registry` (you have an SR and want it mirrored).",
+			HowToClose: "Set `schema_strategy` in `plan-inputs.yaml` to one of `no_schemas | adopt_schemas_during_migration | migrate_existing_schema_registry`, then re-run `kcp report plan`.",
+		})
+	}
+
+	// State / strategy mismatch: customer declared no_schemas but the
+	// scan found a Schema Registry on the source. Yellow rather than
+	// red — the customer's intent could be deliberate (we'll discard
+	// the SR) or accidental (they forgot it was there). When this
+	// fires we SHORT-CIRCUIT the eligibility OQs below: until the
+	// mismatch is reconciled, asking about CP version / edition /
+	// reachability is premature.
+	//
+	// CONTRACT for future contributors: any NEW OQ detector unrelated
+	// to the mismatch must be appended ABOVE this block, not below.
+	// The `return oqs` here intentionally drops the eligibility OQs
+	// only; OQs that are independent of the no_schemas contradiction
+	// belong above the mismatch gate so they still fire.
+	mismatch := strategy == SchemaStrategyNoSchemas && dec.Source != types.SchemaSourceNone
+	if mismatch {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "schema_state_strategy_mismatch",
+			Title:      "`schema_strategy: no_schemas` but the scan found a Schema Registry on the source",
+			Body:       "If you intend to retire the source SR during the migration, this is fine — leave the setting and acknowledge this OQ. If the SR was scanned in error (e.g. it belongs to a different team), narrow the scan scope. Otherwise switch `schema_strategy` to `migrate_existing_schema_registry` so the Plan applies the SR-detected path.",
+			HowToClose: "Either keep `schema_strategy: no_schemas` (acknowledge the gap), narrow `kcp scan schema-registry` / `kcp scan glue-schema-registry`, or switch `schema_strategy` to `migrate_existing_schema_registry` and re-run.",
+		})
+		return oqs
+	}
+
+	// Confluent SR detected but Schema-Linking eligibility unknown
+	// (one or more of CP version, edition, outbound reachability
+	// hasn't been declared). The Plan can't pick between the
+	// schema_linking and defer_to_account_team paths until the
+	// customer fills these in.
+	if sourceTouchesConfluent(dec.Source) &&
+		schemaLinkingEligibilityVerdict(dec) == eligibilityVerdictUnknown {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "schema_linking_eligibility_unknown",
+			Title:      "Declare source SR CP version, edition, and outbound reachability in `plan-inputs.yaml`",
+			Body:       fmt.Sprintf("Schema Linking requires the source SR to (1) be on CP %s or later, (2) run the `%s` edition (other editions do not ship Schema Linking), and (3) be able to make outbound TCP connections to your CC Schema Registry endpoint. Until all three are declared, the Plan can't pick between the Schema Linking path and the account-team-handoff path.", cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition),
+			HowToClose: "Set `confluent_sr_cp_version`, `confluent_sr_cp_edition`, and `source_sr_outbound_reachable_to_cc` (true|false) in `plan-inputs.yaml`, then re-run `kcp report plan`. If any constraint fails after declaring, the path becomes an account-team conversation — REST API export/import is not a kcp-automated fallback.",
+		})
+	}
+
+	// Confluent SR detected and verifiably ineligible (at least one
+	// declared flag is false). Defer to account team — explain which
+	// constraint failed so the customer can decide whether to fix
+	// (upgrade CP, change edition, open network reachability) or
+	// accept the manual path.
+	if sourceTouchesConfluent(dec.Source) &&
+		schemaLinkingEligibilityVerdict(dec) == eligibilityVerdictIneligible {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "schema_linking_ineligible",
+			Title:      "Schema Linking blocked — fix the failing constraint or defer to your Confluent account team",
+			Body:       ineligibilityBody(dec, cfg, inputs),
+			HowToClose: fmt.Sprintf("Either resolve the failing constraint (upgrade source CP, switch to `%s` edition, open outbound TCP from source SR to CC SR) and re-run `kcp report plan`, OR confirm with your account team that the manual REST API path is acceptable.", cfg.SchemaLinking.RequiresCPEdition),
+		})
+	}
+
+	return oqs
+}
+
+// ineligibilityBody renders the schema_linking_ineligible OQ body
+// with the *declared* values surfaced (e.g. "declared as `6.2.1`
+// is below the `7.0` floor") so the customer sees exactly which input
+// to change. The configured floor + required edition come from `cfg`
+// so the OQ stays in lockstep with the eligibility table whenever an
+// admin tunes plan-config.yaml. Joins failure reasons with "; " so
+// the list reads as one sentence.
+func ineligibilityBody(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) string {
+	var reasons []string
+	if dec.MeetsCPVersionFloor != nil && !*dec.MeetsCPVersionFloor {
+		reasons = append(reasons, fmt.Sprintf("CP version declared as `%s` is below the `%s` floor", inputs.ConfluentSRCPVersion, cfg.SchemaLinking.MinCPVersion))
+	}
+	if dec.MeetsCPEditionRequirement != nil && !*dec.MeetsCPEditionRequirement {
+		reasons = append(reasons, fmt.Sprintf("CP edition declared as `%s` (Schema Linking requires `%s`)", inputs.ConfluentSRCPEdition, cfg.SchemaLinking.RequiresCPEdition))
+	}
+	if dec.SourceSROutboundReachable != nil && !*dec.SourceSROutboundReachable {
+		reasons = append(reasons, "source SR cannot reach CC SR outbound (Schema Linking's Schema Exporter is source → CC, one-directional)")
+	}
+	if len(reasons) == 0 {
+		return "(constraint failed but reason was not captured)"
+	}
+	return "Failing constraint" + pluralize("", len(reasons)) + ": " + strings.Join(reasons, "; ") + ". REST API export/import is technically possible but carries complexity that kcp does not automate today (consumer-by-consumer subject coordination, ID remapping when destinations already have schemas)."
+}

--- a/internal/services/plan/schema_test.go
+++ b/internal/services/plan/schema_test.go
@@ -1,0 +1,262 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schemaState builds a ProcessedState with optional Confluent / Glue
+// registries. nil omits the SchemaRegistries block entirely (the
+// `source = none` case); empty slices model a scanner that ran but
+// found nothing (still resolves to `none`).
+func schemaState(confluentURLs, glueNames []string) types.ProcessedState {
+	if confluentURLs == nil && glueNames == nil {
+		return types.ProcessedState{}
+	}
+	srs := &types.SchemaRegistriesState{}
+	for _, u := range confluentURLs {
+		srs.ConfluentSchemaRegistry = append(srs.ConfluentSchemaRegistry, types.SchemaRegistryInformation{URL: u})
+	}
+	for _, n := range glueNames {
+		srs.AWSGlue = append(srs.AWSGlue, types.GlueSchemaRegistryInformation{RegistryName: n})
+	}
+	return types.ProcessedState{SchemaRegistries: srs}
+}
+
+func schemaInputs(strategy string) types.PlanInputsResolved {
+	return types.PlanInputsResolved{SchemaStrategy: strategy}
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+// Glue detected → kcp_migrate_schemas_glue, regardless of strategy
+// (the kcp-automated path doesn't need a strategy declaration).
+func TestDecideSchema_GlueDetected(t *testing.T) {
+	dec := DecideSchema(schemaState(nil, []string{"my-glue"}), defaultCfg(t), schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceGlue, dec.Source)
+	assert.Equal(t, types.SchemaPathMigrateGlue, primaryPath(dec))
+	assert.Equal(t, []string{"my-glue"}, dec.GlueRegistries)
+}
+
+// Confluent SR + all three eligibility flags positive → schema_linking.
+func TestDecideSchema_ConfluentEligible(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "7.5.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
+	inputs.SourceSROutboundReachableToCC = ptrBool(true)
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
+	assert.Equal(t, types.SchemaPathSchemaLinking, primaryPath(dec))
+	require.NotNil(t, dec.MeetsCPVersionFloor)
+	assert.True(t, *dec.MeetsCPVersionFloor)
+	require.NotNil(t, dec.MeetsCPEditionRequirement)
+	assert.True(t, *dec.MeetsCPEditionRequirement)
+}
+
+// Confluent SR + CP version below 7.0 → defer_to_account_team.
+func TestDecideSchema_ConfluentBelowCPFloor(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "6.2.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
+	inputs.SourceSROutboundReachableToCC = ptrBool(true)
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
+	require.NotNil(t, dec.MeetsCPVersionFloor)
+	assert.False(t, *dec.MeetsCPVersionFloor)
+}
+
+// Confluent SR + Community edition → defer_to_account_team.
+func TestDecideSchema_ConfluentCommunityEdition(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "7.5.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionCommunity
+	inputs.SourceSROutboundReachableToCC = ptrBool(true)
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
+	require.NotNil(t, dec.MeetsCPEditionRequirement)
+	assert.False(t, *dec.MeetsCPEditionRequirement)
+}
+
+// Confluent SR + reachability undeclared → unknown (OQ asks).
+func TestDecideSchema_ConfluentReachabilityUnknown(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "7.5.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
+	// SourceSROutboundReachableToCC left nil
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+	assert.Nil(t, dec.SourceSROutboundReachable, "nil tri-state preserved when input is unset")
+}
+
+// State empty + strategy=no_schemas → schemaless (section omitted by Build).
+func TestDecideSchema_NoneAndNoSchemas(t *testing.T) {
+	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceNone, dec.Source)
+	assert.Equal(t, types.SchemaPathSchemaless, primaryPath(dec))
+}
+
+// Strategy=unknown (default) → unknown (OQ asks customer to declare).
+func TestDecideSchema_StrategyUnknown(t *testing.T) {
+	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyUnknown))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+}
+
+// Strategy typo'd → unknown (OQ flags the typo before any path applies).
+func TestDecideSchema_StrategyTypo(t *testing.T) {
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs("no_schemaz"))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "typo'd strategy must not select a downstream path")
+}
+
+// Both Confluent + Glue with eligible flags → Paths carries BOTH
+// arms ([migrate_glue, schema_linking]) so JSON consumers branching
+// on a single slot don't miss the Confluent verdict.
+func TestDecideSchema_ConfluentAndGlue(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "7.5.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
+	inputs.SourceSROutboundReachableToCC = ptrBool(true)
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceConfluentAndGlue, dec.Source)
+	require.Len(t, dec.Paths, 2, "dual-source must carry both arms in Paths")
+	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0], "Glue path renders first")
+	assert.Equal(t, types.SchemaPathSchemaLinking, dec.Paths[1], "Confluent verdict in second slot")
+	assert.True(t, HasPath(dec, types.SchemaPathSchemaLinking))
+	assert.True(t, HasPath(dec, types.SchemaPathMigrateGlue))
+	require.NotNil(t, dec.MeetsCPVersionFloor, "Confluent eligibility populated even when Glue is the leading verdict")
+}
+
+// Dual-source with Confluent arm UNDECLARED — Paths must NOT include
+// `unknown` (overloaded with the all-unknown fallback). The pending
+// signal is carried by the schema_linking_eligibility_unknown OQ.
+func TestDecideSchema_ConfluentAndGlue_PendingConfluentArmDropped(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	// All eligibility inputs left nil → Confluent arm unknown.
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	require.Len(t, dec.Paths, 1, "pending Confluent arm must NOT serialise as Paths[1]==unknown")
+	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
+	assert.False(t, HasPath(dec, types.SchemaPathUnknown))
+}
+
+// Dual-source with Confluent arm INELIGIBLE (e.g. CP below floor) —
+// Paths carries [MigrateGlue, DeferToAccount].
+func TestDecideSchema_ConfluentAndGlue_ConfluentArmIneligible(t *testing.T) {
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "6.2.1"
+	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
+	inputs.SourceSROutboundReachableToCC = ptrBool(true)
+
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	require.NotNil(t, dec)
+	require.Len(t, dec.Paths, 2)
+	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
+	assert.Equal(t, types.SchemaPathDeferToAccount, dec.Paths[1])
+}
+
+// State has no SR + customer declared `adopt_schemas_during_migration`
+// (the schemas-on-the-roadmap branch). Verdict resolves to `unknown` —
+// the customer's intent is real but kcp can't recommend a concrete
+// path until a source SR is scanned or "no existing SR" is confirmed.
+func TestDecideSchema_NoneWithAdoptStrategy(t *testing.T) {
+	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyAdoptSchemasDuringMigration))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceNone, dec.Source)
+	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+	assert.Nil(t, dec.MeetsCPVersionFloor, "eligibility flags must not be populated when no Confluent SR was scanned")
+}
+
+// Customer declared `no_schemas` but the scan found a Confluent SR.
+// Verdict short-circuits to `unknown` WITHOUT populating eligibility
+// flags — the renderer would otherwise show a misleading "❔ unknown"
+// 3-row table to someone who said they're not migrating schemas.
+// The mismatch OQ carries the contradiction.
+func TestDecideSchema_NoSchemasButConfluentDetected(t *testing.T) {
+	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
+	require.NotNil(t, dec)
+	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
+	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "verdict short-circuits to unknown; OQ carries the message")
+	assert.Nil(t, dec.MeetsCPVersionFloor, "eligibility flags must remain nil on the no_schemas+scanned-SR contradiction")
+	assert.Nil(t, dec.MeetsCPEditionRequirement)
+	assert.Nil(t, dec.SourceSROutboundReachable)
+}
+
+// detectSchemaOpenQuestions emits schema_linking_ineligible when any
+// declared flag is false. The body names the failing constraint AND
+// the declared value the customer can edit.
+func TestDetectSchemaOpenQuestions_IneligibleSurfacesReason(t *testing.T) {
+	dec := &types.SchemaDecision{
+		Source:                    types.SchemaSourceConfluent,
+		Paths:                     []types.SchemaPath{types.SchemaPathDeferToAccount},
+		MeetsCPVersionFloor:       ptrBool(false),
+		MeetsCPEditionRequirement: ptrBool(true),
+		SourceSROutboundReachable: ptrBool(true),
+	}
+	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
+	inputs.ConfluentSRCPVersion = "6.2.1"
+	oqs := detectSchemaOpenQuestions(dec, defaultCfg(t), inputs)
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "schema_linking_ineligible", oqs[0].ID)
+	assert.Contains(t, oqs[0].Body, "6.2.1", "ineligibility body must surface the declared CP version")
+	assert.Contains(t, oqs[0].Body, "`7.0`", "ineligibility body must surface the configured floor from plan-config")
+}
+
+// schema_state_strategy_mismatch fires when no_schemas is declared
+// but the scan found a registry — 🟡, not 🔴 (could be deliberate).
+func TestDetectSchemaOpenQuestions_NoSchemasMismatch(t *testing.T) {
+	dec := &types.SchemaDecision{Source: types.SchemaSourceConfluent, Paths: []types.SchemaPath{types.SchemaPathUnknown}}
+	oqs := detectSchemaOpenQuestions(dec, defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
+	require.NotEmpty(t, oqs)
+	found := false
+	for _, oq := range oqs {
+		if oq.ID == "schema_state_strategy_mismatch" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected schema_state_strategy_mismatch OQ when strategy=no_schemas conflicts with scanned SR")
+}
+
+// versionAtLeast handles dot-separated segment comparison + tolerates
+// missing trailing segments ("7.0" vs "7.0.0" → equal).
+func TestCPVersionAtLeast(t *testing.T) {
+	cases := []struct {
+		have, floor string
+		want        bool
+	}{
+		{"7.0", "7.0", true},
+		{"7.0.0", "7.0", true},
+		{"7.5.1", "7.0", true},
+		{"6.2.1", "7.0", false},
+		{"8.0", "7.0", true},
+		{"latest", "7.0", true},     // "latest" always clears any floor
+		{"current", "7.0", true},    // case-insensitive alias
+		{"LATEST", "7.0", true},     // case-insensitive
+		{"7.0.0-rc1", "7.0", true},  // pre-release suffix stripped before compare
+		{"7.0+build5", "7.0", true}, // build-metadata suffix stripped
+		{"6.2.1-rc3", "7.0", false}, // pre-release stripped, base compares below floor
+		{"garbage", "7.0", false},   // truly unparseable → safe direction (false)
+		{"7.-1.0", "7.0", false},    // negative segment rejected → unparseable
+	}
+	for _, c := range cases {
+		t.Run(c.have+"_vs_"+c.floor, func(t *testing.T) {
+			assert.Equal(t, c.want, versionAtLeast(c.have, c.floor))
+		})
+	}
+}

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -122,7 +122,7 @@ func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 
 // normalizePercentile maps the customer's sizing_percentile input
 // (p95 | p99 | max) to the canonical lowercase form. Accepts legacy
-// uppercase variants (`P95`, `P99`) for back-compat with pre-spec
+// uppercase variants (`P95`, `P99`) for back-compat with older
 // inputs, but the canonical surface is lowercase to match Confluent
 // dashboards. Unknown values fall back to "p95".
 func normalizePercentile(s string) string {

--- a/internal/services/plan/version.go
+++ b/internal/services/plan/version.go
@@ -1,0 +1,77 @@
+package plan
+
+import (
+	"strconv"
+	"strings"
+)
+
+// versionAtLeast reports whether `have` is >= `floor` using
+// dot-separated integer-segment comparison. Versions are compared
+// pairwise; missing segments on either side are treated as 0 so "7.0"
+// vs "7.0.1" works ("7.0.1" wins) and "7" vs "7.0" is equal.
+//
+// Special cases:
+//   - "latest" / "current" (case-insensitive) → treated as >= any
+//     floor (the most current release always clears every floor).
+//   - Pre-release suffixes (e.g. "7.0.0-rc1", "7.0+build5") → stripped
+//     before parsing; "7.0.0-rc1" compares as "7.0.0".
+//
+// Returns false on still-unparseable input — that's the safe direction:
+// an unrecognised version doesn't claim it clears the floor.
+//
+// Lives at the package level so any future version-floor check (e.g.
+// Cluster Linking's source Kafka version when that rule lands) can
+// reuse the same comparator without duplication. Today only the
+// Schema Linking CP-version check calls it.
+func versionAtLeast(have, floor string) bool {
+	switch strings.ToLower(strings.TrimSpace(have)) {
+	case "latest", "current":
+		return true
+	}
+	h := parseVersionSegments(have)
+	f := parseVersionSegments(floor)
+	if h == nil || f == nil {
+		return false
+	}
+	n := len(h)
+	if len(f) > n {
+		n = len(f)
+	}
+	for i := 0; i < n; i++ {
+		var hv, fv int
+		if i < len(h) {
+			hv = h[i]
+		}
+		if i < len(f) {
+			fv = f[i]
+		}
+		if hv != fv {
+			return hv > fv
+		}
+	}
+	return true
+}
+
+// parseVersionSegments splits a dotted version into integer segments,
+// dropping any pre-release / build suffix introduced by '-' or '+'.
+// Returns nil on any non-integer or negative segment so the caller's
+// fallback path can fire safely.
+func parseVersionSegments(s string) []int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 0 {
+			return nil
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -19,7 +19,12 @@ type Plan struct {
 	Cutover *CutoverDecision `json:"cutover,omitempty"`
 	// Auth is per-cluster — source auth methods differ across MSK clusters
 	// in the same fleet, so each gets its own source→target mapping.
-	Auth           []AuthDecision     `json:"auth,omitempty"`
+	Auth []AuthDecision `json:"auth,omitempty"`
+	// Schema is fleet-wide (the schema registry is one shared system,
+	// not per-cluster). Nil when the section is omitted — currently the
+	// `schemaless` path (`sr_detected == none` AND
+	// `schema_strategy == no_schemas`).
+	Schema         *SchemaDecision    `json:"schema,omitempty"`
 	SizingAppendix []SizingMathDetail `json:"sizing_appendix"`
 	OpenQuestions  []OpenQuestion     `json:"open_questions,omitempty"`
 }
@@ -317,6 +322,17 @@ type PlanInputsResolved struct {
 	// Auth — target verdict; cluster-level override flows through
 	// `applyClusterOverride` per the heterogeneous-fleet rule.
 	TargetAuthMethod string `json:"target_auth_method"`
+
+	// Schema migration. Strings/bools resolved from the customer
+	// input with `unknown` / nil-tri-state semantics: SchemaStrategy
+	// defaults to `unknown` so first-run plans don't fire spurious
+	// schemaless verdicts. The CP version + edition + outbound
+	// reachability stay nil-tri-state because "false" and "unknown"
+	// produce different OQs.
+	SchemaStrategy                string `json:"schema_strategy"`
+	SourceSROutboundReachableToCC *bool  `json:"source_sr_outbound_reachable_to_cc,omitempty"`
+	ConfluentSRCPVersion          string `json:"confluent_sr_cp_version,omitempty"`
+	ConfluentSRCPEdition          string `json:"confluent_sr_cp_edition,omitempty"`
 }
 
 // ----- cutover -----
@@ -422,6 +438,93 @@ type AuthDecision struct {
 	ClusterID      string           `json:"cluster_id"`
 	SourceAuths    []string         `json:"source_auths_detected"`
 	TargetMappings []AuthMappingRow `json:"target_mappings,omitempty"`
+}
+
+// ----- schema -----
+
+// SchemaSource is the detected source-side schema registry, derived
+// from the scanner's `state.schema_registries`. `none` means the
+// scanner ran but found neither a Confluent SR nor a Glue registry.
+// `confluent_and_glue` covers the rare both-registries deployment —
+// the decision applies each path independently.
+type SchemaSource string
+
+const (
+	SchemaSourceNone             SchemaSource = "none"
+	SchemaSourceConfluent        SchemaSource = "confluent"
+	SchemaSourceGlue             SchemaSource = "glue"
+	SchemaSourceConfluentAndGlue SchemaSource = "confluent_and_glue"
+)
+
+// SchemaPath is the recommended migration path:
+//   - `schema_linking` — Schema Linking from source Confluent SR → CC SR
+//     (zero-data-loss mirror; all three eligibility constraints hold).
+//   - `kcp_migrate_schemas_glue` — `kcp create-asset migrate-schemas
+//     --glue-registry` generates Terraform that imports every Glue
+//     schema into CC SR in one apply.
+//   - `defer_to_account_team` — Confluent SR detected but Schema-Linking
+//     eligibility fails (CP < 7.0, Community edition, or no outbound
+//     reachability). REST API export/import is technically possible but
+//     not deterministically described by kcp.
+//   - `schemaless` — no source SR + customer declared `no_schemas`.
+//   - `unknown` — fallback when an Open Question must close before the
+//     path is decidable (typically `schema_strategy: unknown`).
+type SchemaPath string
+
+const (
+	SchemaPathSchemaLinking  SchemaPath = "schema_linking"
+	SchemaPathMigrateGlue    SchemaPath = "kcp_migrate_schemas_glue"
+	SchemaPathDeferToAccount SchemaPath = "defer_to_account_team"
+	SchemaPathSchemaless     SchemaPath = "schemaless"
+	SchemaPathUnknown        SchemaPath = "unknown"
+)
+
+// SchemaDecision is the fleet-wide Schema Migration recommendation.
+// Source describes what was scanned; Paths describes every verdict
+// that applies — usually a single-element slice (one source → one
+// path), but the dual `confluent_and_glue` case carries two so JSON
+// consumers branching on a single path-slot don't miss the second
+// arm.
+//
+// The eligibility flags are populated only when Source includes
+// `confluent` so the renderer can show why Schema Linking was or
+// wasn't chosen.
+type SchemaDecision struct {
+	Source SchemaSource `json:"source"`
+	// Paths lists every recommended verdict that applies, in
+	// rendering order. Single-source cases have len(Paths)==1; the
+	// dual-source `confluent_and_glue` case has 2 entries (Glue
+	// first — it's the automatable path; Confluent path second).
+	//
+	// **JSON-consumer note for dual-source.** When Source is
+	// `confluent_and_glue` and len(Paths)==1 (only the Glue arm
+	// landed), the Confluent arm is in one of two states:
+	//   (a) eligibility flags undeclared — pending. Disambiguate by
+	//       reading the OpenQuestions for `schema_linking_eligibility_unknown`.
+	//   (b) all three eligibility flags resolved AND at least one is
+	//       false — verified ineligible. The OQ
+	//       `schema_linking_ineligible` will be present.
+	// Reading `MeetsCPVersionFloor` / `MeetsCPEditionRequirement` /
+	// `SourceSROutboundReachable` tri-states gives the same signal.
+	Paths []SchemaPath `json:"paths"`
+	// Schema-Linking eligibility constraints — all three must hold for
+	// SchemaPathSchemaLinking. Populated only when Source includes
+	// `confluent`; the renderer prints a 3-row eligibility table from
+	// these flags. *KnownAsTrue distinguishes "verified true" from
+	// "verified false" vs "unknown" — when any one is unknown the
+	// resulting Paths include `unknown` and the OQ asks the customer
+	// to confirm rather than guessing.
+	MeetsCPVersionFloor       *bool `json:"meets_cp_version_floor,omitempty"`
+	MeetsCPEditionRequirement *bool `json:"meets_cp_edition_requirement,omitempty"`
+	SourceSROutboundReachable *bool `json:"source_sr_outbound_reachable,omitempty"`
+	// GlueRegistries lists the Glue registry names detected on the
+	// source side — surfaced in the Terraform command the renderer
+	// emits for SchemaPathMigrateGlue (one apply per registry).
+	GlueRegistries []string `json:"glue_registries,omitempty"`
+	// ConfluentSRURLs lists the Confluent SR URLs detected. Surfaced
+	// in the eligibility table header so a reader knows which SR the
+	// verdict applies to.
+	ConfluentSRURLs []string `json:"confluent_sr_urls,omitempty"`
 }
 
 // AuthMappingRow describes one source→target option. TransparentSwap

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -3,10 +3,10 @@ package types
 import "time"
 
 // Plan is the deterministic Migration Plan emitted by `kcp report plan`.
-// This MVP scope covers source-environment summary, sizing, cluster-type
-// decision, and networking decision only. Auth approach, switchover,
-// red flags, cost reconciliation, and the rest of the §4 surface in the
-// design doc land in follow-up PRs.
+// Current scope: source-environment summary, sizing, cluster-type,
+// networking, cutover (fleet-wide), and auth (per-cluster). Red flags,
+// tiered storage, cost reconciliation, and the rest of the design-doc
+// surface land in follow-up PRs.
 type Plan struct {
 	Header              PlanHeader            `json:"header"`
 	Inputs              PlanInputsResolved    `json:"inputs"`
@@ -14,8 +14,14 @@ type Plan struct {
 	Sizing              []ClusterSizing       `json:"sizing"`
 	ClusterTypeDecision []ClusterTypeDecision `json:"cluster_type_decision"`
 	NetworkingDecision  []NetworkingDecision  `json:"networking_decision"`
-	SizingAppendix      []SizingMathDetail    `json:"sizing_appendix"`
-	OpenQuestions       []OpenQuestion        `json:"open_questions,omitempty"`
+	// Cutover is fleet-wide — one Plan can't ship two cutover styles.
+	// Nil when no clusters were found in the state file.
+	Cutover *CutoverDecision `json:"cutover,omitempty"`
+	// Auth is per-cluster — source auth methods differ across MSK clusters
+	// in the same fleet, so each gets its own source→target mapping.
+	Auth           []AuthDecision     `json:"auth,omitempty"`
+	SizingAppendix []SizingMathDetail `json:"sizing_appendix"`
+	OpenQuestions  []OpenQuestion     `json:"open_questions,omitempty"`
 }
 
 // OpenQuestion is a per-cluster (or plan-level) gap the customer needs
@@ -36,6 +42,11 @@ type PlanHeader struct {
 	StateFilePath string    `json:"state_file_path"`
 	KCPVersion    string    `json:"kcp_version"`
 	GeneratedAt   time.Time `json:"generated_at"`
+	// StateGeneratedAt is the timestamp the source state file was
+	// produced (state.Timestamp). Surfaced in the rendered Plan so a
+	// reviewer can see how fresh the underlying scan is — important
+	// for negative-evidence claims like "0 ACLs" in Appendix A2.
+	StateGeneratedAt time.Time `json:"state_generated_at,omitempty"`
 
 	// PlanSchemaVersion is a string while the JSON shape is still
 	// shifting: top-level keys (auth_approach, switchover_approach,
@@ -61,6 +72,12 @@ type SourceClusterSummary struct {
 	// uses it to suppress Provisioned-only framing (broker counts,
 	// "incomplete scan" guidance) that doesn't apply to Serverless.
 	IsServerless bool `json:"is_serverless,omitempty"`
+	// SourceAuths lists the auth methods enabled on the source cluster
+	// (stable enum tokens: scram, iam, mtls, unauth). Drawn from the
+	// same MSK ClientAuthentication signals AuthDecision reads — surfaced here in
+	// §1 so a reader scanning the Source Environment table sees the
+	// auth posture alongside brokers / topics before the §4 mapping.
+	SourceAuths []string `json:"source_auths,omitempty"`
 }
 
 // ----- sizing & decisions -----
@@ -287,4 +304,141 @@ type PlanInputsResolved struct {
 	// workload properties, not state-derived.
 	CCEgressRequired         bool `json:"cc_egress_required"`
 	ProjectedPNIGatewayCount int  `json:"projected_pni_gateway_count"`
+
+	// Cutover — `downtime_tolerance` drives the style; the others
+	// govern gateway eligibility + opt-out.
+	DowntimeTolerance            string `json:"downtime_tolerance"`
+	SubPattern                   string `json:"sub_pattern"`
+	PreferGateway                bool   `json:"prefer_gateway"`
+	ConfluentForKubernetesStatus string `json:"confluent_for_kubernetes_status"`
+	CCGatewayLicenseStatus       string `json:"cc_gateway_license_status"`
+	IAMPreMigrationStatus        string `json:"iam_pre_migration_status"`
+
+	// Auth — target verdict; cluster-level override flows through
+	// `applyClusterOverride` per the heterogeneous-fleet rule.
+	TargetAuthMethod string `json:"target_auth_method"`
+}
+
+// ----- cutover -----
+
+// CutoverStyle is the strategic shape of the cutover.
+// Mapped 1:1 from `downtime_tolerance` in plan-inputs.yaml.
+type CutoverStyle string
+
+const (
+	// String values match the customer-facing tokens (hyphenated).
+	// Go identifiers can't contain hyphens; the renderer translates these
+	// to display labels via cutoverStyleName.
+	CutoverStopRestartRepeat CutoverStyle = "Stop-Restart-Repeat"
+	CutoverStopWaitRestart   CutoverStyle = "Stop-Wait-Restart"
+	CutoverRestartAllAtOnce  CutoverStyle = "Restart-All-At-Once"
+	CutoverBlueGreen         CutoverStyle = "Blue/Green"
+)
+
+// CutoverSubPattern is the team-topology choice within Stop-Restart-Repeat.
+// Empty for any other CutoverStyle.
+type CutoverSubPattern string
+
+const (
+	SubPatternUnset        CutoverSubPattern = ""
+	SubPatternAppByApp     CutoverSubPattern = "app-by-app"
+	SubPatternTopicByTopic CutoverSubPattern = "topic-by-topic"
+)
+
+// GatewayMediated is tri-state: true / false / not_applicable. The
+// last value fires only on Blue/Green, where the gateway doesn't sit
+// on the cutover step at all.
+type GatewayMediated string
+
+const (
+	GatewayMediatedTrue          GatewayMediated = "true"
+	GatewayMediatedFalse         GatewayMediated = "false"
+	GatewayMediatedNotApplicable GatewayMediated = "not_applicable"
+)
+
+// RecommendationStatus signals how confident the plan is in the
+// recommendation, and what (if anything) the customer should resolve to
+// move it forward.
+type RecommendationStatus string
+
+const (
+	// RecommendationCanonical: customer is gateway-eligible and the
+	// Stop-Restart-Repeat + Gateway pairing is being recommended.
+	RecommendationCanonical RecommendationStatus = "canonical"
+	// RecommendationCustomerChoice: customer either opted out of the
+	// gateway (prefer_gateway: false) or picked Blue/Green.
+	RecommendationCustomerChoice RecommendationStatus = "customer_choice"
+	// RecommendationDegradedAwaitingOQ: prefer_gateway is still default
+	// and all three gateway prereqs are not_started — customer hasn't
+	// engaged with the gateway question. Plan falls back to plain CL.
+	RecommendationDegradedAwaitingOQ RecommendationStatus = "degraded_awaiting_oq"
+	// RecommendationDegradedPrereqsPending: prefer_gateway is true but
+	// at least one prereq is still at not_started. Some engagement,
+	// not finished.
+	RecommendationDegradedPrereqsPending RecommendationStatus = "degraded_prereqs_pending"
+)
+
+// PrereqStatus mirrors the customer-facing plan-inputs status values
+// (`not_started` → blocked, `in_progress` → in-progress, `complete` →
+// met) plus an `unconfirmed` fallback for prereqs whose source data
+// isn't pinned (e.g. Express tier compatibility per release).
+type PrereqStatus string
+
+const (
+	PrereqMet         PrereqStatus = "met"
+	PrereqInProgress  PrereqStatus = "in_progress"
+	PrereqBlocked     PrereqStatus = "blocked"
+	PrereqUnconfirmed PrereqStatus = "unconfirmed"
+)
+
+// Prereq is one item in the rendered Prerequisites table on the
+// cutover section. Description is the human-readable label; the
+// renderer doesn't transform it.
+type Prereq struct {
+	Description string       `json:"description"`
+	Status      PrereqStatus `json:"status"`
+}
+
+// CutoverDecision is the fleet-wide cutover plan.
+type CutoverDecision struct {
+	Style                CutoverStyle         `json:"style"`
+	SubPattern           CutoverSubPattern    `json:"sub_pattern,omitempty"` // only when Style == StopRestartRepeat
+	GatewayMediated      GatewayMediated      `json:"gateway_mediated"`
+	RecommendationStatus RecommendationStatus `json:"recommendation_status"`
+	// AlternativesShown lists the styles the renderer explains for
+	// trust but doesn't recommend — gives the reader the full pattern
+	// set without forcing a deeper decision tree.
+	AlternativesShown []CutoverStyle `json:"alternatives_shown_for_trust,omitempty"`
+	Prereqs           []Prereq       `json:"prereqs,omitempty"`
+}
+
+// ----- auth -----
+
+// AuthDecision is the per-cluster source→target auth mapping.
+// SourceAuths holds the methods detected on the source MSK cluster as
+// stable enum tokens ("scram", "iam", "mtls", "unauth"); the plan does
+// NOT pick one when multiple are enabled — it shows all options.
+type AuthDecision struct {
+	ClusterID      string           `json:"cluster_id"`
+	SourceAuths    []string         `json:"source_auths_detected"`
+	TargetMappings []AuthMappingRow `json:"target_mappings,omitempty"`
+}
+
+// AuthMappingRow describes one source→target option. TransparentSwap
+// fires when the CC Gateway can swap credentials without a producer
+// restart (e.g. SCRAM → SASL/PLAIN with API key). GatewayCompatible is
+// false for IAM — IAM clients cannot connect to the gateway and must
+// pre-migrate to SCRAM or mTLS first.
+type AuthMappingRow struct {
+	SourceAuth        string `json:"source_auth"`
+	EffectiveTarget   string `json:"effective_target"`
+	GatewayCompatible bool   `json:"gateway_compatible"`
+	TransparentSwap   bool   `json:"transparent_swap"`
+	Note              string `json:"note,omitempty"`
+	// Source + LastVerified carry per-row provenance from the
+	// auth_mapping table in plan-config.yaml — surfaced in the
+	// rendered Plan as a footnote so the reviewer can audit where the
+	// recommendation comes from.
+	Source       string `json:"source,omitempty"`
+	LastVerified string `json:"last_verified,omitempty"`
 }

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -51,6 +51,44 @@ type PlanInputs struct {
 	// PrivateLink. Default 1 (single gateway).
 	ProjectedPNIGatewayCount *int `yaml:"projected_pni_gateway_count,omitempty" json:"projected_pni_gateway_count,omitempty"`
 
+	// ----- cutover -----
+
+	// DowntimeTolerance maps 1:1 to a cutover style. Enum values:
+	//   zero                          → Blue/Green
+	//   seconds_per_service           → Stop-Restart-Repeat (gateway REQUIRED)
+	//   minutes_per_service           → Stop-Restart-Repeat (gateway optional)
+	//   scheduled_window_sequential   → Stop-Wait-Restart
+	//   scheduled_window_all_at_once  → Restart-All-At-Once
+	//   let_confluent_choose          → Stop-Restart-Repeat (Confluent default)
+	DowntimeTolerance *string `yaml:"downtime_tolerance,omitempty" json:"downtime_tolerance,omitempty"`
+
+	// SubPattern is only consulted when the resolved style is
+	// Stop-Restart-Repeat. Values: `app-by-app` (default) | `topic-by-topic`.
+	SubPattern *string `yaml:"sub_pattern,omitempty" json:"sub_pattern,omitempty"`
+
+	// PreferGateway lets the customer opt out of the gateway-mediated
+	// recommendation even when they're eligible. Default true mirrors
+	// Confluent's canonical recommendation; set false for plain Cluster
+	// Linking.
+	PreferGateway *bool `yaml:"prefer_gateway,omitempty" json:"prefer_gateway,omitempty"`
+
+	// Gateway prereq statuses. Each is one of `not_started` |
+	// `in_progress` | `complete`. Eligibility for the canonical
+	// recommendation requires all three to be at `in_progress` or
+	// `complete` (with the IAM prereq only relevant when IAM is
+	// detected on any source cluster).
+	ConfluentForKubernetesStatus *string `yaml:"confluent_for_kubernetes_status,omitempty" json:"confluent_for_kubernetes_status,omitempty"`
+	CCGatewayLicenseStatus       *string `yaml:"cc_gateway_license_status,omitempty"       json:"cc_gateway_license_status,omitempty"`
+	IAMPreMigrationStatus        *string `yaml:"iam_pre_migration_status,omitempty"        json:"iam_pre_migration_status,omitempty"`
+
+	// ----- auth -----
+
+	// TargetAuthMethod overrides the default target auth (looked up
+	// per source auth in `auth_mapping`). Enum:
+	// `confluent_cloud_api_keys` (default) | `mtls` | `oauth`.
+	// Per-cluster override available via `clusters[name].target_auth_method`.
+	TargetAuthMethod *string `yaml:"target_auth_method,omitempty" json:"target_auth_method,omitempty"`
+
 	// Clusters — per-cluster overrides keyed by source cluster name.
 	// Heterogeneous fleets (mixed-SLA, mixed-tier) need finer-grained
 	// inputs than the global flags above; without this, flipping a
@@ -83,4 +121,7 @@ type ClusterPlanInputs struct {
 	ExistingVPCConnectivity              *string  `yaml:"existing_vpc_connectivity,omitempty"                  json:"existing_vpc_connectivity,omitempty"`
 	CCEgressRequired                     *bool    `yaml:"cc_egress_required,omitempty"                         json:"cc_egress_required,omitempty"`
 	ProjectedPNIGatewayCount             *int     `yaml:"projected_pni_gateway_count,omitempty"                json:"projected_pni_gateway_count,omitempty"`
+	// TargetAuthMethod is the per-cluster override for the target
+	// auth verdict. Same enum as the global field.
+	TargetAuthMethod *string `yaml:"target_auth_method,omitempty" json:"target_auth_method,omitempty"`
 }

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -4,10 +4,6 @@ package types
 // from the zero value so the loader can echo only the fields the customer
 // explicitly set.
 //
-// MVP scope: sizing knobs + the customer-declared hard-requirement flags
-// that force Dedicated, plus the networking-topology signal that selects
-// PNI / Transit Gateway / VPC Peering on the Dedicated path.
-//
 // Customer-declared flags that flip the cluster-type verdict
 // (`EnforceSchemasAtTheBroker`, `RequiresHighThroughputRESTProduceAPI`,
 // `Requires9995SLAWithinSingleZone`) are wrong-click sensitive — a
@@ -88,6 +84,35 @@ type PlanInputs struct {
 	// `confluent_cloud_api_keys` (default) | `mtls` | `oauth`.
 	// Per-cluster override available via `clusters[name].target_auth_method`.
 	TargetAuthMethod *string `yaml:"target_auth_method,omitempty" json:"target_auth_method,omitempty"`
+
+	// ----- schema migration -----
+
+	// SchemaStrategy declares the customer's intent for schemas. Enum:
+	//   unknown                          → emit OQ (default; first-run safety)
+	//   no_schemas                       → schemaless path (omit §Schema)
+	//   adopt_schemas_during_migration   → start with no source SR, adopt CC SR
+	//   migrate_existing_schema_registry → run the SR-detected path
+	SchemaStrategy *string `yaml:"schema_strategy,omitempty" json:"schema_strategy,omitempty"`
+
+	// SourceSROutboundReachableToCC is the customer's network-reachability
+	// declaration: can the source Confluent SR reach the CC SR endpoint
+	// outbound? Schema Linking's Schema Exporter is one-directional from
+	// source SR → CC SR, so without this the gateway-eligible verdict
+	// can't hold. Default nil = unknown.
+	SourceSROutboundReachableToCC *bool `yaml:"source_sr_outbound_reachable_to_cc,omitempty" json:"source_sr_outbound_reachable_to_cc,omitempty"`
+
+	// ConfluentSRCPVersion is the customer-declared Confluent Platform
+	// version of the source Schema Registry. Schema Linking requires
+	// CP 7.0 or later. Default nil = unknown — the scanner does not
+	// populate this today, so the customer declares it via plan-inputs.
+	// Accepted shape: "7.5.1" / "7.0" / "6.2" — string compare against
+	// the configured floor.
+	ConfluentSRCPVersion *string `yaml:"confluent_sr_cp_version,omitempty" json:"confluent_sr_cp_version,omitempty"`
+
+	// ConfluentSRCPEdition is the customer-declared Confluent Platform
+	// edition. Schema Linking requires `enterprise` (CP 7.0 Community
+	// does not include it). Enum: `enterprise` | `community`.
+	ConfluentSRCPEdition *string `yaml:"confluent_sr_cp_edition,omitempty" json:"confluent_sr_cp_edition,omitempty"`
 
 	// Clusters — per-cluster overrides keyed by source cluster name.
 	// Heterogeneous fleets (mixed-SLA, mixed-tier) need finer-grained


### PR DESCRIPTION
## Summary

Adds three deterministic decisions to `kcp report plan` on top of the merged baseline (sizing / cluster-type / networking):

- **Cutover (fleet-wide)** — picks Stop-Restart-Repeat / Stop-Wait-Restart / Restart-All-At-Once / Blue-Green from `downtime_tolerance`; renders gateway prereq status; emits cause-specific Open Questions when the requested tolerance is incompatible with the chosen path.
- **Client Auth Migration (per-cluster)** — renders source→target auth mapping from `auth_mapping` in `plan-config.yaml`; honors global and per-cluster `target_auth_method` overrides; flags overrides aimed at a gateway-incompatible source.
- **Schema Migration (fleet-wide)** — combines what `kcp scan schema-registry` / `kcp scan glue-schema-registry` found with customer-declared `schema_strategy` / CP version / edition / network-reachability inputs. Emits Schema Linking, the Glue Terraform command (`kcp create-asset migrate-schemas --glue-registry`), defer-to-account-team, or schemaless; surfaces eligibility constraints as a 3-row table on the Confluent SR path.

Other rendered-Plan changes:

- Open Questions go through a single registry that owns priority, 🔴/🟡/🟢 severity, and sibling-aware promotion. Gateway-intent / gateway-prereqs OQs promote to 🔴 with a rewritten title when an auth conflict blocks the gateway path. The severity legend lists only severities that actually appear.
- Section numbers are assigned dynamically: an empty Cutover, Auth, or Schema slice no longer leaves a gap in the numbered headings.
- Fleet-level "Cost direction" banner replaces the per-cluster note when ≥ 2 clusters land on Dedicated via state-derived rules.
- `thresholds.stale_state_days` and `thresholds.pni_gateway_breakeven` move into `plan-config.yaml` so admins can tune them without code changes.
- Sizing & Cluster Decisions, Client Auth Migration, and Schema Migration sections gain short narrative preambles. The Schema preamble defines "Schema Linking" inline when the source actually engages it.
- New `plan-config.yaml` block: `schema_linking.min_cp_version` (7.0) + `requires_cp_edition` (enterprise), with provenance + `last_verified` date.
- New plan-inputs.yaml fields: `schema_strategy`, `source_sr_outbound_reachable_to_cc`, `confluent_sr_cp_version`, `confluent_sr_cp_edition`. No scanner changes.

`plan_schema_version` stays `1-experimental`.

### Validation tightened

- Per-cluster `clusters[<name>].target_auth_method` typos now surface as cluster-scoped Open Questions instead of silently falling back to the per-source default.
- `ambiguousGatewayIntent` ignores `iam_pre_migration_status` for non-IAM fleets, mirroring `gatewayEligible` so a stray IAM prereq value can't flip the recommendation status.
- Stale-state OQ rounds the rendered "N days old" (a 7d 23h-old state file reads as "8 days old").
- Schema-Linking ineligibility OQ body now surfaces the *declared* CP version and the *configured* floor (e.g. "CP version declared as `6.2.1` is below the `7.0` floor") — stays in lockstep with `plan-config.yaml` overrides.

### Doc + sample changes

- `docs/assets/plan.sample.md` and `docs/assets/plan.sample.json` regenerated against the new decisions.
- `docs/assets/plan-inputs.example.yaml` extended with the new cutover / auth / schema fields.
- Section numbers in the rendered Plan re-render dynamically based on which sections actually fire.

## Test plan

- [ ] `go test ./internal/services/plan/...`
- [ ] Review `docs/assets/plan.sample.md` for the Cutover Approach, Client Auth Migration, and Schema Migration sections
- [ ] Run against a real state.json with `downtime_tolerance: seconds_per_service` and confirm the gateway-required OQ fires when prereqs are `not_started`
- [ ] Run with a `target_auth_method` typo (e.g. `oauthhh`) and confirm the fleet-level `target_auth_method_unknown` OQ surfaces once
- [ ] Run with a per-cluster typo (`clusters[<name>].target_auth_method: oauthhh`) and confirm a cluster-scoped OQ fires for that cluster
- [ ] Run with a scanned source Schema Registry + `confluent_sr_cp_version: 6.2` and confirm `schema_linking_ineligible` OQ fires with the declared value surfaced
- [ ] Run with `schema_strategy: no_schemas` AND a scanned SR; confirm the Schema section shows **Conflict** in the verdict line and only the `schema_state_strategy_mismatch` OQ fires
