### PR TITLE
feat(plan): red flags, effort signals, tiered storage, cost & cutover

### DIFF
--- a/cmd/report/plan/cmd_report_plan.go
+++ b/cmd/report/plan/cmd_report_plan.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,31 +150,179 @@ func runReportPlan(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// loadState reads the state file and falls back to a pre-0.7 layout —
-// `regions` at the top level instead of `msk_sources.regions` — when the
-// modern unmarshal produces a state with no source data. The fallback uses
-// a typed decode (not a map round-trip), so byte ordering of the original
-// state file does not influence the resulting `*types.State`.
+// loadState reads the state file and tolerates two pre-0.7 layouts the
+// strict decoder rejects on its own: (1) `regions` at the top level
+// instead of `msk_sources.regions`, and (2) `schema_registries` as a
+// flat array (entries discriminated by a `type` field) instead of an
+// object with `confluent_schema_registry` / `aws_glue` buckets. When
+// the strict decode succeeds the file is taken as-is; only on strict
+// failure do we attempt the lenient legacy decode and rebuild into the
+// modern shape. The fallback uses typed decodes (not map round-trips),
+// so byte ordering of the original state file does not influence the
+// resulting `*types.State`.
 func loadState(path string) (*types.State, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	state, err := types.NewStateFromBytes(data)
+	state, strictErr := types.NewStateFromBytes(data)
+	if strictErr == nil {
+		return state, nil
+	}
+	migrated, mErr := migrateLegacyState(data)
+	if mErr != nil {
+		// Surface the original strict-decode error (more actionable
+		// for genuine version mismatches than the legacy attempt's
+		// own failure).
+		return nil, strictErr
+	}
+	return migrated, nil
+}
+
+// migrateLegacyState rebuilds a *types.State from a pre-0.7 state-file
+// JSON layout. Strips known-legacy top-level keys (`regions`,
+// `schema_registries`-as-array) from the raw JSON before the lenient
+// decode so a type mismatch on a legacy field can't block migration,
+// then re-attaches each legacy field into the modern shape. Returns an
+// error if no recognised legacy shape is found so the caller falls
+// back to surfacing the original strict-decode error.
+func migrateLegacyState(data []byte) (*types.State, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	// Refuse to migrate when the state file claims it was produced by
+	// kcp >= 0.7. The legacy shapes only existed pre-0.7; a newer file
+	// hitting this path means we encountered a forward-incompatible
+	// shape (not a legacy one) and should NOT silently mutate it into
+	// the modern layout. The strict-decode error path is the correct
+	// signal in that case.
+	if v := stateFileKCPVersion(raw); v != "" && isPostLegacyVersion(v) {
+		return nil, fmt.Errorf("state file claims kcp_build_info.version=%q, which is post-legacy; refusing to apply pre-0.7 migration shim", v)
+	}
+	legacyRegions := raw["regions"]
+	legacySchemaRegistries := raw["schema_registries"]
+	// Only strip schema_registries if it's a JSON array (legacy shape);
+	// modern files have it as an object and should be preserved as-is.
+	isLegacySR := len(legacySchemaRegistries) > 0 && legacySchemaRegistries[0] == '['
+	if len(legacyRegions) == 0 && !isLegacySR {
+		return nil, fmt.Errorf("no legacy state-file shape detected")
+	}
+	delete(raw, "regions")
+	if isLegacySR {
+		delete(raw, "schema_registries")
+	}
+	stripped, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err
 	}
-	if state.MSKSources != nil || state.OSKSources != nil {
-		return state, nil
+	var state types.State
+	if err := json.Unmarshal(stripped, &state); err != nil {
+		return nil, err
 	}
-	// Legacy MSK-only shape: try `{ "regions": [...] }`.
-	var legacy struct {
-		Regions []types.DiscoveredRegion `json:"regions"`
+	if len(legacyRegions) > 0 && state.MSKSources == nil {
+		var regions []types.DiscoveredRegion
+		if err := json.Unmarshal(legacyRegions, &regions); err == nil && len(regions) > 0 {
+			state.MSKSources = &types.MSKSourcesState{Regions: regions}
+		}
 	}
-	if jerr := json.Unmarshal(data, &legacy); jerr == nil && len(legacy.Regions) > 0 {
-		state.MSKSources = &types.MSKSourcesState{Regions: legacy.Regions}
+	if isLegacySR && state.SchemaRegistries == nil {
+		var entries []json.RawMessage
+		if err := json.Unmarshal(legacySchemaRegistries, &entries); err == nil {
+			srs := &types.SchemaRegistriesState{}
+			for _, raw := range entries {
+				var disc struct {
+					Type string `json:"type"`
+				}
+				if err := json.Unmarshal(raw, &disc); err != nil {
+					continue
+				}
+				switch disc.Type {
+				case "glue", "aws_glue":
+					var g types.GlueSchemaRegistryInformation
+					if err := json.Unmarshal(raw, &g); err == nil {
+						srs.AWSGlue = append(srs.AWSGlue, g)
+					}
+				default:
+					var sr types.SchemaRegistryInformation
+					if err := json.Unmarshal(raw, &sr); err == nil {
+						srs.ConfluentSchemaRegistry = append(srs.ConfluentSchemaRegistry, sr)
+					}
+				}
+			}
+			if len(srs.ConfluentSchemaRegistry) > 0 || len(srs.AWSGlue) > 0 {
+				state.SchemaRegistries = srs
+			}
+		}
 	}
-	return state, nil
+	if state.MSKSources == nil && state.OSKSources == nil && state.SchemaRegistries == nil {
+		return nil, fmt.Errorf("legacy keys present but nothing populated after migration")
+	}
+	slog.Warn("loaded pre-0.7 state-file layout in legacy-compatibility mode; re-run `kcp discover` / `kcp scan` to refresh the file in the current schema")
+	return &state, nil
+}
+
+// stateFileKCPVersion extracts kcp_build_info.version from the raw
+// state-file JSON map. Returns "" when the field is absent or
+// unparseable — the caller treats absent / unparseable as "no signal"
+// and proceeds with the legacy migration.
+func stateFileKCPVersion(raw map[string]json.RawMessage) string {
+	bi, ok := raw["kcp_build_info"]
+	if !ok {
+		return ""
+	}
+	var info struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(bi, &info); err != nil {
+		return ""
+	}
+	return info.Version
+}
+
+// isPostLegacyVersion reports whether the state-file version string
+// represents kcp 0.7 or later (the cutoff where legacy `regions` /
+// flat `schema_registries` shapes ceased to be produced). The
+// localdev sentinel "0.0.0-localdev" is treated as pre-0.7 by virtue
+// of its leading zeros — fine, since dev builds shouldn't be loading
+// production state files.
+func isPostLegacyVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	// Strip leading "v" if present.
+	if strings.HasPrefix(v, "v") || strings.HasPrefix(v, "V") {
+		v = v[1:]
+	}
+	// Strip pre-release / build suffix at the first '-' or '+'.
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	major, mErr := parseInt(parts[0])
+	minor, nErr := parseInt(parts[1])
+	if mErr != nil || nErr != nil {
+		return false
+	}
+	if major > 0 {
+		return true
+	}
+	return minor >= 7
+}
+
+func parseInt(s string) (int, error) {
+	var n int
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("not a non-negative integer: %q", s)
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, nil
 }
 
 // parseOutputFormats accepts a comma-separated `md,json` list (or the legacy

--- a/cmd/report/plan/cmd_report_plan_test.go
+++ b/cmd/report/plan/cmd_report_plan_test.go
@@ -1,0 +1,92 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Pre-0.7 state files used `regions` at the top level instead of
+// `msk_sources.regions`. migrateLegacyState rebuilds them into the
+// modern shape so `kcp report plan` can still load them.
+func TestMigrateLegacyState_TopLevelRegions(t *testing.T) {
+	legacy := []byte(`{
+		"regions": [
+			{ "name": "us-east-1", "clusters": [] }
+		],
+		"kcp_build_info": { "version": "0.6.6" },
+		"timestamp": "2026-03-12T13:24:50Z"
+	}`)
+	state, err := migrateLegacyState(legacy)
+	require.NoError(t, err)
+	require.NotNil(t, state.MSKSources)
+	require.Len(t, state.MSKSources.Regions, 1)
+	assert.Equal(t, "us-east-1", state.MSKSources.Regions[0].Name)
+}
+
+// Pre-0.7 state files used a flat `schema_registries: [...]` array with
+// a `type` discriminator. migrateLegacyState buckets each entry into
+// `confluent_schema_registry` or `aws_glue`.
+func TestMigrateLegacyState_FlatSchemaRegistriesArray(t *testing.T) {
+	legacy := []byte(`{
+		"regions": [],
+		"schema_registries": [
+			{ "type": "confluent", "url": "http://sr1:8081" },
+			{ "type": "glue", "name": "glue-registry-1", "arn": "arn:aws:glue:us-east-1:111:registry/glue-registry-1" }
+		],
+		"kcp_build_info": { "version": "0.6.6" }
+	}`)
+	state, err := migrateLegacyState(legacy)
+	require.NoError(t, err)
+	require.NotNil(t, state.SchemaRegistries)
+	assert.Len(t, state.SchemaRegistries.ConfluentSchemaRegistry, 1)
+	assert.Len(t, state.SchemaRegistries.AWSGlue, 1)
+}
+
+// Modern state files (no legacy keys) must not be misidentified as
+// legacy — migrateLegacyState returns an error so loadState surfaces
+// the original strict-decode error to the user.
+func TestMigrateLegacyState_ModernShapeRejected(t *testing.T) {
+	modern := []byte(`{
+		"msk_sources": { "regions": [] },
+		"schema_registries": { "confluent_schema_registry": [] },
+		"kcp_build_info": { "version": "0.7.0" }
+	}`)
+	_, err := migrateLegacyState(modern)
+	assert.Error(t, err, "modern shape (no legacy keys) must not match the migration path")
+}
+
+// Forward-incompatible state file (kcp >= 0.7) that happens to use a
+// top-level `regions` field must NOT be silently migrated — the
+// strict-decode error path is the right signal. Otherwise a future
+// shape change could be quietly mangled by the legacy shim.
+func TestMigrateLegacyState_PostLegacyVersionRefused(t *testing.T) {
+	postLegacy := []byte(`{
+		"regions": [{ "name": "us-east-1", "clusters": [] }],
+		"kcp_build_info": { "version": "0.8.2" }
+	}`)
+	_, err := migrateLegacyState(postLegacy)
+	assert.Error(t, err, "kcp >= 0.7 must refuse the pre-0.7 migration shim")
+}
+
+func TestIsPostLegacyVersion(t *testing.T) {
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"", false},
+		{"0.6.6", false},
+		{"0.6.99", false},
+		{"0.7.0", true},
+		{"0.8.2", true},
+		{"1.0.0", true},
+		{"v1.2.3", true},
+		{"0.7.0-rc1", true},
+		{"0.0.0-localdev", false},
+		{"garbage", false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isPostLegacyVersion(c.v), c.v)
+	}
+}

--- a/internal/services/plan/auth.go
+++ b/internal/services/plan/auth.go
@@ -20,7 +20,7 @@ func knownTargetAuthMethod(t string) bool {
 	return knownEnum(t, TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth)
 }
 
-// DecideAuth produces the per-cluster source→target auth mapping.
+// decideAuth produces the per-cluster source→target auth mapping.
 // Sources come from the MSK ClientAuthentication detection in
 // cluster_signals.go; per-source target defaults come from
 // `auth_mapping` in plan-config.yaml.
@@ -30,7 +30,7 @@ func knownTargetAuthMethod(t string) bool {
 // target across all source rows for that cluster — the renderer
 // surfaces the source/target pair and a `Note` so the customer can
 // see the trade-off.
-func DecideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.AuthDecision {
+func decideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.AuthDecision {
 	sources := sourceAuthsDetected(c)
 	out := types.AuthDecision{
 		ClusterID:   c.Name,
@@ -40,6 +40,10 @@ func DecideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInpu
 		return out
 	}
 	override := inputs.TargetAuthMethod
+	if override != "" && !knownTargetAuthMethod(override) {
+		out.OverrideRejected = true
+		out.RejectedOverrideValue = override
+	}
 	for _, src := range sources {
 		mapping, ok := cfg.AuthMapping[src]
 		if !ok {

--- a/internal/services/plan/auth_test.go
+++ b/internal/services/plan/auth_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // authInputs builds a PlanInputsResolved with the default target_auth
-// unset — DecideAuth falls back to the per-source default from
+// unset — decideAuth falls back to the per-source default from
 // auth_mapping. Tests that want an override-everywhere behavior set
 // inputs.TargetAuthMethod explicitly.
 func authInputs() types.PlanInputsResolved {
@@ -18,7 +18,7 @@ func authInputs() types.PlanInputsResolved {
 
 func TestDecideAuth_NoSourceAuthsDetected(t *testing.T) {
 	c := types.ProcessedCluster{Name: "blank"}
-	d := DecideAuth(c, defaultCfg(t), authInputs())
+	d := decideAuth(c, defaultCfg(t), authInputs())
 	assert.Equal(t, "blank", d.ClusterID)
 	assert.Empty(t, d.SourceAuths, "no auth flags enabled → empty SourceAuths")
 	assert.Empty(t, d.TargetMappings, "empty SourceAuths → no mapping rows")
@@ -26,7 +26,7 @@ func TestDecideAuth_NoSourceAuthsDetected(t *testing.T) {
 
 func TestDecideAuth_SCRAMMapsToAPIKeysAndIsGatewayCompatible(t *testing.T) {
 	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
-	d := DecideAuth(c, defaultCfg(t), authInputs())
+	d := decideAuth(c, defaultCfg(t), authInputs())
 	assert.Equal(t, []string{SourceAuthSCRAM}, d.SourceAuths)
 	require := requireRow(t, d, SourceAuthSCRAM)
 	assert.Equal(t, TargetAuthAPIKeys, require.EffectiveTarget)
@@ -36,7 +36,7 @@ func TestDecideAuth_SCRAMMapsToAPIKeysAndIsGatewayCompatible(t *testing.T) {
 
 func TestDecideAuth_IAMTargetsAPIKeysButGatewayIncompatible(t *testing.T) {
 	c := withSourceAuth("iam-cluster", SourceAuthIAM)
-	d := DecideAuth(c, defaultCfg(t), authInputs())
+	d := decideAuth(c, defaultCfg(t), authInputs())
 	row := requireRow(t, d, SourceAuthIAM)
 	assert.Equal(t, TargetAuthAPIKeys, row.EffectiveTarget)
 	assert.False(t, row.GatewayCompatible, "IAM clients cannot connect to the CC Gateway")
@@ -44,7 +44,7 @@ func TestDecideAuth_IAMTargetsAPIKeysButGatewayIncompatible(t *testing.T) {
 
 func TestDecideAuth_MTLSStaysMTLS(t *testing.T) {
 	c := withSourceAuth("mtls-cluster", SourceAuthMTLS)
-	d := DecideAuth(c, defaultCfg(t), authInputs())
+	d := decideAuth(c, defaultCfg(t), authInputs())
 	row := requireRow(t, d, SourceAuthMTLS)
 	assert.Equal(t, TargetAuthMTLS, row.EffectiveTarget)
 	assert.True(t, row.GatewayCompatible, "mTLS gateway path uses auth-swap mode")
@@ -53,12 +53,12 @@ func TestDecideAuth_MTLSStaysMTLS(t *testing.T) {
 
 // Customer override replaces the auth_mapping default. Verified end-to-end
 // through PlanService.Build's per-cluster resolution in
-// plan_service_test.go; here we exercise DecideAuth directly.
+// plan_service_test.go; here we exercise decideAuth directly.
 func TestDecideAuth_TargetAuthMethodOverrideWins(t *testing.T) {
 	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
 	inputs := authInputs()
 	inputs.TargetAuthMethod = TargetAuthOAuth
-	d := DecideAuth(c, defaultCfg(t), inputs)
+	d := decideAuth(c, defaultCfg(t), inputs)
 	row := requireRow(t, d, SourceAuthSCRAM)
 	assert.Equal(t, TargetAuthOAuth, row.EffectiveTarget, "customer override must beat the auth_mapping default")
 }
@@ -70,7 +70,7 @@ func TestDecideAuth_MultipleSourceAuthsAllRendered(t *testing.T) {
 	c := withSourceAuth("multi-cluster", SourceAuthSCRAM)
 	enabled := true
 	c.AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication.Tls = &kafkatypes.Tls{Enabled: &enabled}
-	d := DecideAuth(c, defaultCfg(t), authInputs())
+	d := decideAuth(c, defaultCfg(t), authInputs())
 	assert.Len(t, d.SourceAuths, 2, "both SCRAM and mTLS should appear")
 	assert.Len(t, d.TargetMappings, 2, "one row per source auth — plan never picks one")
 }
@@ -84,4 +84,32 @@ func requireRow(t *testing.T, d types.AuthDecision, sourceAuth string) types.Aut
 	}
 	t.Fatalf("AuthDecision missing row for source auth %q; got: %+v", sourceAuth, d.TargetMappings)
 	return types.AuthMappingRow{}
+}
+
+// When `target_auth_method` is set to a string outside the recognised
+// enum, decideAuth flags the row as OverrideRejected with the typo'd
+// value preserved so JSON consumers (and the renderer's `*` marker)
+// can detect rejected overrides structurally — not just as an OQ.
+func TestDecideAuth_OverrideRejectedRecordedOnTypo(t *testing.T) {
+	c := withSourceAuth("iam-cluster", SourceAuthIAM)
+	inputs := types.PlanInputsResolved{TargetAuthMethod: "oauthhh"}
+	d := decideAuth(c, defaultCfg(t), inputs)
+	assert.True(t, d.OverrideRejected, "typo'd override must set OverrideRejected")
+	assert.Equal(t, "oauthhh", d.RejectedOverrideValue)
+	// effectiveTarget should fall back to the per-source default
+	// (confluent_cloud_api_keys for IAM), not the typo value.
+	row := requireRow(t, d, SourceAuthIAM)
+	assert.NotEqual(t, "oauthhh", row.EffectiveTarget, "row must NOT carry the typo as its effective target")
+}
+
+// Recognised override values keep OverrideRejected false; absent
+// override is also fine. Without this guard a regression could
+// silently mark every cluster as rejected.
+func TestDecideAuth_OverrideRejectedFalseForGoodValues(t *testing.T) {
+	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
+	for _, override := range []string{"", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth} {
+		d := decideAuth(c, defaultCfg(t), types.PlanInputsResolved{TargetAuthMethod: override})
+		assert.False(t, d.OverrideRejected, "good override %q must not be marked rejected", override)
+		assert.Empty(t, d.RejectedOverrideValue, "good override %q must not leak a rejected value", override)
+	}
 }

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -68,6 +68,20 @@ func brokerInventoryGap(c types.ProcessedCluster) bool {
 	return len(c.AWSClientInformation.Nodes) == 0
 }
 
+// clusterStorageMode returns the cluster's StorageMode enum
+// (`LOCAL` / `TIERED` / empty). Consumed by both the Red Flag
+// "tiered_storage_in_use" detector and the Tiered Storage
+// per-cluster section — same MskClusterConfig pointer-chase as
+// `brokerInstanceType` / `kafkaVersionOf`, so it lives here next to
+// its peers.
+func clusterStorageMode(c types.ProcessedCluster) kafkatypes.StorageMode {
+	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
+	if prov == nil {
+		return ""
+	}
+	return prov.StorageMode
+}
+
 // knownEnum reports whether `value` is one of `valid` (empty value
 // always counts as known — it means "default applies"). Used by enum
 // validators across decisions (downtime_tolerance, target_auth_method)
@@ -92,6 +106,22 @@ const (
 	SourceAuthIAM    = "iam"
 	SourceAuthMTLS   = "mtls"
 	SourceAuthUnauth = "unauth"
+)
+
+// DiscoveredClientAuth* mirrors the literal strings that
+// `kcp scan client-inventory` writes into `DiscoveredClient.Auth`
+// (see `cmd/scan/client_inventory/kafka_trace_line_parser.go`).
+//
+// **Heads-up:** `types.AuthTypeIAM` in `internal/types/types.go`
+// resolves to `"SASL/IAM"` — a DIFFERENT string used elsewhere. Use
+// these constants when comparing against the persisted client
+// inventory, not the `types.AuthType*` constants.
+const (
+	DiscoveredClientAuthIAM             = "IAM"
+	DiscoveredClientAuthSASLSCRAM       = "SASL_SCRAM"
+	DiscoveredClientAuthTLS             = "TLS"
+	DiscoveredClientAuthUnauthenticated = "UNAUTHENTICATED"
+	DiscoveredClientAuthUnknown         = "UNKNOWN"
 )
 
 // sourceAuthsDetected returns the set of auth methods enabled on the

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -154,7 +154,7 @@ func sourceUsesMTLS(c types.ProcessedCluster) bool {
 	return tls.Enabled != nil && *tls.Enabled
 }
 
-// DecideClusterType returns the recommended Confluent Cloud cluster type
+// decideClusterType returns the recommended Confluent Cloud cluster type
 // for one source cluster.
 //
 // Standard is intentionally not a verdict: MSK migration workloads
@@ -162,7 +162,7 @@ func sourceUsesMTLS(c types.ProcessedCluster) bool {
 // that Standard doesn't offer. Enterprise is the default; hard-limit
 // rules escalate to Dedicated when a cap is exceeded or a workload
 // constraint can't be served on Enterprise.
-func DecideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
+func decideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
 	var firedTriggers []types.HardLimitTrigger
 	evaluated := make([]types.RuleEvaluation, 0, len(hardLimitCatalog))
 	for _, hl := range hardLimitCatalog {

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -12,7 +12,7 @@ import (
 func TestDecideClusterType_DefaultEnterprise(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
-	d := DecideClusterType(types.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
+	d := decideClusterType(types.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
 	assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
 	assert.Empty(t, d.Triggers)
 }
@@ -21,7 +21,7 @@ func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 	cfg := defaultCfg(t)
 	// pni_max_eCKU = 32; size at 33 to fire the rule.
 	sizing := types.ClusterSizing{ClusterID: "huge", FinalECKU: 33}
-	d := DecideClusterType(types.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
+	d := decideClusterType(types.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
 	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 	assert.Len(t, d.Triggers, 1)
 	assert.Equal(t, "eCKU_exceeds_pni_cap", d.Triggers[0].RowID)
@@ -53,7 +53,7 @@ func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
 	c := provisionedClusterWithScan("many-acls", make([]types.Acls, 4001))
 	sizing := types.ClusterSizing{ClusterID: "many-acls", FinalECKU: 5}
 
-	d := DecideClusterType(c, sizing, cfg, defaultInputs())
+	d := decideClusterType(c, sizing, cfg, defaultInputs())
 	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 	assert.Len(t, d.Triggers, 1)
 	assert.Equal(t, "acl_count_exceeds_cap", d.Triggers[0].RowID)
@@ -79,7 +79,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 
 	t.Run("non-nil ACL slice evaluates the rule (under cap)", func(t *testing.T) {
 		c := provisionedClusterWithScan("provisioned-empty-acls", []types.Acls{})
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "0 ACLs is under the 4000 cap — rule should evaluate, not fire")
 	})
 
@@ -88,7 +88,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 		// without an explicit "scanned" flag we take the conservative
 		// position that nil means "uncertain" and skip the rule.
 		c := provisionedClusterWithScan("provisioned-nil-acls", nil)
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip rule 2 (count is unknown), not fire it")
 	})
 
@@ -96,7 +96,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 		c := types.ProcessedCluster{Name: "serverless"}
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "SERVERLESS doesn't expose ACLs via this API — rule should skip")
 	})
 }
@@ -136,7 +136,7 @@ func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			in := defaultInputs()
 			tc.mutator(&in)
-			d := DecideClusterType(c, sizing, cfg, in)
+			d := decideClusterType(c, sizing, cfg, in)
 			assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 			assert.Len(t, d.Triggers, 1)
 			assert.Equal(t, tc.ruleID, d.Triggers[0].RowID)
@@ -160,14 +160,14 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 	t.Run("aws target leaves Enterprise", func(t *testing.T) {
 		in := defaultInputs()
 		in.TargetCloud = "aws"
-		d := DecideClusterType(c, sizing, cfg, in)
+		d := decideClusterType(c, sizing, cfg, in)
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
 	})
 
 	t.Run("azure target forces Dedicated", func(t *testing.T) {
 		in := defaultInputs()
 		in.TargetCloud = "azure"
-		d := DecideClusterType(c, sizing, cfg, in)
+		d := decideClusterType(c, sizing, cfg, in)
 		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 		assert.Len(t, d.Triggers, 1)
 		assert.Equal(t, "mtls_on_non_aws_target", d.Triggers[0].RowID)
@@ -178,7 +178,7 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 		c2 := types.ProcessedCluster{Name: "scram"}
 		in := defaultInputs()
 		in.TargetCloud = "gcp"
-		d := DecideClusterType(c2, sizing, cfg, in)
+		d := decideClusterType(c2, sizing, cfg, in)
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
 	})
 }
@@ -189,7 +189,7 @@ func TestDecideClusterType_Topology(t *testing.T) {
 	c := types.ProcessedCluster{Name: "x"}
 
 	t.Run("Enterprise verdict has no topology", func(t *testing.T) {
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
 		assert.Equal(t, types.TopologyNotApplicable, d.Topology)
 		assert.Nil(t, d.FinalCKU, "Enterprise clusters are sized in eCKU only — no FinalCKU mirror")
@@ -197,7 +197,7 @@ func TestDecideClusterType_Topology(t *testing.T) {
 
 	t.Run("Dedicated via eCKU cap → Multi-Zone", func(t *testing.T) {
 		big := types.ClusterSizing{ClusterID: "big", FinalECKU: 33}
-		d := DecideClusterType(c, big, cfg, defaultInputs())
+		d := decideClusterType(c, big, cfg, defaultInputs())
 		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 		assert.Equal(t, types.TopologyMultiZone, d.Topology)
 		require.NotNil(t, d.FinalCKU)
@@ -207,7 +207,7 @@ func TestDecideClusterType_Topology(t *testing.T) {
 	t.Run("Dedicated via 99.95 single-zone SLA → Single-Zone", func(t *testing.T) {
 		in := defaultInputs()
 		in.Requires9995SLAWithinSingleZone = true
-		d := DecideClusterType(c, sizing, cfg, in)
+		d := decideClusterType(c, sizing, cfg, in)
 		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 		assert.Equal(t, types.TopologySingleZone, d.Topology)
 		require.NotNil(t, d.FinalCKU)
@@ -220,7 +220,7 @@ func TestDecideClusterType_Topology(t *testing.T) {
 		c2 := provisionedClusterWithScan("combo", make([]types.Acls, 4001))
 		in := defaultInputs()
 		in.Requires9995SLAWithinSingleZone = true
-		d := DecideClusterType(c2, sizing, cfg, in)
+		d := decideClusterType(c2, sizing, cfg, in)
 		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
 		assert.Equal(t, types.TopologySingleZone, d.Topology)
 		assert.GreaterOrEqual(t, len(d.Triggers), 2, "both rules should have fired")

--- a/internal/services/plan/config.go
+++ b/internal/services/plan/config.go
@@ -11,9 +11,9 @@ import (
 //go:embed plan-config.yaml
 var embeddedPlanConfig []byte
 
-// ExpectedSchemaVersion is the schema_version this loader understands.
+// expectedSchemaVersion is the schema_version this loader understands.
 // Bump in lockstep with breaking YAML structure changes.
-const ExpectedSchemaVersion = 1
+const expectedSchemaVersion = 1
 
 // PlanConfig is the deserialized plan-config.yaml. The embedded copy is
 // the default; an admin-supplied override file replaces only the fields
@@ -24,12 +24,22 @@ type PlanConfig struct {
 	LastVerified             string `yaml:"last_verified"`
 	KCPVersionAtVerification string `yaml:"kcp_version_at_verification"`
 
-	EnterpriseCaps    EnterpriseCaps         `yaml:"enterprise_caps"`
-	ClusterLinking    ClusterLinking         `yaml:"cluster_linking"`
-	SchemaLinking     SchemaLinking          `yaml:"schema_linking"`
-	PlanInputDefaults PlanInputDefaults      `yaml:"plan_input_defaults"`
-	AuthMapping       map[string]AuthMapping `yaml:"auth_mapping"`
-	Thresholds        Thresholds             `yaml:"thresholds"`
+	EnterpriseCaps     EnterpriseCaps         `yaml:"enterprise_caps"`
+	ClusterLinking     ClusterLinking         `yaml:"cluster_linking"`
+	SchemaLinking      SchemaLinking          `yaml:"schema_linking"`
+	PlanInputDefaults  PlanInputDefaults      `yaml:"plan_input_defaults"`
+	AuthMapping        map[string]AuthMapping `yaml:"auth_mapping"`
+	Thresholds         Thresholds             `yaml:"thresholds"`
+	CostReconciliation CostReconciliationCfg  `yaml:"cost_reconciliation"`
+}
+
+// CostReconciliationCfg pins the AWS Cost Explorer usage-string
+// families that count as MSK broker spend. Today AWS bills MSK
+// under `Kafka.*` and `Express.*`; new broker tiers will land as
+// new family tokens. Admins extend this list when a new tier ships
+// without waiting for a kcp release.
+type CostReconciliationCfg struct {
+	UsageFamilies []string `yaml:"usage_families"`
 }
 
 // Thresholds collects numeric cutoffs that the rule engine and the
@@ -43,6 +53,12 @@ type Thresholds struct {
 	// PNIGatewayBreakeven — projected PNI gateway count at or above
 	// which the recommendation flips from PNI to PrivateLink.
 	PNIGatewayBreakeven int `yaml:"pni_gateway_breakeven"`
+	// PartitionApproachingFraction — Red Flag row 5 fires when
+	// user-topic partitions exceed this fraction of the cluster's
+	// sized eCKU capacity (per_eCKU_partition_rate * FinalECKU).
+	// 0.30 means "fire at 30% of sized capacity"; pre-fix this was
+	// hardcoded in red_flags.go.
+	PartitionApproachingFraction float64 `yaml:"partition_approaching_fraction"`
 }
 
 // AuthMapping is one row in the source→target auth lookup table
@@ -154,8 +170,8 @@ func LoadPlanConfig(overridePath string) (*PlanConfig, error) {
 }
 
 func (c *PlanConfig) Validate() error {
-	if c.SchemaVersion != ExpectedSchemaVersion {
-		return fmt.Errorf("plan-config schema_version %d does not match expected %d", c.SchemaVersion, ExpectedSchemaVersion)
+	if c.SchemaVersion != expectedSchemaVersion {
+		return fmt.Errorf("plan-config schema_version %d does not match expected %d", c.SchemaVersion, expectedSchemaVersion)
 	}
 	caps := c.EnterpriseCaps
 	if caps.PerECKUIngressMBps <= 0 {
@@ -202,6 +218,12 @@ func (c *PlanConfig) Validate() error {
 	}
 	if c.Thresholds.PNIGatewayBreakeven < 1 {
 		return fmt.Errorf("plan-config thresholds.pni_gateway_breakeven must be >= 1 (got %v)", c.Thresholds.PNIGatewayBreakeven)
+	}
+	if c.Thresholds.PartitionApproachingFraction <= 0 || c.Thresholds.PartitionApproachingFraction >= 1 {
+		return fmt.Errorf("plan-config thresholds.partition_approaching_fraction must be in (0, 1) (got %v)", c.Thresholds.PartitionApproachingFraction)
+	}
+	if len(c.CostReconciliation.UsageFamilies) == 0 {
+		return fmt.Errorf("plan-config cost_reconciliation.usage_families must be non-empty (the cost-explorer parser uses this list to identify MSK broker usage strings)")
 	}
 	// Every auth_mapping entry MUST carry Target + provenance (Source +
 	// LastVerified). The fields exist so the rendered Plan can audit

--- a/internal/services/plan/config_test.go
+++ b/internal/services/plan/config_test.go
@@ -13,7 +13,7 @@ func TestLoadPlanConfigEmbedded(t *testing.T) {
 	cfg, err := LoadPlanConfig("")
 	require.NoError(t, err)
 
-	assert.Equal(t, ExpectedSchemaVersion, cfg.SchemaVersion)
+	assert.Equal(t, expectedSchemaVersion, cfg.SchemaVersion)
 	assert.Equal(t, 60, cfg.EnterpriseCaps.PerECKUIngressMBps)
 	assert.Equal(t, 180, cfg.EnterpriseCaps.PerECKUEgressMBps)
 	assert.Equal(t, 3000, cfg.EnterpriseCaps.PerECKUPartitionRate)

--- a/internal/services/plan/cost_reconciliation.go
+++ b/internal/services/plan/cost_reconciliation.go
@@ -1,0 +1,210 @@
+package plan
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// mskUsageTypeRegex compiles a usage-string regex from the
+// configured `cost_reconciliation.usage_families` list. The shape:
+//
+//	^<REGION_PREFIX>-<FAMILY>.<INSTANCE_OR_TIER>$
+//
+// Examples covered by the default config (`Kafka`, `Express`):
+//
+//	USE1-Kafka.m5.large
+//	APN1-Express.m7g.large
+//	EU-Kafka.kraft.t3.small
+//	USE1-Kafka.Serverless-Hours       (MSK Serverless)
+//	USW2-AZ1-Kafka.m5.large           (AZ-suffixed region prefix)
+//
+// Capture groups: [1] family, [2] instance-type or tier descriptor.
+// The region prefix isn't captured — the cost record's `Region`
+// field is the source of truth.
+func mskUsageTypeRegex(cfg *PlanConfig) *regexp.Regexp {
+	families := cfg.CostReconciliation.UsageFamilies
+	if len(families) == 0 {
+		families = []string{"Kafka", "Express"}
+	}
+	familyAlt := strings.Join(families, "|")
+	return regexp.MustCompile(`^[A-Z0-9-]+?-((?:` + familyAlt + `))\.([A-Za-z0-9.\-]+)$`)
+}
+
+// detectCostReconciliation produces the per-region diff between MSK
+// instance types in the AWS cost report and instance types that
+// `kcp discover` actually found in the inventory. Sorted by spend
+// desc; no materiality threshold (the customer decides what's
+// "real"). Returns nil when there are no candidates or no MSK source
+// data — the renderer omits the section in that case.
+func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *types.CostReconciliationSection {
+	re := mskUsageTypeRegex(cfg)
+	var candidates []types.HiddenClusterCandidate
+	for _, src := range state.Sources {
+		if src.MSKData == nil {
+			continue
+		}
+		for _, region := range src.MSKData.Regions {
+			inventory := inventoryInstanceTypes(region)
+			byType := aggregateCostByInstanceType(region.Costs, re)
+			for instType, agg := range byType {
+				if _, present := inventory[instType]; present {
+					continue
+				}
+				candidates = append(candidates, types.HiddenClusterCandidate{
+					Region:         region.Name,
+					InstanceType:   instType,
+					TotalSpend:     agg.totalSpend,
+					MonthsObserved: agg.monthsObserved,
+					DaysObserved:   agg.daysObserved,
+				})
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	// Sort by spend desc; tie-break on (Region, InstanceType) so the
+	// output is deterministic across runs even when two candidates
+	// share the same spend.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].TotalSpend != candidates[j].TotalSpend {
+			return candidates[i].TotalSpend > candidates[j].TotalSpend
+		}
+		if candidates[i].Region != candidates[j].Region {
+			return candidates[i].Region < candidates[j].Region
+		}
+		return candidates[i].InstanceType < candidates[j].InstanceType
+	})
+	return &types.CostReconciliationSection{Candidates: candidates}
+}
+
+// inventoryInstanceTypes returns the set of instance types
+// `kcp discover` found in the given region. Stored as a map for
+// O(1) lookup during the diff.
+func inventoryInstanceTypes(region types.ProcessedRegion) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, c := range region.Clusters {
+		if t := brokerInstanceType(c); t != "" {
+			out[t] = struct{}{}
+		}
+	}
+	return out
+}
+
+// costAgg accumulates per-instance-type cost across observation
+// windows. monthsObserved counts distinct month prefixes (`YYYY-MM`)
+// in the `Start` timestamps; daysObserved counts distinct
+// `YYYY-MM-DD` values. Both are surfaced in the rendered section so
+// the customer can judge whether a candidate looks like a
+// short-lived cluster vs. a long-running one.
+type costAgg struct {
+	totalSpend     float64
+	months         map[string]struct{}
+	days           map[string]struct{}
+	monthsObserved int
+	daysObserved   int
+}
+
+func aggregateCostByInstanceType(costs types.ProcessedRegionCosts, re *regexp.Regexp) map[string]*costAgg {
+	out := map[string]*costAgg{}
+	for _, r := range costs.Results {
+		instType := parseMSKInstanceType(r.UsageType, re)
+		if instType == "" {
+			continue
+		}
+		agg, ok := out[instType]
+		if !ok {
+			agg = &costAgg{
+				months: map[string]struct{}{},
+				days:   map[string]struct{}{},
+			}
+			out[instType] = agg
+		}
+		agg.totalSpend += r.Values.UnblendedCost
+		// Cost Explorer Start is `YYYY-MM-DD`; trim to substrings.
+		if len(r.Start) >= 7 {
+			agg.months[r.Start[:7]] = struct{}{}
+		}
+		if len(r.Start) >= 10 {
+			agg.days[r.Start[:10]] = struct{}{}
+		}
+		// Tolerate RFC3339 timestamps too.
+		if t, err := time.Parse(time.RFC3339, r.Start); err == nil {
+			agg.months[t.Format("2006-01")] = struct{}{}
+			agg.days[t.Format("2006-01-02")] = struct{}{}
+		}
+	}
+	for _, agg := range out {
+		agg.monthsObserved = len(agg.months)
+		agg.daysObserved = len(agg.days)
+	}
+	return out
+}
+
+// parseMSKInstanceType extracts the MSK instance type from an AWS
+// Cost Explorer usage string against a pre-compiled regex (built
+// from `cfg.CostReconciliation.UsageFamilies`). Returns empty when
+// the string isn't an MSK broker usage type — Cost Explorer mixes
+// data-transfer / EBS / etc. rows into the MSK service's results,
+// and only broker rows belong in the diff.
+func parseMSKInstanceType(usageType string, re *regexp.Regexp) string {
+	m := re.FindStringSubmatch(usageType)
+	if m == nil {
+		return ""
+	}
+	// m[1] = family (Kafka | Express | ...), m[2] = instance/tier
+	// (e.g. m5.large, Serverless-Hours). Rendered as
+	// `<lowercase-family>.<m2>` to mirror the shape of
+	// BrokerNodeGroupInfo.InstanceType in the inventory diff.
+	return strings.ToLower(m[1]) + "." + m[2]
+}
+
+// detectCostReconciliationOpenQuestions emits an OQ when the cost
+// data is empty across all regions — the diff isn't actionable
+// without cost data. Returns nil when at least one region has cost
+// data (even if the diff was clean).
+func detectCostReconciliationOpenQuestions(state types.ProcessedState) []types.OpenQuestion {
+	hasCost := false
+	for _, src := range state.Sources {
+		if src.MSKData == nil {
+			continue
+		}
+		for _, region := range src.MSKData.Regions {
+			if len(region.Costs.Results) > 0 {
+				hasCost = true
+				break
+			}
+		}
+		if hasCost {
+			break
+		}
+	}
+	if hasCost {
+		return nil
+	}
+	// If there are no MSK regions at all, this signal isn't
+	// applicable — the renderer's broader empty-fleet handling
+	// covers that case.
+	if !hasAnyMSKRegion(state) {
+		return nil
+	}
+	return []types.OpenQuestion{{
+		ID:         "cost_data_not_collected",
+		Title:      "Cost-vs-inventory reconciliation skipped — run `kcp report costs`",
+		Body:       "No AWS Cost Explorer data is present in the state file. The cost-vs-inventory diff (which surfaces MSK instance types billed by AWS but NOT discovered by `kcp discover`) needs cost data to run.",
+		HowToClose: "Run `kcp report costs --state-file <path> --region <region> --start <YYYY-MM-DD> --end <YYYY-MM-DD>` for each source region, then re-run `kcp report plan`.",
+	}}
+}
+
+func hasAnyMSKRegion(state types.ProcessedState) bool {
+	for _, src := range state.Sources {
+		if src.MSKData != nil && len(src.MSKData.Regions) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/plan/cost_reconciliation.go
+++ b/internal/services/plan/cost_reconciliation.go
@@ -30,7 +30,15 @@ func mskUsageTypeRegex(cfg *PlanConfig) *regexp.Regexp {
 	if len(families) == 0 {
 		families = []string{"Kafka", "Express"}
 	}
-	familyAlt := strings.Join(families, "|")
+	// QuoteMeta each family token before joining — `usage_families` is
+	// configurable and a stray regex metacharacter (`.`, `+`, `(`, …)
+	// would otherwise change the match semantics or invalidate the
+	// regex at MustCompile time.
+	escaped := make([]string, len(families))
+	for i, f := range families {
+		escaped[i] = regexp.QuoteMeta(f)
+	}
+	familyAlt := strings.Join(escaped, "|")
 	return regexp.MustCompile(`^[A-Z0-9-]+?-((?:` + familyAlt + `))\.([A-Za-z0-9.\-]+)$`)
 }
 

--- a/internal/services/plan/cost_reconciliation_test.go
+++ b/internal/services/plan/cost_reconciliation_test.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseMSKInstanceType extracts the `<family>.<size>` portion from
+// the AWS Cost Explorer usage string and lowercases the family token
+// to match BrokerNodeGroupInfo.InstanceType shape.
+func TestParseMSKInstanceType(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"USE1-Kafka.m5.large", "kafka.m5.large"},
+		{"APN1-Express.m7g.large", "express.m7g.large"},
+		{"EU-Kafka.kraft.t3.small", "kafka.kraft.t3.small"},
+		{"USE1-DataTransfer-Out-Bytes", ""}, // non-broker row
+		{"", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, parseMSKInstanceType(c.in, mskUsageTypeRegex(defaultCfg(t))))
+		})
+	}
+}
+
+// Diff surfaces a cost-billed instance type that's NOT in inventory.
+func TestDetectCostReconciliation_DiffSurfacesHiddenType(t *testing.T) {
+	discovered := redFlagCluster("discovered-cluster", "3.5.0", "kafka.m5.large", "")
+	state := wrapClusters(discovered)
+	// Inject cost data: m5.large (present in inventory) + m7g.large (NOT in inventory)
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.50}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.75}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	require.NotNil(t, section)
+	require.Len(t, section.Candidates, 1, "only the hidden type appears as a candidate")
+	assert.Equal(t, "kafka.m7g.large", section.Candidates[0].InstanceType)
+	assert.InDelta(t, 250.75, section.Candidates[0].TotalSpend, 0.01)
+}
+
+// Candidates are sorted by TotalSpend descending.
+func TestDetectCostReconciliation_SortedByTotalSpendDesc(t *testing.T) {
+	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.0}},
+			{Start: "2026-04-01", UsageType: "USE1-Express.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.0}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	require.NotNil(t, section)
+	require.Len(t, section.Candidates, 3)
+	assert.Equal(t, "kafka.m7g.large", section.Candidates[0].InstanceType, "highest-spend first")
+	assert.Equal(t, "express.m7g.large", section.Candidates[1].InstanceType)
+	assert.Equal(t, "kafka.m5.large", section.Candidates[2].InstanceType)
+}
+
+// Empty cost data → detectCostReconciliation returns nil AND the OQ
+// detector fires `cost_data_not_collected`.
+func TestDetectCostReconciliation_EmptyCostDataEmitsOQ(t *testing.T) {
+	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
+	// No cost data attached.
+	assert.Nil(t, detectCostReconciliation(state, defaultCfg(t)))
+	oqs := detectCostReconciliationOpenQuestions(state)
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "cost_data_not_collected", oqs[0].ID)
+}
+
+// Non-broker usage strings (data transfer, EBS, etc.) are ignored.
+func TestDetectCostReconciliation_NonBrokerRowsIgnored(t *testing.T) {
+	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.0}},
+			{Start: "2026-04-01", UsageType: "USE1-EBS:VolumeUsage.gp3", Values: types.ProcessedCostBreakdown{UnblendedCost: 200.0}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	assert.Nil(t, section, "non-broker rows must not generate candidates")
+}
+
+// Months / days observed roll up across distinct timestamps.
+func TestDetectCostReconciliation_ObservationCounts(t *testing.T) {
+	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-04-02", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-05-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	require.NotNil(t, section)
+	require.Len(t, section.Candidates, 1)
+	assert.Equal(t, 2, section.Candidates[0].MonthsObserved, "April + May")
+	assert.Equal(t, 3, section.Candidates[0].DaysObserved)
+	assert.InDelta(t, 300.0, section.Candidates[0].TotalSpend, 0.01)
+}

--- a/internal/services/plan/cutover.go
+++ b/internal/services/plan/cutover.go
@@ -23,7 +23,7 @@ const (
 	PrereqStatusCompleteInput   = "complete"
 )
 
-// DecideCutover produces the fleet-wide cutover decision.
+// decideCutover produces the fleet-wide cutover decision.
 // Reads:
 //   - inputs.DowntimeTolerance → CutoverStyle (1:1 mapping)
 //   - gateway eligibility (3 prereqs + fleet-wide IAM cross-reference)
@@ -40,7 +40,7 @@ const (
 // distinct from "the customer set `prefer_gateway: false`" but
 // indistinguishable at this layer. Callers from tests should construct
 // inputs via the resolver, not by struct literal.
-func DecideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.CutoverDecision {
+func decideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.CutoverDecision {
 	style, sub := resolveStyle(inputs)
 
 	// Blue/Green sidesteps the gateway question entirely — the gateway
@@ -147,6 +147,16 @@ func knownDowntimeTolerance(tolerance string) bool {
 		DowntimeScheduledWindowSequential,
 		DowntimeScheduledWindowAllAtOnce,
 		DowntimeLetConfluentChoose,
+	)
+}
+
+// knownCutoverSubPattern reports whether `sub` is one of the
+// Stop-Restart-Repeat sub-patterns. Empty counts as known (falls back
+// to app-by-app in resolveStyle).
+func knownCutoverSubPattern(sub string) bool {
+	return knownEnum(sub,
+		string(types.SubPatternAppByApp),
+		string(types.SubPatternTopicByTopic),
 	)
 }
 

--- a/internal/services/plan/cutover_test.go
+++ b/internal/services/plan/cutover_test.go
@@ -7,6 +7,7 @@ import (
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // styleInputs returns a base PlanInputsResolved with the given
@@ -37,7 +38,7 @@ func TestDecideCutover_StyleMapping(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.tolerance, func(t *testing.T) {
-			d := DecideCutover(nil, styleInputs(tc.tolerance))
+			d := decideCutover(nil, styleInputs(tc.tolerance))
 			assert.Equal(t, tc.want, d.Style)
 		})
 	}
@@ -46,17 +47,17 @@ func TestDecideCutover_StyleMapping(t *testing.T) {
 func TestDecideCutover_SubPatternOnlyForSRR(t *testing.T) {
 	srr := styleInputs(DowntimeMinutesPerService)
 	srr.SubPattern = string(types.SubPatternTopicByTopic)
-	d := DecideCutover(nil, srr)
+	d := decideCutover(nil, srr)
 	assert.Equal(t, types.SubPatternTopicByTopic, d.SubPattern, "SRR should carry the sub-pattern")
 
 	bg := styleInputs(DowntimeZero)
 	bg.SubPattern = string(types.SubPatternTopicByTopic)
-	d = DecideCutover(nil, bg)
+	d = decideCutover(nil, bg)
 	assert.Empty(t, d.SubPattern, "non-SRR styles must not surface a sub-pattern")
 }
 
 func TestDecideCutover_Canonical(t *testing.T) {
-	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	d := decideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
 	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus)
 	assert.Equal(t, types.GatewayMediatedTrue, d.GatewayMediated)
 }
@@ -64,13 +65,13 @@ func TestDecideCutover_Canonical(t *testing.T) {
 func TestDecideCutover_CustomerChoiceOptOut(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	inputs.PreferGateway = false
-	d := DecideCutover(nil, inputs)
+	d := decideCutover(nil, inputs)
 	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
 	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
 }
 
 func TestDecideCutover_BlueGreenIsCustomerChoice(t *testing.T) {
-	d := DecideCutover(nil, styleInputs(DowntimeZero))
+	d := decideCutover(nil, styleInputs(DowntimeZero))
 	assert.Equal(t, types.CutoverBlueGreen, d.Style)
 	assert.Equal(t, types.GatewayMediatedNotApplicable, d.GatewayMediated)
 	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
@@ -83,7 +84,7 @@ func TestDecideCutover_DegradedAwaitingOQ(t *testing.T) {
 	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
-	d := DecideCutover(nil, inputs)
+	d := decideCutover(nil, inputs)
 	assert.Equal(t, types.RecommendationDegradedAwaitingOQ, d.RecommendationStatus)
 	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
 }
@@ -94,7 +95,7 @@ func TestDecideCutover_DegradedPrereqsPending(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	inputs.ConfluentForKubernetesStatus = PrereqStatusInProgressInput
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
-	d := DecideCutover(nil, inputs)
+	d := decideCutover(nil, inputs)
 	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus)
 	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
 }
@@ -106,16 +107,16 @@ func TestDecideCutover_IAMPrereqOnlyMattersWhenIAMInFleet(t *testing.T) {
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
 
 	// Without IAM in the fleet, still eligible / canonical.
-	d := DecideCutover([]types.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
+	d := decideCutover([]types.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
 	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus, "no IAM in fleet → IAM prereq irrelevant")
 
 	// With IAM in the fleet, the IAM-not-started prereq now blocks eligibility.
-	d = DecideCutover([]types.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
+	d = decideCutover([]types.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
 	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus, "IAM in fleet → IAM prereq required")
 }
 
 func TestDecideCutover_AlternativesShown(t *testing.T) {
-	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	d := decideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
 	assert.Equal(t, types.CutoverStopRestartRepeat, d.Style)
 	assert.Len(t, d.AlternativesShown, 3, "alternatives = all styles except the recommended one")
 	assert.NotContains(t, d.AlternativesShown, types.CutoverStopRestartRepeat)
@@ -127,12 +128,12 @@ func TestDecideCutover_AlternativesShown(t *testing.T) {
 func TestDecideCutover_IAMPrereqRowOnlyWhenIAMInFleet(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 
-	noIAM := DecideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthSCRAM)}, inputs)
+	noIAM := decideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthSCRAM)}, inputs)
 	for _, p := range noIAM.Prereqs {
 		assert.False(t, strings.Contains(p.Description, "IAM"), "IAM prereq must NOT appear when fleet has no IAM")
 	}
 
-	iam := DecideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthIAM)}, inputs)
+	iam := decideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthIAM)}, inputs)
 	var sawIAM bool
 	for _, p := range iam.Prereqs {
 		if strings.Contains(p.Description, "IAM") {
@@ -144,7 +145,7 @@ func TestDecideCutover_IAMPrereqRowOnlyWhenIAMInFleet(t *testing.T) {
 
 // withSourceAuth returns a minimal ProcessedCluster with the named
 // source auth enabled on the AWS-side ClientAuthentication. Used to
-// drive fleetUsesIAM() through DecideCutover.
+// drive fleetUsesIAM() through decideCutover.
 func withSourceAuth(name, auth string) types.ProcessedCluster {
 	c := types.ProcessedCluster{Name: name}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
@@ -181,8 +182,8 @@ func TestDetectCutoverOpenQuestions_AmbiguousIntent(t *testing.T) {
 	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.True(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
 	assert.False(t, hasOQ(oqs, "gateway_prereqs_pending"))
 }
@@ -191,8 +192,8 @@ func TestDetectCutoverOpenQuestions_PrereqsPending(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	inputs.ConfluentForKubernetesStatus = PrereqStatusInProgressInput
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.True(t, hasOQ(oqs, "gateway_prereqs_pending"))
 	assert.False(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
 }
@@ -202,8 +203,8 @@ func TestDetectCutoverOpenQuestions_PrereqsPending(t *testing.T) {
 func TestDetectCutoverOpenQuestions_SecondsPerServiceOptOut(t *testing.T) {
 	inputs := styleInputs(DowntimeSecondsPerService)
 	inputs.PreferGateway = false
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.True(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
 }
 
@@ -214,8 +215,8 @@ func TestDetectCutoverOpenQuestions_SecondsPerServiceAmbiguous(t *testing.T) {
 	inputs.ConfluentForKubernetesStatus = PrereqNotStarted
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.True(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
 	assert.True(t, hasOQ(oqs, "gateway_intent_unconfirmed"))
 }
@@ -225,21 +226,21 @@ func TestDetectCutoverOpenQuestions_SecondsPerServiceAmbiguous(t *testing.T) {
 // OQ should NOT fire on a Blue/Green resolved style.
 func TestDetectCutoverOpenQuestions_BlueGreenSkipsCrossCheck(t *testing.T) {
 	inputs := styleInputs(DowntimeZero)
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.False(t, hasOQ(oqs, "downtime_tolerance_requires_gateway"))
 }
 
 func TestDetectCutoverOpenQuestions_UnknownTolerance(t *testing.T) {
 	inputs := styleInputs("scheduled_window_quarterly") // typo
-	d := DecideCutover(nil, inputs)
-	oqs := detectCutoverOpenQuestions(d, inputs, false)
+	d := decideCutover(nil, inputs)
+	oqs := detectCutoverOpenQuestions(d, nil, inputs, false)
 	assert.True(t, hasOQ(oqs, "downtime_tolerance_unknown"))
 }
 
 func TestDetectCutoverOpenQuestions_CanonicalEmits_NoOQs(t *testing.T) {
-	d := DecideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
-	oqs := detectCutoverOpenQuestions(d, styleInputs(DowntimeLetConfluentChoose), false)
+	d := decideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
+	oqs := detectCutoverOpenQuestions(d, nil, styleInputs(DowntimeLetConfluentChoose), false)
 	assert.Empty(t, oqs, "canonical recommendation has nothing to ask")
 }
 
@@ -248,10 +249,203 @@ func TestDetectCutoverOpenQuestions_CanonicalEmits_NoOQs(t *testing.T) {
 func TestDecideCutover_PrereqsSuppressedOnOptOut(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	inputs.PreferGateway = false
-	d := DecideCutover(nil, inputs)
+	d := decideCutover(nil, inputs)
 	assert.Empty(t, d.Prereqs, "opt-out hides the gateway prereq table — they don't apply")
 
 	inputs.PreferGateway = true
-	d = DecideCutover(nil, inputs)
+	d = decideCutover(nil, inputs)
 	assert.NotEmpty(t, d.Prereqs, "opt-in keeps the prereq table visible")
+}
+
+// Per-cluster `downtime_tolerance` override emits a CutoverOverrides
+// entry whose style differs from the fleet default; clusters that
+// match the fleet (or have no override) don't appear.
+func TestComputeCutoverOverrides_PerClusterDifference(t *testing.T) {
+	fleet := decideCutover(nil, styleInputs(DowntimeMinutesPerService))
+	inputs := styleInputs(DowntimeMinutesPerService)
+	zero := DowntimeZero
+	sched := DowntimeScheduledWindowAllAtOnce
+	inputs.Raw = &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"a": {DowntimeTolerance: &zero},  // override → Blue/Green
+			"b": {DowntimeTolerance: &sched}, // override → Restart-All-At-Once
+			"c": {},                          // no cutover override → no entry
+		},
+	}
+	clusters := []types.ProcessedCluster{
+		{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}, // d has no entry in Clusters map
+	}
+	out := computeCutoverOverrides(clusters, fleet, inputs)
+	require := []struct {
+		id    string
+		style types.CutoverStyle
+	}{
+		{"a", types.CutoverBlueGreen},
+		{"b", types.CutoverRestartAllAtOnce},
+	}
+	assert.Len(t, out, len(require), "only clusters whose resolved style differs surface")
+	for i, want := range require {
+		assert.Equal(t, want.id, out[i].ClusterID)
+		assert.Equal(t, want.style, out[i].Style)
+	}
+}
+
+// Typo'd per-cluster downtime_tolerance fires a per-cluster OQ — the
+// override silently falls back to the fleet default in
+// applyClusterOverride, so without this detector the reader can't
+// tell why their override didn't take effect.
+func TestDetectClusterCutoverOpenQuestions_TypoPerCluster(t *testing.T) {
+	typo := "zerooo"
+	inputs := types.PlanInputsResolved{
+		Raw: &types.PlanInputs{
+			Clusters: map[string]types.ClusterPlanInputs{
+				"a": {DowntimeTolerance: &typo},
+			},
+		},
+	}
+	oqs := detectClusterCutoverOpenQuestions([]types.ProcessedCluster{{Name: "a"}}, inputs)
+	require := 1
+	assert.Len(t, oqs, require)
+	assert.Equal(t, "downtime_tolerance_unknown", oqs[0].ID)
+	assert.Equal(t, "a", oqs[0].ClusterID)
+	assert.Contains(t, oqs[0].Title, "zerooo")
+}
+
+// One cluster can carry BOTH a per-cluster target_auth_method AND a
+// per-cluster downtime_tolerance override. Both must propagate to the
+// per-cluster resolved inputs and surface in the right Plan sections
+// (auth row + cutover override entry). Without this guard a future
+// refactor of applyClusterOverride could silently drop one of them.
+func TestPerCluster_AuthAndCutoverOverridesCoexistOnSameCluster(t *testing.T) {
+	zero := DowntimeZero
+	oauth := "oauth"
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {
+				DowntimeTolerance: &zero,
+				TargetAuthMethod:  &oauth,
+			},
+		},
+	}
+	base := styleInputs(DowntimeMinutesPerService)
+	base.Raw = raw
+
+	resolved := applyClusterOverride(base, raw, "alpha")
+	assert.Equal(t, DowntimeZero, resolved.DowntimeTolerance, "per-cluster downtime_tolerance must layer on top of fleet inputs")
+	assert.Equal(t, "oauth", resolved.TargetAuthMethod, "per-cluster target_auth_method must layer on top of fleet inputs")
+
+	fleet := decideCutover([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, base)
+	overrides := computeCutoverOverrides([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, fleet, base)
+	require.Len(t, overrides, 1, "per-cluster downtime_tolerance must produce a cutover override entry")
+	assert.Equal(t, types.CutoverBlueGreen, overrides[0].Style)
+
+	auth := decideAuth(withSourceAuth("alpha", SourceAuthSCRAM), defaultCfg(t), resolved)
+	row := requireRow(t, auth, SourceAuthSCRAM)
+	assert.Equal(t, "oauth", row.EffectiveTarget, "per-cluster target_auth_method must beat the fleet default on the auth row")
+}
+
+// Per-cluster `sub_pattern` set WITHOUT `downtime_tolerance` should
+// flip only the sub-pattern (the cluster inherits the fleet's
+// downtime_tolerance → style). Without this guard a refactor of
+// computeCutoverOverrides could miss the sub_pattern-only path
+// because `raw.DowntimeTolerance == nil` looks like "no override".
+func TestPerCluster_SubPatternOnlyOverride(t *testing.T) {
+	tbt := string(types.SubPatternTopicByTopic)
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {SubPattern: &tbt},
+		},
+	}
+	base := styleInputs(DowntimeMinutesPerService)
+	base.SubPattern = string(types.SubPatternAppByApp) // fleet default
+	base.Raw = raw
+
+	fleet := decideCutover(nil, base)
+	assert.Equal(t, types.CutoverStopRestartRepeat, fleet.Style, "fleet must still resolve to SRR")
+	assert.Equal(t, types.SubPatternAppByApp, fleet.SubPattern, "fleet sub-pattern unchanged")
+
+	overrides := computeCutoverOverrides([]types.ProcessedCluster{{Name: "alpha"}}, fleet, base)
+	require.Len(t, overrides, 1, "sub_pattern-only override must still produce a CutoverOverrides entry")
+	assert.Equal(t, "alpha", overrides[0].ClusterID)
+	assert.Equal(t, types.CutoverStopRestartRepeat, overrides[0].Style, "style inherits the fleet's")
+	assert.Equal(t, types.SubPatternTopicByTopic, overrides[0].SubPattern, "sub-pattern reflects the override")
+}
+
+// Fleet has all 3 gateway prereqs complete (so canonical recommendation
+// is gateway-mediated) + IAM on the source + a per-cluster Blue/Green
+// override on the IAM cluster. Expectations:
+//   - Fleet cutover is canonical, gateway-mediated.
+//   - Override cluster surfaces as Blue/Green with gateway N/A.
+//   - No fleet-level gateway OQ fires (recommendation_status is canonical),
+//     so no exemption suffix is needed. Specifically `gateway_intent_unconfirmed`
+//     and `gateway_prereqs_pending` MUST stay silent.
+func TestPerCluster_BlueGreenOverrideOnIAMClusterWithCompletePrereqs(t *testing.T) {
+	zero := DowntimeZero
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"iam-cluster": {DowntimeTolerance: &zero},
+		},
+	}
+	base := styleInputs(DowntimeMinutesPerService)
+	// IAM source means the IAM prereq is consulted — set it complete
+	// so the fleet decision is canonical, not degraded.
+	base.IAMPreMigrationStatus = PrereqStatusCompleteInput
+	base.Raw = raw
+	clusters := []types.ProcessedCluster{withSourceAuth("iam-cluster", SourceAuthIAM)}
+
+	fleet := decideCutover(clusters, base)
+	assert.Equal(t, types.RecommendationCanonical, fleet.RecommendationStatus, "all prereqs complete + IAM in fleet must still resolve canonical")
+	assert.Equal(t, types.GatewayMediatedTrue, fleet.GatewayMediated)
+
+	overrides := computeCutoverOverrides(clusters, fleet, base)
+	require.Len(t, overrides, 1)
+	assert.Equal(t, types.CutoverBlueGreen, overrides[0].Style)
+	assert.Equal(t, types.GatewayMediatedNotApplicable, overrides[0].GatewayMediated, "BG override on IAM cluster still sidesteps the gateway")
+
+	oqs := detectCutoverOpenQuestions(fleet, overrides, base, fleetUsesIAM(clusters))
+	for _, oq := range oqs {
+		assert.NotEqual(t, "gateway_intent_unconfirmed", oq.ID, "canonical fleet must not fire gateway-intent OQ")
+		assert.NotEqual(t, "gateway_prereqs_pending", oq.ID, "complete prereqs must not fire prereqs-pending OQ")
+	}
+}
+
+// Per-cluster `downtime_tolerance: seconds_per_service` against a
+// fleet without gateway mediation must surface the conflict — gateway
+// prereqs are fleet-scoped so a per-cluster override can't earn its
+// own gateway path. Without an explicit OQ the customer's choice is
+// silently lost.
+func TestPerCluster_SecondsPerServiceWithoutFleetGateway(t *testing.T) {
+	sps := DowntimeSecondsPerService
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			"alpha": {DowntimeTolerance: &sps},
+		},
+	}
+	// Fleet doesn't have any gateway prereqs advanced → plain CL.
+	base := types.PlanInputsResolved{
+		DowntimeTolerance:            DowntimeMinutesPerService,
+		SubPattern:                   string(types.SubPatternAppByApp),
+		PreferGateway:                true,
+		ConfluentForKubernetesStatus: PrereqNotStarted,
+		CCGatewayLicenseStatus:       PrereqNotStarted,
+		IAMPreMigrationStatus:        PrereqNotStarted,
+		Raw:                          raw,
+	}
+	clusters := []types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}
+
+	fleet := decideCutover(clusters, base)
+	require.NotEqual(t, types.GatewayMediatedTrue, fleet.GatewayMediated, "fleet must NOT be gateway-mediated for this scenario")
+
+	oqs := detectPerClusterGatewayIncompat(clusters, fleet, base)
+	require.Len(t, oqs, 1, "per-cluster seconds_per_service must fire the gateway-incompat OQ when fleet isn't mediated")
+	assert.Equal(t, "downtime_tolerance_requires_gateway", oqs[0].ID)
+	assert.Equal(t, "alpha", oqs[0].ClusterID)
+	assert.Contains(t, oqs[0].Title, "seconds_per_service")
+
+	// Inverse: when fleet IS gateway-mediated, no per-cluster OQ.
+	base.ConfluentForKubernetesStatus = PrereqStatusCompleteInput
+	base.CCGatewayLicenseStatus = PrereqStatusCompleteInput
+	mediatedFleet := decideCutover(clusters, base)
+	require.Equal(t, types.GatewayMediatedTrue, mediatedFleet.GatewayMediated)
+	assert.Empty(t, detectPerClusterGatewayIncompat(clusters, mediatedFleet, base), "mediated fleet → no per-cluster OQ")
 }

--- a/internal/services/plan/cutover_test.go
+++ b/internal/services/plan/cutover_test.go
@@ -409,6 +409,45 @@ func TestPerCluster_BlueGreenOverrideOnIAMClusterWithCompletePrereqs(t *testing.
 	}
 }
 
+// Per-cluster cutover overrides inherit the fleet's GatewayMediated
+// for non-Blue/Green styles — gateway prereqs are fleet-scoped, so
+// the override can't be re-evaluated against just this cluster's auth
+// (which is what `decideCutover([]{c}, ...)` would do via
+// `fleetUsesIAM`). Regression guard: a non-IAM override cluster in a
+// mixed IAM/non-IAM fleet must NOT flip the IAM-prereq gate.
+func TestComputeCutoverOverrides_GatewayMediationInheritedFromFleet(t *testing.T) {
+	base := styleInputs(DowntimeMinutesPerService)
+	base.ConfluentForKubernetesStatus = PrereqStatusCompleteInput
+	base.CCGatewayLicenseStatus = PrereqStatusCompleteInput
+	base.IAMPreMigrationStatus = PrereqNotStarted // not_started — relevant ONLY if fleet uses IAM
+	// Fleet has an IAM cluster → IAM prereq is consulted → fleet is
+	// degraded (not gateway-mediated).
+	clusters := []types.ProcessedCluster{
+		withSourceAuth("iam-cluster", SourceAuthIAM),
+		withSourceAuth("scram-override", SourceAuthSCRAM),
+	}
+	srr := DowntimeMinutesPerService
+	tbt := string(types.SubPatternTopicByTopic)
+	raw := &types.PlanInputs{
+		Clusters: map[string]types.ClusterPlanInputs{
+			// scram-override flips sub-pattern only — same style as fleet.
+			// Pre-fix, decideCutover on a single SCRAM cluster would
+			// IGNORE the IAM prereq (fleetUsesIAM=false for this slice)
+			// and emit GatewayMediated=true, contradicting the fleet.
+			"scram-override": {DowntimeTolerance: &srr, SubPattern: &tbt},
+		},
+	}
+	base.Raw = raw
+	fleet := decideCutover(clusters, base)
+	require.NotEqual(t, types.GatewayMediatedTrue, fleet.GatewayMediated, "fleet must be degraded by the IAM-not-started prereq")
+
+	overrides := computeCutoverOverrides(clusters, fleet, base)
+	require.Len(t, overrides, 1, "scram-override must surface (sub-pattern differs)")
+	assert.Equal(t, "scram-override", overrides[0].ClusterID)
+	assert.Equal(t, fleet.GatewayMediated, overrides[0].GatewayMediated,
+		"non-BG override must inherit fleet's GatewayMediated — not re-evaluate IAM prereqs against this single cluster")
+}
+
 // Per-cluster `downtime_tolerance: seconds_per_service` against a
 // fleet without gateway mediation must surface the conflict — gateway
 // prereqs are fleet-scoped so a per-cluster override can't earn its

--- a/internal/services/plan/effort_signals.go
+++ b/internal/services/plan/effort_signals.go
@@ -1,0 +1,266 @@
+package plan
+
+import (
+	"strings"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// Stable Effort Signal IDs. Matches the spec row order.
+const (
+	EffortSignalIDIAMClientCount           = "iam_to_scram_client_count"
+	EffortSignalIDMM2CheckpointTopics      = "mm2_checkpoint_topic_count"
+	EffortSignalIDSelfManagedConnectFleets = "self_managed_connect_fleet_count"
+	EffortSignalIDGlueSerializerMigration  = "glue_serializer_migration_count"
+)
+
+// detectEffortSignals produces the per-fleet effort signals — the
+// four quantitative inputs the customer's PM consumes to scope
+// migration effort. Counts only; no day-estimate.
+//
+// Returns nil when there are no MSK clusters to evaluate (renderer
+// omits the section).
+func detectEffortSignals(state types.ProcessedState) *types.EffortSignalsSection {
+	clusters := collectClusters(state)
+	if len(clusters) == 0 {
+		return nil
+	}
+	signals := []types.EffortSignal{
+		signalIAMClientCount(clusters),
+		signalMM2CheckpointTopics(clusters),
+		signalSelfManagedConnectFleets(clusters),
+		signalGlueSerializerMigration(state, clusters),
+	}
+	return &types.EffortSignalsSection{Signals: signals}
+}
+
+// intPtr is a tiny constructor for Effort-Signal Counts. nil means
+// "unobservable" (e.g. client-inventory scan didn't run); a pointer
+// to 0 means "scan ran, returned zero".
+func intPtr(n int) *int { return &n }
+
+// ----- Signal 1: IAM → SCRAM workstream size -----
+
+// Count of `discovered_clients[]` where Auth == "IAM" across the
+// fleet. This is the count of client apps a customer would need to
+// migrate off IAM to use the CC Gateway path (IAM clients can't
+// connect to the gateway).
+//
+// The scanner (`cmd/scan/client_inventory/kafka_trace_line_parser.go`)
+// emits the literal string "IAM" — NOT "AWS_MSK_IAM" or "SASL/IAM".
+// Don't be tempted to swap in `types.AuthTypeIAM` from `types.go` —
+// that constant resolves to "SASL/IAM" and would silently mismatch
+// every real state file.
+func signalIAMClientCount(clusters []types.ProcessedCluster) types.EffortSignal {
+	// Distinguish "scan ran, found 0 IAM clients" from "scan didn't
+	// run at all": if no cluster has any discovered_clients populated,
+	// the count is structurally unobservable → return nil. Otherwise
+	// the count is concrete (including 0 if every detected client
+	// uses non-IAM auth).
+	scanRan := false
+	count := 0
+	for _, c := range clusters {
+		if len(c.DiscoveredClients) > 0 {
+			scanRan = true
+		}
+		for _, dc := range c.DiscoveredClients {
+			if dc.Auth == DiscoveredClientAuthIAM {
+				count++
+			}
+		}
+	}
+	sig := types.EffortSignal{
+		ID:    EffortSignalIDIAMClientCount,
+		Label: "IAM → SCRAM workstream size — clients that need re-credentialing before the CC Gateway path",
+	}
+	if !scanRan {
+		sig.Note = "`kcp scan client-inventory` hasn't been run on any cluster (see §Red Flags → \"Client inventory not populated\") — re-run it to enumerate IAM clients before the CC Gateway path is scoped"
+		return sig
+	}
+	sig.Count = intPtr(count)
+	if count == 0 {
+		sig.Note = "scan returned zero clients with `IAM` auth"
+	}
+	return sig
+}
+
+// ----- Signal 2: MM2 checkpoint topic count -----
+
+// MM2 checkpoint topics. Caveat: MM2 deployments using
+// IdentityReplicationPolicy suppress the prefix — those won't show
+// up here. The renderer surfaces the caveat in the Note. Regex lives
+// in topic_patterns.go so red_flags can share it.
+func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) types.EffortSignal {
+	// De-dupe by topic name so a Cluster-Linking mirror that
+	// replicates the same `*.checkpoints.internal` topic across N
+	// clusters doesn't inflate the count to N. Each distinct
+	// topic-name is one replication fleet to enumerate.
+	seen := map[string]struct{}{}
+	for _, c := range clusters {
+		if c.KafkaAdminClientInformation.Topics == nil {
+			continue
+		}
+		for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+			if mm2CheckpointPattern.MatchString(td.Name) {
+				seen[td.Name] = struct{}{}
+			}
+		}
+	}
+	count := len(seen)
+	sig := types.EffortSignal{
+		ID:    EffortSignalIDMM2CheckpointTopics,
+		Label: "MirrorMaker 2 checkpoint topics — replication fleets to enumerate",
+		Count: intPtr(count),
+		Note:  "Counts topics matching `*.checkpoints.internal`. MM2 deployments using `IdentityReplicationPolicy` (Confluent-recommended best practice) suppress the prefix entirely and won't be counted here; cross-check with consumer-group naming patterns.",
+	}
+	return sig
+}
+
+// ----- Signal 3: self-managed Connect fleets -----
+
+// Count of distinct fleet prefixes where two of the canonical Connect
+// internal topics are present (`<prefix>connect-configs` AND
+// `<prefix>connect-status`). The third triad topic
+// (`connect-offsets`) may not exist with the same prefix, so we
+// require only two of three — AND-of-all-three would miss real
+// fleets per the spec. Regex lives in topic_patterns.go.
+func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) types.EffortSignal {
+	// Walk every topic, group by (cluster, prefix), collect which
+	// suffixes appear. Per-cluster scoping prevents two distinct
+	// fleets that both use the default unprefixed `connect-configs`
+	// topic name (on separate clusters) from collapsing into one
+	// bucket via the lazy empty-prefix anchor.
+	type fleetKey struct{ cluster, prefix string }
+	prefixSuffixes := map[fleetKey]map[string]struct{}{}
+	for _, c := range clusters {
+		if c.KafkaAdminClientInformation.Topics == nil {
+			continue
+		}
+		for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+			prefix, kind, ok := connectInternalTopicPrefix(td.Name)
+			if !ok {
+				continue
+			}
+			// Strip the trailing `-` from non-empty prefixes so
+			// `team-a-connect-configs` and `team-a-` group identically
+			// regardless of which boundary char the regex captured.
+			prefix = strings.TrimSuffix(prefix, "-")
+			key := fleetKey{cluster: c.Name, prefix: prefix}
+			if _, exists := prefixSuffixes[key]; !exists {
+				prefixSuffixes[key] = map[string]struct{}{}
+			}
+			prefixSuffixes[key][kind] = struct{}{}
+		}
+	}
+	fleetsByTopic := 0
+	for _, suffixes := range prefixSuffixes {
+		if _, hasConfigs := suffixes["configs"]; !hasConfigs {
+			continue
+		}
+		if _, hasStatus := suffixes["status"]; !hasStatus {
+			continue
+		}
+		fleetsByTopic++
+	}
+	// Cross-check against the scanner-reported self-managed
+	// connectors. The scanner emits a flat list of connectors (not
+	// fleets) — collapsing them to a fleet count is impossible
+	// without more structure, so report whichever signal is larger
+	// as the rough upper bound. Comment explicitly: this is a
+	// mixed-units max, treat the count as a floor.
+	scannerConnectorCount := 0
+	for _, c := range clusters {
+		smc := c.KafkaAdminClientInformation.SelfManagedConnectors
+		if smc == nil {
+			continue
+		}
+		scannerConnectorCount += len(smc.Connectors)
+	}
+	count := fleetsByTopic
+	if scannerConnectorCount > count {
+		count = scannerConnectorCount
+	}
+	return types.EffortSignal{
+		ID:    EffortSignalIDSelfManagedConnectFleets,
+		Label: "Self-managed Connect fleets — review surface area beyond what kcp can describe",
+		Count: intPtr(count),
+		Note:  "Counts distinct `(cluster, prefix)` pairs with `connect-configs` AND `connect-status` topics (the two-of-three triad). Cross-references with `kcp scan self-managed-connectors` output (counted as connectors, not fleets) and surfaces whichever is larger — treat the count as a rough floor. Fleets with entirely custom internal-topic naming may not be counted.",
+	}
+}
+
+// ----- Signal 4: Glue → CC SR client serializer migration size -----
+
+// Cross-references `discovered_clients[]` against the Glue schemas:
+// count clients whose Topic name matches a Glue schema name directly
+// or via the standard `<topic>-value` / `<topic>-key` subject suffix.
+// Server-side schema export is automated by `kcp create-asset
+// migrate-schemas --glue-registry`; this row scopes the *client-side*
+// serializer-swap workstream.
+func signalGlueSerializerMigration(state types.ProcessedState, clusters []types.ProcessedCluster) types.EffortSignal {
+	sig := types.EffortSignal{
+		ID:    EffortSignalIDGlueSerializerMigration,
+		Label: "Glue → CC SR client serializer migration size — clients that need `AWSKafkaAvroSerializer` → `KafkaAvroSerializer`",
+	}
+	if state.SchemaRegistries == nil || len(state.SchemaRegistries.AWSGlue) == 0 {
+		sig.Count = intPtr(0)
+		sig.Note = "no Glue Schema Registry detected; signal not applicable"
+		return sig
+	}
+	// Build lookup of Glue subject names (schema name + standard
+	// `-value` / `-key` suffix variants).
+	glueSubjects := map[string]struct{}{}
+	for _, gr := range state.SchemaRegistries.AWSGlue {
+		for _, gs := range gr.Schemas {
+			glueSubjects[gs.SchemaName] = struct{}{}
+		}
+	}
+	// De-dupe by ClientId so one app producing/consuming N Glue-backed
+	// topics counts as a single workstream, not N. The label is "clients
+	// that need re-serializing" — one client app re-builds its
+	// serializer once regardless of how many topics it touches. Fall
+	// back to the ClientId+Role+Principal composite when ClientId is
+	// empty (rare).
+	seen := map[string]struct{}{}
+	for _, c := range clusters {
+		for _, dc := range c.DiscoveredClients {
+			if !matchesGlueSubject(dc.Topic, glueSubjects) {
+				continue
+			}
+			key := dc.ClientId
+			if key == "" {
+				key = dc.CompositeKey
+			}
+			if key == "" {
+				key = dc.Principal
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	sig.Count = intPtr(len(seen))
+	sig.Note = "Cross-references `discovered_clients[].topic` against Glue `schema_name` (direct match + standard `-value` / `-key` subject suffix variants); de-duped by `ClientId` so one app touching N Glue topics counts as 1. Custom subject-name strategies may not match."
+	return sig
+}
+
+// matchesGlueSubject reports whether `topic` (or its standard
+// `-value` / `-key` subject derivative) is a Glue schema name.
+func matchesGlueSubject(topic string, subjects map[string]struct{}) bool {
+	if topic == "" {
+		return false
+	}
+	candidates := []string{topic, topic + "-value", topic + "-key"}
+	// Also reverse the suffix strip — if the schema names are stored
+	// without the suffix, a topic like "orders-value" should still
+	// match a schema named "orders".
+	if strings.HasSuffix(topic, "-value") {
+		candidates = append(candidates, strings.TrimSuffix(topic, "-value"))
+	}
+	if strings.HasSuffix(topic, "-key") {
+		candidates = append(candidates, strings.TrimSuffix(topic, "-key"))
+	}
+	for _, cand := range candidates {
+		if _, ok := subjects[cand]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/plan/effort_signals_test.go
+++ b/internal/services/plan/effort_signals_test.go
@@ -1,0 +1,120 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findSignal returns the signal matching `id` so tests don't depend on
+// slice ordering.
+func findSignal(t *testing.T, section *types.EffortSignalsSection, id string) types.EffortSignal {
+	t.Helper()
+	require.NotNil(t, section)
+	for _, s := range section.Signals {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("effort signal %q not present in section (got %d signals)", id, len(section.Signals))
+	return types.EffortSignal{}
+}
+
+// Signal 1: IAM → SCRAM client count. Counts discovered_clients whose
+// Auth == "IAM" across the fleet (matches the scanner-emitted token).
+func TestEffortSignal_IAMClientCount(t *testing.T) {
+	c := redFlagCluster("iam-cluster", "3.5.0", "", "")
+	c.DiscoveredClients = []types.DiscoveredClient{
+		{ClientId: "app-a", Auth: DiscoveredClientAuthIAM, Topic: "orders"},
+		{ClientId: "app-b", Auth: DiscoveredClientAuthIAM, Topic: "events"},
+		{ClientId: "app-c", Auth: "SASL_SCRAM", Topic: "orders"},
+	}
+	state := wrapClusters(c)
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	sig := findSignal(t, plan.EffortSignals, EffortSignalIDIAMClientCount)
+	require.NotNil(t, sig.Count)
+	assert.Equal(t, 2, *sig.Count, "two IAM-auth clients, one SCRAM client")
+}
+
+// Signal 2: MM2 checkpoint topics. Matches `*.checkpoints.internal`.
+func TestEffortSignal_MM2CheckpointTopics(t *testing.T) {
+	c := redFlagCluster("mm2-cluster", "3.5.0", "", "")
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{
+		{Name: "us-east.checkpoints.internal"},
+		{Name: "us-west.checkpoints.internal"},
+		{Name: "regular-topic"},
+	}}
+	state := wrapClusters(c)
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	sig := findSignal(t, plan.EffortSignals, EffortSignalIDMM2CheckpointTopics)
+	require.NotNil(t, sig.Count)
+	assert.Equal(t, 2, *sig.Count)
+	assert.Contains(t, sig.Note, "IdentityReplicationPolicy")
+}
+
+// Signal 3: self-managed Connect fleets. Counts distinct prefixes
+// where both `connect-configs` AND `connect-status` topics exist.
+func TestEffortSignal_SelfManagedConnectFleets(t *testing.T) {
+	c := redFlagCluster("connect-cluster", "3.5.0", "", "")
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{
+		// Fleet A — has all three triad topics with prefix "team-a-"
+		{Name: "team-a-connect-configs"},
+		{Name: "team-a-connect-offsets"},
+		{Name: "team-a-connect-status"},
+		// Fleet B — only two of three (configs + status, no offsets)
+		{Name: "team-b-connect-configs"},
+		{Name: "team-b-connect-status"},
+		// Partial — only configs, NOT counted
+		{Name: "team-c-connect-configs"},
+	}}
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	sig := findSignal(t, plan.EffortSignals, EffortSignalIDSelfManagedConnectFleets)
+	require.NotNil(t, sig.Count)
+	assert.Equal(t, 2, *sig.Count, "fleet A + fleet B; fleet C has only configs")
+}
+
+// Signal 4: Glue → CC SR client serializer migration count. Counts
+// clients whose Topic matches a Glue schema name (direct match or
+// via `-value` / `-key` suffix).
+func TestEffortSignal_GlueSerializerMigration(t *testing.T) {
+	c := redFlagCluster("glue-cluster", "3.5.0", "", "")
+	c.DiscoveredClients = []types.DiscoveredClient{
+		{ClientId: "client-a", Topic: "orders"},       // direct match
+		{ClientId: "client-b", Topic: "events-value"}, // -value suffix variant
+		{ClientId: "client-c", Topic: "other-topic"},  // no Glue match
+	}
+	state := wrapClusters(c)
+	// Attach Glue registry with two schemas.
+	state.SchemaRegistries = &types.SchemaRegistriesState{
+		AWSGlue: []types.GlueSchemaRegistryInformation{{
+			RegistryName: "my-glue",
+			Schemas: []types.GlueSchema{
+				{SchemaName: "orders"},
+				{SchemaName: "events"},
+			},
+		}},
+	}
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	sig := findSignal(t, plan.EffortSignals, EffortSignalIDGlueSerializerMigration)
+	require.NotNil(t, sig.Count)
+	assert.Equal(t, 2, *sig.Count)
+}
+
+// Glue absent → signal still surfaces but with count 0 and an
+// explanatory note.
+func TestEffortSignal_GlueAbsent_ZeroWithNote(t *testing.T) {
+	state := wrapClusters(redFlagCluster("plain-cluster", "3.5.0", "", ""))
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	sig := findSignal(t, plan.EffortSignals, EffortSignalIDGlueSerializerMigration)
+	require.NotNil(t, sig.Count)
+	assert.Equal(t, 0, *sig.Count)
+	assert.Contains(t, sig.Note, "no Glue Schema Registry detected")
+}
+
+// detectEffortSignals returns nil on an empty fleet so the renderer
+// omits §Effort Signals.
+func TestDetectEffortSignals_EmptyFleetReturnsNil(t *testing.T) {
+	assert.Nil(t, detectEffortSignals(types.ProcessedState{}))
+}

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -132,6 +132,20 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 	if in.ConfluentSRCPEdition != nil {
 		out.ConfluentSRCPEdition = *in.ConfluentSRCPEdition
 	}
+	if in.ExactlyOnceTransactionsInUse != nil {
+		v := *in.ExactlyOnceTransactionsInUse
+		out.ExactlyOnceTransactionsInUse = &v
+	}
+	if in.KafkaStreamsInUse != nil {
+		v := *in.KafkaStreamsInUse
+		out.KafkaStreamsInUse = &v
+	}
+	if in.ConsumerHistoryRequirement != nil {
+		out.ConsumerHistoryRequirement = *in.ConsumerHistoryRequirement
+	}
+	if in.HistoricalDataStrategy != nil {
+		out.HistoricalDataStrategy = *in.HistoricalDataStrategy
+	}
 	return out
 }
 
@@ -196,6 +210,12 @@ func applyClusterOverride(out types.PlanInputsResolved, in *types.PlanInputs, cl
 	}
 	if override.TargetAuthMethod != nil {
 		out.TargetAuthMethod = *override.TargetAuthMethod
+	}
+	if override.DowntimeTolerance != nil {
+		out.DowntimeTolerance = *override.DowntimeTolerance
+	}
+	if override.SubPattern != nil {
+		out.SubPattern = *override.SubPattern
 	}
 	return out
 }

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -48,7 +48,7 @@ func privateLinkSizingExceedsCap(sizing types.ClusterSizing, ct types.ClusterTyp
 	return sizing.FinalECKU > cfg.EnterpriseCaps.PrivateLinkMaxECKU
 }
 
-// DecideNetworking picks the Confluent Cloud networking product for one
+// decideNetworking picks the Confluent Cloud networking product for one
 // cluster.
 //
 //	Dedicated + target_cloud != "aws"                        → PrivateLink (PNI / TGW / VPC Peering are AWS-only)
@@ -62,7 +62,7 @@ func privateLinkSizingExceedsCap(sizing types.ClusterSizing, ct types.ClusterTyp
 //
 // `existing_vpc_connectivity` is only honored on the AWS-Dedicated path —
 // Transit Gateway and VPC Peering are Dedicated-only AWS products.
-func DecideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
+func decideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
 	target := targetCloud(inputs)
 
 	if ct.Verdict == types.ClusterTypeDedicated {

--- a/internal/services/plan/networking_test.go
+++ b/internal/services/plan/networking_test.go
@@ -12,7 +12,7 @@ func TestDecideNetworking_DedicatedDefaultsToPNI(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
-	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	d := decideNetworking(sizing, ct, cfg, defaultInputs())
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 	assert.Contains(t, d.Reason, "Dedicated")
 }
@@ -23,7 +23,7 @@ func TestDecideNetworking_DedicatedTransitGateway(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "transit_gateway"
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingTransitGateway, d.Verdict)
 	assert.Contains(t, d.Reason, "transit_gateway")
 }
@@ -34,7 +34,7 @@ func TestDecideNetworking_DedicatedVPCPeering(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "vpc_peering"
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingVPCPeering, d.Verdict)
 	assert.Contains(t, d.Reason, "vpc_peering")
 }
@@ -44,7 +44,7 @@ func TestDecideNetworking_EnterpriseDefaultsToPNI(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
-	d := DecideNetworking(sizing, ct, cfg, defaultInputs())
+	d := decideNetworking(sizing, ct, cfg, defaultInputs())
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 	assert.Contains(t, d.Reason, "default for AWS Enterprise")
 }
@@ -58,7 +58,7 @@ func TestDecideNetworking_EnterpriseIgnoresVPCConnectivity(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "transit_gateway"
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 }
 
@@ -69,7 +69,7 @@ func TestDecideNetworking_EnterpriseCrossCloudFlipsToPrivateLink(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.TargetCloud = "azure"
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "AWS-to-AWS only")
 }
@@ -81,7 +81,7 @@ func TestDecideNetworking_EnterpriseCCEgressRequiredFlipsToPrivateLink(t *testin
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.CCEgressRequired = true
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "cc_egress_required")
 }
@@ -93,7 +93,7 @@ func TestDecideNetworking_EnterpriseTwoPNIGatewaysFlipsToPrivateLink(t *testing.
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ProjectedPNIGatewayCount = 2
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "projected_pni_gateway_count=2")
 }
@@ -105,6 +105,6 @@ func TestDecideNetworking_EnterpriseOneGatewayStaysPNI(t *testing.T) {
 	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ProjectedPNIGatewayCount = 1
-	d := DecideNetworking(sizing, ct, cfg, in)
+	d := decideNetworking(sizing, ct, cfg, in)
 	assert.Equal(t, types.NetworkingPNI, d.Verdict)
 }

--- a/internal/services/plan/oq_registry.go
+++ b/internal/services/plan/oq_registry.go
@@ -1,6 +1,6 @@
 package plan
 
-// OQMeta describes how one Open-Question ID should render: its
+// oqMeta describes how one Open-Question ID should render: its
 // priority for sort-order, its base severity prefix, and an optional
 // promoted severity + title when a sibling OQ co-fires.
 //
@@ -9,10 +9,10 @@ package plan
 // emitting the ID, an iota priority constant, a priority-lookup
 // switch, a severity-lookup switch, and a sibling-aware promotion
 // override). New OQ = one new entry in `oqRegistry`.
-type OQMeta struct {
+type oqMeta struct {
 	// Priority controls the Actions Needed sort order — lower
 	// priority renders first. IDs missing from the registry fall
-	// through to PriorityUnknown and sort last. (Actions Needed's
+	// through to priorityUnknown and sort last. (Actions Needed's
 	// section number is computed dynamically by RenderMarkdown
 	// based on which sections fired; the registry only orders the
 	// items within it.)
@@ -43,9 +43,9 @@ type OQMeta struct {
 	PromotedTitle string
 }
 
-// PriorityUnknown is the sort-last fallback. Anchor at a high value
+// priorityUnknown is the sort-last fallback. Anchor at a high value
 // so adding a new low-priority OQ doesn't accidentally outrank it.
-const PriorityUnknown = 1000
+const priorityUnknown = 1000
 
 // oqRegistry holds every OQ ID emitted by the detectors. Priority is
 // sparse + grouped by concern so new IDs land between siblings
@@ -57,11 +57,13 @@ const PriorityUnknown = 1000
 //	400s  — Cutover
 //	500s  — Auth
 //	600s  — Schema
+//	700s  — Tiered Storage
+//	800s  — Cost Reconciliation
 //	900s  — Fleet / state-file (cross-cutting)
 //
 // Within a band, 10-unit spacing leaves room for an inserted OQ to
 // slot between existing entries without a shuffle.
-var oqRegistry = map[string]OQMeta{
+var oqRegistry = map[string]oqMeta{
 	// Networking
 	"networking_privatelink_over_cap": {
 		Priority: 310,
@@ -76,6 +78,10 @@ var oqRegistry = map[string]OQMeta{
 	"downtime_tolerance_unknown": {
 		Priority: 420,
 		Severity: "🔴",
+	},
+	"sub_pattern_unknown": {
+		Priority: 425,
+		Severity: "🟡",
 	},
 	"gateway_prereqs_pending": {
 		Priority:         430,
@@ -128,6 +134,26 @@ var oqRegistry = map[string]OQMeta{
 		Severity: "🟡",
 	},
 
+	// Tiered Storage
+	"tiered_consumer_history_invalid": {
+		Priority: 710,
+		Severity: "🔴",
+	},
+	"tiered_historical_strategy_invalid": {
+		Priority: 720,
+		Severity: "🔴",
+	},
+	"tiered_strategy_undeclared": {
+		Priority: 730,
+		Severity: "🟡",
+	},
+
+	// Cost reconciliation
+	"cost_data_not_collected": {
+		Priority: 810,
+		Severity: "🟡",
+	},
+
 	// Cross-cutting fleet / state-file signals
 	"state_file_stale": {
 		Priority: 910,
@@ -149,25 +175,29 @@ var oqRegistry = map[string]OQMeta{
 		Priority: 950,
 		Severity: "🟡",
 	},
+	"cluster_override_unknown_cluster": {
+		Priority: 960,
+		Severity: "🟡",
+	},
 }
 
 // oqMetaFor returns the registry entry for an OQ ID, or a sentinel
-// (Priority: PriorityUnknown, Severity: 🟡) when the ID is unknown.
+// (Priority: priorityUnknown, Severity: 🟡) when the ID is unknown.
 // 🟡 is the safe default for accuracy-class signals; an unknown ID
 // indicates a missed registry entry — surfacing it as 🟡 keeps it
 // visible without falsely claiming blocker status.
-func oqMetaFor(id string) OQMeta {
+func oqMetaFor(id string) oqMeta {
 	if m, ok := oqRegistry[id]; ok {
 		return m
 	}
-	return OQMeta{Priority: PriorityUnknown, Severity: "🟡"}
+	return oqMeta{Priority: priorityUnknown, Severity: "🟡"}
 }
 
 // promoteSeverity applies the sibling-aware promotion rule: if any
 // of `meta.PromoteWhen` is in `siblings`, returns the promoted
 // severity + title; otherwise returns the base severity + the
 // original title.
-func promoteSeverity(meta OQMeta, originalTitle string, siblings map[string]bool) (severity, title string) {
+func promoteSeverity(meta oqMeta, originalTitle string, siblings map[string]bool) (severity, title string) {
 	for _, trigger := range meta.PromoteWhen {
 		if siblings[trigger] {
 			sev := meta.PromotedSeverity

--- a/internal/services/plan/plan-config.yaml
+++ b/internal/services/plan/plan-config.yaml
@@ -108,7 +108,7 @@ auth_mapping:
     target: confluent_cloud_api_keys
     gateway_compatible: false   # IAM clients cannot connect to the gateway
     transparent_swap: false
-    note: "IAM clients cannot connect to the CC Gateway. Pre-migrate to SCRAM or mTLS first."
+    note: "Source-side IAM clients can't traverse the CC Gateway — the gateway barrier is on the MSK side, independent of which target auth you pick. Pre-migrate source clients to SCRAM or mTLS first."
     source: https://github.com/confluentinc/kcp/blob/main/docs/assets/getting-started-with-zero-cut-migrations.md
     last_verified: "2026-05-20"
   mtls:
@@ -139,3 +139,18 @@ thresholds:
   # recommendation flips from PNI to PrivateLink. 2 = first additional
   # gateway crosses the cost line.
   pni_gateway_breakeven: 2
+  # Red Flag row 5 (partition_approaching_cap) fires when user-topic
+  # partitions exceed this fraction of the cluster's sized eCKU
+  # capacity (per_eCKU_partition_rate * FinalECKU). 0.30 = "fire at
+  # 30% of sized capacity" — early enough that a discussion with the
+  # SE has time to consider headroom or a sizing bump.
+  partition_approaching_fraction: 0.30
+
+# Cost-explorer usage-string families that count as MSK broker spend.
+# AWS bills MSK under `Kafka.*` and `Express.*` today; new broker
+# tiers ship as new family tokens. Extend this list when a new tier
+# lands without waiting for a kcp release.
+cost_reconciliation:
+  usage_families:
+    - Kafka
+    - Express

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -13,6 +13,25 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
+// Function-naming convention across this package:
+//
+//   - `decide*`  — produces a verdict / path from inputs. One decision
+//     per cluster (sizing, cluster type, networking, auth) or one
+//     per fleet (cutover, schema). Output is the rendered §section's
+//     primary recommendation.
+//
+//   - `detect*`  — enumerates findings or signals from `state` /
+//     `plan` (red flags, effort signals, tiered storage, cost
+//     reconciliation, all OQ detectors). Output is a list/section,
+//     not a single verdict. Some detectors also apply small input
+//     cascades (e.g. `detectTieredStorage` defaults
+//     `HistoricalDataStrategy`) — that's deliberate: the cascade is
+//     scoped to the section's findings, not a standalone decision.
+//
+//   - `compute*` — pure numeric / structural transforms with no
+//     verdict (e.g. `computeClusterSizing`, `computeCutoverOverrides`).
+//     Output is intermediate data the renderer + decide* consume.
+//
 // PlanService orchestrates the deterministic plan-generation pipeline.
 // Each Build step is a pure function so the test surface is the
 // orchestration, not its parts.
@@ -54,7 +73,7 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 			KCPVersion:        build_info.Version,
 			GeneratedAt:       s.now().UTC(),
 			StateGeneratedAt:  state.Timestamp.UTC(),
-			PlanSchemaVersion: "1-experimental",
+			PlanSchemaVersion: "1",
 		},
 		Inputs: inputs,
 	}
@@ -74,18 +93,18 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		// re-resolution `ResolvePlanInputsForCluster` would do on every
 		// iteration.
 		clusterInputs := applyClusterOverride(inputs, inputs.Raw, c.Name)
-		sizing := ComputeClusterSizing(c, s.cfg, clusterInputs)
+		sizing := computeClusterSizing(c, s.cfg, clusterInputs)
 		missing := inputsMissing(c)
 		// Each consumer gets its own slice — without Clone, a future
 		// `append` to any one InputsMissing would silently mutate the
 		// others if cap permits.
 		sizing.InputsMissing = slices.Clone(missing)
-		ct := DecideClusterType(c, sizing, s.cfg, clusterInputs)
-		net := DecideNetworking(sizing, ct, s.cfg, clusterInputs)
+		ct := decideClusterType(c, sizing, s.cfg, clusterInputs)
+		net := decideNetworking(sizing, ct, s.cfg, clusterInputs)
 		ct.InputsMissing = slices.Clone(missing)
 		net.InputsMissing = slices.Clone(missing)
 
-		auth := DecideAuth(c, s.cfg, clusterInputs)
+		auth := decideAuth(c, s.cfg, clusterInputs)
 
 		plan.Sizing = append(plan.Sizing, sizing)
 		plan.ClusterTypeDecision = append(plan.ClusterTypeDecision, ct)
@@ -104,25 +123,53 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 	plan.SourceEnvironment.TotalRegions = countRegions(state)
 	plan.SizingAppendix = buildSizingAppendix(plan.Sizing, s.cfg, inputs)
 
-	// Cutover is fleet-wide (one Plan = one cutover style). Only emit
-	// when there are clusters to migrate; an empty fleet has nothing
-	// to cut over.
+	// Cutover defaults are fleet-wide; per-cluster overrides layer on
+	// top via clusters[<name>].downtime_tolerance / .sub_pattern.
+	// Empty fleet → no cutover decision at all.
 	if len(clusters) > 0 {
-		cutover := DecideCutover(clusters, inputs)
+		cutover := decideCutover(clusters, inputs)
 		plan.Cutover = &cutover
-		plan.OpenQuestions = append(plan.OpenQuestions, detectCutoverOpenQuestions(cutover, inputs, fleetUsesIAM(clusters))...)
-		plan.OpenQuestions = append(plan.OpenQuestions, detectAuthFleetOpenQuestions(inputs)...)
+		plan.CutoverOverrides = computeCutoverOverrides(clusters, cutover, inputs)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectCutoverOpenQuestions(cutover, plan.CutoverOverrides, inputs, fleetUsesIAM(clusters))...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectAuthFleetOpenQuestions(clusters, inputs)...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectClusterCutoverOpenQuestions(clusters, inputs)...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectPerClusterGatewayIncompat(clusters, cutover, inputs)...)
+		plan.OpenQuestions = append(plan.OpenQuestions, detectUnknownClusterOverrides(clusters, inputs)...)
 	}
 	// Schema migration — fleet-wide; one Plan, one verdict. The
 	// `schemaless` branch returns nil so the renderer can omit the
 	// whole section cleanly. We still run the OQ detector either way:
 	// the strategy-typo / strategy-unknown signals are valuable even
 	// when the verdict resolves to no recommendation.
-	schema := DecideSchema(state, s.cfg, inputs)
-	if schema != nil && !HasPath(schema, types.SchemaPathSchemaless) {
+	schema := decideSchema(state, s.cfg, inputs)
+	if schema != nil && !hasPath(schema, types.SchemaPathSchemaless) {
 		plan.Schema = schema
 	}
 	plan.OpenQuestions = append(plan.OpenQuestions, detectSchemaOpenQuestions(schema, s.cfg, inputs)...)
+
+	// Red Flags — fleet-wide list of trigger rows the customer should
+	// discuss with the SE. Each row carries its own evidence (field
+	// path + value) so the conversation is grounded in scan facts.
+	plan.RedFlags = detectRedFlags(state, plan, s.cfg, inputs)
+
+	// Effort Signals — quantitative inputs the customer's PM consumes
+	// to scope migration effort. Counts only; no day-estimate.
+	plan.EffortSignals = detectEffortSignals(state)
+
+	// Tiered Storage — per-cluster trade-off framing for fleets with
+	// MSK tiered storage enabled. Customer-decision shaped; kcp
+	// doesn't pick a path, just makes the three dimensions
+	// (mechanism / duration / cost direction) legible.
+	plan.TieredStorage = detectTieredStorage(state, inputs)
+	plan.OpenQuestions = append(plan.OpenQuestions, detectTieredStorageOpenQuestions(plan.TieredStorage, inputs)...)
+
+	// Cost-vs-Inventory Reconciliation — lists MSK instance types in
+	// the AWS cost report that `kcp discover` didn't surface. Sorted
+	// by spend desc; no materiality threshold (the customer judges
+	// what's real). Emits an OQ when cost data is empty.
+	plan.CostReconciliation = detectCostReconciliation(state, s.cfg)
+	plan.OpenQuestions = append(plan.OpenQuestions, detectCostReconciliationOpenQuestions(state)...)
+
 	// Stale-state OQ: surface a fleet-wide accuracy warning when the
 	// source state file is older than the freshness window. The Plan
 	// still renders against whatever's in state.json — but a 14-day-old
@@ -248,14 +295,6 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	return oqs
 }
 
-// detectCutoverOpenQuestions surfaces fleet-wide gateway-intent / prereq
-// gaps. Emitted once per Plan (no ClusterID — these aren't per-cluster).
-// Three independent OQs can fire:
-//   - gateway intent ambiguous (degraded_awaiting_oq)
-//   - gateway prereqs pending (degraded_prereqs_pending)
-//   - seconds_per_service tolerance requires the gateway, but it isn't
-//     mediated for some reason (cross-check; message varies by cause).
-//
 // detectStaleStateOQ surfaces a fleet-wide OQ when the source state
 // file is older than `staleDays`. Compares state.Timestamp against the
 // Plan's GeneratedAt time; if the state was empty (zero timestamp) the
@@ -283,7 +322,19 @@ func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDa
 	}}
 }
 
-func detectCutoverOpenQuestions(cutover types.CutoverDecision, inputs types.PlanInputsResolved, iamInUse bool) []types.OpenQuestion {
+// detectCutoverOpenQuestions surfaces fleet-wide gateway-intent /
+// prereq gaps. Emitted once per Plan (no ClusterID — these aren't
+// per-cluster). Independent OQs that can fire:
+//   - gateway intent ambiguous (degraded_awaiting_oq)
+//   - gateway prereqs pending (degraded_prereqs_pending)
+//   - seconds_per_service tolerance requires the gateway, but it isn't
+//     mediated for some reason (cross-check; message varies by cause).
+//
+// `overrides` carries per-cluster cutover exceptions; when any cluster
+// overrides to Blue/Green, the gateway-intent / prereq OQs add a note
+// that those clusters are exempt — otherwise the OQ reads as if it
+// applies to the entire fleet.
+func detectCutoverOpenQuestions(cutover types.CutoverDecision, overrides []types.ClusterCutoverOverride, inputs types.PlanInputsResolved, iamInUse bool) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
 	if !knownDowntimeTolerance(inputs.DowntimeTolerance) {
 		oqs = append(oqs, types.OpenQuestion{
@@ -293,19 +344,29 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, inputs types.Plan
 			HowToClose: "Set `downtime_tolerance` in `plan-inputs.yaml` to one of the recognised values, then re-run `kcp report plan`.",
 		})
 	}
+	// Clusters with a Blue/Green override sidestep the gateway-mediation
+	// question entirely; the fleet-wide gateway OQs below need to
+	// acknowledge that or the reader sees a contradiction between §3's
+	// "gateway N/A for this style" note and the OQ asking them to pick
+	// a gateway path "for the fleet".
+	gatewayExempt := bgOverrideClusterNames(overrides)
+	exemptSuffix := ""
+	if len(gatewayExempt) > 0 {
+		exemptSuffix = fmt.Sprintf(" Per-cluster Blue/Green overrides (`%s`) sidestep the gateway question — this OQ applies to the rest of the fleet.", strings.Join(gatewayExempt, "`, `"))
+	}
 	switch cutover.RecommendationStatus {
 	case types.RecommendationDegradedAwaitingOQ:
 		oqs = append(oqs, types.OpenQuestion{
 			ID:         "gateway_intent_unconfirmed",
 			Title:      "Gateway intent — pick CC Gateway or plain Cluster Linking",
-			Body:       "`prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open.",
+			Body:       "`prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open." + exemptSuffix,
 			HowToClose: "In `plan-inputs.yaml`, either (a) set `prefer_gateway: false` to commit to plain Cluster Linking, OR (b) move at least one gateway prereq to `in_progress` to commit to the gateway path. Re-run `kcp report plan` to clear the OQ.",
 		})
 	case types.RecommendationDegradedPrereqsPending:
 		oqs = append(oqs, types.OpenQuestion{
 			ID:         "gateway_prereqs_pending",
 			Title:      "Gateway prereqs — pending items before the gateway path can be recommended",
-			Body:       fmt.Sprintf("`prefer_gateway: true` and at least one gateway prereq is still at `not_started`: %s. The gateway-mediated path needs all applicable prereqs at `in_progress` or `complete`. Plain Cluster Linking applies until they advance.", pendingPrereqList(inputs, iamInUse)),
+			Body:       fmt.Sprintf("`prefer_gateway: true` and at least one gateway prereq is still at `not_started`: %s. The gateway-mediated path needs all applicable prereqs at `in_progress` or `complete`. Plain Cluster Linking applies until they advance.%s", pendingPrereqList(inputs, iamInUse), exemptSuffix),
 			HowToClose: "Move each pending prereq above to `in_progress` (intent declared) or `complete` (done). Re-run `kcp report plan` once the prereqs advance.",
 		})
 	}
@@ -338,9 +399,9 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, inputs types.Plan
 // (fleet-level OQ, single emit) and any per-cluster
 // `clusters[<name>].target_auth_method` typos (per-cluster OQs so the
 // affected cluster is obvious). Per-cluster typos silently fall back
-// to the per-source default in DecideAuth via effectiveTarget, so
+// to the per-source default in decideAuth via effectiveTarget, so
 // without this detector they're invisible to the customer.
-func detectAuthFleetOpenQuestions(inputs types.PlanInputsResolved) []types.OpenQuestion {
+func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
 	if !knownTargetAuthMethod(inputs.TargetAuthMethod) {
 		oqs = append(oqs, types.OpenQuestion{
@@ -350,28 +411,217 @@ func detectAuthFleetOpenQuestions(inputs types.PlanInputsResolved) []types.OpenQ
 			HowToClose: "Set `target_auth_method` in `plan-inputs.yaml` (or `clusters[<name>].target_auth_method` for a per-cluster override) to one of the recognised values, OR unset it to keep the per-source default.",
 		})
 	}
-	if inputs.Raw != nil {
-		clusterNames := make([]string, 0, len(inputs.Raw.Clusters))
-		for name := range inputs.Raw.Clusters {
-			clusterNames = append(clusterNames, name)
+	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
+		cluster := inputs.Raw.Clusters[name]
+		if cluster.TargetAuthMethod == nil {
+			continue
 		}
-		sort.Strings(clusterNames)
-		for _, name := range clusterNames {
-			cluster := inputs.Raw.Clusters[name]
-			if cluster.TargetAuthMethod == nil {
-				continue
+		value := *cluster.TargetAuthMethod
+		if knownTargetAuthMethod(value) {
+			continue
+		}
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "target_auth_method_unknown",
+			ClusterID:  name,
+			Title:      fmt.Sprintf("`clusters[%s].target_auth_method: %s` is not a recognised value — per-source default applied for this cluster", name, value),
+			Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The override falls outside the enum; the per-source `auth_mapping` default is used silently for `%s`.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth, name),
+			HowToClose: fmt.Sprintf("Set `clusters[%s].target_auth_method` in `plan-inputs.yaml` to one of the recognised values, OR remove the override to keep the per-source default.", name),
+		})
+	}
+	return oqs
+}
+
+// sortedKnownClusterOverrideNames returns the keys of
+// `inputs.Raw.Clusters` that match an actual scanned cluster, in
+// stable alphabetical order. Unknown-cluster overrides are filtered
+// out here; `detectUnknownClusterOverrides` handles surfacing them as
+// their own OQ. Returns nil when no Raw inputs exist.
+func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []string {
+	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
+		return nil
+	}
+	known := make(map[string]struct{}, len(clusters))
+	for _, c := range clusters {
+		known[c.Name] = struct{}{}
+	}
+	names := make([]string, 0, len(inputs.Raw.Clusters))
+	for name := range inputs.Raw.Clusters {
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// detectUnknownClusterOverrides surfaces 🟡 OQs for keys under
+// `clusters:` in plan-inputs.yaml that don't match any scanned
+// cluster. Without this, a typo'd cluster name (e.g. `clusters[trust]`
+// against a fleet with no `trust` cluster) silently produces no
+// override and the reader has no signal that their input was rejected.
+func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
+	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
+		return nil
+	}
+	known := make(map[string]struct{}, len(clusters))
+	for _, c := range clusters {
+		known[c.Name] = struct{}{}
+	}
+	var unknown []string
+	for name := range inputs.Raw.Clusters {
+		if _, ok := known[name]; ok {
+			continue
+		}
+		unknown = append(unknown, name)
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	oqs := make([]types.OpenQuestion, 0, len(unknown))
+	for _, name := range unknown {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "cluster_override_unknown_cluster",
+			Title:      fmt.Sprintf("`clusters[%s]` in `plan-inputs.yaml` doesn't match any scanned cluster — override silently ignored", name),
+			Body:       fmt.Sprintf("The plan-inputs `clusters:` map names `%s`, but the state file contains no cluster with that name. The override block has no effect; either the cluster name is a typo, or the state file is from a different source than expected.", name),
+			HowToClose: fmt.Sprintf("Either correct the cluster name under `clusters:` in `plan-inputs.yaml` to match a real scanned cluster, OR remove the `%s` block entirely.", name),
+		})
+	}
+	return oqs
+}
+
+// computeCutoverOverrides walks each cluster, layers its
+// `clusters[<name>].downtime_tolerance` / `.sub_pattern` override on
+// the global inputs, and emits an override entry whenever the resolved
+// style or sub_pattern differs from the fleet default. Gateway
+// mediation is recomputed per cluster too — a Blue/Green override
+// flips mediation to N/A even when the fleet mediates via the gateway.
+// When the override value isn't in the recognised enum, the entry
+// carries OverrideRejected + RejectedOverrideValue so a JSON consumer
+// can detect rejected overrides structurally (mirrors AuthDecision).
+func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.CutoverDecision, inputs types.PlanInputsResolved) []types.ClusterCutoverOverride {
+	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
+		return nil
+	}
+	var out []types.ClusterCutoverOverride
+	for _, c := range clusters {
+		raw, ok := inputs.Raw.Clusters[c.Name]
+		if !ok || (raw.DowntimeTolerance == nil && raw.SubPattern == nil) {
+			continue
+		}
+		clusterInputs := applyClusterOverride(inputs, inputs.Raw, c.Name)
+		dec := decideCutover([]types.ProcessedCluster{c}, clusterInputs)
+		rejected, rejectedValue := rejectedCutoverOverride(raw)
+		styleMatchesFleet := dec.Style == fleet.Style && dec.SubPattern == fleet.SubPattern && dec.GatewayMediated == fleet.GatewayMediated
+		if styleMatchesFleet && !rejected {
+			continue
+		}
+		out = append(out, types.ClusterCutoverOverride{
+			ClusterID:             c.Name,
+			Style:                 dec.Style,
+			SubPattern:            dec.SubPattern,
+			GatewayMediated:       dec.GatewayMediated,
+			OverrideRejected:      rejected,
+			RejectedOverrideValue: rejectedValue,
+		})
+	}
+	return out
+}
+
+// detectPerClusterGatewayIncompat fires when a per-cluster
+// `downtime_tolerance: seconds_per_service` override exists but the
+// fleet's gateway isn't mediated (gateway prereqs are fleet-scoped, so
+// a per-cluster override can't get its own gateway path). Without
+// this, the customer's per-cluster choice is silently lost — the
+// cluster falls back to the fleet's plain Cluster Linking shape and
+// the reader has no signal.
+func detectPerClusterGatewayIncompat(clusters []types.ProcessedCluster, fleet types.CutoverDecision, inputs types.PlanInputsResolved) []types.OpenQuestion {
+	if fleet.GatewayMediated == types.GatewayMediatedTrue {
+		return nil
+	}
+	var oqs []types.OpenQuestion
+	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
+		cluster := inputs.Raw.Clusters[name]
+		if cluster.DowntimeTolerance == nil || *cluster.DowntimeTolerance != DowntimeSecondsPerService {
+			continue
+		}
+		oqs = append(oqs, types.OpenQuestion{
+			ID:        "downtime_tolerance_requires_gateway",
+			ClusterID: name,
+			Title:     fmt.Sprintf("`clusters[%s].downtime_tolerance: seconds_per_service` requires the gateway but the fleet's recommendation is plain Cluster Linking", name),
+			Body: "seconds_per_service downtime tolerance requires CC-Gateway mediation, and gateway prereqs are fleet-scoped — there's no per-cluster gateway path. " +
+				"The per-cluster override is honoured for the cutover style (Stop-Restart-Repeat), but the sub-minute window depends on the fleet committing to the gateway path.",
+			HowToClose: fmt.Sprintf("Either advance the fleet's gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) so the fleet mediates via the gateway, OR relax `clusters[%s].downtime_tolerance` to `minutes_per_service`.", name),
+		})
+	}
+	return oqs
+}
+
+// bgOverrideClusterNames returns the cluster names that override to
+// Blue/Green — the only style that sidesteps the gateway-mediation
+// question. Used by detectCutoverOpenQuestions to add a clarifying
+// note to fleet-wide gateway OQs so the reader doesn't think the OQ
+// applies to gateway-exempt clusters too.
+func bgOverrideClusterNames(overrides []types.ClusterCutoverOverride) []string {
+	var out []string
+	for _, o := range overrides {
+		if o.Style == types.CutoverBlueGreen {
+			out = append(out, o.ClusterID)
+		}
+	}
+	return out
+}
+
+// rejectedCutoverOverride reports whether the per-cluster override
+// values are outside the recognised enum. Returns the first rejected
+// value found (downtime_tolerance takes precedence over sub_pattern)
+// for the renderer / JSON consumer to display.
+func rejectedCutoverOverride(raw types.ClusterPlanInputs) (bool, string) {
+	if raw.DowntimeTolerance != nil && !knownDowntimeTolerance(*raw.DowntimeTolerance) {
+		return true, *raw.DowntimeTolerance
+	}
+	if raw.SubPattern != nil && !knownCutoverSubPattern(*raw.SubPattern) {
+		return true, *raw.SubPattern
+	}
+	return false, ""
+}
+
+// detectClusterCutoverOpenQuestions emits a per-cluster OQ when a
+// `clusters[<name>].downtime_tolerance` (or `.sub_pattern`) override
+// is typo'd. Mirrors the per-cluster `target_auth_method` typo OQ —
+// without it, the typo silently falls back to a default and the
+// reader has no idea why this cluster doesn't override. Only emits
+// for cluster names that match an actual scanned cluster;
+// unknown-name overrides are handled by
+// detectUnknownClusterOverrides.
+func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
+	var oqs []types.OpenQuestion
+	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
+		cluster := inputs.Raw.Clusters[name]
+		if cluster.DowntimeTolerance != nil {
+			value := *cluster.DowntimeTolerance
+			if !knownDowntimeTolerance(value) {
+				oqs = append(oqs, types.OpenQuestion{
+					ID:         "downtime_tolerance_unknown",
+					ClusterID:  name,
+					Title:      fmt.Sprintf("`clusters[%s].downtime_tolerance: %s` is not a recognised value — treated as `let_confluent_choose` (Stop-Restart-Repeat) for this cluster", name, value),
+					Body:       "The Plan only recognises `zero | seconds_per_service | minutes_per_service | scheduled_window_sequential | scheduled_window_all_at_once | let_confluent_choose`. The override falls outside the enum, so this cluster's cutover style resolves to the Confluent default (Stop-Restart-Repeat) — note this can DIFFER from the fleet-wide default if the fleet itself selected another style, in which case this cluster appears in the **Per-cluster overrides** sub-list above.",
+					HowToClose: fmt.Sprintf("Set `clusters[%s].downtime_tolerance` in `plan-inputs.yaml` to one of the recognised values, OR remove the override to keep the fleet default.", name),
+				})
 			}
-			value := *cluster.TargetAuthMethod
-			if knownTargetAuthMethod(value) {
-				continue
+		}
+		if cluster.SubPattern != nil {
+			value := *cluster.SubPattern
+			if !knownCutoverSubPattern(value) {
+				oqs = append(oqs, types.OpenQuestion{
+					ID:         "sub_pattern_unknown",
+					ClusterID:  name,
+					Title:      fmt.Sprintf("`clusters[%s].sub_pattern: %s` is not a recognised value — `app-by-app` applied for this cluster", name, value),
+					Body:       "The Plan only recognises `app-by-app | topic-by-topic` for the Stop-Restart-Repeat sub-pattern. The override falls outside the enum, so the cluster inherits the default `app-by-app` cadence.",
+					HowToClose: fmt.Sprintf("Set `clusters[%s].sub_pattern` in `plan-inputs.yaml` to `app-by-app` or `topic-by-topic`, OR remove the override.", name),
+				})
 			}
-			oqs = append(oqs, types.OpenQuestion{
-				ID:         "target_auth_method_unknown",
-				ClusterID:  name,
-				Title:      fmt.Sprintf("`clusters[%s].target_auth_method: %s` is not a recognised value — per-source default applied for this cluster", name, value),
-				Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The override falls outside the enum; the per-source `auth_mapping` default is used silently for `%s`.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth, name),
-				HowToClose: fmt.Sprintf("Set `clusters[%s].target_auth_method` in `plan-inputs.yaml` to one of the recognised values, OR remove the override to keep the per-source default.", name),
-			})
 		}
 	}
 	return oqs

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -512,8 +512,22 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.Cuto
 		}
 		clusterInputs := applyClusterOverride(inputs, inputs.Raw, c.Name)
 		dec := decideCutover([]types.ProcessedCluster{c}, clusterInputs)
+		// Gateway prereqs are fleet-scoped — a per-cluster override
+		// can't earn its own gateway path. Inherit the fleet's
+		// mediation verdict unless the override is Blue/Green, which
+		// sidesteps the gateway entirely (N/A). We can't reuse
+		// `dec.GatewayMediated` directly because `decideCutover` ran
+		// against a single-cluster slice and `fleetUsesIAM` would
+		// have re-evaluated against that one cluster's auth instead
+		// of the whole fleet — producing wrong mediation for mixed
+		// IAM / non-IAM fleets. (See `detectPerClusterGatewayIncompat`
+		// for the separate OQ that surfaces the cross-check.)
+		mediated := fleet.GatewayMediated
+		if dec.Style == types.CutoverBlueGreen {
+			mediated = types.GatewayMediatedNotApplicable
+		}
 		rejected, rejectedValue := rejectedCutoverOverride(raw)
-		styleMatchesFleet := dec.Style == fleet.Style && dec.SubPattern == fleet.SubPattern && dec.GatewayMediated == fleet.GatewayMediated
+		styleMatchesFleet := dec.Style == fleet.Style && dec.SubPattern == fleet.SubPattern && mediated == fleet.GatewayMediated
 		if styleMatchesFleet && !rejected {
 			continue
 		}
@@ -521,7 +535,7 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.Cuto
 			ClusterID:             c.Name,
 			Style:                 dec.Style,
 			SubPattern:            dec.SubPattern,
-			GatewayMediated:       dec.GatewayMediated,
+			GatewayMediated:       mediated,
 			OverrideRejected:      rejected,
 			RejectedOverrideValue: rejectedValue,
 		})

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -42,7 +42,7 @@ func TestPlanServiceBuild_BasicShape(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Amazon MSK", p.Header.Source)
-	assert.Equal(t, "1-experimental", p.Header.PlanSchemaVersion)
+	assert.Equal(t, "1", p.Header.PlanSchemaVersion)
 	assert.Equal(t, "kcp-state.json", p.Header.StateFilePath)
 	assert.Equal(t, 1, p.SourceEnvironment.TotalRegions)
 	assert.Len(t, p.Sizing, 2)
@@ -358,7 +358,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 
 	t.Run("nil-Acls PROVISIONED: skipped rule has SkipReason", func(t *testing.T) {
 		c := provisionedClusterWithScan("nil-acls", nil)
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		require.Len(t, d.EvaluatedRules, len(hardLimitCatalog), "EvaluatedRules must carry every catalog entry")
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleACLCountExceedsCap {
@@ -372,7 +372,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 	})
 	t.Run("non-fired rule carries negative evidence", func(t *testing.T) {
 		c := provisionedClusterWithScan("ok", []types.Acls{})
-		d := DecideClusterType(c, sizing, cfg, defaultInputs())
+		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleACLCountExceedsCap {
 				assert.Equal(t, types.RuleNotFired, r.Outcome)
@@ -386,7 +386,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 		c := provisionedClusterWithScan("schema-cluster", []types.Acls{})
 		in := defaultInputs()
 		in.EnforceSchemasAtTheBroker = true
-		d := DecideClusterType(c, sizing, cfg, in)
+		d := decideClusterType(c, sizing, cfg, in)
 		var found bool
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleBrokerSideSchemaValidation {
@@ -504,17 +504,17 @@ func TestDetectStaleStateOQ_HonorsThreshold(t *testing.T) {
 // values + the empty default.
 func TestDetectAuthFleetOpenQuestions_TargetAuthMethodTypo(t *testing.T) {
 	resolved := types.PlanInputsResolved{TargetAuthMethod: "oauthhh"}
-	oqs := detectAuthFleetOpenQuestions(resolved)
+	oqs := detectAuthFleetOpenQuestions(nil, resolved)
 	require.Len(t, oqs, 1)
 	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
 	assert.Contains(t, oqs[0].Title, "oauthhh")
 
 	// Recognised value → silent.
 	resolved.TargetAuthMethod = TargetAuthOAuth
-	assert.Empty(t, detectAuthFleetOpenQuestions(resolved))
+	assert.Empty(t, detectAuthFleetOpenQuestions(nil, resolved))
 	// Empty (default) → silent.
 	resolved.TargetAuthMethod = ""
-	assert.Empty(t, detectAuthFleetOpenQuestions(resolved))
+	assert.Empty(t, detectAuthFleetOpenQuestions(nil, resolved))
 }
 
 // Per-cluster target_auth_method typos surface as cluster-scoped OQs
@@ -529,8 +529,9 @@ func TestDetectAuthFleetOpenQuestions_PerClusterTargetAuthTypo(t *testing.T) {
 			"bravo": {TargetAuthMethod: &good},
 		},
 	}
+	clusters := []types.ProcessedCluster{{Name: "alpha"}, {Name: "bravo"}}
 	resolved := types.PlanInputsResolved{Raw: raw}
-	oqs := detectAuthFleetOpenQuestions(resolved)
+	oqs := detectAuthFleetOpenQuestions(clusters, resolved)
 	require.Len(t, oqs, 1, "only the typo cluster should emit an OQ")
 	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
 	assert.Equal(t, "alpha", oqs[0].ClusterID)
@@ -590,7 +591,7 @@ func TestSeverityLegend_OnlyPresent(t *testing.T) {
 }
 
 // attachAuth gives a fixture cluster a SCRAM (or other) source auth so
-// it surfaces in DecideAuth output. Mirrors withSourceAuth in
+// it surfaces in decideAuth output. Mirrors withSourceAuth in
 // cutover_test.go but layers on top of an existing fixtureCluster.
 func attachAuth(c types.ProcessedCluster, sourceAuth string) types.ProcessedCluster {
 	enabled := true

--- a/internal/services/plan/red_flags.go
+++ b/internal/services/plan/red_flags.go
@@ -1,0 +1,600 @@
+package plan
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/confluentinc/kcp/internal/types"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+// Stable Red Flag IDs. Matches the spec's row numbering — kept stable
+// so JSON consumers can branch on the ID without parsing the title.
+const (
+	RedFlagIDSchemalessSource          = "schemaless_source"
+	RedFlagIDKafkaVersionBelowCLFloor  = "kafka_version_below_cl_floor"
+	RedFlagIDIAMAuthEnabled            = "iam_auth_enabled"
+	RedFlagIDGlueSRInUse               = "glue_sr_in_use"
+	RedFlagIDPartitionApproachingCap   = "partition_approaching_cap"
+	RedFlagIDMSKConnectPresent         = "msk_connect_present"
+	RedFlagIDSelfManagedConnectPresent = "self_managed_connect_present"
+	RedFlagIDMultiRegionSource         = "multi_region_source"
+	RedFlagIDZeroACLsWithIAM           = "zero_acls_with_iam"
+	RedFlagIDClientInventoryGap        = "client_inventory_gap"
+	RedFlagIDMSKExpressBrokerTier      = "msk_express_broker_tier"
+	RedFlagIDTieredStorageInUse        = "tiered_storage_in_use"
+	RedFlagIDEOSInUse                  = "eos_in_use"
+	RedFlagIDKafkaStreamsInUse         = "kafka_streams_in_use"
+	RedFlagIDBroadTopicPatternMatch    = "broad_topic_pattern_match"
+)
+
+// expressInstanceFamilies are the MSK Express broker instance-type
+// prefixes. Express tier is a Cluster-Linking compatibility caveat —
+// row 11 surfaces it for SE discussion.
+var expressInstanceFamilies = []string{"express.m7g."}
+
+// broadTopicPatterns drives row 15: catch-all naming patterns the
+// structured Connect / Streams scans (rows 6, 7, 14) may miss when
+// topics use custom prefixes. Each entry pairs a regex with a
+// human-readable label surfaced in the rendered evidence string.
+var broadTopicPatterns = []struct {
+	label string
+	re    *regexp.Regexp
+}{
+	{label: "MM2 active replication (`mm2-` prefix)", re: regexp.MustCompile(`^mm2-`)},
+	{label: "MM2 active replication (`.replica` suffix)", re: regexp.MustCompile(`\.replica$`)},
+	{label: "Connect fleet (`connect-(configs|offsets|status)`, with or without a prefix)", re: connectInternalTopicPattern},
+	{label: "Kafka Streams changelog (`-changelog`)", re: kafkaStreamsChangelogPattern},
+	{label: "Kafka Streams repartition (`-repartition`)", re: kafkaStreamsRepartitionPattern},
+	{label: "Kafka transactions (`__transaction_state`)", re: regexp.MustCompile(`^__transaction_state$`)},
+	{label: "Connector heartbeats (`-heartbeats`)", re: regexp.MustCompile(`-heartbeats$`)},
+}
+
+// detectRedFlags evaluates the 15 boolean trigger rows from the spec.
+// Returns nil when there are no clusters in the state file (the
+// renderer omits the section in that case). Each row is evaluated
+// independently and produces a {Status, Evidence} pair — Triggered
+// rows render at the top of §Red Flags, with NotTriggered / Unknown
+// collapsed into a tail summary.
+func detectRedFlags(state types.ProcessedState, plan *types.Plan, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.RedFlagsSection {
+	clusters := collectClusters(state)
+	if len(clusters) == 0 {
+		return nil
+	}
+	rows := []types.RedFlag{
+		evalSchemalessSource(plan, inputs),
+		evalKafkaVersionBelowFloor(clusters, cfg),
+		evalIAMAuthEnabled(clusters),
+		evalGlueSRInUse(plan),
+		evalPartitionApproachingCap(plan, cfg),
+		evalMSKConnectPresent(clusters),
+		evalSelfManagedConnectPresent(clusters),
+		evalMultiRegionSource(state),
+		evalZeroACLsWithIAM(clusters),
+		evalClientInventoryGap(clusters),
+		evalMSKExpressBrokerTier(clusters),
+		evalTieredStorageInUse(clusters),
+		evalEOSInUse(inputs),
+		evalKafkaStreamsInUse(clusters, inputs),
+		evalBroadTopicPatternMatch(clusters),
+	}
+	return &types.RedFlagsSection{Rows: rows}
+}
+
+// ----- Row 1: schemaless source -----
+
+// Triggered when no Schema Registry was detected AND the customer
+// declared a non-unknown schema_strategy. While `schema_strategy ==
+// unknown` the row is suppressed to avoid a spurious first-run warning.
+func evalSchemalessSource(plan *types.Plan, inputs types.PlanInputsResolved) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDSchemalessSource, Title: "Schemaless source (no Schema Registry detected)"}
+	strategy := inputs.SchemaStrategy
+	if strategy == "" || strategy == SchemaStrategyUnknown {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "`schema_strategy` not yet declared — set it in `plan-inputs.yaml` to evaluate this row"
+		return rf
+	}
+	// When the customer DECLARED they have an SR but the scan didn't
+	// find one, §5 already surfaces this as a "Scan gap" with a
+	// rescan / correct-strategy action. Firing this Red Flag too
+	// would double-count the same fact under contradictory framings
+	// (§5 says "you have an SR but we couldn't see it"; §6 would
+	// say "you don't have an SR"). Resolve as NotTriggered so the
+	// scan-gap copy in §5 is the single source of truth.
+	noScanSource := plan.Schema == nil || plan.Schema.Source == types.SchemaSourceNone
+	if noScanSource && strategy == SchemaStrategyMigrateExistingSchemaRegistry {
+		rf.Status = types.RedFlagNotTriggered
+		return rf
+	}
+	if noScanSource {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = fmt.Sprintf("`schema_strategy: %s`, no Schema Registry detected by `kcp scan schema-registry` / `kcp scan glue-schema-registry`", strategy)
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 2: Kafka version below the Cluster Linking floor -----
+
+// `kafka_version < 2.4.0` per the published Cluster Linking floor.
+// Versions are dot-separated integer segments; the comparator
+// (`versionAtLeast`) already strips pre-release suffixes and handles
+// the "latest" alias.
+func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConfig) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDKafkaVersionBelowCLFloor, Title: "Kafka version below the Cluster Linking floor"}
+	floor := cfg.ClusterLinking.SourceMinKafkaVersion
+	type versionHit struct {
+		Cluster string `json:"cluster"`
+		Version string `json:"version"`
+	}
+	var below []versionHit
+	var belowStrs []string
+	var unparseable []string
+	for _, c := range clusters {
+		v := kafkaVersionOf(c)
+		if v == "" {
+			unparseable = append(unparseable, c.Name+" (no version recorded)")
+			continue
+		}
+		if !versionAtLeast(v, floor) {
+			below = append(below, versionHit{Cluster: c.Name, Version: v})
+			belowStrs = append(belowStrs, fmt.Sprintf("%s=%s", c.Name, v))
+		}
+	}
+	switch {
+	case len(below) > 0:
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = fmt.Sprintf("clusters below floor `%s`: %s", floor, strings.Join(belowStrs, ", "))
+		rf.EvidenceFields = map[string]any{
+			"floor":    floor,
+			"clusters": below,
+		}
+	case len(unparseable) > 0:
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = fmt.Sprintf("kafka_version missing for: %s — re-run `kcp discover`", strings.Join(unparseable, ", "))
+	default:
+		rf.Status = types.RedFlagNotTriggered
+	}
+	return rf
+}
+
+func kafkaVersionOf(c types.ProcessedCluster) string {
+	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
+	if prov == nil || prov.CurrentBrokerSoftwareInfo == nil || prov.CurrentBrokerSoftwareInfo.KafkaVersion == nil {
+		return ""
+	}
+	return *prov.CurrentBrokerSoftwareInfo.KafkaVersion
+}
+
+// ----- Row 3: IAM auth enabled -----
+
+func evalIAMAuthEnabled(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDIAMAuthEnabled, Title: "IAM authentication enabled on the source"}
+	var hits []string
+	for _, c := range clusters {
+		for _, a := range sourceAuthsDetected(c) {
+			if a == SourceAuthIAM {
+				hits = append(hits, c.Name)
+				break
+			}
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "IAM detected on: " + strings.Join(hits, ", ")
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 4: AWS Glue Schema Registry in use -----
+
+func evalGlueSRInUse(plan *types.Plan) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDGlueSRInUse, Title: "AWS Glue Schema Registry in use"}
+	if plan.Schema == nil {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "schema migration verdict unavailable"
+		return rf
+	}
+	if hasPath(plan.Schema, types.SchemaPathMigrateGlue) ||
+		plan.Schema.Source == types.SchemaSourceGlue ||
+		plan.Schema.Source == types.SchemaSourceConfluentAndGlue {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = fmt.Sprintf("Glue registries detected: %s", strings.Join(plan.Schema.GlueRegistries, ", "))
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 5: partition count approaching the cluster's partition ceiling -----
+
+// Triggered when any cluster's `user_partitions` exceeds 30% of the
+// sized eCKU's per-eCKU partition cap. Dynamic to the cluster's
+// sized footprint, not the Enterprise PNI ceiling — so a 5-eCKU
+// cluster trips at 4,500 partitions; a 32-eCKU cluster at 28,800.
+func evalPartitionApproachingCap(plan *types.Plan, cfg *PlanConfig) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDPartitionApproachingCap, Title: "Partition count approaching the cluster's sized partition ceiling"}
+	if cfg.EnterpriseCaps.PerECKUPartitionRate <= 0 {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "config: per_eCKU_partition_rate missing"
+		return rf
+	}
+	var hits []string
+	for _, s := range plan.Sizing {
+		if s.FinalECKU <= 0 || s.UserPartitions <= 0 {
+			continue
+		}
+		threshold := cfg.Thresholds.PartitionApproachingFraction * float64(cfg.EnterpriseCaps.PerECKUPartitionRate) * float64(s.FinalECKU)
+		if float64(s.UserPartitions) > threshold {
+			hits = append(hits, fmt.Sprintf("%s=%d partitions (%.0f%% of %d eCKU sized capacity)",
+				s.ClusterID, s.UserPartitions,
+				100.0*float64(s.UserPartitions)/(float64(cfg.EnterpriseCaps.PerECKUPartitionRate)*float64(s.FinalECKU)),
+				s.FinalECKU))
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = strings.Join(hits, "; ")
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 6: MSK Connect managed connectors present -----
+
+// Distinguishes "scan ran successfully with 0 connectors" (don't fire)
+// from "scan didn't run" (fire as Unknown). The disambiguation reads
+// topic-population + cluster type per the spec: a PROVISIONED cluster
+// with topics populated AND an empty `connectors` slice counts as
+// "actually zero".
+func evalMSKConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDMSKConnectPresent, Title: "MSK Connect managed connectors present"}
+	var triggered []string
+	var unscanned []string
+	for _, c := range clusters {
+		connectors := c.AWSClientInformation.Connectors
+		if len(connectors) > 0 {
+			triggered = append(triggered, fmt.Sprintf("%s (%d connector(s))", c.Name, len(connectors)))
+			continue
+		}
+		if isServerless(c) {
+			// MSK Connect doesn't apply to Serverless — treat as 0.
+			continue
+		}
+		// PROVISIONED + topics populated AND empty slice → actually 0.
+		if c.KafkaAdminClientInformation.Topics != nil && len(c.KafkaAdminClientInformation.Topics.Details) > 0 {
+			continue
+		}
+		// Otherwise: can't disambiguate scan-didn't-run from really-zero.
+		unscanned = append(unscanned, c.Name)
+	}
+	switch {
+	case len(triggered) > 0:
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = strings.Join(triggered, ", ")
+	case len(unscanned) > 0:
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "scan inconclusive for: " + strings.Join(unscanned, ", ")
+	default:
+		rf.Status = types.RedFlagNotTriggered
+	}
+	return rf
+}
+
+// ----- Row 7: self-managed Connect clusters present -----
+
+// Reads `KafkaAdminClientInformation.SelfManagedConnectors` directly.
+// Same nil-vs-empty disambiguation as row 6: empty struct with topics
+// populated counts as "no Connect clusters"; nil struct = scan didn't
+// run.
+func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDSelfManagedConnectPresent, Title: "Self-managed Connect clusters present"}
+	var triggered []string
+	var unscanned []string
+	for _, c := range clusters {
+		smc := c.KafkaAdminClientInformation.SelfManagedConnectors
+		switch {
+		case smc != nil && len(smc.Connectors) > 0:
+			triggered = append(triggered, fmt.Sprintf("%s (%d connector(s))", c.Name, len(smc.Connectors)))
+		case smc != nil:
+			// Empty struct with `Connectors` cleared — scan ran, found nothing.
+		default:
+			// nil — scan didn't run. Cross-check topic patterns for
+			// `connect-(configs|offsets|status)` so a stale state file
+			// doesn't suppress a real fleet.
+			if patternHit, _ := topicPatternFound(c, connectInternalTopicPattern); patternHit {
+				triggered = append(triggered, c.Name+" (Connect topic pattern detected; SelfManagedConnectors scan didn't run)")
+			} else {
+				unscanned = append(unscanned, c.Name)
+			}
+		}
+	}
+	switch {
+	case len(triggered) > 0:
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = strings.Join(triggered, ", ")
+	case len(unscanned) > 0:
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "scan inconclusive for: " + strings.Join(unscanned, ", ")
+	default:
+		rf.Status = types.RedFlagNotTriggered
+	}
+	return rf
+}
+
+// ----- Row 8: multi-region source -----
+
+func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDMultiRegionSource, Title: "Source clusters span multiple AWS regions"}
+	regions := map[string]struct{}{}
+	for _, src := range state.Sources {
+		if src.MSKData == nil {
+			continue
+		}
+		for _, r := range src.MSKData.Regions {
+			regions[r.Name] = struct{}{}
+		}
+	}
+	if len(regions) > 1 {
+		names := make([]string, 0, len(regions))
+		for r := range regions {
+			names = append(names, r)
+		}
+		// Sort: map iteration is randomized in Go, so without this
+		// two consecutive `kcp report plan` runs produce different
+		// evidence-string orderings. Deterministic output is
+		// load-bearing for the "same state file + same plan-inputs
+		// → byte-identical plan" guarantee.
+		sort.Strings(names)
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = fmt.Sprintf("%d regions: %s", len(regions), strings.Join(names, ", "))
+		rf.EvidenceFields = map[string]any{
+			"region_count": len(names),
+			"regions":      names,
+		}
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 9: zero ACLs with IAM enabled -----
+
+// IAM-only clusters legitimately have zero ACLs (IAM policy carries
+// the auth/authz model), but a non-IAM cluster with zero ACLs may be
+// a scan gap — the row fires only when IAM is present AND the
+// ACL-list disambiguation says "actually zero".
+//
+// Delegates the nil-vs-empty disambiguation to `aclScanRan` (see
+// cluster_signals.go) so semantics stay in lockstep with V1 — when
+// `aclScanRan` returns true the scan succeeded; an empty slice in
+// that case is "actually zero", not "scan didn't run".
+func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDZeroACLsWithIAM, Title: "Zero ACLs with IAM auth enabled — verify SE expected behavior"}
+	var hits []string
+	for _, c := range clusters {
+		iam := false
+		for _, a := range sourceAuthsDetected(c) {
+			if a == SourceAuthIAM {
+				iam = true
+				break
+			}
+		}
+		if !iam {
+			continue
+		}
+		if aclScanRan(c) && len(c.KafkaAdminClientInformation.Acls) == 0 {
+			hits = append(hits, c.Name)
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "IAM + 0 ACLs on: " + strings.Join(hits, ", ")
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 10: client inventory gap -----
+
+func evalClientInventoryGap(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDClientInventoryGap, Title: "Client inventory not populated"}
+	var hits []string
+	for _, c := range clusters {
+		if len(c.DiscoveredClients) == 0 {
+			hits = append(hits, c.Name)
+		}
+	}
+	if len(hits) == 0 {
+		rf.Status = types.RedFlagNotTriggered
+		return rf
+	}
+	if len(hits) == len(clusters) {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "no `discovered_clients` on any cluster — run `kcp scan client-inventory`"
+		return rf
+	}
+	rf.Status = types.RedFlagTriggered
+	rf.Evidence = "missing on: " + strings.Join(hits, ", ")
+	return rf
+}
+
+// ----- Row 11: MSK Express broker tier -----
+
+func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDMSKExpressBrokerTier, Title: "MSK Express broker tier in use"}
+	type expressHit struct {
+		Cluster      string `json:"cluster"`
+		InstanceType string `json:"instance_type"`
+	}
+	var hits []expressHit
+	var hitStrs []string
+	for _, c := range clusters {
+		instType := brokerInstanceType(c)
+		if instType == "" {
+			continue
+		}
+		for _, family := range expressInstanceFamilies {
+			if strings.HasPrefix(instType, family) {
+				hits = append(hits, expressHit{Cluster: c.Name, InstanceType: instType})
+				hitStrs = append(hitStrs, fmt.Sprintf("%s=%s", c.Name, instType))
+				break
+			}
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "Express tier on: " + strings.Join(hitStrs, ", ")
+		rf.EvidenceFields = map[string]any{"clusters": hits}
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+func brokerInstanceType(c types.ProcessedCluster) string {
+	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
+	if prov == nil || prov.BrokerNodeGroupInfo == nil || prov.BrokerNodeGroupInfo.InstanceType == nil {
+		return ""
+	}
+	return *prov.BrokerNodeGroupInfo.InstanceType
+}
+
+// ----- Row 12: tiered storage in use -----
+
+func evalTieredStorageInUse(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDTieredStorageInUse, Title: "Tiered storage in use on the source"}
+	var hits []string
+	for _, c := range clusters {
+		if clusterStorageMode(c) == kafkatypes.StorageModeTiered {
+			hits = append(hits, c.Name)
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "TIERED on: " + strings.Join(hits, ", ") + " — Cluster Linking does NOT carry historical tiered data forward; see Tiered Storage section"
+		rf.EvidenceFields = map[string]any{"clusters": hits}
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 13: exactly-once / Kafka transactions in use -----
+
+// No state signal exists for EOS / transactions; returns Unknown
+// unless the customer flags it. Surfaces as "not scanned" rather
+// than firing false.
+func evalEOSInUse(inputs types.PlanInputsResolved) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDEOSInUse, Title: "Exactly-once semantics (EOS) / Kafka transactions in use"}
+	if inputs.ExactlyOnceTransactionsInUse == nil {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "no state signal; declare `exactly_once_transactions_in_use: true|false` in `plan-inputs.yaml`"
+		return rf
+	}
+	if *inputs.ExactlyOnceTransactionsInUse {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "`exactly_once_transactions_in_use: true` declared in plan-inputs"
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 14: Kafka Streams apps consuming -----
+
+// Two signals: explicit customer declaration OR topic-pattern scan
+// for `-changelog` / `-repartition` artifacts. Either one fires the
+// row; the evidence string names which signal won.
+func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDKafkaStreamsInUse, Title: "Kafka Streams apps consuming from the source"}
+	if inputs.KafkaStreamsInUse != nil && *inputs.KafkaStreamsInUse {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "`kafka_streams_in_use: true` declared in plan-inputs"
+		return rf
+	}
+	var hits []string
+	for _, c := range clusters {
+		clHit, _ := topicPatternFound(c, kafkaStreamsChangelogPattern)
+		rpHit, _ := topicPatternFound(c, kafkaStreamsRepartitionPattern)
+		if clHit || rpHit {
+			hits = append(hits, c.Name)
+		}
+	}
+	if len(hits) > 0 {
+		rf.Status = types.RedFlagTriggered
+		rf.Evidence = "Streams topic pattern detected on: " + strings.Join(hits, ", ")
+		return rf
+	}
+	// No topic-pattern hits AND no customer declaration → Unknown,
+	// matching the row-13 EOS shape: there is no state signal that
+	// definitively rules out Streams when topic names use custom
+	// suffixes. Customer declaration of `kafka_streams_in_use: false`
+	// flips this to NotTriggered explicitly.
+	if inputs.KafkaStreamsInUse == nil {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "no state signal — declare `kafka_streams_in_use: true|false` in `plan-inputs.yaml` if you know"
+		return rf
+	}
+	rf.Status = types.RedFlagNotTriggered
+	return rf
+}
+
+// ----- Row 15: broad topic-name pattern scan -----
+
+// Catch-all row that runs the structured patterns (mm2, connect-*,
+// changelog/repartition, transactions, heartbeats) against every
+// topic on every cluster. Surfaces deployments with custom prefixes
+// that the structured rows above might miss.
+func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) types.RedFlag {
+	rf := types.RedFlag{ID: RedFlagIDBroadTopicPatternMatch, Title: "Broad topic-name pattern scan — items the structured rows might miss"}
+	hitsByPattern := map[string][]string{}
+	anyHits := false
+	for _, c := range clusters {
+		if c.KafkaAdminClientInformation.Topics == nil {
+			continue
+		}
+		for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+			for _, p := range broadTopicPatterns {
+				if p.re.MatchString(td.Name) {
+					hitsByPattern[p.label] = append(hitsByPattern[p.label], fmt.Sprintf("%s/%s", c.Name, td.Name))
+					anyHits = true
+				}
+			}
+		}
+	}
+	if !anyHits {
+		rf.Status = types.RedFlagNotTriggered
+		return rf
+	}
+	var parts []string
+	for _, p := range broadTopicPatterns {
+		hits := hitsByPattern[p.label]
+		if len(hits) == 0 {
+			continue
+		}
+		// Take the first 3 into a fresh slice so the "(+N more)"
+		// suffix doesn't clobber the underlying backing array of
+		// hitsByPattern[p.label]. The previous `append(hits[:3], …)`
+		// form was an aliasing trap — single-iteration read meant it
+		// didn't fire in practice today, but future re-reads would
+		// see corrupted lengths.
+		const sample = 3
+		shown := hits
+		if len(hits) > sample {
+			shown = append(append([]string(nil), hits[:sample]...), fmt.Sprintf("(+%d more)", len(hits)-sample))
+		}
+		parts = append(parts, fmt.Sprintf("%s — %s", p.label, strings.Join(shown, ", ")))
+	}
+	rf.Status = types.RedFlagTriggered
+	rf.Evidence = strings.Join(parts, "; ")
+	return rf
+}

--- a/internal/services/plan/red_flags_test.go
+++ b/internal/services/plan/red_flags_test.go
@@ -1,0 +1,177 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+// findRow returns the row matching `id` so tests don't depend on slice
+// ordering. Fails the test when the row is missing.
+func findRow(t *testing.T, section *types.RedFlagsSection, id string) types.RedFlag {
+	t.Helper()
+	require.NotNil(t, section)
+	for _, r := range section.Rows {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("red flag row %q not present in section (got %d rows)", id, len(section.Rows))
+	return types.RedFlag{}
+}
+
+// Row 1 — schemaless source. Suppressed when `schema_strategy` is
+// unknown; fires when a strategy is declared AND no SR was scanned.
+func TestRedFlags_SchemalessSource(t *testing.T) {
+	// Need at least one MSK cluster — detectRedFlags returns nil on
+	// empty fleets so §Red Flags can be omitted cleanly. The cluster
+	// itself doesn't carry an SR; the schemaless verdict comes from
+	// the absence of a SchemaRegistriesState on the state file.
+	state := wrapClusters(redFlagCluster("plain-cluster", "3.5.0", "", ""))
+	cfg := defaultCfg(t)
+
+	// strategy = unknown → row is Unknown, not Triggered.
+	inputs := schemaInputs(SchemaStrategyUnknown)
+	plan := buildPlanForRedFlags(t, state, cfg, inputs)
+	row := findRow(t, plan.RedFlags, RedFlagIDSchemalessSource)
+	assert.Equal(t, types.RedFlagUnknown, row.Status, "strategy=unknown must not fire row 1")
+
+	// strategy = adopt_schemas_during_migration → row fires.
+	inputs = schemaInputs(SchemaStrategyAdoptSchemasDuringMigration)
+	plan = buildPlanForRedFlags(t, state, cfg, inputs)
+	row = findRow(t, plan.RedFlags, RedFlagIDSchemalessSource)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "adopt_schemas_during_migration")
+}
+
+// Row 2 — Kafka version below Cluster Linking floor (2.4.0).
+func TestRedFlags_KafkaVersionBelowFloor(t *testing.T) {
+	below := redFlagCluster("old-cluster", "2.2.1", "", "")
+	above := redFlagCluster("new-cluster", "3.5.0", "", "")
+	state := wrapClusters(below, above)
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "old-cluster=2.2.1")
+	assert.NotContains(t, row.Evidence, "new-cluster")
+}
+
+// Row 11 — MSK Express broker tier.
+func TestRedFlags_ExpressBrokerTier(t *testing.T) {
+	expressCluster := redFlagCluster("express-cluster", "3.5.0", "express.m7g.large", "")
+	standardCluster := redFlagCluster("standard-cluster", "3.5.0", "kafka.m5.large", "")
+	plan := buildPlanForRedFlags(t, wrapClusters(expressCluster, standardCluster), defaultCfg(t), defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "express-cluster=express.m7g.large")
+}
+
+// Row 12 — tiered storage in use.
+func TestRedFlags_TieredStorageInUse(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	local := redFlagCluster("local-cluster", "3.5.0", "", string(kafkatypes.StorageModeLocal))
+	plan := buildPlanForRedFlags(t, wrapClusters(tiered, local), defaultCfg(t), defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "tiered-cluster")
+}
+
+// Row 13 — EOS / Kafka transactions. Customer-declared only.
+func TestRedFlags_EOSInUse(t *testing.T) {
+	state := wrapClusters(redFlagCluster("eos-cluster", "3.5.0", "", ""))
+	cfg := defaultCfg(t)
+
+	// nil → Unknown
+	plan := buildPlanForRedFlags(t, state, cfg, defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
+	assert.Equal(t, types.RedFlagUnknown, row.Status)
+
+	// true → Triggered
+	inputs := defaultInputs()
+	inputs.ExactlyOnceTransactionsInUse = ptrBool(true)
+	plan = buildPlanForRedFlags(t, state, cfg, inputs)
+	row = findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+
+	// false → NotTriggered
+	inputs.ExactlyOnceTransactionsInUse = ptrBool(false)
+	plan = buildPlanForRedFlags(t, state, cfg, inputs)
+	row = findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
+	assert.Equal(t, types.RedFlagNotTriggered, row.Status)
+}
+
+// Row 15 — broad topic-name pattern scan: catches MM2 / Connect /
+// Streams / heartbeats artifacts via topic-name regex.
+func TestRedFlags_BroadTopicPatternMatch(t *testing.T) {
+	c := redFlagCluster("scan-target", "3.5.0", "", "")
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{
+		{Name: "regular-topic"},
+		{Name: "mm2-source-data"},
+		{Name: "events-changelog"},
+	}}
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDBroadTopicPatternMatch)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "mm2-source-data")
+	assert.Contains(t, row.Evidence, "events-changelog")
+}
+
+// Empty fleet (no MSK clusters) → detectRedFlags returns nil so the
+// renderer omits the §Red Flags section entirely.
+func TestDetectRedFlags_EmptyFleetReturnsNil(t *testing.T) {
+	assert.Nil(t, detectRedFlags(types.ProcessedState{}, &types.Plan{}, defaultCfg(t), defaultInputs()))
+}
+
+// ----- helpers -----
+
+// redFlagCluster constructs a ProcessedCluster with the AWS SDK
+// MskClusterConfig fields the Red Flag detectors read. Pass empty
+// strings to leave a field unset.
+func redFlagCluster(name, kafkaVersion, instanceType, storageMode string) types.ProcessedCluster {
+	c := types.ProcessedCluster{Name: name, Region: "us-east-1"}
+	prov := &kafkatypes.Provisioned{}
+	if kafkaVersion != "" {
+		v := kafkaVersion
+		prov.CurrentBrokerSoftwareInfo = &kafkatypes.BrokerSoftwareInfo{KafkaVersion: &v}
+	}
+	if instanceType != "" {
+		it := instanceType
+		prov.BrokerNodeGroupInfo = &kafkatypes.BrokerNodeGroupInfo{InstanceType: &it}
+	}
+	if storageMode != "" {
+		prov.StorageMode = kafkatypes.StorageMode(storageMode)
+	}
+	c.AWSClientInformation.MskClusterConfig.Provisioned = prov
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+	// Populate topics minimally so the MSK Connect / Self-managed
+	// Connect "topics populated" disambiguation can fire on its own.
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{{Name: name + "-topic"}}}
+	return c
+}
+
+func wrapClusters(clusters ...types.ProcessedCluster) types.ProcessedState {
+	return types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{{Name: "us-east-1", Clusters: clusters}},
+			},
+		}},
+	}
+}
+
+// buildPlanForRedFlags runs PlanService.Build so the test exercises
+// the full integration (V2 detector + V1 plumbing) rather than
+// calling detectRedFlags in isolation. Same default time / cfg used
+// by the rest of the plan tests.
+func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.Plan {
+	t.Helper()
+	svc := NewPlanService(cfg, fixedNow)
+	p, err := svc.Build(state, inputs, "redflags-test.json")
+	require.NoError(t, err)
+	return p
+}

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -3,12 +3,24 @@ package plan
 import (
 	"bytes"
 	"fmt"
+	"math"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
 	"github.com/confluentinc/kcp/internal/types"
 )
+
+// regionFlagToken matches the inline `--region <value>` flag that
+// per-cluster HowToClose strings embed. Used by `groupOpenQuestions`
+// to normalize the flag for grouping so OQs identical except for
+// region collapse to one entry, and by the renderer to swap the
+// concrete region for a `<region>` placeholder when the collapsed
+// group spans multiple regions. Restricted to the AWS region-name
+// character class (`[a-z0-9-]`) so a literal `--region <region>`
+// placeholder embedded in a template never accidentally matches.
+var regionFlagToken = regexp.MustCompile(`--region\s+[a-zA-Z0-9-]+`)
 
 // RenderMarkdown emits the human-readable Plan: Source Environment,
 // Sizing & Cluster Decisions, Actions Needed, and collapsed appendices.
@@ -42,7 +54,7 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	writeSizingAndDecisions(&b, p, cfg, section)
 	section++
 	if p.Cutover != nil {
-		writeCutover(&b, p.Cutover, cfg, section)
+		writeCutover(&b, p.Cutover, p.CutoverOverrides, cfg, section)
 		section++
 	}
 	if len(p.Auth) > 0 {
@@ -51,6 +63,22 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	}
 	if p.Schema != nil {
 		writeSchema(&b, p.Schema, p.Inputs, cfg, section)
+		section++
+	}
+	if p.RedFlags != nil && len(p.RedFlags.Rows) > 0 {
+		writeRedFlags(&b, p.RedFlags, section)
+		section++
+	}
+	if p.EffortSignals != nil && len(p.EffortSignals.Signals) > 0 {
+		writeEffortSignals(&b, p.EffortSignals, section)
+		section++
+	}
+	if p.TieredStorage != nil && len(p.TieredStorage.Clusters) > 0 {
+		writeTieredStorage(&b, p.TieredStorage, section)
+		section++
+	}
+	if p.CostReconciliation != nil && len(p.CostReconciliation.Candidates) > 0 {
+		writeCostReconciliation(&b, p.CostReconciliation, section)
 		section++
 	}
 	writeOpenQuestions(&b, p, section)
@@ -96,8 +124,16 @@ func writeOpenQuestions(b *bytes.Buffer, p *types.Plan, section int) {
 		if g.oq.Body != "" {
 			fmt.Fprintf(b, "   - %s\n", indentMultiline(g.oq.Body, "     "))
 		}
-		if g.oq.HowToClose != "" {
-			fmt.Fprintf(b, "   - _How to close:_ %s\n", indentMultiline(g.oq.HowToClose, "     "))
+		howToClose := g.oq.HowToClose
+		// When a group spans multiple source regions, swap the inline
+		// `--region <X>` from the first-seen OQ for a `<region>`
+		// placeholder so the rendered command reads generically and
+		// the reader knows to map it per cluster from §1 inventory.
+		if len(g.regions) > 1 {
+			howToClose = regionFlagToken.ReplaceAllString(howToClose, "--region <region>")
+		}
+		if howToClose != "" {
+			fmt.Fprintf(b, "   - _How to close:_ %s\n", indentMultiline(howToClose, "     "))
 		}
 	}
 	b.WriteString("\n")
@@ -138,12 +174,16 @@ func oqIDSet(oqs []types.OpenQuestion) map[string]bool {
 }
 
 // oqGroup collapses OQs that render identically (same ID + Body +
-// HowToClose) into one entry with an `Affects:` line. Plan-level OQs
-// (empty ClusterID) never merge with per-cluster OQs; OQs whose
-// HowToClose differs (e.g. per-region commands) stay distinct.
+// normalized HowToClose) into one entry with an `Affects:` line.
+// Plan-level OQs (empty ClusterID) never merge with per-cluster OQs.
+// Per-cluster OQs whose only HowToClose difference is the embedded
+// `--region <X>` flag DO merge — the renderer swaps the concrete
+// region for a `<region>` placeholder when the collapsed group spans
+// multiple regions, since each cluster lives in exactly one region.
 type oqGroup struct {
 	oq       types.OpenQuestion
 	clusters []string
+	regions  map[string]struct{}
 }
 
 // groupOpenQuestions returns first-seen-order groups; callers must pass
@@ -158,22 +198,29 @@ func groupOpenQuestions(oqs []types.OpenQuestion) []oqGroup {
 			// Plan-level — never merge with per-cluster OQs.
 			key = "plan-level\x00" + oq.ID + "\x00" + oq.Title
 		case oq.ID != "":
-			// Per-cluster grouping: include Body + HowToClose so two
-			// clusters whose rendered text differs (e.g. per-region
-			// commands) stay as separate items.
-			key = "cluster\x00" + oq.ID + "\x00" + oq.Body + "\x00" + oq.HowToClose
+			// Per-cluster grouping: include Body + region-normalized
+			// HowToClose so two OQs identical except for `--region <X>`
+			// collapse to one entry. Other HowToClose differences keep
+			// the items distinct.
+			normalized := regionFlagToken.ReplaceAllString(oq.HowToClose, "--region <region>")
+			key = "cluster\x00" + oq.ID + "\x00" + oq.Body + "\x00" + normalized
 		default:
 			// No ID and a ClusterID — can't safely group; keep distinct.
 			key = "cluster\x00\x00" + oq.Title + "\x00" + oq.ClusterID
 		}
 		idx, ok := byKey[key]
 		if !ok {
-			groups = append(groups, oqGroup{oq: oq})
+			groups = append(groups, oqGroup{oq: oq, regions: map[string]struct{}{}})
 			idx = len(groups) - 1
 			byKey[key] = idx
 		}
 		if oq.ClusterID != "" {
 			groups[idx].clusters = append(groups[idx].clusters, oq.ClusterID)
+		}
+		// Track distinct regions seen across collapsed OQs so the
+		// renderer can swap to a `<region>` placeholder when >1.
+		if m := regionFlagToken.FindString(oq.HowToClose); m != "" {
+			groups[idx].regions[m] = struct{}{}
 		}
 	}
 	return groups
@@ -395,19 +442,41 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 		fmt.Fprintf(b, "> ℹ **Cost direction (fleet):** %d clusters land on Dedicated because of state-derived hard-limit rules — i.e. the cluster as scanned hit a cap that Enterprise can't carry. The escalation isn't recoverable by editing `plan-inputs.yaml`; confirm with your Confluent account team that the scanned capacity reflects each cluster's actual workload before committing. Dedicated has a higher monthly cost than Enterprise.\n\n",
 			stateDerivedDedicatedCount)
 	}
+	// First pass: compute each cluster's rationale prose + per-cluster
+	// extras (InputsMissing, customer-declared cost callout, SZ
+	// tradeoff, spiky note, state-derived cost note). Bucket clusters
+	// by (rationale + extras) — clusters sharing BOTH the same verdict
+	// and the same extras paragraph collapse into one bullet with a
+	// cluster-list affix. Spiky FYI notes embed per-cluster numeric
+	// values so those clusters bucket alone naturally; structural
+	// extras like "Inputs missing: acls" collapse across the fleet (the
+	// prior version only collapsed when extras were empty, so real
+	// scans missing ACLs spammed the paragraph per cluster). Degraded
+	// rows always stay standalone.
+	type rationaleBucket struct {
+		rationale string
+		extras    string
+		clusters  []string
+		order     int
+	}
+	bucketByKey := map[string]*rationaleBucket{}
+	var bucketOrder []*rationaleBucket
+	standaloneRows := []string{} // pre-formatted bullets for degraded rows only
+
 	for _, s := range p.Sizing {
 		ct := ctByID[s.ClusterID]
 		unit := finalSizeUnit(ct)
 		src := srcByID[s.ClusterID]
 		if s.Degraded {
-			// Metrics-degraded clusters get a symptom-only line here;
-			// the action lives in Actions Needed (so the symptom isn't
-			// duplicated across two surfaces).
+			// Degraded rows always render standalone — the reason
+			// string is per-cluster.
+			var line string
 			if src.IsServerless {
-				fmt.Fprintf(b, "- **%s** — **MSK Serverless source**; broker count is N/A by design and the CloudWatch metrics path differs from Provisioned. Final %s defaults to the SLA floor (%d) until throughput is supplied. See Actions Needed below.\n", s.ClusterID, unit, s.FinalECKU)
+				line = fmt.Sprintf("- **%s** — **MSK Serverless source**; broker count is N/A by design and the CloudWatch metrics path differs from Provisioned. Final %s defaults to the SLA floor (%d) until throughput is supplied. See Actions Needed below.", s.ClusterID, unit, s.FinalECKU)
 			} else {
-				fmt.Fprintf(b, "- **%s** — metrics missing (%s). Final %s defaults to the SLA floor (%d). See Actions Needed below.\n", s.ClusterID, s.DegradedReason, unit, s.FinalECKU)
+				line = fmt.Sprintf("- **%s** — metrics missing (%s). Final %s defaults to the SLA floor (%d). See Actions Needed below.", s.ClusterID, s.DegradedReason, unit, s.FinalECKU)
 			}
+			standaloneRows = append(standaloneRows, line+"\n")
 			continue
 		}
 		var pieces []string
@@ -432,43 +501,62 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 		if n, ok := netByID[s.ClusterID]; ok {
 			pieces = append(pieces, fmt.Sprintf("Networking **%s** — %s", n.Verdict, n.Reason))
 		}
-		fmt.Fprintf(b, "- **%s** — %s.\n", s.ClusterID, strings.Join(pieces, ". "))
+		rationale := strings.Join(pieces, ". ")
+
+		// Compute per-cluster extras (rendered below the bullet).
+		var extras bytes.Buffer
 		if len(s.InputsMissing) > 0 {
-			fmt.Fprintf(b, "  - _Inputs missing: %s — sizing math is provisional until the scan is re-run; the verdict above resolves on the rules that could still evaluate. See Actions Needed below for the next command._\n", strings.Join(s.InputsMissing, ", "))
+			fmt.Fprintf(&extras, "  - _Inputs missing: %s — sizing math is provisional until the scan is re-run; the verdict above resolves on the rules that could still evaluate. See Actions Needed below for the next command._\n", strings.Join(s.InputsMissing, ", "))
 		}
-		// Per-cluster cost callout: only render triggers that didn't
-		// already fire as global (those got the one-time banner up top).
 		perClusterTriggers := filterNonGlobalTriggers(customerDeclaredTriggers, globalCustomerTriggers)
 		if len(perClusterTriggers) > 0 {
-			writeCostCallout(b, perClusterTriggers, calloutPerCluster)
+			writeCostCallout(&extras, perClusterTriggers, calloutPerCluster)
 		}
-		// State-derived Dedicated cost note: when the verdict is
-		// Dedicated and none of the firing rules are customer-declared
-		// (so the customer-callout above didn't fire), surface a
-		// shorter note so the cost direction is visible. Recovery isn't
-		// "flip a flag" here — the fleet's state forced the escalation
-		// — but the cost-direction signal is the same. Suppressed when
-		// the fleet-level banner above already covers it.
 		if !hoistStateDerivedBanner && ct.Verdict == types.ClusterTypeDedicated && len(customerDeclaredTriggers) == 0 && len(ct.Triggers) > 0 {
-			b.WriteString("  - ℹ **Cost direction:** Dedicated has a higher monthly cost than Enterprise. This verdict is state-derived (a hard-limit rule fired on the cluster as scanned), so the escalation isn't recoverable by editing `plan-inputs.yaml`. Confirm with your Confluent account team that the cluster's capacity reflects your actual workload before committing.\n")
+			extras.WriteString("  - ℹ **Cost direction:** Dedicated has a higher monthly cost than Enterprise. This verdict is state-derived (a hard-limit rule fired on the cluster as scanned), so the escalation isn't recoverable by editing `plan-inputs.yaml`. Confirm with your Confluent account team that the cluster's capacity reflects your actual workload before committing.\n")
 		}
-		// Single-Zone resilience tradeoff: skipped when the SZ trigger
-		// fired globally (banner already covered it); otherwise emit
-		// inline so the per-cluster reader sees the failure-domain
-		// note next to the verdict.
 		if ct.Verdict == types.ClusterTypeDedicated && ct.Topology == types.TopologySingleZone && !szIsGlobal(globalCustomerTriggers) {
-			writeSZTradeoff(b, cfg, calloutPerCluster)
+			writeSZTradeoff(&extras, cfg, calloutPerCluster)
 		}
-		// Spiky-workload note (FYI only — sizing already absorbs the spike).
-		// Suppress when sizing landed on the SLA floor: the spike couldn't
-		// have pushed the cluster larger anyway (floor binds first), so
-		// the hint to flip `sizing_percentile: p99` would be misleading.
 		if (s.SpikyIngress || s.SpikyEgress) && s.FinalECKU > s.SLAFloorECKU {
 			absorbed := "Enterprise elasticity absorbs"
 			if ct.Verdict == types.ClusterTypeDedicated {
 				absorbed = "the sized Dedicated capacity absorbs"
 			}
-			fmt.Fprintf(b, "  - _Note: %s. Sizing is P95-based and %s the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s), absorbed)
+			fmt.Fprintf(&extras, "  - _Note: %s. Sizing is P95-based and %s the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s), absorbed)
+		}
+
+		// Bucket by (rationale + extras). Identical extras paragraphs
+		// collapse to one entry with a cluster-list affix; differing
+		// extras keep clusters in separate buckets.
+		extrasStr := extras.String()
+		key := rationale + "\x00" + extrasStr
+		bucket, ok := bucketByKey[key]
+		if !ok {
+			bucket = &rationaleBucket{rationale: rationale, extras: extrasStr, order: len(bucketOrder)}
+			bucketByKey[key] = bucket
+			bucketOrder = append(bucketOrder, bucket)
+		}
+		bucket.clusters = append(bucket.clusters, s.ClusterID)
+	}
+
+	// Render in two passes: (1) standalone rows (in original Sizing
+	// order they appeared), (2) buckets — each bucket rendered once
+	// with its cluster-list lead. Order across (1) + (2) follows the
+	// first-appearance order in Sizing, but for simplicity we render
+	// standalones first then buckets — at fleet scale this preserves
+	// scannability (the special cases lead, then "everything else").
+	for _, row := range standaloneRows {
+		b.WriteString(row)
+	}
+	for _, bucket := range bucketOrder {
+		if len(bucket.clusters) == 1 {
+			fmt.Fprintf(b, "- **%s** — %s.\n", bucket.clusters[0], bucket.rationale)
+		} else {
+			fmt.Fprintf(b, "- **%s** (%d clusters) — %s.\n", strings.Join(bucket.clusters, ", "), len(bucket.clusters), bucket.rationale)
+		}
+		if bucket.extras != "" {
+			b.WriteString(bucket.extras)
 		}
 	}
 	b.WriteString("\n")
@@ -771,7 +859,7 @@ func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types
 	}
 	// Count occurrences per customer-declared RowID across all clusters.
 	// Use a per-cluster `seen` set so a duplicate RowID inside one
-	// cluster's Triggers (defensive — DecideClusterType today emits at
+	// cluster's Triggers (defensive — decideClusterType today emits at
 	// most once) doesn't inflate the count past `len(decisions)` and
 	// fool the "fires on every cluster" check.
 	count := make(map[string]int)
@@ -887,14 +975,16 @@ func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) 
 
 // writeCutover renders the fleet-wide cutover recommendation: chosen
 // style, gateway mediation status with degraded markers, alternatives
-// shown for trust, and the gateway prereq table. Skips the section
-// entirely when there's no cutover decision (empty fleet).
-func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, cfg *PlanConfig, section int) {
+// shown for trust, and the gateway prereq table. `overrides` carries
+// per-cluster exceptions — clusters whose resolved style differs from
+// the fleet default. Skips the section entirely when there's no
+// cutover decision (empty fleet).
+func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, overrides []types.ClusterCutoverOverride, cfg *PlanConfig, section int) {
 	if c == nil {
 		return
 	}
 	fmt.Fprintf(b, "## %d. Cutover Approach\n\n", section)
-	b.WriteString("_The cutover style below applies to the **entire fleet**. Per-cluster cutover overrides aren't supported in this kcp version (planned for a follow-up). Heterogeneous fleets can run kcp against a state-file subset that contains only the clusters sharing a style — re-run for each subset and combine the recommendations manually._\n\n")
+	b.WriteString("_The style below is the **fleet default** — applied to every cluster that doesn't carry a per-cluster override (`clusters[<name>].downtime_tolerance`). Any cluster-specific overrides land in the **Per-cluster overrides** sub-list below the fleet block._\n\n")
 	fmt.Fprintf(b, "- **Style:** %s\n", cutoverStyleLabel(c.Style, c.SubPattern))
 	fmt.Fprintf(b, "- **Gateway mediation:** %s\n", cutoverGatewayLabel(c.GatewayMediated, c.RecommendationStatus))
 	if marker := recommendationStatusMarker(c.RecommendationStatus); marker != "" {
@@ -902,7 +992,10 @@ func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, cfg *PlanConfig, se
 	}
 	writeCutoverAlternatives(b, c.AlternativesShown)
 	writeCutoverPrereqs(b, c.Prereqs)
-	b.WriteString("\n")
+	writeCutoverOverrides(b, overrides)
+	// (writeCutoverPrereqs already emits a trailing blank line; do
+	// NOT add another one here — the prior extra `\n` produced a
+	// double blank before §4 across every plan.)
 	// Blue/Green is customer-designed — kcp doesn't generate the
 	// orchestration. Promote the runbook hint to its own sub-heading
 	// so the multi-sentence content reads as a separate concern, not
@@ -1043,6 +1136,37 @@ func writeCutoverPrereqs(b *bytes.Buffer, prereqs []types.Prereq) {
 	b.WriteString("\n")
 }
 
+// writeCutoverOverrides renders one bullet per cluster that resolves
+// to a different cutover style than the fleet default. Empty slice =
+// homogeneous fleet → nothing emitted. Rejected overrides carry a `*`
+// marker + footnote (mirrors §4 Auth's OverrideRejected handling).
+func writeCutoverOverrides(b *bytes.Buffer, overrides []types.ClusterCutoverOverride) {
+	if len(overrides) == 0 {
+		return
+	}
+	b.WriteString("- **Per-cluster overrides:**\n")
+	anyRejected := false
+	for _, o := range overrides {
+		marker := ""
+		if o.OverrideRejected {
+			marker = " *"
+			anyRejected = true
+		}
+		fmt.Fprintf(b, "  - `%s` → %s%s", o.ClusterID, cutoverStyleLabel(o.Style, o.SubPattern), marker)
+		switch o.GatewayMediated {
+		case types.GatewayMediatedTrue:
+			b.WriteString(" (gateway-mediated)")
+		case types.GatewayMediatedNotApplicable:
+			b.WriteString(" (gateway N/A for this style)")
+		}
+		b.WriteString("\n")
+	}
+	if anyRejected {
+		b.WriteString("\n  `*` = the per-cluster `downtime_tolerance` / `sub_pattern` override wasn't a recognised value, so the cluster fell through to a default. See Actions Needed for the exact typo.\n")
+	}
+	b.WriteString("\n")
+}
+
 func prereqStatusLabel(s types.PrereqStatus) string {
 	switch s {
 	case types.PrereqMet:
@@ -1074,49 +1198,44 @@ func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.Cutov
 	}
 	fmt.Fprintf(b, "## %d. Client Auth Migration\n\n", section)
 	b.WriteString("Per-cluster source→target mapping. Each source-auth method on every cluster maps to a recommended Confluent Cloud auth — the recommendation can be overridden globally via `target_auth_method` or per-cluster via `clusters[<name>].target_auth_method`. The **Works via CC Gateway** column describes whether this auth method *could* flow through the CC Gateway when the gateway path is in use — it's a property of the auth mapping, not a statement about which path §3 picked.\n\n")
-	// Notes column carries non-empty values only on rows where the
-	// auth_mapping row has something specific to say (IAM blocker,
-	// mTLS auth-swap detail, unauth review hint). All-empty notes
-	// across the entire table drop the column entirely.
-	notesUseful := anyNotesPresent(auths)
-	if notesUseful {
-		b.WriteString("| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway | Notes |\n")
-		b.WriteString("|---|---|---|---|---|\n")
-	} else {
-		b.WriteString("| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway |\n")
-		b.WriteString("|---|---|---|---|\n")
-	}
+	// Notes column always renders (`—` placeholder for empty cells)
+	// so the §Auth table has identical column structure across all
+	// plans. Earlier optimization that dropped the column when no
+	// row had a note caused 4-col vs 5-col drift between scenarios
+	// — a customer comparing two plans saw inconsistent layouts.
+	b.WriteString("| Cluster | Source auth | Target on Confluent Cloud | Works via CC Gateway | Notes |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	anyOverrideRejected := false
 	for _, a := range auths {
 		if len(a.TargetMappings) == 0 {
-			if notesUseful {
-				fmt.Fprintf(b, "| %s | _none detected_ | _n/a_ | _n/a_ | _Source auth posture unknown — see Actions Needed._ |\n",
-					escapeMarkdownTableCell(a.ClusterID))
-			} else {
-				fmt.Fprintf(b, "| %s | _none detected_ | _n/a_ | _n/a_ |\n",
-					escapeMarkdownTableCell(a.ClusterID))
-			}
+			fmt.Fprintf(b, "| %s | _none detected_ | _n/a_ | _n/a_ | _Source auth posture unknown — see Actions Needed._ |\n",
+				escapeMarkdownTableCell(a.ClusterID))
 			continue
+		}
+		if a.OverrideRejected {
+			anyOverrideRejected = true
 		}
 		for i, row := range a.TargetMappings {
 			cluster := escapeMarkdownTableCell(a.ClusterID)
 			if i > 0 {
 				cluster = ""
 			}
+			target := fmt.Sprintf("`%s`", row.EffectiveTarget)
+			if a.OverrideRejected {
+				target += " *"
+			}
 			noteCell := strings.TrimSpace(row.Note)
 			if noteCell == "" {
 				noteCell = "—"
 			}
-			if notesUseful {
-				fmt.Fprintf(b, "| %s | `%s` | `%s` | %s | %s |\n",
-					cluster, row.SourceAuth, row.EffectiveTarget,
-					gatewayCompatibleLabel(row.GatewayCompatible, row.TransparentSwap),
-					escapeMarkdownTableCell(noteCell))
-			} else {
-				fmt.Fprintf(b, "| %s | `%s` | `%s` | %s |\n",
-					cluster, row.SourceAuth, row.EffectiveTarget,
-					gatewayCompatibleLabel(row.GatewayCompatible, row.TransparentSwap))
-			}
+			fmt.Fprintf(b, "| %s | `%s` | %s | %s | %s |\n",
+				cluster, row.SourceAuth, target,
+				gatewayCompatibleLabel(row.GatewayCompatible, row.TransparentSwap),
+				escapeMarkdownTableCell(noteCell))
 		}
+	}
+	if anyOverrideRejected {
+		b.WriteString("\n`*` = a `target_auth_method` override was supplied but didn't match a recognised value, so the per-source default applies for that row; see Actions Needed for the exact typo.\n")
 	}
 	// IAM-transition footnote — when prereq is `complete` and
 	// gateway is in play, the IAM rows above are a pre-migration
@@ -1171,20 +1290,6 @@ func writeAuthMappingProvenance(b *bytes.Buffer, auths []types.AuthDecision) {
 	}
 }
 
-// anyNotesPresent reports whether any auth-mapping row across the
-// fleet has a non-empty Note. Drives the §4 Notes-column drop when
-// nothing in the column would carry information.
-func anyNotesPresent(auths []types.AuthDecision) bool {
-	for _, a := range auths {
-		for _, row := range a.TargetMappings {
-			if strings.TrimSpace(row.Note) != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // gatewayCompatibleLabel renders the Gateway-compatible cell.
 // Transparent swap means clients don't restart at cutover (gateway
 // handles credential exchange in flight); non-transparent gateway
@@ -1235,7 +1340,7 @@ func writeSchema(b *bytes.Buffer, dec *types.SchemaDecision, inputs types.PlanIn
 	// otherwise show all-❔ unknown to a reader who explicitly said
 	// they're not migrating schemas. The mismatch OQ carries the
 	// reconciliation prompt. Normalize "" → unknown here so the
-	// comparison matches DecideSchema's own normalization (schema.go).
+	// comparison matches decideSchema's own normalization (schema.go).
 	strategy := inputs.SchemaStrategy
 	if strategy == "" {
 		strategy = SchemaStrategyUnknown
@@ -1310,9 +1415,17 @@ func schemaPathsLabel(paths []types.SchemaPath) string {
 //     is Unknown but the underlying issue is the mismatch, not a
 //     missing input. Surface "Conflict" so the reader's eye lands on
 //     the contradiction rather than chasing a phantom missing field.
+//   - `migrate_existing_schema_registry` declared but the scan found
+//     nothing: the customer asserts they have an SR, kcp didn't see
+//     one. Don't render "Pending — declare the missing input" (the
+//     declaration is already complete); instead point the reader at
+//     re-running the scan or correcting the strategy.
 func schemaPathsLabelForContext(paths []types.SchemaPath, strategy string, source types.SchemaSource) string {
 	if strategy == SchemaStrategyNoSchemas && source != types.SchemaSourceNone {
 		return "**Conflict** — strategy declares `no_schemas` but the scan found a Schema Registry; see §Actions Needed for reconciliation"
+	}
+	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && source == types.SchemaSourceNone {
+		return "**Scan gap** — strategy declares `migrate_existing_schema_registry` but no SR was found in the state file; re-run `kcp scan schema-registry` / `kcp scan glue-schema-registry` against the source, OR correct `schema_strategy` if the source genuinely has no registry"
 	}
 	return schemaPathsLabel(paths)
 }
@@ -1327,6 +1440,12 @@ func schemaStrategyDeclaredLabel(strategy string, dec *types.SchemaDecision) str
 	}
 	if strategy == SchemaStrategyNoSchemas && dec.Source != types.SchemaSourceNone {
 		return fmt.Sprintf("`%s` ⚠ (scan found a Schema Registry)", strategy)
+	}
+	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && dec.Source == types.SchemaSourceNone {
+		return fmt.Sprintf("`%s` ⚠ (scan found no Schema Registry — re-scan or correct the strategy)", strategy)
+	}
+	if !knownSchemaStrategy(strategy) && strategy != SchemaStrategyUnknown {
+		return fmt.Sprintf("`%s` ⚠ (unrecognised value — see Actions Needed)", strategy)
 	}
 	return fmt.Sprintf("`%s`", strategy)
 }
@@ -1411,4 +1530,314 @@ func quoteAll(values []string) []string {
 		out = append(out, "`"+v+"`")
 	}
 	return out
+}
+
+// ----- §red flags -----
+
+// writeRedFlags renders the fleet-wide §Red Flags section.
+// Triggered rows lead the section with their evidence; NotTriggered
+// and Unknown rows collapse into a tail summary (count + comma list)
+// so the customer can scan triggered items in one screenful even on
+// a 15-row table.
+func writeRedFlags(b *bytes.Buffer, rf *types.RedFlagsSection, section int) {
+	if rf == nil || len(rf.Rows) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "## %d. Red Flags\n\n", section)
+	b.WriteString("Items below aren't blockers — they're things to discuss with your Confluent SE. Each row's evidence is the field path + value from the scan so the conversation grounds in scan facts, not inference.\n\n")
+	var triggered, unknown, notTriggered []types.RedFlag
+	for _, r := range rf.Rows {
+		switch r.Status {
+		case types.RedFlagTriggered:
+			triggered = append(triggered, r)
+		case types.RedFlagUnknown:
+			unknown = append(unknown, r)
+		default:
+			notTriggered = append(notTriggered, r)
+		}
+	}
+	if len(triggered) > 0 {
+		b.WriteString("### Triggered\n\n")
+		for _, r := range triggered {
+			fmt.Fprintf(b, "- 🔴 **%s**\n", r.Title)
+			if r.Evidence != "" {
+				fmt.Fprintf(b, "  - _Evidence:_ %s\n", r.Evidence)
+			}
+		}
+		b.WriteString("\n")
+	}
+	if len(unknown) > 0 {
+		b.WriteString("### Not scanned (declare in `plan-inputs.yaml` or re-run the scanner)\n\n")
+		for _, r := range unknown {
+			fmt.Fprintf(b, "- ❔ **%s**\n", r.Title)
+			if r.Evidence != "" {
+				fmt.Fprintf(b, "  - _Evidence:_ %s\n", r.Evidence)
+			}
+		}
+		b.WriteString("\n")
+	}
+	if len(notTriggered) > 0 {
+		labels := make([]string, 0, len(notTriggered))
+		for _, r := range notTriggered {
+			labels = append(labels, r.Title)
+		}
+		// Inline comma list reads fine for short tails; once the
+		// list outgrows the screen (≥ 6 items) hide it behind
+		// <details> so the rendered Plan stays scannable.
+		const inlineThreshold = 5
+		if len(labels) <= inlineThreshold {
+			fmt.Fprintf(b, "_Not triggered (%d): %s._\n\n", len(labels), strings.Join(labels, "; "))
+		} else {
+			fmt.Fprintf(b, "<details><summary><em>Not triggered (%d) — expand</em></summary>\n\n", len(labels))
+			for _, l := range labels {
+				fmt.Fprintf(b, "- %s\n", l)
+			}
+			b.WriteString("\n</details>\n\n")
+		}
+	}
+}
+
+// ----- §effort signals -----
+
+// writeEffortSignals renders the fleet-wide list of quantitative
+// effort inputs. The customer's PM uses these counts (combined with
+// their team's velocity) to scope days of work — kcp doesn't ship a
+// day-count estimate itself.
+//
+// Rendering rules:
+//   - When every signal is zero, collapse to a one-liner. The full
+//     table-of-zeros + caveat block was noise — most scenarios hit
+//     that case and the reader's eyes glaze.
+//   - Non-zero counts render in a table; caveats sit inline as
+//     superscript-referenced footnotes only for rows that have them.
+//     Verbose label-repeating bullets dropped.
+//   - Structurally-unobservable zero (e.g. IAM client count when the
+//     client-inventory scan didn't run) renders as `_unknown_`
+//     instead of `0` so the customer doesn't read it as "no work".
+func writeEffortSignals(b *bytes.Buffer, es *types.EffortSignalsSection, section int) {
+	if es == nil || len(es.Signals) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "## %d. Effort Signals\n\n", section)
+	b.WriteString("Quantitative inputs your PM consumes to scope migration effort. kcp doesn't ship a day-count — these counts plus your team's velocity produce the estimate.\n\n")
+	// "All-zero" carve-out: only collapse when EVERY signal has a
+	// concrete Count of 0 (the scan ran AND returned zero). A `nil`
+	// Count means "scan didn't run / unobservable" — that's a
+	// surface-worthy state, not a collapse trigger. Without this
+	// carve-out the IAM-unknown signal silently disappeared.
+	allConcreteZero := true
+	for _, s := range es.Signals {
+		if s.Count == nil || *s.Count > 0 {
+			allConcreteZero = false
+			break
+		}
+	}
+	if allConcreteZero {
+		b.WriteString("_No effort signals triggered — every signal returned zero. (Pattern-free topic names can also produce zero counts; if you have IAM clients, Connect fleets, or Glue schemas you'd expect to see, re-run the matching `kcp scan ...` subcommand.)_\n\n")
+		return
+	}
+	// Footnote markers are assigned by ROW POSITION, not by "has a
+	// note today". This keeps marker numbers stable across plans
+	// even when some rows are unknown vs zero — a reader comparing
+	// two plans sees the same signal referenced by the same `¹` /
+	// `²` regardless of state. Rows without a note get no marker.
+	footnoteFor := make([]int, len(es.Signals))
+	footnoteForIdx := 0
+	for i, s := range es.Signals {
+		footnoteForIdx++
+		if s.Note == "" {
+			footnoteFor[i] = 0
+			continue
+		}
+		footnoteFor[i] = footnoteForIdx
+	}
+	b.WriteString("| Count | Signal |\n")
+	b.WriteString("|---:|---|\n")
+	for i, s := range es.Signals {
+		label := s.Label
+		if footnoteFor[i] > 0 {
+			label += effortSignalSuperscript(footnoteFor[i])
+		}
+		fmt.Fprintf(b, "| %s | %s |\n", effortSignalCountCell(s), label)
+	}
+	b.WriteString("\n")
+	hasAnyNote := false
+	for _, s := range es.Signals {
+		if s.Note != "" {
+			hasAnyNote = true
+			break
+		}
+	}
+	if hasAnyNote {
+		b.WriteString("**Notes:**\n\n")
+		for i, s := range es.Signals {
+			if s.Note == "" {
+				continue
+			}
+			fmt.Fprintf(b, "%s %s\n", effortSignalSuperscript(footnoteFor[i]), s.Note)
+		}
+		b.WriteString("\n")
+	}
+}
+
+// effortSignalCountCell renders the count column. `nil` Count is the
+// signal's structurally-unobservable state (the upstream scan didn't
+// run); render it as `_unknown_` so the customer doesn't read it as
+// "no work". Concrete 0 stays as `0` — the scan ran and returned
+// zero hits.
+func effortSignalCountCell(s types.EffortSignal) string {
+	if s.Count == nil {
+		return "_unknown_"
+	}
+	return fmt.Sprintf("%d", *s.Count)
+}
+
+// effortSignalSuperscript returns the Unicode superscript glyph for
+// n in 1..9. Falls back to `^n` for n > 9.
+func effortSignalSuperscript(n int) string {
+	if n < 1 || n > 9 {
+		return fmt.Sprintf("^%d", n)
+	}
+	return []string{"¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"}[n-1]
+}
+
+// ----- §tiered storage -----
+
+// writeTieredStorage renders the per-cluster tiered-storage view +
+// the three-dimension trade-off table. Customer-decision shaped: no
+// dollar estimate, no recommendation — kcp surfaces the mechanism /
+// duration / cost-direction so the customer (and account team) can
+// decide whether the cold data is worth re-fetching.
+func writeTieredStorage(b *bytes.Buffer, ts *types.TieredStorageSection, section int) {
+	if ts == nil || len(ts.Clusters) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "## %d. Tiered Storage\n\n", section)
+	b.WriteString("Cluster Linking does **not** carry historical tiered data forward. This section names the three dimensions of the trade-off (mechanism / duration / cost direction) so you can decide whether the cold data is worth re-fetching.\n\n")
+
+	// Per-cluster header
+	b.WriteString("**Clusters with tiered storage enabled:**\n\n")
+	b.WriteString("| Cluster | Storage mode | Remote log size (peak) |\n")
+	b.WriteString("|---|---|---:|\n")
+	missingMetric := false
+	for _, c := range ts.Clusters {
+		if c.RemoteLogSizeBytes <= 0 {
+			missingMetric = true
+		}
+		fmt.Fprintf(b, "| %s | `%s` | %s |\n", c.ClusterID, c.StorageMode, formatBytesHuman(c.RemoteLogSizeBytes))
+	}
+	if missingMetric {
+		b.WriteString("\n_`_not collected_` means CloudWatch's `RemoteLogSizeBytes` aggregate is absent from the state file's metric window — re-run `kcp discover` with metrics enabled to populate it. The Trade-off framing below applies regardless._\n")
+	}
+	b.WriteString("\n")
+
+	// Three dimensions as a bullet list — matches §Cutover's rhythm.
+	// A 3-row "Dimension / What it is" table was visually heavier
+	// than the content warranted (the rows are a glossary, not a
+	// comparison).
+	b.WriteString("**Three dimensions of the trade-off:**\n\n")
+	b.WriteString("- **Mechanism — S3 re-fetch.** Backfilling means re-reading from MSK tiered storage (S3) and re-publishing into CC. Cluster Linking does not carry historical tiered data forward; some external tool (or extended dual-run) re-fetches it.\n")
+	b.WriteString("- **Duration — backfill time.** Time-to-complete is a function of GB volume and ingest rate. Large historical volumes can take days or weeks to backfill.\n")
+	b.WriteString("- **Cost direction — backfill $.** S3 GET / data-transfer-out charges on MSK, plus extra CC ingest. kcp does not estimate dollars; pull the AWS unit prices from your account team.\n")
+	b.WriteString("\n")
+
+	// Customer declarations
+	fmt.Fprintf(b, "- **Consumer history requirement (declared):** `%s`\n", ts.ConsumerHistoryRequirement)
+	strategy := ts.HistoricalDataStrategy
+	if strategy == "" {
+		fmt.Fprintf(b, "- **Historical data strategy:** _undeclared — see §Actions Needed_\n")
+	} else {
+		fmt.Fprintf(b, "- **Historical data strategy:** `%s`\n", strategy)
+	}
+	b.WriteString("\n")
+}
+
+// formatBytesHuman renders a byte count as KB / MB / GB / TB with a
+// single decimal. Returns `_not collected_` when v is zero — the
+// CloudWatch metric was not present in the state file.
+func formatBytesHuman(v float64) string {
+	if v <= 0 {
+		return "_not collected_"
+	}
+	const (
+		kb = 1024.0
+		mb = kb * 1024
+		gb = mb * 1024
+		tb = gb * 1024
+	)
+	switch {
+	case v >= tb:
+		return fmt.Sprintf("%.1f TB", v/tb)
+	case v >= gb:
+		return fmt.Sprintf("%.1f GB", v/gb)
+	case v >= mb:
+		return fmt.Sprintf("%.1f MB", v/mb)
+	default:
+		return fmt.Sprintf("%.1f KB", v/kb)
+	}
+}
+
+// ----- §cost reconciliation -----
+
+// writeCostReconciliation renders the per-region table of MSK
+// instance types billed by AWS but NOT discovered by `kcp discover`.
+// No materiality threshold — the customer (FinOps / cloud lead /
+// platform engineer) decides which candidates are "real" hidden
+// clusters vs. decommissioned-but-still-billed ones.
+func writeCostReconciliation(b *bytes.Buffer, cr *types.CostReconciliationSection, section int) {
+	if cr == nil || len(cr.Candidates) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "## %d. Cost vs Inventory Reconciliation\n\n", section)
+	b.WriteString("MSK instance types that show up in the AWS cost report but were NOT discovered by `kcp discover`. Sorted by spend descending — no materiality threshold; the customer (FinOps / cloud lead) decides what's real vs. decommissioned-but-still-billed.\n\n")
+	b.WriteString("| Region | Instance type | Total spend (USD) | Billing window (months observed / days observed) |\n")
+	b.WriteString("|---|---|---:|---:|\n")
+	for _, c := range cr.Candidates {
+		fmt.Fprintf(b, "| %s | `%s` | $%s | %d / %d |\n",
+			c.Region, c.InstanceType, formatUSDWithCommas(c.TotalSpend), c.MonthsObserved, c.DaysObserved)
+	}
+	b.WriteString("\n")
+	b.WriteString("_Cross-reference each candidate with your AWS console; common causes: a cluster intentionally excluded from `kcp discover` scope, a decommissioned cluster still showing up on the bill, or a cross-account cluster the scanner's IAM role can't see._\n\n")
+}
+
+// formatUSDWithCommas renders a dollar amount with thousands
+// separators and 2 decimal places (`1234567.89` → `1,234,567.89`).
+// Keeps amounts in §Cost Reconciliation scannable at a glance.
+//
+// Two non-obvious cases the old implementation got wrong:
+//   - **Negative values in (-1, 0)** (e.g. AWS credit of $-0.99):
+//     `int64(-0.99) == 0` and `"0"` has len ≤ 3, so the
+//     neg-prefix branch was skipped. Tracking `neg` from the float
+//     itself fixes this.
+//   - **Fractional carry** (e.g. `v = 1.999`): rounding the fraction
+//     separately to `100` cents produced `"1.100"`. Rounding the
+//     whole value with `math.Round(v*100)` first, then splitting
+//     into whole + cents, avoids the carry hole.
+func formatUSDWithCommas(v float64) string {
+	neg := v < 0
+	abs := v
+	if neg {
+		abs = -abs
+	}
+	cents := int64(math.Round(abs * 100))
+	whole := cents / 100
+	frac := cents % 100
+	wholeStr := fmt.Sprintf("%d", whole)
+	// Insert commas every 3 digits from the right when the whole part
+	// is large enough to need them.
+	if len(wholeStr) > 3 {
+		var grouped []string
+		for i := len(wholeStr); i > 0; i -= 3 {
+			lo := i - 3
+			if lo < 0 {
+				lo = 0
+			}
+			grouped = append([]string{wholeStr[lo:i]}, grouped...)
+		}
+		wholeStr = strings.Join(grouped, ",")
+	}
+	if neg {
+		wholeStr = "-" + wholeStr
+	}
+	return fmt.Sprintf("%s.%02d", wholeStr, frac)
 }

--- a/internal/services/plan/render_markdown_test.go
+++ b/internal/services/plan/render_markdown_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -392,6 +393,111 @@ func TestDetectGlobalCustomerTriggers_PartialFireKeepsInline(t *testing.T) {
 	perClusterCount := strings.Count(body, "  - ⚠ **Cost callout:**")
 	szTradeoffCount := strings.Count(body, "Single-Zone resilience tradeoff")
 	assert.Equal(t, 0, bannerCount, "partial fire (2 of 3) must NOT collapse to a global banner")
-	assert.Equal(t, 2, perClusterCount, "each firing cluster must keep its inline cost callout when scope is partial")
-	assert.Equal(t, 2, szTradeoffCount, "each SZ cluster must keep its inline resilience tradeoff when scope is partial")
+	// Both firing clusters share identical rationale + identical extras,
+	// so they collapse to ONE bullet with both clusters listed and the
+	// inline cost callout rendered once. The non-firing cluster (c) is
+	// its own bullet with no callout. Pre-fix behavior rendered the
+	// same paragraph N times; post-fix collapses identical paragraphs.
+	assert.Equal(t, 1, perClusterCount, "identical inline cost callouts must collapse to one bullet across firing clusters")
+	assert.Equal(t, 1, szTradeoffCount, "identical SZ tradeoff callouts must collapse to one bullet across firing clusters")
+}
+
+// groupOpenQuestions collapses two OQs identical except for the
+// embedded `--region <X>` flag in HowToClose: the per-region command
+// difference must NOT defeat the grouping, and the renderer should
+// swap a `<region>` placeholder once multiple distinct regions exist
+// in the merged group.
+func TestGroupOpenQuestions_RegionFlagNormalizationCollapses(t *testing.T) {
+	oqs := []types.OpenQuestion{
+		{
+			ID:         "auth_posture_unknown",
+			ClusterID:  "a",
+			Title:      "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
+			Body:       "Body shared across regions",
+			HowToClose: "Re-run `kcp discover --region us-east-1` against the source AWS account.",
+		},
+		{
+			ID:         "auth_posture_unknown",
+			ClusterID:  "b",
+			Title:      "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
+			Body:       "Body shared across regions",
+			HowToClose: "Re-run `kcp discover --region eu-central-1` against the source AWS account.",
+		},
+	}
+	groups := groupOpenQuestions(oqs)
+	require.Len(t, groups, 1, "OQs identical except for --region must collapse to one group")
+	require.Len(t, groups[0].clusters, 2)
+	require.Len(t, groups[0].regions, 2, "the two distinct regions must be tracked")
+}
+
+// Renderer swap path: when a grouped OQ spans multiple regions, the
+// concrete `--region <X>` is replaced with `--region <region>` in the
+// rendered HowToClose so the user sees a generic command, not the
+// first-seen region.
+func TestActionsNeededRender_MultiRegionGroupSwapsPlaceholder(t *testing.T) {
+	cfg := defaultCfg(t)
+	p := &types.Plan{
+		OpenQuestions: []types.OpenQuestion{
+			{
+				ID:         "auth_posture_unknown",
+				ClusterID:  "a",
+				Title:      "No client-authentication methods detected — region a",
+				Body:       "shared body",
+				HowToClose: "Re-run `kcp discover --region us-east-1` against the source AWS account.",
+			},
+			{
+				ID:         "auth_posture_unknown",
+				ClusterID:  "b",
+				Title:      "No client-authentication methods detected — region a",
+				Body:       "shared body",
+				HowToClose: "Re-run `kcp discover --region eu-central-1` against the source AWS account.",
+			},
+		},
+	}
+	out, err := RenderMarkdown(p, cfg)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, "--region <region>", "multi-region grouped OQ must render a placeholder")
+	assert.NotContains(t, body, "--region us-east-1", "concrete first-seen region must be swapped out")
+	assert.NotContains(t, body, "--region eu-central-1")
+}
+
+// §5 Schema Migration "Scan gap" branch: when the customer declared
+// `migrate_existing_schema_registry` but the scan found no SR, both
+// the recommended-path line and the strategy-declared line should
+// surface the contradiction so the reader doesn't see a misleading
+// "Pending — declare the missing input".
+func TestSchemaLabels_ScanGapWhenDeclaredButNotScanned(t *testing.T) {
+	dec := &types.SchemaDecision{Source: types.SchemaSourceNone}
+	pathLabel := schemaPathsLabelForContext(nil, SchemaStrategyMigrateExistingSchemaRegistry, dec.Source)
+	assert.Contains(t, pathLabel, "Scan gap", "recommended-path should call out the scan gap explicitly")
+	assert.Contains(t, pathLabel, "re-run", "scan-gap label must nudge the customer to re-run the scan")
+
+	strategyLabel := schemaStrategyDeclaredLabel(SchemaStrategyMigrateExistingSchemaRegistry, dec)
+	assert.Contains(t, strategyLabel, "⚠", "declared strategy must carry the ⚠ marker when it contradicts the scan")
+	assert.Contains(t, strategyLabel, "no Schema Registry", "the strategy label must name the contradiction")
+}
+
+// formatUSDWithCommas handles the edge cases that broke the prior
+// implementation: small-magnitude negatives losing their sign, and
+// fractional carry on values just below an integer boundary.
+func TestFormatUSDWithCommas(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "0.00"},
+		{0.5, "0.50"},
+		{1.999, "2.00"},      // fractional carry
+		{-0.99, "-0.99"},     // small-magnitude negative kept its sign
+		{1234.5, "1,234.50"}, // thousands separator
+		{1234567.89, "1,234,567.89"},
+		{-1234567.89, "-1,234,567.89"},
+		{1795.75, "1,795.75"}, // the canonical §Cost Reconciliation amount
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%v", c.in), func(t *testing.T) {
+			assert.Equal(t, c.want, formatUSDWithCommas(c.in))
+		})
+	}
 }

--- a/internal/services/plan/schema.go
+++ b/internal/services/plan/schema.go
@@ -35,7 +35,7 @@ func knownSchemaCPEdition(value string) bool {
 	return knownEnum(value, SchemaCPEditionEnterprise, SchemaCPEditionCommunity)
 }
 
-// DecideSchema produces the fleet-wide schema migration recommendation.
+// decideSchema produces the fleet-wide schema migration recommendation.
 // The branches:
 //   - Glue detected                    → kcp_migrate_schemas_glue
 //   - Confluent + eligible             → schema_linking
@@ -50,7 +50,7 @@ func knownSchemaCPEdition(value string) bool {
 // The result's `Paths` slice carries every verdict that applies —
 // usually one entry, two for the dual-source case so JSON consumers
 // branching on a single slot don't miss the second arm.
-func DecideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.SchemaDecision {
+func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.SchemaDecision {
 	source, confluentURLs, glueNames := detectSchemaSource(state)
 	strategy := inputs.SchemaStrategy
 	if strategy == "" {
@@ -126,7 +126,7 @@ func DecideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 }
 
 // confluentEligibilityPath maps the three-flag eligibility verdict
-// onto the corresponding SchemaPath. Extracted from DecideSchema so
+// onto the corresponding SchemaPath. Extracted from decideSchema so
 // both the pure-Confluent and the dual ConfluentAndGlue branches share
 // one rule.
 func confluentEligibilityPath(dec *types.SchemaDecision) types.SchemaPath {
@@ -143,7 +143,7 @@ func confluentEligibilityPath(dec *types.SchemaDecision) types.SchemaPath {
 // primaryPath returns the first Path on a SchemaDecision, or
 // SchemaPathUnknown if Paths is empty. Package-private — only test
 // assertions care about the leading verdict; production code uses
-// HasPath or reads `dec.Paths` directly.
+// hasPath or reads `dec.Paths` directly.
 func primaryPath(dec *types.SchemaDecision) types.SchemaPath {
 	if dec == nil || len(dec.Paths) == 0 {
 		return types.SchemaPathUnknown
@@ -159,10 +159,10 @@ func sourceTouchesConfluent(s types.SchemaSource) bool {
 	return s == types.SchemaSourceConfluent || s == types.SchemaSourceConfluentAndGlue
 }
 
-// HasPath reports whether a SchemaDecision's Paths slice contains `p`.
+// hasPath reports whether a SchemaDecision's Paths slice contains `p`.
 // Used by Build to decide whether to suppress the §Schema section
 // (schemaless) and by the renderer for path-specific rendering.
-func HasPath(dec *types.SchemaDecision, p types.SchemaPath) bool {
+func hasPath(dec *types.SchemaDecision, p types.SchemaPath) bool {
 	if dec == nil {
 		return false
 	}
@@ -253,7 +253,7 @@ func schemaLinkingEligibilityVerdict(dec *types.SchemaDecision) eligibilityVerdi
 
 // detectSchemaOpenQuestions surfaces what the customer must close
 // before the schema-migration verdict above is fully reliable. Called
-// after DecideSchema so the detector can read the verdict directly
+// after decideSchema so the detector can read the verdict directly
 // rather than recomputing eligibility flags. Takes `cfg` so the OQ
 // body can quote the configured CP-version floor + edition the same
 // way the rendered eligibility table does — keeps the two surfaces

--- a/internal/services/plan/schema_test.go
+++ b/internal/services/plan/schema_test.go
@@ -35,7 +35,7 @@ func ptrBool(b bool) *bool { return &b }
 // Glue detected → kcp_migrate_schemas_glue, regardless of strategy
 // (the kcp-automated path doesn't need a strategy declaration).
 func TestDecideSchema_GlueDetected(t *testing.T) {
-	dec := DecideSchema(schemaState(nil, []string{"my-glue"}), defaultCfg(t), schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry))
+	dec := decideSchema(schemaState(nil, []string{"my-glue"}), defaultCfg(t), schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceGlue, dec.Source)
 	assert.Equal(t, types.SchemaPathMigrateGlue, primaryPath(dec))
@@ -49,7 +49,7 @@ func TestDecideSchema_ConfluentEligible(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
 	inputs.SourceSROutboundReachableToCC = ptrBool(true)
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
 	assert.Equal(t, types.SchemaPathSchemaLinking, primaryPath(dec))
@@ -66,7 +66,7 @@ func TestDecideSchema_ConfluentBelowCPFloor(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
 	inputs.SourceSROutboundReachableToCC = ptrBool(true)
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
 	require.NotNil(t, dec.MeetsCPVersionFloor)
@@ -80,7 +80,7 @@ func TestDecideSchema_ConfluentCommunityEdition(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionCommunity
 	inputs.SourceSROutboundReachableToCC = ptrBool(true)
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
 	require.NotNil(t, dec.MeetsCPEditionRequirement)
@@ -94,7 +94,7 @@ func TestDecideSchema_ConfluentReachabilityUnknown(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
 	// SourceSROutboundReachableToCC left nil
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
 	assert.Nil(t, dec.SourceSROutboundReachable, "nil tri-state preserved when input is unset")
@@ -102,7 +102,7 @@ func TestDecideSchema_ConfluentReachabilityUnknown(t *testing.T) {
 
 // State empty + strategy=no_schemas → schemaless (section omitted by Build).
 func TestDecideSchema_NoneAndNoSchemas(t *testing.T) {
-	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
+	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceNone, dec.Source)
 	assert.Equal(t, types.SchemaPathSchemaless, primaryPath(dec))
@@ -110,14 +110,14 @@ func TestDecideSchema_NoneAndNoSchemas(t *testing.T) {
 
 // Strategy=unknown (default) → unknown (OQ asks customer to declare).
 func TestDecideSchema_StrategyUnknown(t *testing.T) {
-	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyUnknown))
+	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyUnknown))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
 }
 
 // Strategy typo'd → unknown (OQ flags the typo before any path applies).
 func TestDecideSchema_StrategyTypo(t *testing.T) {
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs("no_schemaz"))
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs("no_schemaz"))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "typo'd strategy must not select a downstream path")
 }
@@ -131,14 +131,14 @@ func TestDecideSchema_ConfluentAndGlue(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
 	inputs.SourceSROutboundReachableToCC = ptrBool(true)
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceConfluentAndGlue, dec.Source)
 	require.Len(t, dec.Paths, 2, "dual-source must carry both arms in Paths")
 	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0], "Glue path renders first")
 	assert.Equal(t, types.SchemaPathSchemaLinking, dec.Paths[1], "Confluent verdict in second slot")
-	assert.True(t, HasPath(dec, types.SchemaPathSchemaLinking))
-	assert.True(t, HasPath(dec, types.SchemaPathMigrateGlue))
+	assert.True(t, hasPath(dec, types.SchemaPathSchemaLinking))
+	assert.True(t, hasPath(dec, types.SchemaPathMigrateGlue))
 	require.NotNil(t, dec.MeetsCPVersionFloor, "Confluent eligibility populated even when Glue is the leading verdict")
 }
 
@@ -149,11 +149,11 @@ func TestDecideSchema_ConfluentAndGlue_PendingConfluentArmDropped(t *testing.T) 
 	inputs := schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry)
 	// All eligibility inputs left nil → Confluent arm unknown.
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	require.Len(t, dec.Paths, 1, "pending Confluent arm must NOT serialise as Paths[1]==unknown")
 	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
-	assert.False(t, HasPath(dec, types.SchemaPathUnknown))
+	assert.False(t, hasPath(dec, types.SchemaPathUnknown))
 }
 
 // Dual-source with Confluent arm INELIGIBLE (e.g. CP below floor) —
@@ -164,7 +164,7 @@ func TestDecideSchema_ConfluentAndGlue_ConfluentArmIneligible(t *testing.T) {
 	inputs.ConfluentSRCPEdition = SchemaCPEditionEnterprise
 	inputs.SourceSROutboundReachableToCC = ptrBool(true)
 
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	require.Len(t, dec.Paths, 2)
 	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
@@ -176,7 +176,7 @@ func TestDecideSchema_ConfluentAndGlue_ConfluentArmIneligible(t *testing.T) {
 // the customer's intent is real but kcp can't recommend a concrete
 // path until a source SR is scanned or "no existing SR" is confirmed.
 func TestDecideSchema_NoneWithAdoptStrategy(t *testing.T) {
-	dec := DecideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyAdoptSchemasDuringMigration))
+	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyAdoptSchemasDuringMigration))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceNone, dec.Source)
 	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
@@ -189,7 +189,7 @@ func TestDecideSchema_NoneWithAdoptStrategy(t *testing.T) {
 // 3-row table to someone who said they're not migrating schemas.
 // The mismatch OQ carries the contradiction.
 func TestDecideSchema_NoSchemasButConfluentDetected(t *testing.T) {
-	dec := DecideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
+	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
 	require.NotNil(t, dec)
 	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
 	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "verdict short-circuits to unknown; OQ carries the message")
@@ -245,14 +245,19 @@ func TestCPVersionAtLeast(t *testing.T) {
 		{"7.5.1", "7.0", true},
 		{"6.2.1", "7.0", false},
 		{"8.0", "7.0", true},
-		{"latest", "7.0", true},     // "latest" always clears any floor
-		{"current", "7.0", true},    // case-insensitive alias
-		{"LATEST", "7.0", true},     // case-insensitive
-		{"7.0.0-rc1", "7.0", true},  // pre-release suffix stripped before compare
-		{"7.0+build5", "7.0", true}, // build-metadata suffix stripped
-		{"6.2.1-rc3", "7.0", false}, // pre-release stripped, base compares below floor
-		{"garbage", "7.0", false},   // truly unparseable → safe direction (false)
-		{"7.-1.0", "7.0", false},    // negative segment rejected → unparseable
+		{"latest", "7.0", true},        // "latest" always clears any floor
+		{"current", "7.0", true},       // case-insensitive alias
+		{"LATEST", "7.0", true},        // case-insensitive
+		{"7.0.0-rc1", "7.0", true},     // pre-release suffix stripped before compare
+		{"7.0+build5", "7.0", true},    // build-metadata suffix stripped
+		{"6.2.1-rc3", "7.0", false},    // pre-release stripped, base compares below floor
+		{"garbage", "7.0", false},      // truly unparseable → safe direction (false)
+		{"7.-1.0", "7.0", false},       // negative segment rejected → unparseable
+		{"3.8.x", "2.4.0", true},       // AWS MSK trailing 'x' suffix → 3.8.0 clears 2.4.0
+		{"4.0.x.kraft", "2.4.0", true}, // AWS MSK KRaft suffix → 4.0.0 clears 2.4.0
+		{"3.9.x.kraft", "3.9.0", true}, // trailing alphanumeric segments treated as 0
+		{"3.8.x", "3.8.1", false},      // 'x' is a placeholder; conservatively treated as 0, so 3.8.0 < 3.8.1
+		{"x.8.0", "2.4.0", false},      // first segment non-numeric → unparseable, safe direction
 	}
 	for _, c := range cases {
 		t.Run(c.have+"_vs_"+c.floor, func(t *testing.T) {

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -10,7 +10,7 @@ import (
 // bytesPerMBps turns CloudWatch byte-rates into MBps (1024 * 1024).
 const bytesPerMBps = 1_048_576.0
 
-// ComputeClusterSizing implements the deterministic sizing formula:
+// computeClusterSizing implements the deterministic sizing formula:
 //
 //	max_ratio = max(P95In/per_eCKU_ingress_mbps,
 //	                P95Out/per_eCKU_egress_mbps,
@@ -26,7 +26,7 @@ const bytesPerMBps = 1_048_576.0
 // FinalECKU = SLA floor and Degraded = true rather than failing the whole
 // plan build. The renderer surfaces the gap so the customer knows the
 // sizing column is a placeholder.
-func ComputeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterSizing {
+func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterSizing {
 	caps := cfg.EnterpriseCaps
 	aggs := c.ClusterMetrics.Aggregates
 

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -53,7 +53,7 @@ func TestComputeClusterSizing_EgressDominant(t *testing.T) {
 	// well above ingress and partitions, so the egress dimension wins and
 	// sizing snaps to 8 eCKU.
 	c := fixtureCluster("read-heavy", 2058, 88.7, 994.8, 99.0, 1200.0)
-	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	s := computeClusterSizing(c, defaultCfg(t), defaultInputs())
 
 	assert.False(t, s.Degraded)
 	assert.InDelta(t, 88.7, s.SizedInMBps, 0.1)
@@ -69,7 +69,7 @@ func TestComputeClusterSizing_SLAFloorBinds(t *testing.T) {
 	c := fixtureCluster("small", 10, 0.1, 0.1, 0.2, 0.2)
 	inputs := defaultInputs()
 	inputs.SLATarget = "99.99"
-	s := ComputeClusterSizing(c, defaultCfg(t), inputs)
+	s := computeClusterSizing(c, defaultCfg(t), inputs)
 	assert.Equal(t, 1, s.SizedECKU)
 	assert.Equal(t, 2, s.SLAFloorECKU)
 	assert.Equal(t, 2, s.FinalECKU)
@@ -83,7 +83,7 @@ func TestComputeClusterSizing_DegradedOnMissingP95(t *testing.T) {
 		ClusterMetrics:              types.ProcessedClusterMetrics{Aggregates: map[string]types.MetricAggregate{}},
 		KafkaAdminClientInformation: types.KafkaAdminClientInformation{Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: 50}}},
 	}
-	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	s := computeClusterSizing(c, defaultCfg(t), defaultInputs())
 	require.True(t, s.Degraded)
 	assert.Contains(t, s.DegradedReason, "BytesInPerSec")
 	assert.Equal(t, 50, s.UserPartitions)
@@ -94,7 +94,7 @@ func TestComputeClusterSizing_DegradedOnMissingP95(t *testing.T) {
 func TestComputeClusterSizing_SpikyDetection(t *testing.T) {
 	// Peak 5× P95 → spiky flag fires.
 	c := fixtureCluster("spike", 100, 10.0, 10.0, 50.0, 50.0)
-	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	s := computeClusterSizing(c, defaultCfg(t), defaultInputs())
 	assert.True(t, s.SpikyIngress)
 	assert.True(t, s.SpikyEgress)
 }
@@ -102,7 +102,7 @@ func TestComputeClusterSizing_SpikyDetection(t *testing.T) {
 func TestComputeClusterSizing_PartitionWinner(t *testing.T) {
 	// 100k partitions dominate throughput in the max-ratio.
 	c := fixtureCluster("part", 100_000, 1.0, 1.0, 1.0, 1.0)
-	s := ComputeClusterSizing(c, defaultCfg(t), defaultInputs())
+	s := computeClusterSizing(c, defaultCfg(t), defaultInputs())
 	// partition ratio = 100000 / 3000 = 33.33; CEIL(33.33 * 1.30) = 44
 	assert.Equal(t, 44, s.SizedECKU)
 }

--- a/internal/services/plan/tiered_storage.go
+++ b/internal/services/plan/tiered_storage.go
@@ -1,0 +1,156 @@
+package plan
+
+import (
+	"github.com/confluentinc/kcp/internal/types"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+// Plan-input enum tokens for tiered-storage knobs. Stable
+// customer-facing strings; the resolver surfaces them through
+// PlanInputsResolved.ConsumerHistoryRequirement and HistoricalDataStrategy.
+const (
+	ConsumerHistoryRequired    = "required"
+	ConsumerHistoryNotRequired = "not_required"
+	ConsumerHistoryUnknown     = "unknown"
+
+	HistoricalKeepMSKRunning = "keep_msk_running_until_data_expires"
+	HistoricalBulkLoadExtern = "bulk_load_historical_via_external_tool"
+	HistoricalDeferToAccount = "defer_to_account_team"
+)
+
+// detectTieredStorage produces the per-cluster tiered-storage view.
+// Returns nil when no source cluster has tiered storage enabled —
+// section is omitted entirely in that case (most fleets won't use it).
+//
+// The section is intentionally informational: kcp does not pick a
+// migration path here. The renderer surfaces the three-dimension
+// trade-off (mechanism / duration / cost direction) so the customer
+// (and account team) can decide whether the cold data is worth
+// re-fetching.
+func detectTieredStorage(state types.ProcessedState, inputs types.PlanInputsResolved) *types.TieredStorageSection {
+	clusters := collectClusters(state)
+	var tiered []types.TieredStorageCluster
+	for _, c := range clusters {
+		if clusterStorageMode(c) != kafkatypes.StorageModeTiered {
+			continue
+		}
+		tiered = append(tiered, types.TieredStorageCluster{
+			ClusterID:          c.Name,
+			StorageMode:        string(kafkatypes.StorageModeTiered),
+			RemoteLogSizeBytes: remoteLogSizeBytesOf(c),
+		})
+	}
+	if len(tiered) == 0 {
+		return nil
+	}
+	return &types.TieredStorageSection{
+		Clusters:                   tiered,
+		ConsumerHistoryRequirement: defaultedConsumerHistory(inputs.ConsumerHistoryRequirement),
+		HistoricalDataStrategy:     defaultedHistoricalStrategy(inputs.HistoricalDataStrategy, inputs.ConsumerHistoryRequirement),
+	}
+}
+
+// remoteLogSizeBytesOf reads the CloudWatch `RemoteLogSizeBytes`
+// peak (Maximum) for the cluster. Returns 0 when the metric wasn't
+// collected — informational only, not the basis for a dollar
+// estimate.
+//
+// Maximum is the right aggregate for a monotonically-accumulating
+// gauge like RemoteLogSize: it surfaces the peak observed footprint,
+// whereas Average over a 30-day window for a fixed 7-day retention
+// would report ~half the real current footprint. Falls back to
+// Average when Maximum isn't populated.
+func remoteLogSizeBytesOf(c types.ProcessedCluster) float64 {
+	agg, ok := c.ClusterMetrics.Aggregates["RemoteLogSizeBytes"]
+	if !ok {
+		return 0
+	}
+	if agg.Maximum != nil {
+		return *agg.Maximum
+	}
+	if agg.Average != nil {
+		return *agg.Average
+	}
+	return 0
+}
+
+// defaultedConsumerHistory normalizes the customer's
+// `consumer_history_requirement` input: empty (no preference declared)
+// resolves to `required` (the safer default — assume history matters
+// until the customer says otherwise).
+func defaultedConsumerHistory(v string) string {
+	if v == "" {
+		return ConsumerHistoryRequired
+	}
+	return v
+}
+
+// defaultedHistoricalStrategy applies the spec's cascade: when
+// `consumer_history_requirement == not_required`, the strategy
+// defaults to `defer_to_account_team` (the consumer-offset /
+// per-topic cascade is workload-specific and lives with the account
+// team). Otherwise empty stays empty so the renderer can emit an OQ
+// asking the customer to pick.
+func defaultedHistoricalStrategy(v, consumerHistory string) string {
+	if v != "" {
+		return v
+	}
+	if consumerHistory == ConsumerHistoryNotRequired {
+		return HistoricalDeferToAccount
+	}
+	return ""
+}
+
+// knownConsumerHistory + knownHistoricalStrategy validate the
+// customer-declared enums so a typo in plan-inputs.yaml surfaces as
+// an OQ instead of being silently swallowed.
+func knownConsumerHistory(v string) bool {
+	return knownEnum(v, ConsumerHistoryRequired, ConsumerHistoryNotRequired, ConsumerHistoryUnknown)
+}
+
+func knownHistoricalStrategy(v string) bool {
+	return knownEnum(v, HistoricalKeepMSKRunning, HistoricalBulkLoadExtern, HistoricalDeferToAccount)
+}
+
+// detectTieredStorageOpenQuestions emits the OQs that gate full
+// confidence in the tiered-storage recommendation: typos in the two
+// enums and the "you have tiered storage but haven't picked a
+// strategy" prompt.
+func detectTieredStorageOpenQuestions(section *types.TieredStorageSection, inputs types.PlanInputsResolved) []types.OpenQuestion {
+	if section == nil {
+		return nil
+	}
+	var oqs []types.OpenQuestion
+	if !knownConsumerHistory(inputs.ConsumerHistoryRequirement) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "tiered_consumer_history_invalid",
+			Title:      "`consumer_history_requirement` is not a recognised value",
+			Body:       "Recognised values: `required` (default) | `not_required` | `unknown`. The current value falls outside the enum; the Plan treats it as `required` until corrected.",
+			HowToClose: "Set `consumer_history_requirement` in `plan-inputs.yaml` to one of the recognised values, then re-run `kcp report plan`.",
+		})
+	}
+	if inputs.HistoricalDataStrategy != "" && !knownHistoricalStrategy(inputs.HistoricalDataStrategy) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "tiered_historical_strategy_invalid",
+			Title:      "`historical_data_strategy` is not a recognised value",
+			Body:       "Recognised values: `keep_msk_running_until_data_expires` | `bulk_load_historical_via_external_tool` | `defer_to_account_team`. The current value falls outside the enum; the Plan ignores it and treats the strategy as undeclared.",
+			HowToClose: "Set `historical_data_strategy` in `plan-inputs.yaml` to one of the recognised values, then re-run `kcp report plan`.",
+		})
+	}
+	// Strategy undeclared AND the customer either hasn't expressed a
+	// consumer-history preference OR explicitly said `unknown` →
+	// prompt them to pick. The `not_required` cascade auto-defaults
+	// the strategy to `defer_to_account_team` upstream, so this OQ
+	// stays quiet on that branch.
+	consumerHistory := defaultedConsumerHistory(inputs.ConsumerHistoryRequirement)
+	if section.HistoricalDataStrategy == "" && consumerHistory != ConsumerHistoryNotRequired {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "tiered_strategy_undeclared",
+			Title:      "Tiered storage detected — declare `historical_data_strategy` in `plan-inputs.yaml`",
+			Body:       "Cluster Linking does NOT carry historical tiered data forward. Pick the path that matches your operational constraints: keep MSK running until your retention window expires (lowest engineering cost, highest infra cost), bulk-load historical data via an external tool, or defer the cascade to your Confluent account team.",
+			HowToClose: "Set `historical_data_strategy` in `plan-inputs.yaml` to `keep_msk_running_until_data_expires` | `bulk_load_historical_via_external_tool` | `defer_to_account_team`, then re-run `kcp report plan`. If you set `consumer_history_requirement: not_required`, the Plan defaults this to `defer_to_account_team` automatically.",
+		})
+	}
+	return oqs
+}

--- a/internal/services/plan/tiered_storage_test.go
+++ b/internal/services/plan/tiered_storage_test.go
@@ -1,0 +1,124 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+)
+
+// Tiered storage detection picks up StorageMode == "TIERED" and
+// surfaces the cluster in §Tiered Storage.
+func TestDetectTieredStorage_TieredClusterSurfaces(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	local := redFlagCluster("local-cluster", "3.5.0", "", string(kafkatypes.StorageModeLocal))
+	state := wrapClusters(tiered, local)
+
+	section := detectTieredStorage(state, defaultInputs())
+	require.NotNil(t, section)
+	require.Len(t, section.Clusters, 1)
+	assert.Equal(t, "tiered-cluster", section.Clusters[0].ClusterID)
+}
+
+// No tiered storage anywhere → section nils so the renderer omits.
+func TestDetectTieredStorage_NoTieredFleetReturnsNil(t *testing.T) {
+	local := redFlagCluster("local-cluster", "3.5.0", "", string(kafkatypes.StorageModeLocal))
+	state := wrapClusters(local)
+	assert.Nil(t, detectTieredStorage(state, defaultInputs()))
+}
+
+// RemoteLogSizeBytes from CloudWatch aggregates is plumbed through;
+// falls back to Average when Maximum is absent.
+func TestDetectTieredStorage_RemoteLogSizeBytes(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	v := 1024.0 * 1024 * 1024 * 50 // 50 GB
+	tiered.ClusterMetrics.Aggregates = map[string]types.MetricAggregate{
+		"RemoteLogSizeBytes": {Average: &v},
+	}
+	state := wrapClusters(tiered)
+	section := detectTieredStorage(state, defaultInputs())
+	require.NotNil(t, section)
+	require.Len(t, section.Clusters, 1)
+	assert.InDelta(t, v, section.Clusters[0].RemoteLogSizeBytes, 0.1)
+}
+
+// When CloudWatch publishes both Maximum and Average for
+// RemoteLogSizeBytes, the renderer reads Maximum (peak observed
+// footprint) rather than Average — Average over a 30-day window
+// for a fixed 7-day retention would report ~half the real current
+// footprint, which is misleading for the trade-off framing.
+func TestDetectTieredStorage_RemoteLogSizeBytes_MaximumWinsOverAverage(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	avg := 1024.0 * 1024 * 1024 * 20 // 20 GB avg
+	max := 1024.0 * 1024 * 1024 * 50 // 50 GB peak
+	tiered.ClusterMetrics.Aggregates = map[string]types.MetricAggregate{
+		"RemoteLogSizeBytes": {Average: &avg, Maximum: &max},
+	}
+	state := wrapClusters(tiered)
+	section := detectTieredStorage(state, defaultInputs())
+	require.NotNil(t, section)
+	require.Len(t, section.Clusters, 1)
+	assert.InDelta(t, max, section.Clusters[0].RemoteLogSizeBytes, 0.1, "Maximum must win when both aggregates are present")
+}
+
+// consumer_history_requirement defaults to `required` when undeclared.
+// historical_data_strategy stays empty unless the customer declares
+// it, EXCEPT when consumer_history_requirement == not_required (then
+// the cascade defaults strategy to defer_to_account_team).
+func TestDetectTieredStorage_StrategyCascade(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	state := wrapClusters(tiered)
+
+	// Default — required + undeclared strategy.
+	section := detectTieredStorage(state, defaultInputs())
+	require.NotNil(t, section)
+	assert.Equal(t, ConsumerHistoryRequired, section.ConsumerHistoryRequirement)
+	assert.Equal(t, "", section.HistoricalDataStrategy, "default empty strategy when history is required")
+
+	// not_required → defer_to_account_team cascade.
+	inputs := defaultInputs()
+	inputs.ConsumerHistoryRequirement = ConsumerHistoryNotRequired
+	section = detectTieredStorage(state, inputs)
+	require.NotNil(t, section)
+	assert.Equal(t, HistoricalDeferToAccount, section.HistoricalDataStrategy, "cascade defaults to defer when history not required")
+
+	// Explicit strategy declared → respected.
+	inputs.HistoricalDataStrategy = HistoricalBulkLoadExtern
+	section = detectTieredStorage(state, inputs)
+	require.NotNil(t, section)
+	assert.Equal(t, HistoricalBulkLoadExtern, section.HistoricalDataStrategy)
+}
+
+// `tiered_strategy_undeclared` OQ fires when tiered storage is
+// detected, consumer history is required (default), and the strategy
+// hasn't been declared.
+func TestDetectTieredStorageOQ_StrategyUndeclared(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	state := wrapClusters(tiered)
+	section := detectTieredStorage(state, defaultInputs())
+
+	oqs := detectTieredStorageOpenQuestions(section, defaultInputs())
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "tiered_strategy_undeclared", oqs[0].ID)
+}
+
+// Typo in consumer_history_requirement → tiered_consumer_history_invalid OQ.
+func TestDetectTieredStorageOQ_ConsumerHistoryTypo(t *testing.T) {
+	tiered := redFlagCluster("tiered-cluster", "3.5.0", "", string(kafkatypes.StorageModeTiered))
+	state := wrapClusters(tiered)
+	inputs := defaultInputs()
+	inputs.ConsumerHistoryRequirement = "requiredd" // typo
+	section := detectTieredStorage(state, inputs)
+
+	oqs := detectTieredStorageOpenQuestions(section, inputs)
+	found := false
+	for _, oq := range oqs {
+		if oq.ID == "tiered_consumer_history_invalid" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected tiered_consumer_history_invalid OQ for typo")
+}

--- a/internal/services/plan/topic_patterns.go
+++ b/internal/services/plan/topic_patterns.go
@@ -13,21 +13,20 @@ import (
 // look like?" is the kind of drift that bit V2 review round 1.
 
 // Connect internal topic — boundary-required form. The leading
-// `(^|-)` anchor stops a topic like "disconnect-configs" from
-// matching while still permitting both an empty prefix
+// `(?:^|-)` non-capturing anchor stops a topic like "disconnect-configs"
+// from matching while still permitting both an empty prefix
 // (`connect-configs`) and any dash-suffixed prefix
 // (`team-a-connect-configs`). Used by the red-flags row 7
 // cross-check, the row-15 broad-pattern scan, and the
 // effort-signals self-managed Connect fleet counter.
 //
-// Capture groups in this anchored form:
+// Single capture group:
 //
-//	[1] = "" or "-" (the boundary that matched)
-//	[2] = the kind suffix (configs | offsets | status)
+//	[1] = the kind suffix (configs | offsets | status)
 //
-// Use `connectInternalTopicPrefix(topic)` (below) to extract the
-// fleet prefix — it folds out the boundary character so callers
-// don't have to.
+// The boundary is intentionally non-capturing — callers that need the
+// fleet prefix use `connectInternalTopicPrefix(topic)` (below), which
+// derives it from the match-start offset rather than a capture group.
 var connectInternalTopicPattern = regexp.MustCompile(`(?:^|-)connect-(configs|offsets|status)$`)
 
 // connectInternalTopicPrefix returns the fleet prefix portion of a

--- a/internal/services/plan/topic_patterns.go
+++ b/internal/services/plan/topic_patterns.go
@@ -1,0 +1,84 @@
+package plan
+
+import (
+	"regexp"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// Shared topic-name regexes used by both the Red Flags detector
+// (per-row heuristics) and the Effort Signals detector (counters).
+// Lives in its own file so the patterns are a single source of
+// truth — multiple files inferring "what does a Connect fleet topic
+// look like?" is the kind of drift that bit V2 review round 1.
+
+// Connect internal topic — boundary-required form. The leading
+// `(^|-)` anchor stops a topic like "disconnect-configs" from
+// matching while still permitting both an empty prefix
+// (`connect-configs`) and any dash-suffixed prefix
+// (`team-a-connect-configs`). Used by the red-flags row 7
+// cross-check, the row-15 broad-pattern scan, and the
+// effort-signals self-managed Connect fleet counter.
+//
+// Capture groups in this anchored form:
+//
+//	[1] = "" or "-" (the boundary that matched)
+//	[2] = the kind suffix (configs | offsets | status)
+//
+// Use `connectInternalTopicPrefix(topic)` (below) to extract the
+// fleet prefix — it folds out the boundary character so callers
+// don't have to.
+var connectInternalTopicPattern = regexp.MustCompile(`(?:^|-)connect-(configs|offsets|status)$`)
+
+// connectInternalTopicPrefix returns the fleet prefix portion of a
+// Connect internal topic name plus the kind suffix
+// (configs|offsets|status), or ("", "", false) when the name doesn't
+// match. The prefix is what precedes `-connect-…` (empty for the
+// unprefixed default case). Callers use the prefix to group topics
+// into fleets without re-implementing the regex.
+func connectInternalTopicPrefix(topic string) (prefix, kind string, ok bool) {
+	m := connectInternalTopicPattern.FindStringSubmatchIndex(topic)
+	if m == nil {
+		return "", "", false
+	}
+	// m[0] = match start, m[2..3] = group 1 (configs|offsets|status).
+	// The fleet prefix is everything before the match start; when the
+	// match starts at offset 0, the prefix is empty.
+	if m[0] > 0 {
+		prefix = topic[:m[0]]
+	}
+	kind = topic[m[2]:m[3]]
+	return prefix, kind, true
+}
+
+// MM2 checkpoint topic. `<source-alias>.checkpoints.internal` is the
+// MM2 default naming convention; deployments using
+// IdentityReplicationPolicy suppress the prefix entirely (Effort
+// Signal note surfaces that caveat to the customer).
+var mm2CheckpointPattern = regexp.MustCompile(`\.checkpoints\.internal$`)
+
+// Kafka Streams internal topic suffixes. Both the broad-pattern Red
+// Flag row (15) and the Streams cross-check (`kafkaStreamsTopicsHit`)
+// match against these — defined here so changing one suffix doesn't
+// silently miss the other surface.
+var (
+	kafkaStreamsChangelogPattern   = regexp.MustCompile(`-changelog$`)
+	kafkaStreamsRepartitionPattern = regexp.MustCompile(`-repartition$`)
+)
+
+// topicPatternFound reports whether any topic on `c` matches `re`,
+// returning the first matched topic name so callers can surface
+// evidence. Returns (false, "") when the topics scan didn't populate
+// — the upstream `topic_inventory_empty` OQ already surfaces that
+// gap, so callers shouldn't conflate "no match" with "no scan".
+func topicPatternFound(c types.ProcessedCluster, re *regexp.Regexp) (bool, string) {
+	if c.KafkaAdminClientInformation.Topics == nil {
+		return false, ""
+	}
+	for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+		if re.MatchString(td.Name) {
+			return true, td.Name
+		}
+	}
+	return false, ""
+}

--- a/internal/services/plan/version.go
+++ b/internal/services/plan/version.go
@@ -54,8 +54,11 @@ func versionAtLeast(have, floor string) bool {
 
 // parseVersionSegments splits a dotted version into integer segments,
 // dropping any pre-release / build suffix introduced by '-' or '+'.
-// Returns nil on any non-integer or negative segment so the caller's
-// fallback path can fire safely.
+// The first segment must be numeric; non-numeric trailing segments are
+// treated as 0 to tolerate AWS MSK strings like "3.8.x", "4.0.x.kraft"
+// and similar vendor-specific suffixes. Returns nil if the first
+// segment isn't numeric (entirely-non-version input) or any segment is
+// negative.
 func parseVersionSegments(s string) []int {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -66,9 +69,20 @@ func parseVersionSegments(s string) []int {
 	}
 	parts := strings.Split(s, ".")
 	out := make([]int, 0, len(parts))
-	for _, p := range parts {
-		n, err := strconv.Atoi(strings.TrimSpace(p))
-		if err != nil || n < 0 {
+	for i, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			if i == 0 {
+				return nil
+			}
+			out = append(out, 0)
+			continue
+		}
+		if n < 0 {
 			return nil
 		}
 		out = append(out, n)

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -3,10 +3,29 @@ package types
 import "time"
 
 // Plan is the deterministic Migration Plan emitted by `kcp report plan`.
-// Current scope: source-environment summary, sizing, cluster-type,
-// networking, cutover (fleet-wide), and auth (per-cluster). Red flags,
-// tiered storage, cost reconciliation, and the rest of the design-doc
-// surface land in follow-up PRs.
+// Scope: source-environment summary, sizing, cluster-type, networking,
+// cutover, auth (per-cluster), schema migration, red flags, effort
+// signals, tiered storage, and cost-vs-inventory reconciliation. Each
+// section is optional in the JSON and the renderer skips empty ones.
+//
+// Empty-section conventions across the struct:
+//
+//   - Per-cluster slices (`Sizing`, `ClusterTypeDecision`,
+//     `NetworkingDecision`, `Auth`, `CutoverOverrides`) — empty slice
+//     means "no clusters / no overrides"; the renderer either skips
+//     them or emits an empty table. JSON serialises as `[]` when empty
+//     (no `omitempty`) so consumers can tell "no clusters" from "the
+//     field is missing".
+//
+//   - Fleet-wide pointer sections (`Cutover`, `Schema`, `RedFlags`,
+//     `EffortSignals`, `TieredStorage`, `CostReconciliation`) — nil
+//     means "section omitted entirely" (no source data, or the path is
+//     intentionally skipped, e.g. schemaless). JSON uses `omitempty`
+//     so the key disappears from the output.
+//
+//   - `OpenQuestions` and `SizingAppendix` always render in the JSON
+//     (empty slice if there are none); the renderer hides the
+//     corresponding §section when the slice is empty.
 type Plan struct {
 	Header              PlanHeader            `json:"header"`
 	Inputs              PlanInputsResolved    `json:"inputs"`
@@ -14,9 +33,18 @@ type Plan struct {
 	Sizing              []ClusterSizing       `json:"sizing"`
 	ClusterTypeDecision []ClusterTypeDecision `json:"cluster_type_decision"`
 	NetworkingDecision  []NetworkingDecision  `json:"networking_decision"`
-	// Cutover is fleet-wide — one Plan can't ship two cutover styles.
-	// Nil when no clusters were found in the state file.
+	// Cutover is the fleet-wide cutover decision — the default style
+	// applied to every cluster that doesn't carry a per-cluster
+	// override in CutoverOverrides. Nil when no clusters were found in
+	// the state file.
 	Cutover *CutoverDecision `json:"cutover,omitempty"`
+	// CutoverOverrides carries clusters whose resolved
+	// `downtime_tolerance` (or `sub_pattern`) differs from the fleet
+	// — only the clusters that diverge appear here, so an
+	// all-homogeneous fleet keeps this slice empty. Heterogeneous
+	// fleets previously had to slice the state file and run kcp once
+	// per subset; per-cluster overrides remove that workaround.
+	CutoverOverrides []ClusterCutoverOverride `json:"cutover_overrides,omitempty"`
 	// Auth is per-cluster — source auth methods differ across MSK clusters
 	// in the same fleet, so each gets its own source→target mapping.
 	Auth []AuthDecision `json:"auth,omitempty"`
@@ -24,9 +52,28 @@ type Plan struct {
 	// not per-cluster). Nil when the section is omitted — currently the
 	// `schemaless` path (`sr_detected == none` AND
 	// `schema_strategy == no_schemas`).
-	Schema         *SchemaDecision    `json:"schema,omitempty"`
-	SizingAppendix []SizingMathDetail `json:"sizing_appendix"`
-	OpenQuestions  []OpenQuestion     `json:"open_questions,omitempty"`
+	Schema *SchemaDecision `json:"schema,omitempty"`
+	// RedFlags surfaces the boolean trigger rows over the Plan + state
+	// file. Triggered rows are items to discuss with the SE; each row
+	// carries its own evidence (field path + value) so the discussion
+	// is grounded in the scan, not on inference.
+	RedFlags *RedFlagsSection `json:"red_flags,omitempty"`
+	// EffortSignals is the list of quantitative signals the customer's
+	// PM consumes to scope migration effort. Counts only, no
+	// day-estimate.
+	EffortSignals *EffortSignalsSection `json:"effort_signals,omitempty"`
+	// TieredStorage is a per-cluster section describing the
+	// three-dimension trade-off (mechanism / duration / cost direction)
+	// for clusters with MSK tiered storage enabled. Nil when no source
+	// cluster has TIERED storage.
+	TieredStorage *TieredStorageSection `json:"tiered_storage,omitempty"`
+	// CostReconciliation lists MSK clusters that show up in the AWS
+	// cost report but were NOT discovered by `kcp discover`. Sorted by
+	// TotalSpend desc. Nil when cost data is empty or the diff is
+	// clean.
+	CostReconciliation *CostReconciliationSection `json:"cost_reconciliation,omitempty"`
+	SizingAppendix     []SizingMathDetail         `json:"sizing_appendix"`
+	OpenQuestions      []OpenQuestion             `json:"open_questions,omitempty"`
 }
 
 // OpenQuestion is a per-cluster (or plan-level) gap the customer needs
@@ -53,11 +100,12 @@ type PlanHeader struct {
 	// for negative-evidence claims like "0 ACLs" in Appendix A2.
 	StateGeneratedAt time.Time `json:"state_generated_at,omitempty"`
 
-	// PlanSchemaVersion is a string while the JSON shape is still
-	// shifting: top-level keys (auth_approach, switchover_approach,
-	// red_flags, …) are landing in follow-up PRs. Hub consumers should
-	// treat "1-experimental" as "additive changes only; renames may
-	// happen". Bumps to "1" once §4 of the design ships in full.
+	// PlanSchemaVersion identifies the JSON shape of the Plan. Stable
+	// at "1" now that the full deterministic decision set ships
+	// (sizing / cluster type / networking / cutover / auth / schema /
+	// red flags / effort signals / tiered storage / cost
+	// reconciliation). Additive top-level keys at this version are
+	// allowed; renames or removals require a version bump.
 	PlanSchemaVersion string `json:"plan_schema_version"`
 }
 
@@ -333,6 +381,16 @@ type PlanInputsResolved struct {
 	SourceSROutboundReachableToCC *bool  `json:"source_sr_outbound_reachable_to_cc,omitempty"`
 	ConfluentSRCPVersion          string `json:"confluent_sr_cp_version,omitempty"`
 	ConfluentSRCPEdition          string `json:"confluent_sr_cp_edition,omitempty"`
+
+	// Red Flags customer flags — nil tri-state.
+	ExactlyOnceTransactionsInUse *bool `json:"exactly_once_transactions_in_use,omitempty"`
+	KafkaStreamsInUse            *bool `json:"kafka_streams_in_use,omitempty"`
+
+	// Tiered Storage knobs. Strings normalized to lowercase tokens by
+	// the resolver; empty means "no preference declared" (treated as
+	// `unknown` by the detector so the section surfaces the OQ).
+	ConsumerHistoryRequirement string `json:"consumer_history_requirement,omitempty"`
+	HistoricalDataStrategy     string `json:"historical_data_strategy,omitempty"`
 }
 
 // ----- cutover -----
@@ -415,7 +473,8 @@ type Prereq struct {
 	Status      PrereqStatus `json:"status"`
 }
 
-// CutoverDecision is the fleet-wide cutover plan.
+// CutoverDecision is the fleet-wide cutover plan — applied to every
+// cluster that doesn't carry a per-cluster override.
 type CutoverDecision struct {
 	Style                CutoverStyle         `json:"style"`
 	SubPattern           CutoverSubPattern    `json:"sub_pattern,omitempty"` // only when Style == StopRestartRepeat
@@ -428,6 +487,25 @@ type CutoverDecision struct {
 	Prereqs           []Prereq       `json:"prereqs,omitempty"`
 }
 
+// ClusterCutoverOverride captures a single cluster that resolves to a
+// different cutover style than the fleet-wide default. Only the fields
+// that can differ from the fleet decision are carried — alternatives
+// and prereqs come from the fleet entry.
+//
+// OverrideRejected mirrors AuthDecision's same-named field — set when
+// the customer supplied a per-cluster `downtime_tolerance` (or
+// `sub_pattern`) value that wasn't in the recognised enum. JSON
+// consumers can detect rejected per-cluster overrides structurally
+// without scanning OpenQuestion titles.
+type ClusterCutoverOverride struct {
+	ClusterID             string            `json:"cluster_id"`
+	Style                 CutoverStyle      `json:"style"`
+	SubPattern            CutoverSubPattern `json:"sub_pattern,omitempty"`
+	GatewayMediated       GatewayMediated   `json:"gateway_mediated"`
+	OverrideRejected      bool              `json:"override_rejected,omitempty"`
+	RejectedOverrideValue string            `json:"rejected_override_value,omitempty"`
+}
+
 // ----- auth -----
 
 // AuthDecision is the per-cluster source→target auth mapping.
@@ -438,6 +516,18 @@ type AuthDecision struct {
 	ClusterID      string           `json:"cluster_id"`
 	SourceAuths    []string         `json:"source_auths_detected"`
 	TargetMappings []AuthMappingRow `json:"target_mappings,omitempty"`
+	// OverrideRejected is true when the (cluster-scoped or global)
+	// `target_auth_method` override was set to a value outside the
+	// recognised enum — the row's `effective_target` reflects the per-
+	// source default. The renderer surfaces an inline marker in §4 so
+	// a reader scanning the table sees why this cluster's target
+	// differs from peers without scrolling to the Actions Needed
+	// section to read the typo OQ.
+	OverrideRejected bool `json:"override_rejected,omitempty"`
+	// RejectedOverrideValue is the customer-supplied invalid value;
+	// surfaced in the renderer footnote so the reader recognises the
+	// typo at a glance.
+	RejectedOverrideValue string `json:"rejected_override_value,omitempty"`
 }
 
 // ----- schema -----
@@ -544,4 +634,128 @@ type AuthMappingRow struct {
 	// recommendation comes from.
 	Source       string `json:"source,omitempty"`
 	LastVerified string `json:"last_verified,omitempty"`
+}
+
+// ----- red flags -----
+
+// RedFlagStatus is the tri-state verdict for one Red Flag row:
+//
+//   - `triggered` — the boolean predicate over the state file is true.
+//   - `not_triggered` — the predicate is false and we have enough
+//     scan data to say so with confidence.
+//   - `unknown` — the underlying signal isn't available (scan didn't
+//     run, customer-declared flag wasn't set, etc.). The rendered
+//     Plan surfaces it as "not scanned" rather than silently
+//     defaulting to `not_triggered`.
+type RedFlagStatus string
+
+const (
+	RedFlagTriggered    RedFlagStatus = "triggered"
+	RedFlagNotTriggered RedFlagStatus = "not_triggered"
+	RedFlagUnknown      RedFlagStatus = "unknown"
+)
+
+// RedFlag is one row in §Red Flags. Title is the customer-facing
+// label; Evidence is the field path + value that drove the verdict so
+// the SE-customer discussion can ground in scan facts. ClusterID is
+// populated only for per-cluster rows; fleet-level rows leave it
+// empty.
+type RedFlag struct {
+	ID     string        `json:"id"`
+	Title  string        `json:"title"`
+	Status RedFlagStatus `json:"status"`
+	// Evidence is the human-readable prose surfaced in the rendered
+	// Plan. Keep it under control of the row's evaluator so a reader
+	// can tell at a glance WHY the row fired.
+	Evidence string `json:"evidence,omitempty"`
+	// EvidenceFields carries the structured signals the evaluator
+	// computed: scalar counts, cluster lists, version strings, etc.
+	// Downstream JSON consumers branch on these instead of parsing
+	// `Evidence`. Stable shape (additive only) at
+	// `plan_schema_version: "1"`.
+	EvidenceFields map[string]any `json:"evidence_fields,omitempty"`
+	ClusterID      string         `json:"cluster_id,omitempty"`
+}
+
+// RedFlagsSection is the fleet-wide Red Flags decision output. Rows is
+// the full set evaluated in row order; the renderer leads with
+// triggered rows and collapses not-triggered/unknown into a tail
+// summary.
+type RedFlagsSection struct {
+	Rows []RedFlag `json:"rows"`
+}
+
+// ----- effort signals -----
+
+// EffortSignal is one quantitative input the customer's PM consumes
+// to scope migration effort. Count is the raw integer the signal
+// produced (e.g. number of IAM-auth clients). Count is `*int` (nil
+// = unobservable) so a missing client-inventory scan reads as
+// "unknown", not "zero". Note carries any caveat the spec calls out
+// (e.g. MM2 `IdentityReplicationPolicy` undercounts checkpoint
+// topics).
+type EffortSignal struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Count is the integer signal value. `nil` means the signal is
+	// structurally unobservable (the upstream scan didn't run);
+	// `0` means the scan ran and returned zero hits.
+	Count *int   `json:"count"`
+	Note  string `json:"note,omitempty"`
+}
+
+// EffortSignalsSection is the fleet-wide list of effort signals.
+type EffortSignalsSection struct {
+	Signals []EffortSignal `json:"signals"`
+}
+
+// ----- tiered storage -----
+
+// TieredStorageCluster is the per-cluster tiered-storage view: which
+// cluster has TIERED storage, the peak GB volume from CloudWatch
+// (`RemoteLogSizeBytes` Maximum — informational, not the basis for a
+// dollar estimate), and whether the customer's
+// `consumer_history_requirement` indicates the data must be carried
+// forward.
+type TieredStorageCluster struct {
+	ClusterID   string `json:"cluster_id"`
+	StorageMode string `json:"storage_mode"`
+	// RemoteLogSizeBytes is the peak observed footprint (CloudWatch
+	// Maximum aggregate) — appropriate for a monotonically-
+	// accumulating gauge. Falls back to Average when Max isn't
+	// populated. Zero when the metric wasn't collected or the
+	// cluster doesn't have tiered data yet.
+	RemoteLogSizeBytes float64 `json:"remote_log_size_bytes,omitempty"`
+}
+
+// TieredStorageSection surfaces the three-dimension trade-off
+// (mechanism / duration / cost direction) for fleets with at least one
+// TIERED-storage cluster. Customer-decision shaped: kcp does not pick
+// a path, it makes the trade-off legible.
+type TieredStorageSection struct {
+	Clusters                   []TieredStorageCluster `json:"clusters"`
+	ConsumerHistoryRequirement string                 `json:"consumer_history_requirement"`
+	HistoricalDataStrategy     string                 `json:"historical_data_strategy"`
+}
+
+// ----- cost reconciliation -----
+
+// HiddenClusterCandidate is one MSK instance type that shows up in the
+// AWS cost report but was NOT discovered by `kcp discover`. Sorted by
+// TotalSpend desc; the customer (FinOps / cloud lead) decides which
+// candidates are real.
+type HiddenClusterCandidate struct {
+	Region         string  `json:"region"`
+	InstanceType   string  `json:"instance_type"`
+	TotalSpend     float64 `json:"total_spend"`
+	MonthsObserved int     `json:"months_observed,omitempty"`
+	DaysObserved   int     `json:"days_observed,omitempty"`
+}
+
+// CostReconciliationSection lists the candidate hidden MSK clusters
+// per region. Nil when cost data is empty or the diff is clean. When
+// cost data IS empty, the section nils and the detector emits an OQ
+// pointing at `kcp report costs`.
+type CostReconciliationSection struct {
+	Candidates []HiddenClusterCandidate `json:"candidates"`
 }

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -10,22 +10,26 @@ import "time"
 //
 // Empty-section conventions across the struct:
 //
-//   - Per-cluster slices (`Sizing`, `ClusterTypeDecision`,
-//     `NetworkingDecision`, `Auth`, `CutoverOverrides`) — empty slice
-//     means "no clusters / no overrides"; the renderer either skips
-//     them or emits an empty table. JSON serialises as `[]` when empty
-//     (no `omitempty`) so consumers can tell "no clusters" from "the
-//     field is missing".
+//   - Always-present per-cluster slices — `Sizing`,
+//     `ClusterTypeDecision`, `NetworkingDecision`, `SizingAppendix`.
+//     No `omitempty`. JSON renders `[]` when the fleet is empty so a
+//     consumer can tell "fleet had no clusters" from "the key is
+//     missing because the field was renamed".
 //
-//   - Fleet-wide pointer sections (`Cutover`, `Schema`, `RedFlags`,
-//     `EffortSignals`, `TieredStorage`, `CostReconciliation`) — nil
-//     means "section omitted entirely" (no source data, or the path is
-//     intentionally skipped, e.g. schemaless). JSON uses `omitempty`
-//     so the key disappears from the output.
+//   - Conditionally-present per-cluster slices — `Auth`,
+//     `CutoverOverrides`, `OpenQuestions`. Tagged `omitempty`, so an
+//     empty slice (or nil) drops the key from the JSON entirely. Used
+//     when the section either runs for every cluster but may be empty
+//     (no clusters found in the state file) or runs only when there's
+//     something to say (no overrides → no key; no OQs → no key).
 //
-//   - `OpenQuestions` and `SizingAppendix` always render in the JSON
-//     (empty slice if there are none); the renderer hides the
-//     corresponding §section when the slice is empty.
+//   - Fleet-wide pointer sections — `Cutover`, `Schema`, `RedFlags`,
+//     `EffortSignals`, `TieredStorage`, `CostReconciliation`. Tagged
+//     `omitempty`. Nil means "section omitted entirely" (no source
+//     data, or the path is intentionally skipped, e.g. schemaless).
+//
+// In all three cases the renderer hides the corresponding §section
+// when the JSON value is empty / nil.
 type Plan struct {
 	Header              PlanHeader            `json:"header"`
 	Inputs              PlanInputsResolved    `json:"inputs"`
@@ -387,8 +391,12 @@ type PlanInputsResolved struct {
 	KafkaStreamsInUse            *bool `json:"kafka_streams_in_use,omitempty"`
 
 	// Tiered Storage knobs. Strings normalized to lowercase tokens by
-	// the resolver; empty means "no preference declared" (treated as
-	// `unknown` by the detector so the section surfaces the OQ).
+	// the resolver. `ConsumerHistoryRequirement` empty means "not
+	// declared" and is defaulted to `required` by the detector (so the
+	// section surfaces the trade-off rather than the unknown-OQ
+	// branch). `HistoricalDataStrategy` empty is "not declared" and
+	// stays empty unless `ConsumerHistoryRequirement == not_required`,
+	// in which case it cascades to `defer_to_account_team`.
 	ConsumerHistoryRequirement string `json:"consumer_history_requirement,omitempty"`
 	HistoricalDataStrategy     string `json:"historical_data_strategy,omitempty"`
 }

--- a/internal/types/plan_inputs.go
+++ b/internal/types/plan_inputs.go
@@ -114,6 +114,39 @@ type PlanInputs struct {
 	// does not include it). Enum: `enterprise` | `community`.
 	ConfluentSRCPEdition *string `yaml:"confluent_sr_cp_edition,omitempty" json:"confluent_sr_cp_edition,omitempty"`
 
+	// ----- red flags -----
+
+	// ExactlyOnceTransactionsInUse declares whether the source has
+	// EOS / Kafka transactions enabled. There is no detectable state
+	// signal for this; customer-only. Default nil = unknown — the
+	// Red Flag row surfaces as "not scanned" rather than firing false.
+	ExactlyOnceTransactionsInUse *bool `yaml:"exactly_once_transactions_in_use,omitempty" json:"exactly_once_transactions_in_use,omitempty"`
+
+	// KafkaStreamsInUse declares whether Kafka Streams apps consume
+	// from the source. The Red Flag detector also runs a
+	// topic-pattern scan (`-changelog` / `-repartition`); this flag
+	// lets the customer affirm even when topic patterns miss.
+	KafkaStreamsInUse *bool `yaml:"kafka_streams_in_use,omitempty" json:"kafka_streams_in_use,omitempty"`
+
+	// ----- tiered storage -----
+
+	// ConsumerHistoryRequirement declares whether downstream consumers
+	// actually need to replay historical (tiered) data. Enum:
+	//   required (default)  → backfill is required; weigh the 3
+	//                         dimensions (mechanism / duration / cost)
+	//   not_required        → real-time-only consumers; defer to the
+	//                         account team for the cascade of
+	//                         per-topic + consumer-offset decisions
+	//   unknown             → customer hasn't decided yet
+	ConsumerHistoryRequirement *string `yaml:"consumer_history_requirement,omitempty" json:"consumer_history_requirement,omitempty"`
+
+	// HistoricalDataStrategy is the customer's preferred path when
+	// tiered-storage backfill IS required. Enum:
+	//   keep_msk_running_until_data_expires
+	//   bulk_load_historical_via_external_tool
+	//   defer_to_account_team   (default for the not_required cascade)
+	HistoricalDataStrategy *string `yaml:"historical_data_strategy,omitempty" json:"historical_data_strategy,omitempty"`
+
 	// Clusters — per-cluster overrides keyed by source cluster name.
 	// Heterogeneous fleets (mixed-SLA, mixed-tier) need finer-grained
 	// inputs than the global flags above; without this, flipping a
@@ -149,4 +182,14 @@ type ClusterPlanInputs struct {
 	// TargetAuthMethod is the per-cluster override for the target
 	// auth verdict. Same enum as the global field.
 	TargetAuthMethod *string `yaml:"target_auth_method,omitempty" json:"target_auth_method,omitempty"`
+	// DowntimeTolerance is the per-cluster override for the cutover
+	// style. Same enum as the global field. Use when heterogeneous
+	// fleets need different cutover styles per cluster — e.g. a
+	// latency-sensitive service on Blue/Green while batch jobs run
+	// Stop-Restart-Repeat. Without this, the customer would have to
+	// slice the state file and run kcp once per cluster subset.
+	DowntimeTolerance *string `yaml:"downtime_tolerance,omitempty" json:"downtime_tolerance,omitempty"`
+	// SubPattern is the per-cluster override; only meaningful when the
+	// resolved style is Stop-Restart-Repeat. Mirrors the global field.
+	SubPattern *string `yaml:"sub_pattern,omitempty" json:"sub_pattern,omitempty"`
 }

--- a/internal/types/plan_test.go
+++ b/internal/types/plan_test.go
@@ -26,7 +26,7 @@ func TestPlanJSONRoundTrip(t *testing.T) {
 				StateFilePath:     "kcp-state.json",
 				KCPVersion:        "0.7.2",
 				GeneratedAt:       time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC),
-				PlanSchemaVersion: "1-experimental",
+				PlanSchemaVersion: "1",
 			},
 			SourceEnvironment: SourceEnvironment{TotalRegions: 1, Clusters: []SourceClusterSummary{{ClusterID: "x", Region: "us-east-1"}}},
 			Sizing: []ClusterSizing{


### PR DESCRIPTION
## Summary

Adds five new sections to `kcp report plan` plus per-cluster cutover overrides.

## New sections

- **§Red Flags** — 15 boolean trigger rows over scan + plan inputs (Kafka-version floor, IAM, Glue SR, Connect topics, MSK Express tier, tiered storage, EOS / Streams declarations, multi-region source, etc.). Triggered rows render at the top; NotTriggered/Unknown collapse into a tail summary.
- **§Effort Signals** — counters for Connect connectors, MM2 source aliases, self-managed Connect fleets, Glue serializer clients. `*int` distinguishes "unobservable" (nil) from "scan ran zero" (0).
- **§Tiered Storage** — surfaces clusters with `StorageMode == TIERED` and the customer's `consumer_history_requirement` / `historical_data_strategy` cascade. Reads CloudWatch Maximum (not Average) for RemoteLogSizeBytes.
- **§Cost vs Inventory Reconciliation** — parses AWS Cost Explorer usage strings (`<REGION>-Kafka.<family>.<size>` / `<REGION>-Express.<family>.<size>`) and lists clusters in the cost report but not in discovery.

## Per-cluster cutover overrides

- New inputs: `clusters[<name>].downtime_tolerance` / `.sub_pattern`. Heterogeneous fleets no longer need to be sliced and re-run.
- New `Plan.CutoverOverrides []ClusterCutoverOverride` — only diverging clusters appear. JSON carries structural `override_rejected` + `rejected_override_value` when a value is unrecognised; renderer adds a `*` marker.
- Typo'd values fire per-cluster OQs; overrides against an unknown cluster name fire `cluster_override_unknown_cluster` instead of being silently dropped.
- Per-cluster `seconds_per_service` against a non-mediated fleet fires `downtime_tolerance_requires_gateway` — gateway prereqs are fleet-scoped, so the per-cluster intent can't earn its own gateway.

## Other

Maintainability improvements across the plan package (no behaviour change).

## JSON contract

`PlanSchemaVersion` stays at `"1"`. All new fields are additive top-level keys (`cutover_overrides`, `override_rejected`, `rejected_override_value`) — no renames or removals.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] 40 generated plans across 4 fleet shapes × 10 plan-inputs scenarios; per-cluster overrides, typo OQs, and rejected-override paths verified
