### PR TITLE
fix(plan): handle MSK Serverless + close scan/discover edge-case gaps

### DIFF
--- a/internal/services/plan/auth_test.go
+++ b/internal/services/plan/auth_test.go
@@ -102,6 +102,41 @@ func TestDecideAuth_OverrideRejectedRecordedOnTypo(t *testing.T) {
 	assert.NotEqual(t, "oauthhh", row.EffectiveTarget, "row must NOT carry the typo as its effective target")
 }
 
+// Serverless cluster with IAM enabled on the Serverless block (not
+// Provisioned). DecideAuth must pick up the IAM row via
+// serverlessSourceAuths — Provisioned is nil, so the previous
+// Provisioned-only path would have returned no rows.
+func TestDecideAuth_ServerlessIAM(t *testing.T) {
+	c := serverlessCluster("srv-iam")
+	d := decideAuth(c, defaultCfg(t), authInputs())
+	assert.Equal(t, []string{SourceAuthIAM}, d.SourceAuths)
+	row := requireRow(t, d, SourceAuthIAM)
+	assert.False(t, row.GatewayCompatible, "Serverless IAM still inherits the IAM-→-API-Keys mapping with gateway incompatibility")
+}
+
+// Serverless cluster with no Serverless.ClientAuthentication block.
+// DecideAuth must return empty SourceAuths without panicking.
+func TestDecideAuth_ServerlessNoAuth(t *testing.T) {
+	c := types.ProcessedCluster{Name: "srv-noauth"}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}, SecurityGroupIds: []string{"g"}}},
+	}
+	d := decideAuth(c, defaultCfg(t), authInputs())
+	assert.Empty(t, d.SourceAuths)
+	assert.Empty(t, d.TargetMappings)
+}
+
+// `sourceUsesMTLS` must short-circuit to false for Serverless — even
+// when ClientAuthentication on the Serverless block carries an IAM
+// entry, that's not mTLS. Without the explicit guard, a future
+// refactor could try to read prov.ClientAuthentication.Tls on a nil
+// prov and panic.
+func TestSourceUsesMTLS_ServerlessAlwaysFalse(t *testing.T) {
+	c := serverlessCluster("srv-iam")
+	assert.False(t, sourceUsesMTLS(c), "Serverless never supports mTLS — must short-circuit on isServerless")
+}
+
 // Recognised override values keep OverrideRejected false; absent
 // override is also fine. Without this guard a regression could
 // silently mark every cluster as rejected.

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -74,6 +74,12 @@ func brokerInventoryGap(c types.ProcessedCluster) bool {
 // per-cluster section — same MskClusterConfig pointer-chase as
 // `brokerInstanceType` / `kafkaVersionOf`, so it lives here next to
 // its peers.
+//
+// Serverless clusters always return empty — Provisioned is nil on
+// Serverless, and StorageMode is a Provisioned-only concept. Callers
+// that iterate clusters MUST also guard with `isServerless` if they
+// want to skip Serverless explicitly (recommended: silent fall-through
+// is fragile if helper semantics change later).
 func clusterStorageMode(c types.ProcessedCluster) kafkatypes.StorageMode {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil {
@@ -227,6 +233,14 @@ func fleetUsesIAM(clusters []types.ProcessedCluster) bool {
 // ambiguity the caller would have to re-disambiguate).
 func inputsMissing(c types.ProcessedCluster) []string {
 	var missing []string
+	// MskClusterConfig.Provisioned shape gap — affects every
+	// Provisioned-only helper (kafkaVersionOf, brokerInstanceType,
+	// clusterStorageMode, sourceUsesMTLS). Without surfacing this, the
+	// cluster silently flows through with empty/false everywhere and
+	// no signal back to the customer.
+	if !isServerless(c) && hasUnknownClusterType(c) {
+		missing = append(missing, "msk_cluster_config")
+	}
 	if c.KafkaAdminClientInformation.Topics == nil {
 		missing = append(missing, "topics")
 	}
@@ -237,4 +251,25 @@ func inputsMissing(c types.ProcessedCluster) []string {
 		missing = append(missing, "brokers")
 	}
 	return missing
+}
+
+// hasUnknownClusterType reports whether the cluster's discriminator
+// is something other than the two known values (`PROVISIONED` /
+// `SERVERLESS`), OR is a Provisioned cluster missing its
+// `Provisioned` block entirely. Both cases mean the Provisioned-only
+// helpers will return empty/false silently. Callers should treat this
+// as an inputs-missing gap and surface a cluster-type OQ.
+func hasUnknownClusterType(c types.ProcessedCluster) bool {
+	ct := c.AWSClientInformation.MskClusterConfig.ClusterType
+	if ct == kafkatypes.ClusterTypeServerless {
+		return false
+	}
+	if ct == kafkatypes.ClusterTypeProvisioned {
+		// Provisioned discriminator set but the Provisioned block is
+		// missing — mid-flight scan failure or pre-0.7 file shape.
+		return c.AWSClientInformation.MskClusterConfig.Provisioned == nil
+	}
+	// Anything else (empty discriminator, future AWS variant) is
+	// unrecognised.
+	return true
 }

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -145,7 +145,14 @@ var hardLimitCatalog = []hardLimit{
 // sourceUsesMTLS reads `MskClusterConfig.Provisioned.ClientAuthentication.Tls.Enabled`
 // from `kcp scan clusters` output. Returns false when any layer is unpopulated
 // (the admin scan didn't run, or the cluster is OSK).
+//
+// Serverless clusters always return false — AWS MSK Serverless supports
+// only IAM SASL (no mTLS); its ClientAuthentication block lives on the
+// `Serverless` struct (not `Provisioned`) and has no TLS field.
 func sourceUsesMTLS(c types.ProcessedCluster) bool {
+	if isServerless(c) {
+		return false
+	}
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil || prov.ClientAuthentication == nil || prov.ClientAuthentication.Tls == nil {
 		return false

--- a/internal/services/plan/cost_reconciliation.go
+++ b/internal/services/plan/cost_reconciliation.go
@@ -39,7 +39,13 @@ func mskUsageTypeRegex(cfg *PlanConfig) *regexp.Regexp {
 		escaped[i] = regexp.QuoteMeta(f)
 	}
 	familyAlt := strings.Join(escaped, "|")
-	return regexp.MustCompile(`^[A-Z0-9-]+?-((?:` + familyAlt + `))\.([A-Za-z0-9.\-]+)$`)
+	// Instance-type capture group accepts either:
+	//   - the standard EC2 shape `<family>.<size>` (lowercase / mixed),
+	//     e.g. `m5.large`, `kraft.t3.small`, `m7g.large`
+	//   - the synthetic `Serverless-Hours` AWS bills MSK Serverless under
+	// Anything else (DataTransfer-Out-Bytes, garbage strings) misses on
+	// purpose so it doesn't surface as a phantom hidden-cluster candidate.
+	return regexp.MustCompile(`^[A-Z0-9-]+?-((?:` + familyAlt + `))\.((?:[a-z][a-z0-9]*\.[a-z0-9]+(?:\.[a-z0-9]+)?)|Serverless-Hours)$`)
 }
 
 // detectCostReconciliation produces the per-region diff between MSK
@@ -93,9 +99,22 @@ func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *type
 // inventoryInstanceTypes returns the set of instance types
 // `kcp discover` found in the given region. Stored as a map for
 // O(1) lookup during the diff.
+//
+// Serverless clusters carry no `BrokerNodeGroupInfo.InstanceType` —
+// the AWS cost report bills them under `<REGION>-Kafka.Serverless-Hours`,
+// which `parseMSKInstanceType` renders as `kafka.Serverless-Hours`. We
+// register that string in the inventory whenever a discovered cluster
+// is Serverless so the diff doesn't flag the Serverless-Hours cost
+// line as a "hidden cluster".
+const serverlessInventoryType = "kafka.Serverless-Hours"
+
 func inventoryInstanceTypes(region types.ProcessedRegion) map[string]struct{} {
 	out := map[string]struct{}{}
 	for _, c := range region.Clusters {
+		if isServerless(c) {
+			out[serverlessInventoryType] = struct{}{}
+			continue
+		}
 		if t := brokerInstanceType(c); t != "" {
 			out[t] = struct{}{}
 		}

--- a/internal/services/plan/cost_reconciliation_test.go
+++ b/internal/services/plan/cost_reconciliation_test.go
@@ -18,7 +18,10 @@ func TestParseMSKInstanceType(t *testing.T) {
 		{"USE1-Kafka.m5.large", "kafka.m5.large"},
 		{"APN1-Express.m7g.large", "express.m7g.large"},
 		{"EU-Kafka.kraft.t3.small", "kafka.kraft.t3.small"},
+		{"USE1-Kafka.Serverless-Hours", "kafka.Serverless-Hours"},
 		{"USE1-DataTransfer-Out-Bytes", ""}, // non-broker row
+		{"USE1-Kafka.foo-bar.baz", ""},      // garbage tier descriptor — must be rejected
+		{"USE1-Kafka.M5.LARGE", ""},         // uppercase instance type — AWS lowercases; not real
 		{"", ""},
 	}
 	for _, c := range cases {
@@ -108,4 +111,27 @@ func TestDetectCostReconciliation_ObservationCounts(t *testing.T) {
 	assert.Equal(t, 2, section.Candidates[0].MonthsObserved, "April + May")
 	assert.Equal(t, 3, section.Candidates[0].DaysObserved)
 	assert.InDelta(t, 300.0, section.Candidates[0].TotalSpend, 0.01)
+}
+
+// Discovered Serverless clusters must register in the inventory map
+// as `kafka.Serverless-Hours` so a matching `Kafka.Serverless-Hours`
+// cost line is recognised as a known cluster — not flagged as hidden.
+// Without this, every region with a discovered Serverless cluster
+// would emit a spurious cost-reconciliation candidate.
+func TestDetectCostReconciliation_ServerlessInventoryMatchesCostShape(t *testing.T) {
+	srv := serverlessCluster("srv-cluster")
+	state := wrapClusters(srv)
+	// Inject cost data: the Serverless-Hours line should match the
+	// inventory; the m7g.large line should still flag as hidden.
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.Serverless-Hours", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.00}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.00}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	require.NotNil(t, section)
+	require.Len(t, section.Candidates, 1, "only the hidden m7g.large should flag — Serverless-Hours must match the discovered Serverless inventory")
+	assert.Equal(t, "kafka.m7g.large", section.Candidates[0].InstanceType)
 }

--- a/internal/services/plan/effort_signals.go
+++ b/internal/services/plan/effort_signals.go
@@ -1,10 +1,21 @@
 package plan
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/confluentinc/kcp/internal/types"
 )
+
+// pluralizeY appends "y" or "ies" based on count — "registry" /
+// "registries", "fleet entry" / "fleet entries". Inline helper to
+// avoid pulling the renderer's full pluralize map into the detector.
+func pluralizeY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
 
 // Stable Effort Signal IDs. Matches the spec row order.
 const (
@@ -101,6 +112,9 @@ func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) types.EffortSi
 			continue
 		}
 		for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+			if td.Partitions <= 0 {
+				continue
+			}
 			if mm2CheckpointPattern.MatchString(td.Name) {
 				seen[td.Name] = struct{}{}
 			}
@@ -137,6 +151,13 @@ func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) types.Eff
 			continue
 		}
 		for _, td := range c.KafkaAdminClientInformation.Topics.Details {
+			// Zero-partition topics are pathological: AWS doesn't create
+			// them, but a malformed scan could. They're not a real
+			// Connect fleet either way — skip them so they can't inflate
+			// the count.
+			if td.Partitions <= 0 {
+				continue
+			}
 			prefix, kind, ok := connectInternalTopicPrefix(td.Name)
 			if !ok {
 				continue
@@ -213,6 +234,14 @@ func signalGlueSerializerMigration(state types.ProcessedState, clusters []types.
 		for _, gs := range gr.Schemas {
 			glueSubjects[gs.SchemaName] = struct{}{}
 		}
+	}
+	// Glue registries scanned but every one was empty — the scan ran
+	// but found no schemas. Distinguish from the "Glue not scanned"
+	// path above so the customer knows what to ask about.
+	if len(glueSubjects) == 0 {
+		sig.Count = intPtr(0)
+		sig.Note = fmt.Sprintf("%d Glue registr%s scanned but no schemas found inside — either the registries are empty or the scan ran without permissions to enumerate schemas.", len(state.SchemaRegistries.AWSGlue), pluralizeY(len(state.SchemaRegistries.AWSGlue)))
+		return sig
 	}
 	// De-dupe by ClientId so one app producing/consuming N Glue-backed
 	// topics counts as a single workstream, not N. The label is "clients

--- a/internal/services/plan/effort_signals_test.go
+++ b/internal/services/plan/effort_signals_test.go
@@ -42,9 +42,9 @@ func TestEffortSignal_IAMClientCount(t *testing.T) {
 func TestEffortSignal_MM2CheckpointTopics(t *testing.T) {
 	c := redFlagCluster("mm2-cluster", "3.5.0", "", "")
 	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{
-		{Name: "us-east.checkpoints.internal"},
-		{Name: "us-west.checkpoints.internal"},
-		{Name: "regular-topic"},
+		{Name: "us-east.checkpoints.internal", Partitions: 1},
+		{Name: "us-west.checkpoints.internal", Partitions: 1},
+		{Name: "regular-topic", Partitions: 1},
 	}}
 	state := wrapClusters(c)
 	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
@@ -60,14 +60,14 @@ func TestEffortSignal_SelfManagedConnectFleets(t *testing.T) {
 	c := redFlagCluster("connect-cluster", "3.5.0", "", "")
 	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{
 		// Fleet A — has all three triad topics with prefix "team-a-"
-		{Name: "team-a-connect-configs"},
-		{Name: "team-a-connect-offsets"},
-		{Name: "team-a-connect-status"},
+		{Name: "team-a-connect-configs", Partitions: 1},
+		{Name: "team-a-connect-offsets", Partitions: 25},
+		{Name: "team-a-connect-status", Partitions: 5},
 		// Fleet B — only two of three (configs + status, no offsets)
-		{Name: "team-b-connect-configs"},
-		{Name: "team-b-connect-status"},
+		{Name: "team-b-connect-configs", Partitions: 1},
+		{Name: "team-b-connect-status", Partitions: 5},
 		// Partial — only configs, NOT counted
-		{Name: "team-c-connect-configs"},
+		{Name: "team-c-connect-configs", Partitions: 1},
 	}}
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
 	sig := findSignal(t, plan.EffortSignals, EffortSignalIDSelfManagedConnectFleets)

--- a/internal/services/plan/oq_registry.go
+++ b/internal/services/plan/oq_registry.go
@@ -179,6 +179,14 @@ var oqRegistry = map[string]oqMeta{
 		Priority: 960,
 		Severity: "🟡",
 	},
+	"osk_source_unsupported": {
+		Priority: 970,
+		Severity: "🟡",
+	},
+	"cluster_type_unrecognised": {
+		Priority: 980,
+		Severity: "🟡",
+	},
 }
 
 // oqMetaFor returns the registry entry for an OQ ID, or a sentinel

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -53,6 +53,12 @@ func NewPlanService(cfg *PlanConfig, now func() time.Time) *PlanService {
 // Each step is a pure function so the test surface is the orchestration,
 // not its parts.
 func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsResolved, stateFilePath string) (*types.Plan, error) {
+	// Backfill `ClusterMetrics.Aggregates` once, in-place, against the
+	// canonical state. Every downstream caller (the per-cluster Build
+	// loop, plus every fleet-wide detector that re-runs
+	// `collectClusters`) reads the same populated map without
+	// recomputing CalculateMetricsAggregates per call.
+	backfillAggregates(&state)
 	clusters := collectClusters(state)
 	// Stable sort by (Region, Name, Arn) so two clusters that share a name
 	// across regions still get a deterministic order.
@@ -286,12 +292,16 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		topicsField := c.KafkaAdminClientInformation.Topics
 		var body string
 		switch {
-		case isServerless(c):
-			// Fresh Serverless: legitimately 0 topics.
-			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. For a Serverless cluster that's only plausible if the cluster has genuinely never been used; if apps are connected, the admin scan probably didn't run with credentials to enumerate topics."
 		case topicsField == nil:
-			// Provisioned but the Topics field itself is absent — scan didn't run.
+			// Topics field absent entirely — scan didn't run. Applies to
+			// both Provisioned and Serverless; the wording is shape-agnostic.
 			body = "`KafkaAdminClientInformation.Topics` is absent on this cluster — the admin scan that enumerates topics didn't run (or ran with `--skip-topics`)."
+		case isServerless(c):
+			// Topics field present but `Summary.Topics == 0`. For a
+			// fresh Serverless cluster that's plausible (no system
+			// topics on Serverless either); for an in-use one it's a
+			// scan-credentials gap.
+			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. For a Serverless cluster that's only plausible if the cluster has genuinely never been used; if apps are connected, the admin scan probably didn't run with credentials to enumerate topics."
 		default:
 			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero)."
 		}
@@ -345,23 +355,16 @@ func detectOSKSourceOpenQuestion(state types.ProcessedState) []types.OpenQuestio
 	if oskCount == 0 {
 		return nil
 	}
+	noun, verb := "clusters", "aren't"
+	if oskCount == 1 {
+		noun, verb = "cluster", "isn't"
+	}
 	return []types.OpenQuestion{{
 		ID:         "osk_source_unsupported",
-		Title:      fmt.Sprintf("%d on-prem Kafka cluster%s in the state file aren't covered by `kcp report plan`", oskCount, pluralizeSimple("", oskCount)),
+		Title:      fmt.Sprintf("%d on-prem Kafka %s in the state file %s covered by `kcp report plan`", oskCount, noun, verb),
 		Body:       "The state file includes `osk_sources` clusters (open-source Kafka, e.g. on-prem deployments). `kcp report plan` currently scopes to MSK source clusters only — the OSK clusters are silently dropped from every section above. The MSK-shaped recommendations still stand for any MSK clusters in the same state file.",
 		HowToClose: "Plan the OSK clusters separately: run `kcp report plan` against a state file slice that only contains the OSK clusters, OR work with your Confluent account team on a manual migration plan for the on-prem fleet.",
 	}}
-}
-
-// pluralizeSimple is a one-shot pluralizer for OQ titles ("0 clusters",
-// "1 cluster", "5 clusters"). The plan package has a richer pluralizer
-// for table headers (`pluralize`), but it depends on a registered noun
-// list; this helper just appends "s" when n != 1.
-func pluralizeSimple(_ string, n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }
 
 // detectStaleStateOQ surfaces a fleet-wide OQ when the source state
@@ -737,6 +740,29 @@ func openQuestionPriority(id string) int {
 	return oqMetaFor(id).Priority
 }
 
+// backfillAggregates populates `ClusterMetrics.Aggregates` from raw
+// metric series in-place across every MSK cluster in `state`. Runs
+// once at the top of `Build` so `collectClusters` (and the fleet-wide
+// detectors that call it) read pre-populated maps without recomputing
+// CalculateMetricsAggregates per invocation. Skips clusters where
+// Aggregates is already populated (e.g. test fixtures that pre-set it)
+// or where there are no raw metrics to fold.
+func backfillAggregates(state *types.ProcessedState) {
+	for i := range state.Sources {
+		if state.Sources[i].MSKData == nil {
+			continue
+		}
+		for j := range state.Sources[i].MSKData.Regions {
+			for k := range state.Sources[i].MSKData.Regions[j].Clusters {
+				c := &state.Sources[i].MSKData.Regions[j].Clusters[k]
+				if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
+					c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
+				}
+			}
+		}
+	}
+}
+
 func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
 	var out []types.ProcessedCluster
 	for _, src := range state.Sources {
@@ -744,18 +770,7 @@ func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
 			continue
 		}
 		for _, region := range src.MSKData.Regions {
-			for _, c := range region.Clusters {
-				// ProcessState doesn't populate Aggregates on the
-				// top-level path — only per-subcommand helpers do.
-				// Backfill from raw metrics here so EVERY downstream
-				// consumer (sizing in the Build loop AND fleet-wide
-				// helpers like detectTieredStorage that re-call
-				// collectClusters) sees the same Aggregates map.
-				if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
-					c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
-				}
-				out = append(out, c)
-			}
+			out = append(out, region.Clusters...)
 		}
 	}
 	return out

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -79,12 +79,8 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 	}
 
 	for _, c := range clusters {
-		// ProcessState doesn't populate Aggregates on the top-level path —
-		// only the per-subcommand date-filtered helpers do. Fill it in if
-		// the cluster has raw metrics but no aggregates, so sizing has P95.
-		if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
-			c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
-		}
+		// (Aggregates backfill happens in collectClusters so fleet-wide
+		// helpers see the same map.)
 		// Per-cluster overrides win over globals — heterogeneous fleets
 		// need finer-grained inputs than flipping one global flag across
 		// every cluster. We start from the already-resolved global view
@@ -177,6 +173,11 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 	// change the verdicts.
 	plan.OpenQuestions = append(plan.OpenQuestions, detectStaleStateOQ(state.Timestamp, s.now(), s.cfg.Thresholds.StaleStateDays)...)
 
+	// OSK-source OQ: today's plan covers MSK only; OSK clusters in the
+	// state are silently ignored. Surface a fleet-wide OQ so the
+	// customer knows their on-prem Kafka clusters didn't get planned.
+	plan.OpenQuestions = append(plan.OpenQuestions, detectOSKSourceOpenQuestion(state)...)
+
 	// Stable order: blocker OQs first, acknowledgement OQs last; tie-break
 	// on cluster ID so two clusters of equal priority sort alphabetically.
 	sort.SliceStable(plan.OpenQuestions, func(i, j int) bool {
@@ -200,19 +201,26 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, auth types.AuthDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
 	var oqs []types.OpenQuestion
 	// Auth posture undetectable. Fires whenever the source has no
-	// detected auth methods on a non-serverless cluster — auth is its
-	// own concern, surfaced independently of topic / ACL inventory gaps
-	// (those have their own OQs and don't suppress this one).
-	// Serverless clusters legitimately produce no detected methods
-	// when IAM isn't enabled; suppress only for them.
-	if len(auth.SourceAuths) == 0 && !isServerless(c) {
-		oqs = append(oqs, types.OpenQuestion{
-			ID:         "auth_posture_unknown",
-			ClusterID:  c.Name,
-			Title:      "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
-			Body:       "Neither `AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication` nor `kafka_admin_client_information.sasl_mechanism` reports an enabled auth method. A real MSK Provisioned cluster always has at least one. Likely cause: discover ran without admin credentials (or the state file pre-dates the auth scan).",
-			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account, OR provide admin Kafka credentials to `kcp scan clusters` so the Admin probe can backfill `sasl_mechanism`.", regionFlag(c.Region)),
-		})
+	// detected auth methods — auth is its own concern, surfaced
+	// independently of topic / ACL inventory gaps (those have their
+	// own OQs and don't suppress this one). The OQ body / how-to-close
+	// branch on cluster type because the resolution path differs:
+	// Provisioned needs an admin re-scan; Serverless needs the
+	// Serverless.ClientAuthentication block populated.
+	if len(auth.SourceAuths) == 0 {
+		oq := types.OpenQuestion{
+			ID:        "auth_posture_unknown",
+			ClusterID: c.Name,
+			Title:     "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
+		}
+		if isServerless(c) {
+			oq.Body = "`AWSClientInformation.MskClusterConfig.Serverless.ClientAuthentication` is empty for this Serverless cluster. MSK Serverless supports only SASL/IAM, but the auth block can be missing if the scan ran without admin credentials or the cluster pre-dates the auth setup."
+			oq.HowToClose = fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account to refresh `Serverless.ClientAuthentication`. If the cluster genuinely has no auth wired yet, configure SASL/IAM on the MSK side first.", regionFlag(c.Region))
+		} else {
+			oq.Body = "Neither `AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication` nor `kafka_admin_client_information.sasl_mechanism` reports an enabled auth method. A real MSK Provisioned cluster always has at least one. Likely cause: discover ran without admin credentials (or the state file pre-dates the auth scan)."
+			oq.HowToClose = fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account, OR provide admin Kafka credentials to `kcp scan clusters` so the Admin probe can backfill `sasl_mechanism`.", regionFlag(c.Region))
+		}
+		oqs = append(oqs, oq)
 	}
 	// Customer-set target_auth_method conflicts with a source whose
 	// auth_mapping is gateway_compatible: false (today: IAM). The plan
@@ -238,13 +246,21 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		}
 	}
 	if sizing.Degraded {
+		howToClose := fmt.Sprintf("Re-run `kcp discover%s` without `--skip-metrics` so CloudWatch metrics get backfilled into the state file.", regionFlag(c.Region))
+		if isServerless(c) {
+			// Serverless emits a different CloudWatch metric set than
+			// Provisioned (no `BytesInPerSec` / `BytesOutPerSec` on
+			// the per-broker dimensions), so re-discover alone won't
+			// populate the throughput floor. Customer needs to either
+			// declare throughput or consult the account team.
+			howToClose = "Serverless throughput isn't auto-populated by `kcp discover` — supply ingress/egress targets via `plan-inputs.yaml` (or work with your Confluent account team to size against actual workload rates)."
+		}
 		oqs = append(oqs, types.OpenQuestion{
-			ID:        "missing_p95_metrics",
-			ClusterID: c.Name,
-			Title:     fmt.Sprintf("No %s throughput metrics — sizing fell back to SLA floor", percentileHeader(inputs.SizingPercentile)),
-			Body:      sizing.DegradedReason,
-			// Metrics are collected by `kcp discover` (CloudWatch path), not a separate `scan metrics` subcommand.
-			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` without `--skip-metrics` so CloudWatch metrics get backfilled into the state file.", regionFlag(c.Region)),
+			ID:         "missing_p95_metrics",
+			ClusterID:  c.Name,
+			Title:      fmt.Sprintf("No %s throughput metrics — sizing fell back to SLA floor", percentileHeader(inputs.SizingPercentile)),
+			Body:       sizing.DegradedReason,
+			HowToClose: howToClose,
 		})
 	}
 	if !aclScanRan(c) && !isServerless(c) {
@@ -267,13 +283,33 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		})
 	}
 	if topicCount(c) == 0 {
+		topicsField := c.KafkaAdminClientInformation.Topics
+		var body string
+		switch {
+		case isServerless(c):
+			// Fresh Serverless: legitimately 0 topics.
+			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. For a Serverless cluster that's only plausible if the cluster has genuinely never been used; if apps are connected, the admin scan probably didn't run with credentials to enumerate topics."
+		case topicsField == nil:
+			// Provisioned but the Topics field itself is absent — scan didn't run.
+			body = "`KafkaAdminClientInformation.Topics` is absent on this cluster — the admin scan that enumerates topics didn't run (or ran with `--skip-topics`)."
+		default:
+			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero)."
+		}
 		oqs = append(oqs, types.OpenQuestion{
-			ID:        "topic_inventory_empty",
-			ClusterID: c.Name,
-			Title:     "Source environment shows 0 topics — likely an incomplete scan",
-			Body:      "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero).",
-			// `kcp scan clusters` doesn't take --region — it reads region from the state file.
+			ID:         "topic_inventory_empty",
+			ClusterID:  c.Name,
+			Title:      "Source environment shows 0 topics — likely an incomplete scan",
+			Body:       body,
 			HowToClose: "Re-run `kcp scan clusters --source-type msk --credentials-file <msk-credentials.yaml>` with admin Kafka credentials (without `--skip-topics`) to populate the topic list.",
+		})
+	}
+	if hasUnknownClusterType(c) {
+		oqs = append(oqs, types.OpenQuestion{
+			ID:         "cluster_type_unrecognised",
+			ClusterID:  c.Name,
+			Title:      "MSK cluster discriminator unrecognised — Plan treated as Provisioned with empty fields",
+			Body:       fmt.Sprintf("`MskClusterConfig.ClusterType` is %q. Recognised values are `PROVISIONED` and `SERVERLESS`. Without a recognised discriminator (or with `PROVISIONED` but `Provisioned == nil`), the Provisioned-shaped helpers — Kafka version, broker instance type, storage mode, mTLS detection — all return empty. The cluster appears in the Plan with most signals missing.", string(c.AWSClientInformation.MskClusterConfig.ClusterType)),
+			HowToClose: fmt.Sprintf("Re-run `kcp discover%s` against the source AWS account to refresh `MskClusterConfig`. If the cluster legitimately uses a future MSK variant, file an issue against kcp so it can be added to the recognised set.", regionFlag(c.Region)),
 		})
 	}
 	if privateLinkSizingExceedsCap(sizing, ct, net, cfg) {
@@ -293,6 +329,39 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	// sees the signal and knows the override path (`sizing_percentile: p99`)
 	// exists if they want tighter sizing.
 	return oqs
+}
+
+// detectOSKSourceOpenQuestion surfaces a fleet-wide OQ when the
+// state file contains OSK (open-source Kafka, on-prem) clusters.
+// `kcp report plan` covers MSK only today; without this OQ those
+// clusters would be silently dropped from the plan.
+func detectOSKSourceOpenQuestion(state types.ProcessedState) []types.OpenQuestion {
+	var oskCount int
+	for _, src := range state.Sources {
+		if src.OSKData != nil {
+			oskCount += len(src.OSKData.Clusters)
+		}
+	}
+	if oskCount == 0 {
+		return nil
+	}
+	return []types.OpenQuestion{{
+		ID:         "osk_source_unsupported",
+		Title:      fmt.Sprintf("%d on-prem Kafka cluster%s in the state file aren't covered by `kcp report plan`", oskCount, pluralizeSimple("", oskCount)),
+		Body:       "The state file includes `osk_sources` clusters (open-source Kafka, e.g. on-prem deployments). `kcp report plan` currently scopes to MSK source clusters only — the OSK clusters are silently dropped from every section above. The MSK-shaped recommendations still stand for any MSK clusters in the same state file.",
+		HowToClose: "Plan the OSK clusters separately: run `kcp report plan` against a state file slice that only contains the OSK clusters, OR work with your Confluent account team on a manual migration plan for the on-prem fleet.",
+	}}
+}
+
+// pluralizeSimple is a one-shot pluralizer for OQ titles ("0 clusters",
+// "1 cluster", "5 clusters"). The plan package has a richer pluralizer
+// for table headers (`pluralize`), but it depends on a registered noun
+// list; this helper just appends "s" when n != 1.
+func pluralizeSimple(_ string, n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // detectStaleStateOQ surfaces a fleet-wide OQ when the source state
@@ -675,7 +744,18 @@ func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
 			continue
 		}
 		for _, region := range src.MSKData.Regions {
-			out = append(out, region.Clusters...)
+			for _, c := range region.Clusters {
+				// ProcessState doesn't populate Aggregates on the
+				// top-level path — only per-subcommand helpers do.
+				// Backfill from raw metrics here so EVERY downstream
+				// consumer (sizing in the Build loop AND fleet-wide
+				// helpers like detectTieredStorage that re-call
+				// collectClusters) sees the same Aggregates map.
+				if len(c.ClusterMetrics.Aggregates) == 0 && len(c.ClusterMetrics.Metrics) > 0 {
+					c.ClusterMetrics.Aggregates = report.CalculateMetricsAggregates(c.ClusterMetrics.Metrics)
+				}
+				out = append(out, c)
+			}
 		}
 	}
 	return out

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -219,6 +219,27 @@ func TestDetectOpenQuestions(t *testing.T) {
 		assertContainsOQ(t, oqs, "topic_inventory_empty", "kcp scan clusters")
 	})
 
+	t.Run("Serverless with nil Topics → scan-gap body, not 'Summary.Topics is 0'", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "srv-nil"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+		c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+			VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}}},
+		}
+		// Topics intentionally left nil.
+		auth := types.AuthDecision{ClusterID: "srv-nil", SourceAuths: []string{SourceAuthIAM}}
+		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "srv-nil", FinalECKU: 1}, ent, pniNet("srv-nil"), auth, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		var topicOQ *types.OpenQuestion
+		for i, oq := range oqs {
+			if oq.ID == "topic_inventory_empty" {
+				topicOQ = &oqs[i]
+				break
+			}
+		}
+		require.NotNil(t, topicOQ, "Serverless + nil Topics must still fire topic_inventory_empty")
+		assert.Contains(t, topicOQ.Body, "is absent on this cluster", "nil Topics must use scan-gap wording")
+		assert.NotContains(t, topicOQ.Body, "Summary.Topics` is 0", "nil case must NOT use the 'Summary observed as 0' wording")
+	})
+
 	t.Run("PrivateLink trigger + sized > cap → networking_privatelink_over_cap OQ", func(t *testing.T) {
 		c := provisioned("overCap")
 		sizing := types.ClusterSizing{ClusterID: "overCap", FinalECKU: 15} // > 10 eCKU PL cap
@@ -333,6 +354,30 @@ func TestDetectOSKSourceOpenQuestion_FiresWhenOSKClustersPresent(t *testing.T) {
 func TestDetectOSKSourceOpenQuestion_NoOQWhenOSKAbsent(t *testing.T) {
 	state := types.ProcessedState{}
 	assert.Empty(t, detectOSKSourceOpenQuestion(state))
+}
+
+// Singular vs plural verb agreement in the OQ title.
+func TestDetectOSKSourceOpenQuestion_VerbAgreement(t *testing.T) {
+	t.Run("1 cluster → 'isn't' + singular noun", func(t *testing.T) {
+		state := types.ProcessedState{Sources: []types.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
+				Clusters: []types.ProcessedOSKCluster{{ID: "solo"}},
+			}},
+		}}
+		oqs := detectOSKSourceOpenQuestion(state)
+		require.Len(t, oqs, 1)
+		assert.Contains(t, oqs[0].Title, "1 on-prem Kafka cluster in the state file isn't")
+	})
+	t.Run("2 clusters → 'aren't' + plural noun", func(t *testing.T) {
+		state := types.ProcessedState{Sources: []types.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
+				Clusters: []types.ProcessedOSKCluster{{ID: "a"}, {ID: "b"}},
+			}},
+		}}
+		oqs := detectOSKSourceOpenQuestion(state)
+		require.Len(t, oqs, 1)
+		assert.Contains(t, oqs[0].Title, "2 on-prem Kafka clusters in the state file aren't")
+	})
 }
 
 // MskClusterConfig.ClusterType outside the recognised enum (empty or

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -136,6 +136,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c := types.ProcessedCluster{Name: name}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{} // non-nil to satisfy cluster_type_unrecognised guard
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		c.KafkaAdminClientInformation.Acls = []types.Acls{} // non-nil means "scan ran" under aclScanRan's current heuristic
 		return c
@@ -312,10 +313,77 @@ func withRegion(c types.ProcessedCluster, region string) types.ProcessedCluster 
 	return c
 }
 
+// State with OSKSources but no MSK clusters MUST surface the
+// osk_source_unsupported OQ so the customer knows on-prem clusters
+// were silently dropped. Today the plan only covers MSK.
+func TestDetectOSKSourceOpenQuestion_FiresWhenOSKClustersPresent(t *testing.T) {
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
+				Clusters: []types.ProcessedOSKCluster{{ID: "onprem-1"}, {ID: "onprem-2"}},
+			}},
+		},
+	}
+	oqs := detectOSKSourceOpenQuestion(state)
+	require.Len(t, oqs, 1)
+	assert.Equal(t, "osk_source_unsupported", oqs[0].ID)
+	assert.Contains(t, oqs[0].Title, "2 on-prem Kafka clusters")
+}
+
+func TestDetectOSKSourceOpenQuestion_NoOQWhenOSKAbsent(t *testing.T) {
+	state := types.ProcessedState{}
+	assert.Empty(t, detectOSKSourceOpenQuestion(state))
+}
+
+// MskClusterConfig.ClusterType outside the recognised enum (empty or
+// future variant) MUST surface cluster_type_unrecognised so the
+// customer knows the Provisioned-shaped helpers silently returned
+// empty for that cluster.
+func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
+	t.Run("empty ClusterType → msk_cluster_config", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "no-type"}
+		// ClusterType left as zero-value
+		c.KafkaAdminClientInformation.Topics = &types.Topics{}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
+	})
+	t.Run("PROVISIONED with nil Provisioned → msk_cluster_config", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "nil-prov"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		// Provisioned block left as nil
+		c.KafkaAdminClientInformation.Topics = &types.Topics{}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
+	})
+	t.Run("Future variant ClusterType → msk_cluster_config", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "future"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = "HYBRID"
+		c.KafkaAdminClientInformation.Topics = &types.Topics{}
+		c.KafkaAdminClientInformation.Acls = []types.Acls{}
+		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
+		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
+	})
+	t.Run("Serverless does NOT report msk_cluster_config", func(t *testing.T) {
+		c := types.ProcessedCluster{Name: "srv"}
+		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+		c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+			VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}}},
+		}
+		c.KafkaAdminClientInformation.Topics = &types.Topics{}
+		assert.NotContains(t, inputsMissing(c), "msk_cluster_config")
+	})
+}
+
 func TestInputsMissing_AllSignalsTracked(t *testing.T) {
 	t.Run("fully-scanned PROVISIONED cluster reports no missing inputs", func(t *testing.T) {
 		c := types.ProcessedCluster{Name: "ok"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
+		// Provisioned block must be populated — without it, the
+		// Provisioned-only helpers return empty and the new
+		// `msk_cluster_config` inputs-missing entry fires.
+		c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		c.KafkaAdminClientInformation.Acls = []types.Acls{}

--- a/internal/services/plan/red_flags.go
+++ b/internal/services/plan/red_flags.go
@@ -135,6 +135,12 @@ func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConf
 	var belowStrs []string
 	var unparseable []string
 	for _, c := range clusters {
+		// Serverless clusters don't expose a Kafka version — AWS
+		// manages the version transparently. Skip rather than
+		// surfacing a spurious "kafka_version missing" Unknown.
+		if isServerless(c) {
+			continue
+		}
 		v := kafkaVersionOf(c)
 		if v == "" {
 			unparseable = append(unparseable, c.Name+" (no version recorded)")
@@ -162,6 +168,13 @@ func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConf
 	return rf
 }
 
+// kafkaVersionOf returns the cluster's reported Kafka version, or
+// "" when it isn't recorded.
+//
+// Serverless clusters always return "" — AWS manages the Serverless
+// version transparently and never populates
+// `Provisioned.CurrentBrokerSoftwareInfo`. Callers MUST guard with
+// `isServerless` before interpreting "" as "scan didn't run".
 func kafkaVersionOf(c types.ProcessedCluster) string {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil || prov.CurrentBrokerSoftwareInfo == nil || prov.CurrentBrokerSoftwareInfo.KafkaVersion == nil {
@@ -379,6 +392,8 @@ func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
 func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) types.RedFlag {
 	rf := types.RedFlag{ID: RedFlagIDZeroACLsWithIAM, Title: "Zero ACLs with IAM auth enabled — verify SE expected behavior"}
 	var hits []string
+	var serverlessIAM []string // Serverless+IAM clusters can't expose ACLs via the kcp scan path
+	var unscannedIAM []string  // Provisioned+IAM clusters where the ACL scan didn't run (nil ACLs)
 	for _, c := range clusters {
 		iam := false
 		for _, a := range sourceAuthsDetected(c) {
@@ -390,13 +405,41 @@ func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) types.RedFlag {
 		if !iam {
 			continue
 		}
-		if aclScanRan(c) && len(c.KafkaAdminClientInformation.Acls) == 0 {
+		if isServerless(c) {
+			serverlessIAM = append(serverlessIAM, c.Name)
+			continue
+		}
+		if !aclScanRan(c) {
+			// Provisioned+IAM with nil ACLs (scan didn't run / --skip-acls
+			// / 0-ACL scan ambiguity per aclScanRan). The acls_not_scanned
+			// OQ already nudges the customer to re-run; we just need to
+			// not let the row claim "Not triggered" silently for them.
+			unscannedIAM = append(unscannedIAM, c.Name)
+			continue
+		}
+		if len(c.KafkaAdminClientInformation.Acls) == 0 {
 			hits = append(hits, c.Name)
 		}
 	}
+	excludedNote := ""
+	switch {
+	case len(serverlessIAM) > 0 && len(unscannedIAM) > 0:
+		excludedNote = fmt.Sprintf(" (excluded — Serverless+IAM %s lack ACL scan path; Provisioned+IAM %s had nil ACLs)", strings.Join(serverlessIAM, ", "), strings.Join(unscannedIAM, ", "))
+	case len(serverlessIAM) > 0:
+		excludedNote = fmt.Sprintf(" (Serverless+IAM clusters %s excluded — ACLs aren't exposed via the kcp scan path on Serverless)", strings.Join(serverlessIAM, ", "))
+	case len(unscannedIAM) > 0:
+		excludedNote = fmt.Sprintf(" (Provisioned+IAM clusters %s excluded — ACL scan didn't populate; see `acls_not_scanned` OQ to re-scan)", strings.Join(unscannedIAM, ", "))
+	}
 	if len(hits) > 0 {
 		rf.Status = types.RedFlagTriggered
-		rf.Evidence = "IAM + 0 ACLs on: " + strings.Join(hits, ", ")
+		rf.Evidence = "IAM + 0 ACLs on: " + strings.Join(hits, ", ") + excludedNote
+		return rf
+	}
+	// No Provisioned hits but at least one IAM cluster the row can't
+	// evaluate — Serverless or --skip-acls. Don't claim "Not triggered".
+	if len(serverlessIAM) > 0 || len(unscannedIAM) > 0 {
+		rf.Status = types.RedFlagUnknown
+		rf.Evidence = "Row can't evaluate for one or more IAM clusters" + excludedNote + ". Verify ACL posture manually."
 		return rf
 	}
 	rf.Status = types.RedFlagNotTriggered
@@ -438,6 +481,14 @@ func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) types.RedFlag {
 	var hits []expressHit
 	var hitStrs []string
 	for _, c := range clusters {
+		// Serverless is a distinct tier from Express — it has no
+		// BrokerNodeGroupInfo at all (details live on the Serverless
+		// struct, not Provisioned). Skip explicitly so the empty
+		// brokerInstanceType return for Serverless can't be misread
+		// as "scan didn't run".
+		if isServerless(c) {
+			continue
+		}
 		instType := brokerInstanceType(c)
 		if instType == "" {
 			continue
@@ -460,6 +511,15 @@ func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) types.RedFlag {
 	return rf
 }
 
+// brokerInstanceType returns the cluster's broker EC2 instance-type
+// string, or "" when it isn't recorded.
+//
+// Serverless clusters always return "" — Serverless has no
+// BrokerNodeGroupInfo (its details live on `MskClusterConfig.Serverless`,
+// not `Provisioned`). Callers MUST guard with `isServerless` before
+// treating "" as "scan didn't run"; for Serverless inventory accounting,
+// see `inventoryInstanceTypes` (cost_reconciliation.go), which registers
+// Serverless clusters under the synthetic `Serverless-Hours` type.
 func brokerInstanceType(c types.ProcessedCluster) string {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil || prov.BrokerNodeGroupInfo == nil || prov.BrokerNodeGroupInfo.InstanceType == nil {
@@ -474,6 +534,11 @@ func evalTieredStorageInUse(clusters []types.ProcessedCluster) types.RedFlag {
 	rf := types.RedFlag{ID: RedFlagIDTieredStorageInUse, Title: "Tiered storage in use on the source"}
 	var hits []string
 	for _, c := range clusters {
+		// Serverless has no `StorageMode` concept — the elastic
+		// storage path differs from Provisioned tiered storage. Skip.
+		if isServerless(c) {
+			continue
+		}
 		if clusterStorageMode(c) == kafkatypes.StorageModeTiered {
 			hits = append(hits, c.Name)
 		}

--- a/internal/services/plan/red_flags_test.go
+++ b/internal/services/plan/red_flags_test.go
@@ -175,3 +175,237 @@ func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanCon
 	require.NoError(t, err)
 	return p
 }
+
+// serverlessCluster builds a ProcessedCluster shaped like an MSK
+// Serverless cluster: ClusterType=Serverless, `Provisioned` left nil,
+// and the Serverless block carries the (IAM-only) ClientAuthentication.
+// Mirrors the JSON shape AWS returns — see PR #317 review by adrian-januzi.
+func serverlessCluster(name string) types.ProcessedCluster {
+	c := types.ProcessedCluster{Name: name, Region: "us-east-1"}
+	enabled := true
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+		ClientAuthentication: &kafkatypes.ServerlessClientAuthentication{
+			Sasl: &kafkatypes.ServerlessSasl{Iam: &kafkatypes.Iam{Enabled: &enabled}},
+		},
+	}
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{{Name: name + "-topic"}}}
+	return c
+}
+
+// Serverless clusters must not trigger Provisioned-only Red Flag rows
+// (Kafka version below floor, Express tier, tiered storage) just
+// because their Provisioned-shaped fields are nil. Without the explicit
+// skips, the version row falsely reports "kafka_version missing" for
+// every Serverless cluster.
+func TestRedFlags_ServerlessSkipsProvisionedOnlyRows(t *testing.T) {
+	srv := serverlessCluster("serverless-only")
+	state := wrapClusters(srv)
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+
+	kafkaRow := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
+	assert.Equal(t, types.RedFlagNotTriggered, kafkaRow.Status, "Serverless has no Kafka version — row must NOT fire Unknown")
+
+	expressRow := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
+	assert.Equal(t, types.RedFlagNotTriggered, expressRow.Status, "Serverless is a distinct tier from Express")
+
+	tieredRow := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
+	assert.Equal(t, types.RedFlagNotTriggered, tieredRow.Status, "Serverless has no StorageMode concept")
+}
+
+// Mixed-fleet variant: Serverless cluster alongside a Provisioned
+// cluster with a real Kafka-version-below-floor hit. The Provisioned
+// hit must still fire; the Serverless cluster must NOT show up in
+// the row's evidence or trip the row to Unknown.
+func TestRedFlags_ServerlessDoesntPolluteVersionEvidence(t *testing.T) {
+	below := redFlagCluster("old-provisioned", "2.2.1", "", "")
+	srv := serverlessCluster("serverless-mixed")
+	state := wrapClusters(below, srv)
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+
+	row := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
+	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Contains(t, row.Evidence, "old-provisioned")
+	assert.NotContains(t, row.Evidence, "serverless-mixed", "Serverless cluster must not appear in version-row evidence")
+}
+
+// Serverless cluster with NO ClientAuthentication block at all (the
+// AWS API allows this — auth may be wired later). The auth-detection
+// path must NOT panic, and the cluster must show up in the §Source
+// Environment table with `_none detected_` rather than crashing or
+// being silently dropped.
+func TestRedFlags_ServerlessNoClientAuthentication(t *testing.T) {
+	c := types.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"subnet-x"}, SecurityGroupIds: []string{"sg-x"}}},
+		// ClientAuthentication intentionally nil
+	}
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{{Name: "t"}}}
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+	iamRow := findRow(t, plan.RedFlags, RedFlagIDIAMAuthEnabled)
+	assert.Equal(t, types.RedFlagNotTriggered, iamRow.Status, "no auth block → no IAM detected")
+	// Cluster surfaces as Serverless and the auth fallback is empty.
+	require.Len(t, plan.Auth, 1)
+	assert.Empty(t, plan.Auth[0].SourceAuths)
+}
+
+// Multi-region Serverless: two Serverless clusters across two regions
+// must both surface in §1 caveats, neither pollutes the Provisioned-
+// only Red Flag rows, and the multi-region Red Flag fires correctly
+// based on REGION count (not cluster count).
+func TestRedFlags_ServerlessMultiRegion(t *testing.T) {
+	srvEast := serverlessCluster("srv-east")
+	srvEast.Region = "us-east-1"
+	srvWest := serverlessCluster("srv-west")
+	srvWest.Region = "us-west-2"
+	state := types.ProcessedState{
+		Sources: []types.ProcessedSource{{
+			Type: types.SourceTypeMSK,
+			MSKData: &types.ProcessedMSKSource{
+				Regions: []types.ProcessedRegion{
+					{Name: "us-east-1", Clusters: []types.ProcessedCluster{srvEast}},
+					{Name: "us-west-2", Clusters: []types.ProcessedCluster{srvWest}},
+				},
+			},
+		}},
+	}
+	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+
+	multiRegion := findRow(t, plan.RedFlags, RedFlagIDMultiRegionSource)
+	assert.Equal(t, types.RedFlagTriggered, multiRegion.Status, "two regions → multi-region fires")
+
+	kafkaRow := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
+	assert.Equal(t, types.RedFlagNotTriggered, kafkaRow.Status, "Serverless-only multi-region must not trip the version row")
+}
+
+// Mixed fleet variant for Express + Tiered: a single Provisioned
+// cluster hits both rows; a Serverless cluster in the same fleet
+// must NOT show up in either row's evidence. Regression guard for
+// future helper changes that might re-introduce silent Serverless
+// fall-through into these two Red Flag detectors.
+func TestRedFlags_ServerlessDoesntPolluteExpressOrTieredEvidence(t *testing.T) {
+	express := redFlagCluster("prov-express", "3.5.0", "express.m7g.large", "TIERED")
+	srv := serverlessCluster("serverless-mixed")
+	plan := buildPlanForRedFlags(t, wrapClusters(express, srv), defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+
+	exp := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
+	assert.Equal(t, types.RedFlagTriggered, exp.Status)
+	assert.Contains(t, exp.Evidence, "prov-express=express.m7g.large")
+	assert.NotContains(t, exp.Evidence, "serverless-mixed")
+
+	tier := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
+	assert.Equal(t, types.RedFlagTriggered, tier.Status)
+	assert.Contains(t, tier.Evidence, "prov-express")
+	assert.NotContains(t, tier.Evidence, "serverless-mixed")
+}
+
+// Serverless+IAM cluster in the fleet means the Zero-ACLs-with-IAM
+// row can't actually evaluate (Serverless ACLs aren't exposed via the
+// kcp scan path). Verdict must be Unknown, not Not Triggered.
+func TestRedFlags_ServerlessIAMMakesZeroACLsRowUnknown(t *testing.T) {
+	srv := serverlessCluster("srv-iam")
+	plan := buildPlanForRedFlags(t, wrapClusters(srv), defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
+	assert.Equal(t, types.RedFlagUnknown, row.Status, "Serverless+IAM clusters make the ACL row inconclusive — must be Unknown not Not Triggered")
+	assert.Contains(t, row.Evidence, "srv-iam")
+}
+
+// Mixed-fleet variant for the ACL row: a Provisioned IAM cluster with
+// 0 ACLs SHOULD still fire Triggered, but the evidence must mention
+// that any Serverless+IAM clusters were excluded from the count.
+func TestRedFlags_ZeroACLsWithIAM_MixedFleetSurfacesExclusion(t *testing.T) {
+	provIAM := redFlagCluster("prov-iam", "3.5.0", "", "")
+	// Wire IAM on the Provisioned cluster + zero ACLs (scan ran, returned empty).
+	enabled := true
+	provIAM.AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication = &kafkatypes.ClientAuthentication{
+		Sasl: &kafkatypes.Sasl{Iam: &kafkatypes.Iam{Enabled: &enabled}},
+	}
+	provIAM.KafkaAdminClientInformation.Acls = []types.Acls{}
+	srv := serverlessCluster("srv-iam")
+	plan := buildPlanForRedFlags(t, wrapClusters(provIAM, srv), defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
+	assert.Equal(t, types.RedFlagTriggered, row.Status, "Provisioned IAM + 0 ACLs still triggers the row")
+	assert.Contains(t, row.Evidence, "prov-iam")
+	assert.Contains(t, row.Evidence, "srv-iam", "Serverless+IAM exclusion must be surfaced in the row evidence")
+}
+
+// Serverless cluster with no Serverless.ClientAuthentication block
+// fires `auth_posture_unknown` with Serverless-flavored body/how-to-close.
+// Pre-fix, the OQ was suppressed entirely for Serverless, leaving §4's
+// "see Actions Needed" pointer dangling.
+func TestRedFlags_ServerlessNoAuthFiresAuthPostureOQ(t *testing.T) {
+	c := types.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
+	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
+	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
+		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}, SecurityGroupIds: []string{"g"}}},
+	}
+	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{{Name: "t"}}}
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	var authOQ *types.OpenQuestion
+	for i, oq := range plan.OpenQuestions {
+		if oq.ID == "auth_posture_unknown" && oq.ClusterID == "srv-noauth" {
+			authOQ = &plan.OpenQuestions[i]
+			break
+		}
+	}
+	require.NotNil(t, authOQ, "Serverless with no ClientAuthentication must surface auth_posture_unknown")
+	assert.Contains(t, authOQ.Body, "Serverless", "OQ body must call out the Serverless-specific cause")
+}
+
+// Provisioned IAM cluster with NIL ACLs (--skip-acls / scan didn't run)
+// must NOT silently fall under "Not triggered" — row should be Unknown
+// and the evidence should name the excluded cluster.
+func TestRedFlags_ZeroACLs_SkipACLsCaseSurfacesAsUnknown(t *testing.T) {
+	c := redFlagCluster("prov-iam-skipped", "3.5.0", "", "")
+	enabled := true
+	c.AWSClientInformation.MskClusterConfig.Provisioned.ClientAuthentication = &kafkatypes.ClientAuthentication{
+		Sasl: &kafkatypes.Sasl{Iam: &kafkatypes.Iam{Enabled: &enabled}},
+	}
+	// Acls left nil — simulates --skip-acls / scan-didn't-run case.
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
+	assert.Equal(t, types.RedFlagUnknown, row.Status, "IAM cluster with nil ACLs makes the row Unknown")
+	assert.Contains(t, row.Evidence, "prov-iam-skipped")
+}
+
+// Discovered Serverless cluster, but NO Serverless-Hours cost line:
+// the inventory still registers the Serverless cluster, but cost
+// reconciliation just doesn't include the Serverless row in its diff
+// — the section should either omit or render empty without flagging.
+func TestDetectCostReconciliation_ServerlessClusterWithoutMatchingCostLine(t *testing.T) {
+	srv := serverlessCluster("srv-no-billing")
+	state := wrapClusters(srv)
+	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+		Region: "us-east-1",
+		Results: []types.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: types.ProcessedCostBreakdown{UnblendedCost: 12.50}},
+		},
+	}
+	section := detectCostReconciliation(state, defaultCfg(t))
+	assert.Nil(t, section, "no broker-shaped cost lines → section omitted; Serverless cluster shouldn't surface as a hidden candidate")
+}
+
+// Serverless cluster that ALSO has an admin-probe sasl_mechanism set
+// (e.g. the admin client connected via SCRAM bridging). The Serverless
+// SASL/IAM detection on the MskClusterConfig path is the source of
+// truth — it should NOT fall through to the admin-probe fallback
+// (which would only fire if AWS-side detection returned empty).
+func TestRedFlags_ServerlessAdminProbeFallback(t *testing.T) {
+	c := serverlessCluster("srv-iam-real")
+	// Even with a probed mechanism set, the AWS Serverless IAM takes precedence.
+	c.KafkaAdminClientInformation.SaslMechanism = "AWS_MSK_IAM"
+	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
+	require.NotNil(t, plan.RedFlags)
+	iamRow := findRow(t, plan.RedFlags, RedFlagIDIAMAuthEnabled)
+	assert.Equal(t, types.RedFlagTriggered, iamRow.Status)
+	require.Len(t, plan.Auth, 1)
+	assert.Equal(t, []string{SourceAuthIAM}, plan.Auth[0].SourceAuths)
+}

--- a/internal/services/plan/tiered_storage.go
+++ b/internal/services/plan/tiered_storage.go
@@ -32,6 +32,12 @@ func detectTieredStorage(state types.ProcessedState, inputs types.PlanInputsReso
 	clusters := collectClusters(state)
 	var tiered []types.TieredStorageCluster
 	for _, c := range clusters {
+		// Serverless has no `StorageMode` (Provisioned-only field).
+		// Skip explicitly so the empty `clusterStorageMode` return
+		// can't be misread if the helper semantics change.
+		if isServerless(c) {
+			continue
+		}
 		if clusterStorageMode(c) != kafkatypes.StorageModeTiered {
 			continue
 		}


### PR DESCRIPTION
## Summary

Makes MSK Serverless handling explicit across `kcp report plan` and closes a sweep of related scan/discover edge cases the plan code previously mis-handled.

## Key bug fixes

- **MSK Serverless was silently mis-handled.** Serverless clusters carry their config on `MskClusterConfig.Serverless` (Provisioned is nil). Provisioned-only helpers returned empty for them and the Red Flag detectors emitted misleading verdicts: every Serverless cluster surfaced an Unknown "kafka_version missing" row, the cost-reconciliation diff flagged every `Kafka.Serverless-Hours` AWS cost line as a hidden cluster, and `auth_posture_unknown` was suppressed leaving a dangling "see Actions Needed" pointer. Now explicit-skipped in Kafka-version / Express-tier / tiered-storage Red Flag rows, registered in the cost-inventory map under `kafka.Serverless-Hours`, and a Serverless-flavored `auth_posture_unknown` OQ fires.
- **OSK clusters silently dropped.** State files containing `osk_sources` clusters got a plan covering MSK only with zero signal. New `osk_source_unsupported` OQ.
- **Unknown `ClusterType` silently treated as Provisioned-with-empty-fields.** Empty discriminator, future AWS variants, or `PROVISIONED`-with-nil-`Provisioned` block now surface `cluster_type_unrecognised` OQ + `msk_cluster_config` inputs-missing entry.
- **Zero-ACLs-with-IAM Red Flag** wasn't accounting for clusters where the row couldn't evaluate (Serverless or `--skip-acls`). Verdict goes Unknown when only such clusters exist; evidence names the exclusions.

## Other improvements

- §1 Source Environment renders `_N/A (serverless)_` in the broker column + a Serverless caveats callout when any Serverless cluster is present.
- `missing_p95_metrics` and `topic_inventory_empty` OQ bodies branch on cluster type so Serverless customers don't see Provisioned-flavored recipes.
- `ClusterMetrics.Aggregates` backfill moved into `collectClusters` — fleet-wide helpers (e.g. `detectTieredStorage`'s `RemoteLogSizeBytes` read) no longer see an empty map.
- Glue serializer signal distinguishes "Glue scanned but empty" from "Glue not scanned".
- MM2 / Connect-fleet effort signals filter zero-partition topics.
- Cost-reconciliation regex tightened to reject garbage instance-type strings.
- IAM gateway-compat note reworded to clarify the barrier is source-side, independent of target auth.

## JSON contract

`PlanSchemaVersion` stays at `"1"`. Two new OQ IDs (`osk_source_unsupported`, `cluster_type_unrecognised`) and one new `inputsMissing` token (`msk_cluster_config`). All additive.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] 17 new tests cover Serverless permutations (IAM, no-auth, multi-region, admin-probe fallback, mixed fleet, no-ClientAuthentication), OSK detection, unknown ClusterType, `--skip-acls` case, instance-type regex
- [x] 22 synthetic state-file fixtures exercise the matrix of Provisioned / Serverless / mixed / edge cases end-to-end through `kcp report plan`
