### PR TITLE
fix: remove duplicate error output in CLI

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -27,9 +27,10 @@ import (
 var verbose bool
 
 var RootCmd = &cobra.Command{
-	Use:   "kcp",
-	Short: "A CLI tool for kafka cluster planning and migration",
-	Long:  "A comprehensive CLI tool for planning and executing kafka cluster migrations to confluent cloud. Docs: " + build_info.DocsURL(),
+	Use:           "kcp",
+	Short:         "A CLI tool for kafka cluster planning and migration",
+	Long:          "A comprehensive CLI tool for planning and executing kafka cluster migrations to confluent cloud. Docs: " + build_info.DocsURL(),
+	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// --- Logging setup (must be here so --verbose flag is parsed) ---
 		lumberjackLogger := &lumberjack.Logger{

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -9,9 +8,15 @@ import (
 )
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
-		slog.Error(err.Error())
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	if err := run(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func run() error {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -16,11 +17,12 @@ func TestCommandErrorNotDuplicated(t *testing.T) {
 	// Save originals and restore after test
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
-	oldArgs := os.Args
+	oldLogger := slog.Default()
 	defer func() {
 		os.Stdout = oldStdout
 		os.Stderr = oldStderr
-		os.Args = oldArgs
+		slog.SetDefault(oldLogger)
+		cmd.RootCmd.SetArgs(nil)
 	}()
 
 	// Run in a temp dir to avoid kcp.log in the repo root

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/cmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandErrorNotDuplicated(t *testing.T) {
+	// Save originals and restore after test
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	oldArgs := os.Args
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		os.Args = oldArgs
+	}()
+
+	// Run in a temp dir to avoid kcp.log in the repo root
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origDir) }()
+	require.NoError(t, os.Chdir(t.TempDir()))
+
+	// Create pipes to capture stdout and stderr
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	// Trigger a validation error via an invalid --source-type value.
+	// We use SetArgs so Cobra parses these instead of os.Args.
+	cmd.RootCmd.SetArgs([]string{
+		"scan", "clusters",
+		"--source-type", "invalid",
+		"--credentials-file", "dummy.yaml",
+	})
+
+	runErr := run()
+
+	// Close writers so readers can reach EOF, then collect output
+	require.NoError(t, wOut.Close())
+	require.NoError(t, wErr.Close())
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	_, _ = io.Copy(&stdoutBuf, rOut)
+	_, _ = io.Copy(&stderrBuf, rErr)
+
+	combined := stdoutBuf.String() + stderrBuf.String()
+
+	// The command must have failed
+	require.Error(t, runErr)
+
+	// Use the returned error's text to count occurrences — this avoids
+	// hardcoding any specific message and stays resilient to wording changes.
+	errText := runErr.Error()
+	count := strings.Count(combined, errText)
+	assert.Equalf(t, 1, count,
+		"error message should appear exactly once in combined output, but appeared %d times.\nError text: %q\nCombined output:\n%s",
+		count, errText, combined)
+}


### PR DESCRIPTION
## Summary

- When a command failed, the error was printed twice: once via `slog.Error()` (which writes to both the log file and console via FanOutHandler) and once via `fmt.Fprintf(os.Stderr, ...)`. Removed the redundant `fmt.Fprintf` line from `main.go`.
- Extracted `run()` from `main()` to make error handling testable without `os.Exit`.
- Added `TestCommandErrorNotDuplicated` which triggers a command error, captures stdout+stderr, and asserts the error appears exactly once. The test uses the returned error text dynamically so it won't break if error wording changes.

## Test plan

- [x] `TestCommandErrorNotDuplicated` fails before fix (error count = 2), passes after (count = 1)
- [x] Full test suite passes (`make test-go`)
- [x] Manual verification: `kcp scan clusters --source-type invalid --credentials-file foo.yaml` shows error once

🤖 Generated with [Claude Code](https://claude.com/claude-code)