### PR TITLE
refactor(types): move Terraform models to internal/services/hcl/hcltypes (Pass 2.3)

### DIFF
--- a/cmd/create_asset/bastion_host/bastion_host_generator.go
+++ b/cmd/create_asset/bastion_host/bastion_host_generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/confluentinc/kcp/internal/services/hcl"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 )
@@ -71,7 +72,7 @@ func (bh *BastionHostAssetGenerator) Run() error {
 	return nil
 }
 
-func (bh *BastionHostAssetGenerator) writeTerraformFiles(outputDir string, files types.TerraformFiles) error {
+func (bh *BastionHostAssetGenerator) writeTerraformFiles(outputDir string, files hcltypes.TerraformFiles) error {
 	if files.MainTf != "" {
 		if err := os.WriteFile(filepath.Join(outputDir, "main.tf"), []byte(files.MainTf), 0644); err != nil {
 			return fmt.Errorf("failed to write main.tf: %w", err)

--- a/cmd/create_asset/cmd_create_asset.go
+++ b/cmd/create_asset/cmd_create_asset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/confluentinc/kcp/cmd/create_asset/migrate_topics"
 	"github.com/confluentinc/kcp/cmd/create_asset/migration_infra"
 	"github.com/confluentinc/kcp/cmd/create_asset/reverse_proxy"
-	"github.com/confluentinc/kcp/cmd/create_asset/target_infra"
+	targetinfra "github.com/confluentinc/kcp/cmd/create_asset/target_infra"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/create_asset/migrate_topics/migrate_topics_generator.go
+++ b/cmd/create_asset/migrate_topics/migrate_topics_generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/confluentinc/kcp/internal/services/hcl"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 )
@@ -81,7 +82,7 @@ func (mt *MigrateTopicsAssetGenerator) Run() error {
 // writeProject writes the single-folder migrate-topics project flat into
 // outputDir: providers.tf, variables.tf, plus one .tf per topic from
 // AdditionalFiles.
-func (mt *MigrateTopicsAssetGenerator) writeProject(outputDir string, project types.MigrationScriptsTerraformProject) error {
+func (mt *MigrateTopicsAssetGenerator) writeProject(outputDir string, project hcltypes.MigrationScriptsTerraformProject) error {
 	if len(project.Folders) == 0 {
 		return nil
 	}

--- a/cmd/create_asset/reverse_proxy/reverse_proxy_generator.go
+++ b/cmd/create_asset/reverse_proxy/reverse_proxy_generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/confluentinc/kcp/internal/services/hcl"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 )
@@ -81,7 +82,7 @@ func (rp *ReverseProxyAssetGenerator) Run() error {
 	return nil
 }
 
-func (rp *ReverseProxyAssetGenerator) writeTerraformFiles(outputDir string, files types.TerraformFiles) error {
+func (rp *ReverseProxyAssetGenerator) writeTerraformFiles(outputDir string, files hcltypes.TerraformFiles) error {
 	if files.MainTf != "" {
 		if err := os.WriteFile(filepath.Join(outputDir, "main.tf"), []byte(files.MainTf), 0644); err != nil {
 			return fmt.Errorf("failed to write main.tf: %w", err)

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/confluentinc/kcp/cmd/ui/frontend"
 	"github.com/confluentinc/kcp/internal/services/hcl"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/fatih/color"
 	"github.com/labstack/echo/v4"
@@ -714,8 +715,8 @@ func (ui *UI) hydrateTopicsFromState(c echo.Context, req *types.MirrorTopicsRequ
 // flattenMigrateTopicsProject concatenates per-topic .tf files into a single
 // main.tf string so the legacy UI wizard contract stays intact while the CLI
 // uses the per-file layout.
-func flattenMigrateTopicsProject(project types.MigrationScriptsTerraformProject) types.TerraformFiles {
-	out := types.TerraformFiles{}
+func flattenMigrateTopicsProject(project hcltypes.MigrationScriptsTerraformProject) hcltypes.TerraformFiles {
+	out := hcltypes.TerraformFiles{}
 	if len(project.Folders) == 0 {
 		return out
 	}

--- a/internal/services/hcl/aws/provider.go
+++ b/internal/services/hcl/aws/provider.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -11,7 +11,7 @@ const (
 	VarAwsRegion = "aws_region"
 )
 
-var AwsProviderVariables = []types.TerraformVariable{
+var AwsProviderVariables = []hcltypes.TerraformVariable{
 	{Name: VarAwsRegion, Description: "The AWS region", Sensitive: false, Type: "string"},
 }
 

--- a/internal/services/hcl/bastion_host_hcl_service.go
+++ b/internal/services/hcl/bastion_host_hcl_service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/hcl/aws"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/services/hcl/other"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
@@ -29,8 +30,8 @@ func NewBastionHostHCLService() *BastionHostHCLService {
 	return &BastionHostHCLService{}
 }
 
-func (s *BastionHostHCLService) GenerateBastionHostFiles(request types.BastionHostRequest) (types.TerraformFiles, error) {
-	return types.TerraformFiles{
+func (s *BastionHostHCLService) GenerateBastionHostFiles(request types.BastionHostRequest) (hcltypes.TerraformFiles, error) {
+	return hcltypes.TerraformFiles{
 		MainTf:           s.generateMainTf(request),
 		ProvidersTf:      s.generateProvidersTf(),
 		VariablesTf:      s.generateVariablesTf(),
@@ -261,7 +262,7 @@ func (s *BastionHostHCLService) generateProvidersTf() string {
 }
 
 func (s *BastionHostHCLService) generateVariablesTf() string {
-	return GenerateVariablesTf([]types.TerraformVariable{
+	return GenerateVariablesTf([]hcltypes.TerraformVariable{
 		{Name: "vpc_id", Description: "The ID of the VPC", Type: "string"},
 		{Name: "public_subnet_cidr", Description: "CIDR block for the public subnet", Type: "string"},
 		{Name: "aws_region", Description: "The AWS region", Type: "string"},
@@ -270,7 +271,7 @@ func (s *BastionHostHCLService) generateVariablesTf() string {
 }
 
 func (s *BastionHostHCLService) generateOutputsTf() string {
-	return GenerateOutputsTf([]types.TerraformOutput{
+	return GenerateOutputsTf([]hcltypes.TerraformOutput{
 		{Name: "bastion_host_public_ip", Value: "aws_instance.migration_bastion_host.public_ip"},
 	})
 }

--- a/internal/services/hcl/confluent/exporter.go
+++ b/internal/services/hcl/confluent/exporter.go
@@ -1,6 +1,7 @@
 package confluent
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -19,7 +20,7 @@ const (
 )
 
 // SchemaExporterVariables defines all the variables needed for schema exporter resources
-var SchemaExporterVariables = []types.TerraformVariable{
+var SchemaExporterVariables = []hcltypes.TerraformVariable{
 	{Name: VarSourceSchemaRegistryID, Description: "ID of the source schema registry", Sensitive: false, Type: "string"},
 	{Name: VarSourceSchemaRegistryURL, Description: "URL of the source schema registry", Sensitive: false, Type: "string"},
 	{Name: VarSourceSchemaRegistryUsername, Description: "Username for source schema registry authentication", Sensitive: false, Type: "string"},

--- a/internal/services/hcl/confluent/provider.go
+++ b/internal/services/hcl/confluent/provider.go
@@ -1,7 +1,7 @@
 package confluent
 
 import (
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -11,7 +11,7 @@ const (
 	VarConfluentCloudAPISecret = "confluent_cloud_api_secret"
 )
 
-var ConfluentProviderVariables = []types.TerraformVariable{
+var ConfluentProviderVariables = []hcltypes.TerraformVariable{
 	{Name: VarConfluentCloudAPIKey, Description: "Confluent Cloud API Key", Sensitive: false, Type: "string"},
 	{Name: VarConfluentCloudAPISecret, Description: "Confluent Cloud API Secret", Sensitive: true, Type: "string"},
 }

--- a/internal/services/hcl/confluent/schema.go
+++ b/internal/services/hcl/confluent/schema.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -20,7 +21,7 @@ func safePathName(name string) string {
 }
 
 // GlueSchemaVariables defines the variables needed for Glue schema migration resources
-var GlueSchemaVariables = []types.TerraformVariable{
+var GlueSchemaVariables = []hcltypes.TerraformVariable{
 	{Name: VarConfluentCloudSchemaRegistryURL, Description: "REST endpoint of the target Confluent Cloud Schema Registry", Sensitive: false, Type: "string"},
 	{Name: VarConfluentCloudSchemaRegistryAPIKey, Description: "API key for the target Confluent Cloud Schema Registry", Sensitive: false, Type: "string"},
 	{Name: VarConfluentCloudSchemaRegistrySecret, Description: "API secret for the target Confluent Cloud Schema Registry", Sensitive: true, Type: "string"},

--- a/internal/services/hcl/generate.go
+++ b/internal/services/hcl/generate.go
@@ -3,6 +3,7 @@ package hcl
 import (
 	"sort"
 
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -11,7 +12,7 @@ import (
 
 // GenerateVariablesTf generates a variables.tf file from a list of variable definitions.
 // Duplicate variable names are deduplicated (first occurrence wins).
-func GenerateVariablesTf(tfVariables []types.TerraformVariable) string {
+func GenerateVariablesTf(tfVariables []hcltypes.TerraformVariable) string {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
@@ -40,7 +41,7 @@ func GenerateVariablesTf(tfVariables []types.TerraformVariable) string {
 }
 
 // GenerateOutputsTf generates an outputs.tf file from a list of output definitions.
-func GenerateOutputsTf(tfOutputs []types.TerraformOutput) string {
+func GenerateOutputsTf(tfOutputs []hcltypes.TerraformOutput) string {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 

--- a/internal/services/hcl/hcltypes/types.go
+++ b/internal/services/hcl/hcltypes/types.go
@@ -1,4 +1,8 @@
-package types
+// Package hcltypes holds the Terraform/HCL data models produced by the hcl
+// service. It is a dependency-free leaf package so that the hcl package, its
+// subpackages (modules, confluent, aws), and external callers (cmd, utils) can
+// all import these types without creating a parent/child import cycle.
+package hcltypes
 
 type TerraformState struct {
 	Outputs TerraformOutputOld `json:"outputs"`

--- a/internal/services/hcl/interfaces.go
+++ b/internal/services/hcl/interfaces.go
@@ -1,23 +1,26 @@
 package hcl
 
-import "github.com/confluentinc/kcp/internal/types"
+import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
+	"github.com/confluentinc/kcp/internal/types"
+)
 
 // MigrationInfraGenerator generates Terraform modules for MSK-to-CC migration infrastructure.
 type MigrationInfraGenerator interface {
-	GenerateTerraformModules(request types.MigrationWizardRequest) types.MigrationInfraTerraformProject
+	GenerateTerraformModules(request types.MigrationWizardRequest) hcltypes.MigrationInfraTerraformProject
 }
 
 // TargetInfraGenerator generates Terraform files for Confluent Cloud target infrastructure.
 type TargetInfraGenerator interface {
-	GenerateTerraformFiles(request types.TargetClusterWizardRequest) types.MigrationInfraTerraformProject
+	GenerateTerraformFiles(request types.TargetClusterWizardRequest) hcltypes.MigrationInfraTerraformProject
 }
 
 // MigrationScriptsGenerator generates Terraform files for migration scripts (mirror topics, ACLs, schemas).
 type MigrationScriptsGenerator interface {
-	GenerateMirrorTopicsFiles(request types.MirrorTopicsRequest) (types.MigrationScriptsTerraformProject, error)
-	GenerateMigrateAclsFiles(request types.MigrateAclsRequest) (types.TerraformFiles, error)
-	GenerateMigrateSchemasFiles(request types.MigrateSchemasRequest) (types.MigrationScriptsTerraformProject, error)
-	GenerateMigrateGlueSchemasFiles(request types.MigrateGlueSchemasRequest) (types.MigrationScriptsTerraformProject, error)
+	GenerateMirrorTopicsFiles(request types.MirrorTopicsRequest) (hcltypes.MigrationScriptsTerraformProject, error)
+	GenerateMigrateAclsFiles(request types.MigrateAclsRequest) (hcltypes.TerraformFiles, error)
+	GenerateMigrateSchemasFiles(request types.MigrateSchemasRequest) (hcltypes.MigrationScriptsTerraformProject, error)
+	GenerateMigrateGlueSchemasFiles(request types.MigrateGlueSchemasRequest) (hcltypes.MigrationScriptsTerraformProject, error)
 }
 
 // Compile-time interface satisfaction checks.

--- a/internal/services/hcl/migration_infra_hcl_service.go
+++ b/internal/services/hcl/migration_infra_hcl_service.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/services/hcl/modules"
 	"github.com/confluentinc/kcp/internal/types"
 )
@@ -18,7 +19,7 @@ func NewMigrationInfraHCLService() *MigrationInfraHCLService {
 	return &MigrationInfraHCLService{}
 }
 
-func (mi *MigrationInfraHCLService) GenerateTerraformModules(request types.MigrationWizardRequest) types.MigrationInfraTerraformProject {
+func (mi *MigrationInfraHCLService) GenerateTerraformModules(request types.MigrationWizardRequest) hcltypes.MigrationInfraTerraformProject {
 	if request.HasPublicEndpoints {
 		return mi.handlePublicMigrationInfrastructure(request)
 	}
@@ -30,15 +31,15 @@ func (mi *MigrationInfraHCLService) GenerateTerraformModules(request types.Migra
 	return mi.handleExternalOutboundClusterLinkingInfrastructure(request)
 }
 
-func (mi *MigrationInfraHCLService) handlePublicMigrationInfrastructure(request types.MigrationWizardRequest) types.MigrationInfraTerraformProject {
+func (mi *MigrationInfraHCLService) handlePublicMigrationInfrastructure(request types.MigrationWizardRequest) hcltypes.MigrationInfraTerraformProject {
 	requiredVariables := modules.GetMigrationInfraRootVariableDefinitions(request)
 
-	return types.MigrationInfraTerraformProject{
+	return hcltypes.MigrationInfraTerraformProject{
 		MainTf:           mi.generateRootMainTfForPublicMigrationInfrastructure(request),
 		ProvidersTf:      mi.generateRootProvidersTfForClusterLink(),
 		VariablesTf:      GenerateVariablesTf(requiredVariables),
 		InputsAutoTfvars: mi.generateInputsAutoTfvars(request),
-		Modules: []types.MigrationInfraTerraformModule{
+		Modules: []hcltypes.MigrationInfraTerraformModule{
 			{
 				Name:        "cluster_link",
 				MainTf:      mi.generateClusterLinkMainTf(),
@@ -48,16 +49,16 @@ func (mi *MigrationInfraHCLService) handlePublicMigrationInfrastructure(request 
 	}
 }
 
-func (mi *MigrationInfraHCLService) handlePrivateMigrationInfrastructure(request types.MigrationWizardRequest) types.MigrationInfraTerraformProject {
+func (mi *MigrationInfraHCLService) handlePrivateMigrationInfrastructure(request types.MigrationWizardRequest) hcltypes.MigrationInfraTerraformProject {
 	requiredVariables := modules.GetMigrationInfraRootVariableDefinitions(request)
 
-	return types.MigrationInfraTerraformProject{
+	return hcltypes.MigrationInfraTerraformProject{
 		MainTf:           mi.generateRootMainTfForPrivateMigrationInfrastructure(request),
 		ProvidersTf:      mi.generateRootProvidersTfForPrivateMigrationInfrastructure(),
 		VariablesTf:      GenerateVariablesTf(requiredVariables),
 		ReadmeMd:         mi.generateJumpClusterReadmeMd(request),
 		InputsAutoTfvars: mi.generateInputsAutoTfvars(request),
-		Modules: []types.MigrationInfraTerraformModule{
+		Modules: []hcltypes.MigrationInfraTerraformModule{
 			{
 				Name:        "jump_cluster_setup_host",
 				MainTf:      mi.generateJumpClusterSetupHostMainTf(),
@@ -88,15 +89,15 @@ func (mi *MigrationInfraHCLService) handlePrivateMigrationInfrastructure(request
 	}
 }
 
-func (mi *MigrationInfraHCLService) handleExternalOutboundClusterLinkingInfrastructure(request types.MigrationWizardRequest) types.MigrationInfraTerraformProject {
+func (mi *MigrationInfraHCLService) handleExternalOutboundClusterLinkingInfrastructure(request types.MigrationWizardRequest) hcltypes.MigrationInfraTerraformProject {
 	requiredVariables := modules.GetMigrationInfraRootVariableDefinitions(request)
 
-	return types.MigrationInfraTerraformProject{
+	return hcltypes.MigrationInfraTerraformProject{
 		MainTf:           mi.generateRootMainTfForExternalOutboundClusterLinkingInfrastructure(request),
 		ProvidersTf:      mi.generateRootProvidersTfForExternalOutboundClusterLinkingInfrastructure(),
 		VariablesTf:      GenerateVariablesTf(requiredVariables),
 		InputsAutoTfvars: mi.generateInputsAutoTfvars(request),
-		Modules: []types.MigrationInfraTerraformModule{
+		Modules: []hcltypes.MigrationInfraTerraformModule{
 			{
 				Name:        "external_outbound_cluster_link",
 				MainTf:      mi.generateExternalOutboundClusterLinkMainTf(request),

--- a/internal/services/hcl/migration_scripts_hcl_service.go
+++ b/internal/services/hcl/migration_scripts_hcl_service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/confluentinc/kcp/internal/services/hcl/confluent"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -40,9 +41,9 @@ func NewMigrationScriptsHCLService() *MigrationScriptsHCLService {
 //
 // Filename collisions across sanitized topic names are surfaced as a hard
 // error — auto-disambiguating would hide a real surprise from the user.
-func (s *MigrationScriptsHCLService) GenerateMirrorTopicsFiles(request types.MirrorTopicsRequest) (types.MigrationScriptsTerraformProject, error) {
+func (s *MigrationScriptsHCLService) GenerateMirrorTopicsFiles(request types.MirrorTopicsRequest) (hcltypes.MigrationScriptsTerraformProject, error) {
 	if request.Mode != types.MigrateTopicsModeMirror && request.Mode != types.MigrateTopicsModeNew {
-		return types.MigrationScriptsTerraformProject{}, fmt.Errorf("invalid mode: %q (values: %s, %s)", request.Mode, types.MigrateTopicsModeMirror, types.MigrateTopicsModeNew)
+		return hcltypes.MigrationScriptsTerraformProject{}, fmt.Errorf("invalid mode: %q (values: %s, %s)", request.Mode, types.MigrateTopicsModeMirror, types.MigrateTopicsModeNew)
 	}
 
 	topics := topicsForRequest(request)
@@ -65,16 +66,16 @@ func (s *MigrationScriptsHCLService) GenerateMirrorTopicsFiles(request types.Mir
 		perTopicFiles[filename] = content
 	}
 	if len(collisions) > 0 {
-		return types.MigrationScriptsTerraformProject{}, fmt.Errorf("filename collisions detected: %v — rename or exclude one of the colliding source topics", collisions)
+		return hcltypes.MigrationScriptsTerraformProject{}, fmt.Errorf("filename collisions detected: %v — rename or exclude one of the colliding source topics", collisions)
 	}
 
-	folder := types.MigrationScriptsTerraformFolder{
+	folder := hcltypes.MigrationScriptsTerraformFolder{
 		ProvidersTf:     s.generateProvidersTf(),
 		VariablesTf:     s.generateMirrorTopicsVariablesTf(),
 		AdditionalFiles: perTopicFiles,
 	}
-	return types.MigrationScriptsTerraformProject{
-		Folders: []types.MigrationScriptsTerraformFolder{folder},
+	return hcltypes.MigrationScriptsTerraformProject{
+		Folders: []hcltypes.MigrationScriptsTerraformFolder{folder},
 	}, nil
 }
 
@@ -123,8 +124,8 @@ func topicsForRequest(request types.MirrorTopicsRequest) []types.TopicDetails {
 	return out
 }
 
-func (s *MigrationScriptsHCLService) GenerateMigrateAclsFiles(request types.MigrateAclsRequest) (types.TerraformFiles, error) {
-	return types.TerraformFiles{
+func (s *MigrationScriptsHCLService) GenerateMigrateAclsFiles(request types.MigrateAclsRequest) (hcltypes.TerraformFiles, error) {
+	return hcltypes.TerraformFiles{
 		PerPrincipalTf:   s.generatePerPrincipalACLsTf(request),
 		ProvidersTf:      s.generateProvidersTf(),
 		VariablesTf:      s.generateMigrateACLsVariablesTf(),
@@ -132,13 +133,13 @@ func (s *MigrationScriptsHCLService) GenerateMigrateAclsFiles(request types.Migr
 	}, nil
 }
 
-func (s *MigrationScriptsHCLService) GenerateMigrateSchemasFiles(request types.MigrateSchemasRequest) (types.MigrationScriptsTerraformProject, error) {
-	ms := types.MigrationScriptsTerraformProject{}
-	folders := []types.MigrationScriptsTerraformFolder{}
+func (s *MigrationScriptsHCLService) GenerateMigrateSchemasFiles(request types.MigrateSchemasRequest) (hcltypes.MigrationScriptsTerraformProject, error) {
+	ms := hcltypes.MigrationScriptsTerraformProject{}
+	folders := []hcltypes.MigrationScriptsTerraformFolder{}
 	for _, schemaRegistry := range request.SchemaRegistries {
 		if schemaRegistry.Migrate {
 			folderName := utils.URLToFolderName(schemaRegistry.SourceURL)
-			folder := types.MigrationScriptsTerraformFolder{
+			folder := hcltypes.MigrationScriptsTerraformFolder{
 				Name:             folderName,
 				MainTf:           s.generateMigrateSchemasMainTf(schemaRegistry),
 				ProvidersTf:      s.generateMigrateSchemasProvidersTf(),
@@ -155,8 +156,12 @@ func (s *MigrationScriptsHCLService) GenerateMigrateSchemasFiles(request types.M
 	return ms, nil
 }
 
-func (s *MigrationScriptsHCLService) generateMigrateConnectorsFiles() (types.TerraformFiles, error) {
-	return types.TerraformFiles{
+// generateMigrateConnectorsFiles supports an in-progress migrate-connectors flow
+// that is not yet wired into the orchestrator.
+//
+//nolint:unused // pre-existing, not yet wired up; surfaced by new-from-rev after the hcltypes rename
+func (s *MigrationScriptsHCLService) generateMigrateConnectorsFiles() (hcltypes.TerraformFiles, error) {
+	return hcltypes.TerraformFiles{
 		MainTf:      s.generateMigrateConnectorsMainTf(),
 		ProvidersTf: s.generateProvidersTf(),
 		VariablesTf: s.generateMigrateConnectorsVariablesTf(),
@@ -348,9 +353,9 @@ func (s *MigrationScriptsHCLService) generateMigrateConnectorsVariablesTf() stri
 // Migrate Glue Schemas Generation Methods
 // ============================================================================
 
-func (s *MigrationScriptsHCLService) GenerateMigrateGlueSchemasFiles(request types.MigrateGlueSchemasRequest) (types.MigrationScriptsTerraformProject, error) {
-	ms := types.MigrationScriptsTerraformProject{}
-	folders := []types.MigrationScriptsTerraformFolder{}
+func (s *MigrationScriptsHCLService) GenerateMigrateGlueSchemasFiles(request types.MigrateGlueSchemasRequest) (hcltypes.MigrationScriptsTerraformProject, error) {
+	ms := hcltypes.MigrationScriptsTerraformProject{}
+	folders := []hcltypes.MigrationScriptsTerraformFolder{}
 
 	for _, registry := range request.GlueRegistries {
 		if !registry.Migrate || len(registry.Schemas) == 0 {
@@ -359,9 +364,9 @@ func (s *MigrationScriptsHCLService) GenerateMigrateGlueSchemasFiles(request typ
 
 		generatedFiles, err := confluent.GenerateGlueSchemaMigrationHCL(registry.Schemas)
 		if err != nil {
-			return types.MigrationScriptsTerraformProject{}, fmt.Errorf("failed to generate HCL for Glue registry %q: %w", registry.RegistryName, err)
+			return hcltypes.MigrationScriptsTerraformProject{}, fmt.Errorf("failed to generate HCL for Glue registry %q: %w", registry.RegistryName, err)
 		}
-		folder := types.MigrationScriptsTerraformFolder{
+		folder := hcltypes.MigrationScriptsTerraformFolder{
 			Name:             registry.RegistryName,
 			ProvidersTf:      s.generateProvidersTf(),
 			VariablesTf:      s.generateMigrateGlueSchemasVariablesTf(),

--- a/internal/services/hcl/modules/cluster_link_module.go
+++ b/internal/services/hcl/modules/cluster_link_module.go
@@ -1,6 +1,9 @@
 package modules
 
-import "github.com/confluentinc/kcp/internal/types"
+import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
+	"github.com/confluentinc/kcp/internal/types"
+)
 
 func GetClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	return []ModuleVariable[types.MigrationWizardRequest]{
@@ -71,7 +74,7 @@ func GetClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_sasl_scram_mechanism",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_mechanism",
 				Description: "The SASL/SCRAM mechanism of the source Kafka cluster (SCRAM-SHA-256 or SCRAM-SHA-512).",
 				Sensitive:   false,
@@ -84,6 +87,6 @@ func GetClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	}
 }
 
-func GetClusterLinkModuleVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetClusterLinkModuleVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetClusterLinkVariables(), request)
 }

--- a/internal/services/hcl/modules/confluent_cloud_module.go
+++ b/internal/services/hcl/modules/confluent_cloud_module.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"fmt"
 
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -10,7 +11,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 	return []ModuleVariable[types.TargetClusterWizardRequest]{
 		{
 			Name: "aws_region",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "aws_region",
 				Description: "The AWS region in which the Confluent Cloud cluster is provisioned in.",
 				Sensitive:   false,
@@ -23,7 +24,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "environment_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "environment_id",
 				Description: "ID of the environment",
 				Sensitive:   false,
@@ -38,7 +39,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "environment_name",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "environment_name",
 				Description: "Name of the environment",
 				Sensitive:   false,
@@ -53,7 +54,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "cluster_name",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_name",
 				Description: "Name of the cluster",
 				Sensitive:   false,
@@ -68,7 +69,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "cluster_type",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_type",
 				Description: "Type of the cluster",
 				Sensitive:   false,
@@ -83,7 +84,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "cluster_availability",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_availability",
 				Description: "Cluster availability zone type (SINGLE_ZONE or MULTI_ZONE)",
 				Sensitive:   false,
@@ -98,7 +99,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 		},
 		{
 			Name: "cluster_cku",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_cku",
 				Description: "Number of CKUs for dedicated clusters",
 				Sensitive:   false,
@@ -114,7 +115,7 @@ func GetConfluentCloudVariables() []ModuleVariable[types.TargetClusterWizardRequ
 	}
 }
 
-func GetConfluentCloudVariableDefinitions(request types.TargetClusterWizardRequest) []types.TerraformVariable {
+func GetConfluentCloudVariableDefinitions(request types.TargetClusterWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetConfluentCloudVariables(), request)
 }
 
@@ -126,8 +127,8 @@ type ConfluentCloudOutputParams struct {
 	KafkaAPIKeyName    string
 }
 
-func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardRequest, params ConfluentCloudOutputParams) []types.TerraformOutput {
-	var definitions []types.TerraformOutput
+func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardRequest, params ConfluentCloudOutputParams) []hcltypes.TerraformOutput {
+	var definitions []hcltypes.TerraformOutput
 
 	var envIdValue string
 	if request.NeedsEnvironment {
@@ -136,7 +137,7 @@ func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardR
 		envIdValue = fmt.Sprintf("data.confluent_environment.%s.id", params.EnvironmentName)
 	}
 
-	definitions = append(definitions, types.TerraformOutput{
+	definitions = append(definitions, hcltypes.TerraformOutput{
 		Name:        "environment_id",
 		Description: "ID of the environment",
 		Sensitive:   false,
@@ -145,17 +146,17 @@ func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardR
 
 	// Cluster outputs
 	definitions = append(definitions,
-		types.TerraformOutput{
+		hcltypes.TerraformOutput{
 			Name:        "cluster_id",
 			Description: "ID of the Kafka cluster",
 			Value:       fmt.Sprintf("confluent_kafka_cluster.%s.id", params.ClusterName),
 		},
-		types.TerraformOutput{
+		hcltypes.TerraformOutput{
 			Name:        "cluster_bootstrap_endpoint",
 			Description: "Bootstrap endpoint of the Kafka cluster",
 			Value:       fmt.Sprintf("confluent_kafka_cluster.%s.bootstrap_endpoint", params.ClusterName),
 		},
-		types.TerraformOutput{
+		hcltypes.TerraformOutput{
 			Name:        "cluster_rest_endpoint",
 			Description: "REST endpoint of the Kafka cluster",
 			Value:       fmt.Sprintf("confluent_kafka_cluster.%s.rest_endpoint", params.ClusterName),
@@ -163,7 +164,7 @@ func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardR
 	)
 
 	// Service account output
-	definitions = append(definitions, types.TerraformOutput{
+	definitions = append(definitions, hcltypes.TerraformOutput{
 		Name:        "service_account_id",
 		Description: "ID of the service account",
 		Value:       fmt.Sprintf("confluent_service_account.%s.id", params.ServiceAccountName),
@@ -171,12 +172,12 @@ func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardR
 
 	// Kafka API key outputs
 	definitions = append(definitions,
-		types.TerraformOutput{
+		hcltypes.TerraformOutput{
 			Name:        "kafka_api_key_id",
 			Description: "ID of the Kafka API key",
 			Value:       fmt.Sprintf("confluent_api_key.%s.id", params.KafkaAPIKeyName),
 		},
-		types.TerraformOutput{
+		hcltypes.TerraformOutput{
 			Name:        "kafka_api_key_secret",
 			Description: "Secret of the Kafka API key",
 			Sensitive:   true,
@@ -187,22 +188,22 @@ func GetConfluentCloudModuleOutputDefinitions(request types.TargetClusterWizardR
 	// Network outputs (only for dedicated clusters with private link)
 	if request.NeedsPrivateLink && request.ClusterType == "dedicated" {
 		definitions = append(definitions,
-			types.TerraformOutput{
+			hcltypes.TerraformOutput{
 				Name:        "network_id",
 				Description: "ID of the Confluent Cloud network",
 				Value:       fmt.Sprintf("confluent_network.%s.id", params.NetworkName),
 			},
-			types.TerraformOutput{
+			hcltypes.TerraformOutput{
 				Name:        "network_dns_domain",
 				Description: "DNS domain of the Confluent Cloud network",
 				Value:       fmt.Sprintf("confluent_network.%s.dns_domain", params.NetworkName),
 			},
-			types.TerraformOutput{
+			hcltypes.TerraformOutput{
 				Name:        "network_private_link_endpoint_service",
 				Description: "AWS VPC endpoint service name for the Confluent Cloud network",
 				Value:       fmt.Sprintf("confluent_network.%s.aws[0].private_link_endpoint_service", params.NetworkName),
 			},
-			types.TerraformOutput{
+			hcltypes.TerraformOutput{
 				Name:        "network_zones",
 				Description: "Availability zone IDs supported by the Confluent Cloud network",
 				Value:       fmt.Sprintf("confluent_network.%s.zones", params.NetworkName),

--- a/internal/services/hcl/modules/external_outbound_cluster_link_module.go
+++ b/internal/services/hcl/modules/external_outbound_cluster_link_module.go
@@ -1,12 +1,15 @@
 package modules
 
-import "github.com/confluentinc/kcp/internal/types"
+import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
+	"github.com/confluentinc/kcp/internal/types"
+)
 
 func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	return []ModuleVariable[types.MigrationWizardRequest]{
 		{
 			Name: "subnet_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "subnet_id",
 				Description: "The subnet ID where the EC2 instance will be launched.",
 				Sensitive:   false,
@@ -19,7 +22,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "security_group_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "security_group_id",
 				Description: "The security group ID to attach to the EC2 instance.",
 				Sensitive:   false,
@@ -32,7 +35,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "confluent_cloud_cluster_api_key",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_api_key",
 				Description: "API key of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   true,
@@ -45,7 +48,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "confluent_cloud_cluster_api_secret",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_api_secret",
 				Description: "API secret of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   true,
@@ -58,7 +61,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "target_cluster_rest_endpoint",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "target_cluster_rest_endpoint",
 				Description: "REST endpoint of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   false,
@@ -71,7 +74,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "target_cluster_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "target_cluster_id",
 				Description: "ID of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   false,
@@ -84,7 +87,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "cluster_link_name",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_link_name",
 				Description: "Name of the cluster link that will be created between the source and target Confluent Cloud clusters.",
 				Sensitive:   false,
@@ -97,7 +100,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "source_cluster_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_cluster_id",
 				Description: "ID of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -110,7 +113,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "source_cluster_bootstrap_servers",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_cluster_bootstrap_servers",
 				Description: "Bootstrap brokers of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -126,7 +129,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "source_sasl_scram_mechanism",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_mechanism",
 				Description: "The SASL/SCRAM mechanism of the source Kafka cluster (SCRAM-SHA-256 or SCRAM-SHA-512).",
 				Sensitive:   false,
@@ -142,7 +145,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "source_sasl_scram_username",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_username",
 				Description: "SASL SCRAM username of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   true,
@@ -157,7 +160,7 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 		},
 		{
 			Name: "source_sasl_scram_password",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_password",
 				Description: "SASL SCRAM password of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   true,
@@ -173,6 +176,6 @@ func GetExternalOutboundClusterLinkingVariables() []ModuleVariable[types.Migrati
 	}
 }
 
-func GetExternalOutboundClusterLinkingModuleVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetExternalOutboundClusterLinkingModuleVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetExternalOutboundClusterLinkingVariables(), request)
 }

--- a/internal/services/hcl/modules/jump_cluster_module.go
+++ b/internal/services/hcl/modules/jump_cluster_module.go
@@ -1,12 +1,15 @@
 package modules
 
-import "github.com/confluentinc/kcp/internal/types"
+import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
+	"github.com/confluentinc/kcp/internal/types"
+)
 
 func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	return []ModuleVariable[types.MigrationWizardRequest]{
 		{
 			Name: "jump_cluster_broker_subnet_ids",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_broker_subnet_ids",
 				Description: "IDs of the subnets that the jump cluster broker instances are deployed to.",
 				Sensitive:   false,
@@ -20,7 +23,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "jump_cluster_instance_type",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_instance_type",
 				Description: "Instance type of the jump cluster instances.",
 				Sensitive:   false,
@@ -51,7 +54,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "jump_cluster_iam_auth_role_name",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_iam_auth_role_name",
 				Description: "Name of the IAM role that will be attached to the jump cluster instances to enable IAM authenticated cluster linking between MSK and jump cluster.",
 				Sensitive:   false,
@@ -66,7 +69,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "jump_cluster_broker_storage",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_broker_storage",
 				Description: "Storage size of the jump cluster broker instances.",
 				Sensitive:   false,
@@ -79,7 +82,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "confluent_cloud_cluster_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_id",
 				Description: "ID of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   false,
@@ -92,7 +95,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "confluent_cloud_cluster_bootstrap_endpoint",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_bootstrap_endpoint",
 				Description: "Bootstrap endpoint of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   false,
@@ -105,7 +108,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "confluent_cloud_cluster_rest_endpoint",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_rest_endpoint",
 				Description: "REST endpoint of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   false,
@@ -119,7 +122,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		// Needs to be passed to the module as it is used for creating the cluster link between the jump cluster and Confluent Cloud.
 		{
 			Name: "confluent_cloud_cluster_api_key",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_api_key",
 				Description: "API key of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   true,
@@ -133,7 +136,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "confluent_cloud_cluster_api_secret",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "confluent_cloud_cluster_api_secret",
 				Description: "API secret of the Confluent Cloud cluster that data will be migrated to.",
 				Sensitive:   true,
@@ -147,7 +150,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_cluster_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_cluster_id",
 				Description: "ID of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -160,7 +163,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_cluster_bootstrap_brokers",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_cluster_bootstrap_brokers",
 				Description: "Bootstrap brokers of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -180,7 +183,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_sasl_scram_username",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_username",
 				Description: "SASL SCRAM username of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   true,
@@ -195,7 +198,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_sasl_scram_password",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_password",
 				Description: "SASL SCRAM password of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   true,
@@ -210,7 +213,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "source_sasl_scram_mechanism",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "source_sasl_scram_mechanism",
 				Description: "The SASL/SCRAM mechanism of the source Kafka cluster (SCRAM-SHA-256 or SCRAM-SHA-512).",
 				Sensitive:   false,
@@ -225,7 +228,7 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "cluster_link_name",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "cluster_link_name",
 				Description: "Name of the cluster links between the source Kafka cluster and Confluent Cloud through the jump cluster.",
 				Sensitive:   false,
@@ -239,11 +242,11 @@ func GetJumpClusterVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	}
 }
 
-func GetJumpClusterModuleVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetJumpClusterModuleVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetJumpClusterVariables(), request)
 }
 
-var JumpClusterModuleOutputs = []types.TerraformOutput{
+var JumpClusterModuleOutputs = []hcltypes.TerraformOutput{
 	{
 		Name:        "jump_cluster_instances_private_dns",
 		Description: "Private DNS addresses of the jump cluster instances.",
@@ -252,6 +255,6 @@ var JumpClusterModuleOutputs = []types.TerraformOutput{
 	},
 }
 
-func GetJumpClusterModuleOutputDefinitions() []types.TerraformOutput {
+func GetJumpClusterModuleOutputDefinitions() []hcltypes.TerraformOutput {
 	return JumpClusterModuleOutputs
 }

--- a/internal/services/hcl/modules/jump_cluster_setup_host_module.go
+++ b/internal/services/hcl/modules/jump_cluster_setup_host_module.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -8,7 +9,7 @@ func GetJumpClusterSetupHostVariables() []ModuleVariable[types.MigrationWizardRe
 	return []ModuleVariable[types.MigrationWizardRequest]{
 		{
 			Name: "jump_cluster_setup_host_subnet_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_setup_host_subnet_id",
 				Description: "ID of the subnet that the jump cluster setup host (Ansible) instance is deployed to.",
 				Sensitive:   false,
@@ -40,7 +41,7 @@ func GetJumpClusterSetupHostVariables() []ModuleVariable[types.MigrationWizardRe
 		},
 		{
 			Name: "jump_cluster_instances_private_dns",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_instances_private_dns",
 				Description: "Private DNS addresses of the jump cluster instances.",
 				Sensitive:   false,
@@ -54,7 +55,7 @@ func GetJumpClusterSetupHostVariables() []ModuleVariable[types.MigrationWizardRe
 		},
 		{
 			Name: "private_key",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "private_key",
 				Description: "Private SSH key for accessing the jump cluster (including setup host) instances.",
 				Sensitive:   true,
@@ -69,6 +70,6 @@ func GetJumpClusterSetupHostVariables() []ModuleVariable[types.MigrationWizardRe
 	}
 }
 
-func GetJumpClusterSetupHostVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetJumpClusterSetupHostVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetJumpClusterSetupHostVariables(), request)
 }

--- a/internal/services/hcl/modules/module_definitions.go
+++ b/internal/services/hcl/modules/module_definitions.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -11,7 +12,7 @@ type ModuleVariable[R any] struct {
 	// This may differ from Definition.Name (the root-level variable name).
 	// WriteModuleInputs uses Name for the attribute key and Definition.Name for the var. reference.
 	Name             string
-	Definition       types.TerraformVariable
+	Definition       hcltypes.TerraformVariable
 	ValueExtractor   func(request R) any  // Extracts the value from FE request payload. If nil, it's not a root-level variable.
 	Condition        func(request R) bool // Determines if this variable should be included (nil = always include).
 	FromModuleOutput string               // If non-empty, this variable comes from the named module's output.
@@ -20,7 +21,7 @@ type ModuleVariable[R any] struct {
 // NOTE: VariableSchema migration is partially complete. Variables shared across modules
 // (provider, cluster link, vpc, security group, SSH key pair) use VariableSchema.
 // Remaining module-specific variables (jump cluster, networking, confluent cloud,
-// private link, external outbound) still define types.TerraformVariable inline.
+// private link, external outbound) still define hcltypes.TerraformVariable inline.
 
 // ============================================================================
 // Target Cluster
@@ -38,7 +39,7 @@ func GetTargetClusterModuleVariableValues(request types.TargetClusterWizardReque
 	return extractVariableValues(collectTargetClusterVars(), request)
 }
 
-func GetTargetClusterModuleVariableDefinitions(request types.TargetClusterWizardRequest) []types.TerraformVariable {
+func GetTargetClusterModuleVariableDefinitions(request types.TargetClusterWizardRequest) []hcltypes.TerraformVariable {
 	return extractVariableDefinitions(collectTargetClusterVars(), request)
 }
 
@@ -69,7 +70,7 @@ func GetMigrationInfraRootVariableValues(request types.MigrationWizardRequest) m
 	return extractVariableValues(collectMigrationInfraVars(request), request)
 }
 
-func GetMigrationInfraRootVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetMigrationInfraRootVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return extractVariableDefinitions(collectMigrationInfraVars(request), request)
 }
 
@@ -125,8 +126,8 @@ func extractVariableValues[R any](allVars []ModuleVariable[R], request R) map[st
 
 // extractVariableDefinitions extracts root-level variable definitions.
 // It filters by condition and skips variables without value extractors or those coming from module outputs.
-func extractVariableDefinitions[R any](allVars []ModuleVariable[R], request R) []types.TerraformVariable {
-	var definitions []types.TerraformVariable
+func extractVariableDefinitions[R any](allVars []ModuleVariable[R], request R) []hcltypes.TerraformVariable {
+	var definitions []hcltypes.TerraformVariable
 
 	for _, varDef := range allVars {
 		if varDef.Condition != nil && !varDef.Condition(request) {

--- a/internal/services/hcl/modules/networking_module.go
+++ b/internal/services/hcl/modules/networking_module.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -16,7 +17,7 @@ func GetNetworkingVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "jump_cluster_broker_subnet_cidrs",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_broker_subnet_cidrs",
 				Description: "CIDR ranges of the jump cluster broker subnets",
 				Sensitive:   false,
@@ -29,7 +30,7 @@ func GetNetworkingVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "jump_cluster_setup_host_subnet_cidr",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "jump_cluster_setup_host_subnet_cidr",
 				Description: "CIDR block of the jump cluster setup host subnet",
 				Sensitive:   false,
@@ -42,7 +43,7 @@ func GetNetworkingVariables() []ModuleVariable[types.MigrationWizardRequest] {
 		},
 		{
 			Name: "existing_private_link_vpce_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "existing_private_link_vpce_id",
 				Description: "ID of the existing VPC endpoint for the Private Link connection to Confluent Cloud",
 				Sensitive:   false,
@@ -56,11 +57,11 @@ func GetNetworkingVariables() []ModuleVariable[types.MigrationWizardRequest] {
 	}
 }
 
-func GetNetworkingModuleVariableDefinitions(request types.MigrationWizardRequest) []types.TerraformVariable {
+func GetNetworkingModuleVariableDefinitions(request types.MigrationWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetNetworkingVariables(), request)
 }
 
-var NetworkingModuleOutputs = []types.TerraformOutput{
+var NetworkingModuleOutputs = []hcltypes.TerraformOutput{
 	{
 		Name:        "jump_cluster_setup_host_subnet_id",
 		Description: "ID of the subnet that the Ansible jump cluster setup host instance is deployed to.",
@@ -93,6 +94,6 @@ var NetworkingModuleOutputs = []types.TerraformOutput{
 	},
 }
 
-func GetNetworkingModuleOutputDefinitions() []types.TerraformOutput {
+func GetNetworkingModuleOutputDefinitions() []hcltypes.TerraformOutput {
 	return NetworkingModuleOutputs
 }

--- a/internal/services/hcl/modules/private_cluster_link_module.go
+++ b/internal/services/hcl/modules/private_cluster_link_module.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -8,7 +9,7 @@ func GetPrivateClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequ
 	return []ModuleVariable[types.MigrationWizardRequest]{
 		{
 			Name: "aws_region",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "aws_region",
 				Description: "AWS region of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -22,7 +23,7 @@ func GetPrivateClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequ
 		},
 		{
 			Name: "aws_vpc_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "aws_vpc_id",
 				Description: "VPC ID of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -36,7 +37,7 @@ func GetPrivateClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequ
 		},
 		{
 			Name: "aws_kafka_brokers",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "aws_kafka_brokers",
 				Description: "AWS Kafka brokers of the source Kafka cluster that data will be migrated from.",
 				Sensitive:   false,
@@ -50,7 +51,7 @@ func GetPrivateClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequ
 		},
 		{
 			Name: "cc_env_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "target_environment_id",
 				Description: "Target environment ID where Confluent Cloud cluster is located.",
 				Sensitive:   false,
@@ -64,7 +65,7 @@ func GetPrivateClusterLinkVariables() []ModuleVariable[types.MigrationWizardRequ
 		},
 		{
 			Name: "cc_cluster_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "target_cluster_id",
 				Description: "Target cluster ID where data will be migrated to.",
 				Sensitive:   false,

--- a/internal/services/hcl/modules/private_link_module.go
+++ b/internal/services/hcl/modules/private_link_module.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"fmt"
 
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -10,7 +11,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 	return []ModuleVariable[types.TargetClusterWizardRequest]{
 		{
 			Name: "aws_region",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "aws_region",
 				Description: "The AWS region of the VPC that the private link connection is established in.",
 				Sensitive:   false,
@@ -23,7 +24,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "vpc_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "vpc_id",
 				Description: "The ID of the VPC that the private link connection is established in.",
 				Sensitive:   false,
@@ -36,7 +37,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "subnet_cidr_ranges",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "subnet_cidr_ranges",
 				Description: "The CIDR ranges of the subnets that the private link connection is established in.",
 				Sensitive:   false,
@@ -49,7 +50,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "environment_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "environment_id",
 				Description: "The ID of the environment that the private link connection is established in.",
 				Sensitive:   false,
@@ -61,7 +62,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "network_id",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "network_id",
 				Description: "The ID of the Confluent Cloud network (for dedicated cluster private link).",
 				Sensitive:   false,
@@ -75,7 +76,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "network_dns_domain",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "network_dns_domain",
 				Description: "The DNS domain of the Confluent Cloud network (for dedicated cluster private link).",
 				Sensitive:   false,
@@ -89,7 +90,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "network_private_link_endpoint_service",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "network_private_link_endpoint_service",
 				Description: "The AWS VPC endpoint service name for the Confluent Cloud network (for dedicated cluster private link).",
 				Sensitive:   false,
@@ -103,7 +104,7 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 		},
 		{
 			Name: "network_zones",
-			Definition: types.TerraformVariable{
+			Definition: hcltypes.TerraformVariable{
 				Name:        "network_zones",
 				Description: "Availability zone IDs supported by the Confluent Cloud network (for dedicated cluster private link).",
 				Sensitive:   false,
@@ -118,8 +119,8 @@ func GetTargetClusterPrivateLinkVariables() []ModuleVariable[types.TargetCluster
 	}
 }
 
-func GetPrivateLinkModuleOutputDefinitions(vpcEndpointResourceName string) []types.TerraformOutput {
-	return []types.TerraformOutput{
+func GetPrivateLinkModuleOutputDefinitions(vpcEndpointResourceName string) []hcltypes.TerraformOutput {
+	return []hcltypes.TerraformOutput{
 		{
 			Name:        "vpc_endpoint_id",
 			Description: "ID of the AWS VPC Endpoint for the Private Link connection",
@@ -128,6 +129,6 @@ func GetPrivateLinkModuleOutputDefinitions(vpcEndpointResourceName string) []typ
 	}
 }
 
-func GetTargetClusterPrivateLinkModuleVariableDefinitions(request types.TargetClusterWizardRequest) []types.TerraformVariable {
+func GetTargetClusterPrivateLinkModuleVariableDefinitions(request types.TargetClusterWizardRequest) []hcltypes.TerraformVariable {
 	return ExtractModuleVariableDefinitions(GetTargetClusterPrivateLinkVariables(), request)
 }

--- a/internal/services/hcl/modules/variable_schema.go
+++ b/internal/services/hcl/modules/variable_schema.go
@@ -1,6 +1,6 @@
 package modules
 
-import "github.com/confluentinc/kcp/internal/types"
+import "github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 
 // VariableSchema defines the metadata for a Terraform variable (name, type, description, sensitivity).
 // Shared across modules to avoid duplicating variable definitions.
@@ -11,9 +11,9 @@ type VariableSchema struct {
 	Sensitive   bool
 }
 
-// ToDefinition converts a VariableSchema to a types.TerraformVariable.
-func (v VariableSchema) ToDefinition() types.TerraformVariable {
-	return types.TerraformVariable{
+// ToDefinition converts a VariableSchema to a hcltypes.TerraformVariable.
+func (v VariableSchema) ToDefinition() hcltypes.TerraformVariable {
+	return hcltypes.TerraformVariable{
 		Name:        v.Name,
 		Type:        v.Type,
 		Description: v.Description,
@@ -114,8 +114,8 @@ var (
 // ExtractModuleVariableDefinitions extracts variable definitions for a module.
 // Unlike extractVariableDefinitions (which is for root-level), this includes ALL variables
 // regardless of ValueExtractor or FromModuleOutput — a module needs all its declared variables.
-func ExtractModuleVariableDefinitions[R any](allVars []ModuleVariable[R], request R) []types.TerraformVariable {
-	var definitions []types.TerraformVariable
+func ExtractModuleVariableDefinitions[R any](allVars []ModuleVariable[R], request R) []hcltypes.TerraformVariable {
+	var definitions []hcltypes.TerraformVariable
 
 	for _, varDef := range allVars {
 		if varDef.Condition != nil && !varDef.Condition(request) {

--- a/internal/services/hcl/reverse_proxy_hcl_service.go
+++ b/internal/services/hcl/reverse_proxy_hcl_service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/confluentinc/kcp/internal/services/hcl/aws"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/services/hcl/other"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
@@ -29,8 +30,8 @@ func NewReverseProxyHCLService() *ReverseProxyHCLService {
 	return &ReverseProxyHCLService{}
 }
 
-func (s *ReverseProxyHCLService) GenerateReverseProxyFiles(request types.ReverseProxyRequest) (types.TerraformFiles, error) {
-	return types.TerraformFiles{
+func (s *ReverseProxyHCLService) GenerateReverseProxyFiles(request types.ReverseProxyRequest) (hcltypes.TerraformFiles, error) {
+	return hcltypes.TerraformFiles{
 		MainTf:           s.generateMainTf(request),
 		ProvidersTf:      s.generateProvidersTf(),
 		VariablesTf:      s.generateVariablesTf(),
@@ -297,7 +298,7 @@ func (s *ReverseProxyHCLService) generateVariablesTf() string {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
-	variables := []types.TerraformVariable{
+	variables := []hcltypes.TerraformVariable{
 		{Name: "vpc_id", Description: "The ID of the VPC", Type: "string", Sensitive: false},
 		{Name: "public_subnet_cidr", Description: "CIDR block for the public subnet", Type: "string", Sensitive: false},
 		{Name: "confluent_cloud_cluster_bootstrap_endpoint", Description: "The bootstrap endpoint of the Confluent cluster", Type: "string", Sensitive: false},

--- a/internal/services/hcl/snapshot_test_helper.go
+++ b/internal/services/hcl/snapshot_test_helper.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/require"
 )
@@ -89,7 +89,7 @@ terraform {
 }
 
 // projectToFiles flattens a MigrationInfraTerraformProject into a map of filename → content.
-func projectToFiles(project types.MigrationInfraTerraformProject) map[string]string {
+func projectToFiles(project hcltypes.MigrationInfraTerraformProject) map[string]string {
 	files := map[string]string{}
 
 	if project.MainTf != "" {
@@ -134,7 +134,7 @@ func projectToFiles(project types.MigrationInfraTerraformProject) map[string]str
 }
 
 // terraformFilesToMap flattens a TerraformFiles into a map of filename → content.
-func terraformFilesToMap(tf types.TerraformFiles) map[string]string {
+func terraformFilesToMap(tf hcltypes.TerraformFiles) map[string]string {
 	files := map[string]string{}
 
 	if tf.MainTf != "" {
@@ -163,7 +163,7 @@ func terraformFilesToMap(tf types.TerraformFiles) map[string]string {
 // into a flat filename → content map suitable for terraform validation. Unlike
 // schemaProjectToFiles (which prefixes per-registry folder paths), migrate-topics
 // always returns one folder rendered at the project root.
-func migrateTopicsProjectToFiles(project types.MigrationScriptsTerraformProject) map[string]string {
+func migrateTopicsProjectToFiles(project hcltypes.MigrationScriptsTerraformProject) map[string]string {
 	files := map[string]string{}
 	if len(project.Folders) == 0 {
 		return files
@@ -182,7 +182,7 @@ func migrateTopicsProjectToFiles(project types.MigrationScriptsTerraformProject)
 }
 
 // schemaProjectToFiles flattens a MigrationScriptsTerraformProject into a map.
-func schemaProjectToFiles(project types.MigrationScriptsTerraformProject) map[string]string {
+func schemaProjectToFiles(project hcltypes.MigrationScriptsTerraformProject) map[string]string {
 	files := map[string]string{}
 
 	for _, folder := range project.Folders {

--- a/internal/services/hcl/target_infra_hcl_service.go
+++ b/internal/services/hcl/target_infra_hcl_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/confluentinc/kcp/internal/services/hcl/aws"
 	"github.com/confluentinc/kcp/internal/services/hcl/confluent"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/confluentinc/kcp/internal/services/hcl/modules"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
@@ -82,8 +83,8 @@ func NewTargetInfraHCLService() *TargetInfraHCLService {
 	}
 }
 
-func (ti *TargetInfraHCLService) GenerateTerraformFiles(request types.TargetClusterWizardRequest) types.MigrationInfraTerraformProject {
-	requiredModules := []types.MigrationInfraTerraformModule{
+func (ti *TargetInfraHCLService) GenerateTerraformFiles(request types.TargetClusterWizardRequest) hcltypes.MigrationInfraTerraformProject {
+	requiredModules := []hcltypes.MigrationInfraTerraformModule{
 		{
 			Name:        "confluent_cloud",
 			MainTf:      ti.generateConfluentCloudModuleMainTf(request),
@@ -94,7 +95,7 @@ func (ti *TargetInfraHCLService) GenerateTerraformFiles(request types.TargetClus
 	}
 
 	if request.NeedsPrivateLink {
-		requiredModules = append(requiredModules, types.MigrationInfraTerraformModule{
+		requiredModules = append(requiredModules, hcltypes.MigrationInfraTerraformModule{
 			Name:        "private_link",
 			MainTf:      ti.generatePrivateLinkModuleMainTf(request),
 			VariablesTf: ti.generatePrivateLinkModuleVariablesTf(request),
@@ -103,7 +104,7 @@ func (ti *TargetInfraHCLService) GenerateTerraformFiles(request types.TargetClus
 		})
 	}
 
-	return types.MigrationInfraTerraformProject{
+	return hcltypes.MigrationInfraTerraformProject{
 		MainTf:           ti.generateRootMainTf(request),
 		ProvidersTf:      ti.generateRootProvidersTf(),
 		VariablesTf:      GenerateVariablesTf(modules.GetTargetClusterModuleVariableDefinitions(request)),
@@ -199,7 +200,7 @@ func (ti *TargetInfraHCLService) generateRootOutputsTf(request types.TargetClust
 		KafkaAPIKeyName:    ti.ResourceNames.KafkaAPIKey,
 	})
 
-	var rootOutputs []types.TerraformOutput
+	var rootOutputs []hcltypes.TerraformOutput
 	// For enterprise clusters with Private Link, the default cluster endpoints use
 	// *.aws.private.confluent.cloud which does not resolve via the gateway Route53
 	// Private Hosted Zone. Replace them with gateway-specific endpoints that resolve
@@ -213,7 +214,7 @@ func (ti *TargetInfraHCLService) generateRootOutputsTf(request types.TargetClust
 		if skipDefaultEndpoints && (o.Name == "cluster_bootstrap_endpoint" || o.Name == "cluster_rest_endpoint") {
 			continue
 		}
-		rootOutputs = append(rootOutputs, types.TerraformOutput{
+		rootOutputs = append(rootOutputs, hcltypes.TerraformOutput{
 			Name:        o.Name,
 			Description: o.Description,
 			Sensitive:   o.Sensitive,
@@ -224,7 +225,7 @@ func (ti *TargetInfraHCLService) generateRootOutputsTf(request types.TargetClust
 	if request.NeedsPrivateLink {
 		privateLinkOutputs := modules.GetPrivateLinkModuleOutputDefinitions(ti.ResourceNames.VpcEndpoint)
 		for _, o := range privateLinkOutputs {
-			rootOutputs = append(rootOutputs, types.TerraformOutput{
+			rootOutputs = append(rootOutputs, hcltypes.TerraformOutput{
 				Name:        o.Name,
 				Description: o.Description,
 				Sensitive:   o.Sensitive,
@@ -237,12 +238,12 @@ func (ti *TargetInfraHCLService) generateRootOutputsTf(request types.TargetClust
 		// cluster links (--target-bootstrap-endpoint and --target-rest-endpoint).
 		if request.ClusterType == "enterprise" {
 			rootOutputs = append(rootOutputs,
-				types.TerraformOutput{
+				hcltypes.TerraformOutput{
 					Name:        "cluster_bootstrap_endpoint",
 					Description: "Gateway-specific bootstrap endpoint for Private Link access",
 					Value:       `[for e in data.confluent_endpoint.private_kafka_endpoints.endpoints : e.endpoint if e.endpoint_type == "BOOTSTRAP"][0]`,
 				},
-				types.TerraformOutput{
+				hcltypes.TerraformOutput{
 					Name:        "cluster_rest_endpoint",
 					Description: "Gateway-specific REST endpoint for Private Link access",
 					Value:       `[for e in data.confluent_endpoint.private_kafka_endpoints.endpoints : e.endpoint if e.endpoint_type == "REST"][0]`,

--- a/internal/services/hcl/write_project.go
+++ b/internal/services/hcl/write_project.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 )
 
 // WriteTerraformProject writes a MigrationInfraTerraformProject to disk at the given output directory.
-func WriteTerraformProject(outputDir string, project types.MigrationInfraTerraformProject) error {
+func WriteTerraformProject(outputDir string, project hcltypes.MigrationInfraTerraformProject) error {
 	if project.MainTf != "" {
 		if err := os.WriteFile(filepath.Join(outputDir, "main.tf"), []byte(project.MainTf), 0644); err != nil {
 			return fmt.Errorf("failed to write main.tf: %w", err)

--- a/internal/utils/input_validation.go
+++ b/internal/utils/input_validation.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -49,19 +49,19 @@ func ValidateAWSZones(awsZonesStr string) ([]AWSZone, error) {
 	return awsZones, nil
 }
 
-func ParseTerraformState(targetEnvFolder string, requiredFields []string) (*types.TerraformState, error) {
+func ParseTerraformState(targetEnvFolder string, requiredFields []string) (*hcltypes.TerraformState, error) {
 	outputJsonFile, err := os.ReadFile(filepath.Join(targetEnvFolder, "terraform.tfstate"))
 	if err != nil {
 		return nil, err
 	}
 
-	var terraformState types.TerraformState
+	var terraformState hcltypes.TerraformState
 	if err := json.Unmarshal(outputJsonFile, &terraformState); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal terraform state: %w", err)
 	}
 
 	output := terraformState.Outputs
-	if output == (types.TerraformOutputOld{}) {
+	if output == (hcltypes.TerraformOutputOld{}) {
 		return nil, fmt.Errorf("terraform outputs are missing")
 	}
 
@@ -89,26 +89,26 @@ func ParseTerraformState(targetEnvFolder string, requiredFields []string) (*type
 	return &terraformState, nil
 }
 
-type TerraformOutputGetter func(types.TerraformOutputOld) any
+type TerraformOutputGetter func(hcltypes.TerraformOutputOld) any
 
 // terraformOutputGetters maps field names to functions that extract values from TerraformOutput
 var terraformOutputGetters = map[string]TerraformOutputGetter{
-	"confluent_cloud_cluster_api_key": func(output types.TerraformOutputOld) any {
+	"confluent_cloud_cluster_api_key": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentCloudClusterApiKey.Value
 	},
-	"confluent_cloud_cluster_api_key_secret": func(output types.TerraformOutputOld) any {
+	"confluent_cloud_cluster_api_key_secret": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentCloudClusterApiKeySecret.Value
 	},
-	"confluent_cloud_cluster_id": func(output types.TerraformOutputOld) any {
+	"confluent_cloud_cluster_id": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentCloudClusterId.Value
 	},
-	"confluent_cloud_cluster_rest_endpoint": func(output types.TerraformOutputOld) any {
+	"confluent_cloud_cluster_rest_endpoint": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentCloudClusterRestEndpoint.Value
 	},
-	"confluent_cloud_cluster_bootstrap_endpoint": func(output types.TerraformOutputOld) any {
+	"confluent_cloud_cluster_bootstrap_endpoint": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentCloudClusterBootstrapEndpoint.Value
 	},
-	"confluent_platform_controller_bootstrap_server": func(output types.TerraformOutputOld) any {
+	"confluent_platform_controller_bootstrap_server": func(output hcltypes.TerraformOutputOld) any {
 		return output.ConfluentPlatformControllerBootstrapServer.Value
 	},
 }

--- a/internal/utils/terraform.go
+++ b/internal/utils/terraform.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
 )
 
 // CleanPrincipalName cleans the principal name for use in Terraform resources
@@ -25,7 +25,7 @@ func CleanPrincipalName(principal string) string {
 }
 
 // WriteTerraformFiles writes the generated Terraform files to the output directory
-func WriteTerraformFiles(outputDir string, files types.TerraformFiles) error {
+func WriteTerraformFiles(outputDir string, files hcltypes.TerraformFiles) error {
 	if files.MainTf != "" {
 		if err := os.WriteFile(filepath.Join(outputDir, "main.tf"), []byte(files.MainTf), 0644); err != nil {
 			return fmt.Errorf("failed to write main.tf: %w", err)


### PR DESCRIPTION
## Summary

PR 3 of Pass 2. Relocates the **Terraform/HCL data models** out of `internal/types`.

The plan's destination was the parent `internal/services/hcl` package, but that **causes an import cycle**: the parent `hcl` package imports its subpackages (`modules`, `confluent`, `aws`), and those subpackages are the heaviest users of these types — so `hcl/modules → hcl` (for the types) plus the existing `hcl → hcl/modules` is a cycle.

Instead, the types go into a new **dependency-free leaf package** `internal/services/hcl/hcltypes`, which the parent `hcl`, all subpackages, and external callers (`cmd/create_asset`, `cmd/ui/api`, `internal/utils`) import without any cycle.

Moved: `TerraformState`, `TerraformOutputOld`, `TerraformOutputValue`, `TerraformFiles`, `TerraformVariable`, `TerraformOutput`, `MigrationInfraTerraform*`, `MigrationScriptsTerraform*`. ~169 references rewritten `types.X` → `hcltypes.X` (imports fixed with goimports).

No back-edge: `internal/types` referenced none of these (they aren't part of the persisted `State`), so they leave the shared package cleanly.

One pre-existing unused method (`generateMigrateConnectorsFiles` — WIP, not wired into the orchestrator) got a `//nolint:unused`; the `new-from-rev` linter only surfaced it because the type rename touched its signature line. Flagged for separate cleanup.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` — 47 packages pass
- [x] `golangci-lint run --config .golangci.yml ./...` (v2.11.3, `new-from-rev: main`) — 0 issues
- [x] `gofmt -l` clean

## Pass 2 sequence

PR 3 of remaining. Done: gateway (#325 ✅), migration (#326 ✅). **Skipped** schema_registry (validation: it's shared state-schema, stays in `internal/types`). Next: wizard_requests → `cmd/ui/api`, plan → `plan`, processed (partial) → `report`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)