### PR TITLE
refactor(types): move plan schema + inputs into internal/services/plan (Pass 2.3)

### DIFF
--- a/internal/services/plan/auth.go
+++ b/internal/services/plan/auth.go
@@ -30,9 +30,9 @@ func knownTargetAuthMethod(t string) bool {
 // target across all source rows for that cluster — the renderer
 // surfaces the source/target pair and a `Note` so the customer can
 // see the trade-off.
-func decideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.AuthDecision {
+func decideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) AuthDecision {
 	sources := sourceAuthsDetected(c)
-	out := types.AuthDecision{
+	out := AuthDecision{
 		ClusterID:   c.Name,
 		SourceAuths: sources,
 	}
@@ -50,10 +50,10 @@ func decideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInpu
 			// Unknown source token (shouldn't happen given the closed enum
 			// in cluster_signals.go); emit a row with empty target rather
 			// than dropping it silently.
-			out.TargetMappings = append(out.TargetMappings, types.AuthMappingRow{SourceAuth: src})
+			out.TargetMappings = append(out.TargetMappings, AuthMappingRow{SourceAuth: src})
 			continue
 		}
-		row := types.AuthMappingRow{
+		row := AuthMappingRow{
 			SourceAuth:        src,
 			EffectiveTarget:   effectiveTarget(mapping, override),
 			GatewayCompatible: mapping.GatewayCompatible,

--- a/internal/services/plan/auth_test.go
+++ b/internal/services/plan/auth_test.go
@@ -12,8 +12,8 @@ import (
 // unset — decideAuth falls back to the per-source default from
 // auth_mapping. Tests that want an override-everywhere behavior set
 // inputs.TargetAuthMethod explicitly.
-func authInputs() types.PlanInputsResolved {
-	return types.PlanInputsResolved{}
+func authInputs() PlanInputsResolved {
+	return PlanInputsResolved{}
 }
 
 func TestDecideAuth_NoSourceAuthsDetected(t *testing.T) {
@@ -75,7 +75,7 @@ func TestDecideAuth_MultipleSourceAuthsAllRendered(t *testing.T) {
 	assert.Len(t, d.TargetMappings, 2, "one row per source auth — plan never picks one")
 }
 
-func requireRow(t *testing.T, d types.AuthDecision, sourceAuth string) types.AuthMappingRow {
+func requireRow(t *testing.T, d AuthDecision, sourceAuth string) AuthMappingRow {
 	t.Helper()
 	for _, row := range d.TargetMappings {
 		if row.SourceAuth == sourceAuth {
@@ -83,7 +83,7 @@ func requireRow(t *testing.T, d types.AuthDecision, sourceAuth string) types.Aut
 		}
 	}
 	t.Fatalf("AuthDecision missing row for source auth %q; got: %+v", sourceAuth, d.TargetMappings)
-	return types.AuthMappingRow{}
+	return AuthMappingRow{}
 }
 
 // When `target_auth_method` is set to a string outside the recognised
@@ -92,7 +92,7 @@ func requireRow(t *testing.T, d types.AuthDecision, sourceAuth string) types.Aut
 // can detect rejected overrides structurally — not just as an OQ.
 func TestDecideAuth_OverrideRejectedRecordedOnTypo(t *testing.T) {
 	c := withSourceAuth("iam-cluster", SourceAuthIAM)
-	inputs := types.PlanInputsResolved{TargetAuthMethod: "oauthhh"}
+	inputs := PlanInputsResolved{TargetAuthMethod: "oauthhh"}
 	d := decideAuth(c, defaultCfg(t), inputs)
 	assert.True(t, d.OverrideRejected, "typo'd override must set OverrideRejected")
 	assert.Equal(t, "oauthhh", d.RejectedOverrideValue)
@@ -143,7 +143,7 @@ func TestSourceUsesMTLS_ServerlessAlwaysFalse(t *testing.T) {
 func TestDecideAuth_OverrideRejectedFalseForGoodValues(t *testing.T) {
 	c := withSourceAuth("scram-cluster", SourceAuthSCRAM)
 	for _, override := range []string{"", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth} {
-		d := decideAuth(c, defaultCfg(t), types.PlanInputsResolved{TargetAuthMethod: override})
+		d := decideAuth(c, defaultCfg(t), PlanInputsResolved{TargetAuthMethod: override})
 		assert.False(t, d.OverrideRejected, "good override %q must not be marked rejected", override)
 		assert.Empty(t, d.RejectedOverrideValue, "good override %q must not leak a rejected value", override)
 	}

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -13,7 +13,7 @@ const defaultTargetCloud = "aws"
 // targetCloud returns the customer's `target_cloud` plan-input or the
 // default ("aws") when unset. Centralizes the empty-string fallback so
 // every decision rule reads it the same way.
-func targetCloud(inputs types.PlanInputsResolved) string {
+func targetCloud(inputs PlanInputsResolved) string {
 	if inputs.TargetCloud == "" {
 		return defaultTargetCloud
 	}

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -15,7 +15,7 @@ type hardLimit struct {
 	id               string
 	description      string
 	customerDeclared bool
-	check            func(cfg *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, sizing types.ClusterSizing) ruleResult
+	check            func(cfg *PlanConfig, inputs PlanInputsResolved, cluster types.ProcessedCluster, sizing ClusterSizing) ruleResult
 }
 
 // ruleResult is one rule's evaluation outcome. Either:
@@ -23,21 +23,21 @@ type hardLimit struct {
 //   - Outcome=not_fired + Evidence (e.g. "47 ACLs <= 4000 cap")
 //   - Outcome=skipped + SkipReason (e.g. "Acls == nil; ambiguous")
 type ruleResult struct {
-	Outcome    types.RuleOutcome
+	Outcome    RuleOutcome
 	Evidence   string
 	SkipReason string
 }
 
 func fired(evidence string) ruleResult {
-	return ruleResult{Outcome: types.RuleFired, Evidence: evidence}
+	return ruleResult{Outcome: RuleFired, Evidence: evidence}
 }
 
 func notFired(evidence string) ruleResult {
-	return ruleResult{Outcome: types.RuleNotFired, Evidence: evidence}
+	return ruleResult{Outcome: RuleNotFired, Evidence: evidence}
 }
 
 func skipped(reason string) ruleResult {
-	return ruleResult{Outcome: types.RuleSkipped, SkipReason: reason}
+	return ruleResult{Outcome: RuleSkipped, SkipReason: reason}
 }
 
 // Rule IDs — referenced by both the catalog and the topology logic.
@@ -60,7 +60,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleECKUExceedsPNICap,
 		description: "Sized eCKU exceeds Enterprise PNI cap",
-		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, _ types.ProcessedCluster, sizing types.ClusterSizing) ruleResult {
+		check: func(cfg *PlanConfig, _ PlanInputsResolved, _ types.ProcessedCluster, sizing ClusterSizing) ruleResult {
 			pniCap := cfg.EnterpriseCaps.PNIMaxECKU
 			if sizing.FinalECKU > pniCap {
 				return fired(fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, pniCap))
@@ -71,7 +71,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleACLCountExceedsCap,
 		description: "ACL count exceeds Enterprise cap",
-		check: func(cfg *PlanConfig, _ types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+		check: func(cfg *PlanConfig, _ PlanInputsResolved, cluster types.ProcessedCluster, _ ClusterSizing) ruleResult {
 			aclCap := cfg.EnterpriseCaps.ACLCountCap
 			if aclCap <= 0 {
 				return skipped("acl_count_cap not configured")
@@ -93,7 +93,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleBrokerSideSchemaValidation,
 		description:      "Broker-side schema ID validation required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.EnforceSchemasAtTheBroker {
 				return fired("`enforce_schemas_at_the_broker: true`")
 			}
@@ -104,7 +104,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleRESTProduceHighThroughput,
 		description:      "High-throughput Kafka REST Produce v3 required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.RequiresHighThroughputRESTProduceAPI {
 				return fired("`requires_high_throughput_rest_produce_api: true`")
 			}
@@ -115,7 +115,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleSLA9995SingleZone,
 		description:      "99.95% single-zone SLA required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, _ types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.Requires9995SLAWithinSingleZone {
 				return fired("`requires_99_95_sla_within_a_single_zone: true`")
 			}
@@ -125,7 +125,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleMTLSOnNonAWSTarget,
 		description: "Source uses mTLS, target is non-AWS",
-		check: func(_ *PlanConfig, inputs types.PlanInputsResolved, cluster types.ProcessedCluster, _ types.ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, cluster types.ProcessedCluster, _ ClusterSizing) ruleResult {
 			usesMTLS := sourceUsesMTLS(cluster)
 			target := targetCloud(inputs)
 			// Punctuation kept identical across branches so the rendered
@@ -169,23 +169,23 @@ func sourceUsesMTLS(c types.ProcessedCluster) bool {
 // that Standard doesn't offer. Enterprise is the default; hard-limit
 // rules escalate to Dedicated when a cap is exceeded or a workload
 // constraint can't be served on Enterprise.
-func decideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterTypeDecision {
-	var firedTriggers []types.HardLimitTrigger
-	evaluated := make([]types.RuleEvaluation, 0, len(hardLimitCatalog))
+func decideClusterType(c types.ProcessedCluster, sizing ClusterSizing, cfg *PlanConfig, inputs PlanInputsResolved) ClusterTypeDecision {
+	var firedTriggers []HardLimitTrigger
+	evaluated := make([]RuleEvaluation, 0, len(hardLimitCatalog))
 	for _, hl := range hardLimitCatalog {
 		if hl.check == nil {
 			continue
 		}
 		res := hl.check(cfg, inputs, c, sizing)
-		evaluated = append(evaluated, types.RuleEvaluation{
+		evaluated = append(evaluated, RuleEvaluation{
 			RowID:       hl.id,
 			Description: hl.description,
 			Outcome:     res.Outcome,
 			Evidence:    res.Evidence,
 			SkipReason:  res.SkipReason,
 		})
-		if res.Outcome == types.RuleFired {
-			firedTriggers = append(firedTriggers, types.HardLimitTrigger{
+		if res.Outcome == RuleFired {
+			firedTriggers = append(firedTriggers, HardLimitTrigger{
 				RowID:            hl.id,
 				Description:      hl.description,
 				Evidence:         res.Evidence,
@@ -194,17 +194,17 @@ func decideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg
 		}
 	}
 
-	verdict := types.ClusterTypeEnterprise
-	topology := types.TopologyNotApplicable
+	verdict := ClusterTypeEnterprise
+	topology := TopologyNotApplicable
 	var finalCKU *int
 	if len(firedTriggers) > 0 {
-		verdict = types.ClusterTypeDedicated
+		verdict = ClusterTypeDedicated
 		// Single-Zone wins when the 99.95% SLA rule fires; otherwise
 		// Multi-Zone is the Dedicated default.
-		topology = types.TopologyMultiZone
+		topology = TopologyMultiZone
 		for _, t := range firedTriggers {
 			if t.RowID == ruleSLA9995SingleZone {
-				topology = types.TopologySingleZone
+				topology = TopologySingleZone
 				break
 			}
 		}
@@ -212,7 +212,7 @@ func decideClusterType(c types.ProcessedCluster, sizing types.ClusterSizing, cfg
 		cku := sizing.FinalECKU
 		finalCKU = &cku
 	}
-	return types.ClusterTypeDecision{
+	return ClusterTypeDecision{
 		ClusterID:      c.Name,
 		EvaluatedRules: evaluated,
 		Verdict:        verdict,

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestDecideClusterType_DefaultEnterprise(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 5}
 	d := decideClusterType(types.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
-	assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+	assert.Equal(t, ClusterTypeEnterprise, d.Verdict)
 	assert.Empty(t, d.Triggers)
 }
 
 func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 	cfg := defaultCfg(t)
 	// pni_max_eCKU = 32; size at 33 to fire the rule.
-	sizing := types.ClusterSizing{ClusterID: "huge", FinalECKU: 33}
+	sizing := ClusterSizing{ClusterID: "huge", FinalECKU: 33}
 	d := decideClusterType(types.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
-	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+	assert.Equal(t, ClusterTypeDedicated, d.Verdict)
 	assert.Len(t, d.Triggers, 1)
 	assert.Equal(t, "eCKU_exceeds_pni_cap", d.Triggers[0].RowID)
 	assert.Contains(t, d.Triggers[0].Evidence, "33 eCKU")
@@ -51,10 +51,10 @@ func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
 	cfg := defaultCfg(t)
 	// acl_count_cap = 4000; emit 4001 ACLs against a successful scan.
 	c := provisionedClusterWithScan("many-acls", make([]types.Acls, 4001))
-	sizing := types.ClusterSizing{ClusterID: "many-acls", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "many-acls", FinalECKU: 5}
 
 	d := decideClusterType(c, sizing, cfg, defaultInputs())
-	assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+	assert.Equal(t, ClusterTypeDedicated, d.Verdict)
 	assert.Len(t, d.Triggers, 1)
 	assert.Equal(t, "acl_count_exceeds_cap", d.Triggers[0].RowID)
 	assert.Contains(t, d.Triggers[0].Evidence, "4001")
@@ -75,12 +75,12 @@ func TestDecideClusterType_DedicatedWhenACLsOverCap(t *testing.T) {
 //     skipped (don't false-positive on serverless deployments).
 func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 5}
 
 	t.Run("non-nil ACL slice evaluates the rule (under cap)", func(t *testing.T) {
 		c := provisionedClusterWithScan("provisioned-empty-acls", []types.Acls{})
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "0 ACLs is under the 4000 cap — rule should evaluate, not fire")
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict, "0 ACLs is under the 4000 cap — rule should evaluate, not fire")
 	})
 
 	t.Run("nil ACLs (scan didn't run or --skip-acls or successful 0-ACL scan) — rule skipped", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 		// position that nil means "uncertain" and skip the rule.
 		c := provisionedClusterWithScan("provisioned-nil-acls", nil)
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip rule 2 (count is unknown), not fire it")
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict, "nil ACLs must skip rule 2 (count is unknown), not fire it")
 	})
 
 	t.Run("SERVERLESS cluster — rule skipped regardless of ACL slice", func(t *testing.T) {
@@ -97,36 +97,36 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict, "SERVERLESS doesn't expose ACLs via this API — rule should skip")
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict, "SERVERLESS doesn't expose ACLs via this API — rule should skip")
 	})
 }
 
 func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "small", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "small", FinalECKU: 5}
 	c := types.ProcessedCluster{Name: "small"}
 
 	cases := []struct {
 		name        string
-		mutator     func(*types.PlanInputsResolved)
+		mutator     func(*PlanInputsResolved)
 		ruleID      string
 		evidenceHas string // substring the evidence must name (the flag, not just its value)
 	}{
 		{
 			name:        "broker-side schema validation forces Dedicated",
-			mutator:     func(in *types.PlanInputsResolved) { in.EnforceSchemasAtTheBroker = true },
+			mutator:     func(in *PlanInputsResolved) { in.EnforceSchemasAtTheBroker = true },
 			ruleID:      ruleBrokerSideSchemaValidation,
 			evidenceHas: "enforce_schemas_at_the_broker",
 		},
 		{
 			name:        "REST Produce v3 high-throughput forces Dedicated",
-			mutator:     func(in *types.PlanInputsResolved) { in.RequiresHighThroughputRESTProduceAPI = true },
+			mutator:     func(in *PlanInputsResolved) { in.RequiresHighThroughputRESTProduceAPI = true },
 			ruleID:      ruleRESTProduceHighThroughput,
 			evidenceHas: "requires_high_throughput_rest_produce_api",
 		},
 		{
 			name:        "99.95 single-zone SLA forces Dedicated",
-			mutator:     func(in *types.PlanInputsResolved) { in.Requires9995SLAWithinSingleZone = true },
+			mutator:     func(in *PlanInputsResolved) { in.Requires9995SLAWithinSingleZone = true },
 			ruleID:      ruleSLA9995SingleZone,
 			evidenceHas: "requires_99_95_sla_within_a_single_zone",
 		},
@@ -137,7 +137,7 @@ func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
 			in := defaultInputs()
 			tc.mutator(&in)
 			d := decideClusterType(c, sizing, cfg, in)
-			assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+			assert.Equal(t, ClusterTypeDedicated, d.Verdict)
 			assert.Len(t, d.Triggers, 1)
 			assert.Equal(t, tc.ruleID, d.Triggers[0].RowID)
 			assert.True(t, d.Triggers[0].CustomerDeclared, "customer-declared rules must carry the cost-callout marker")
@@ -148,7 +148,7 @@ func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
 
 func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "mtls", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "mtls", FinalECKU: 5}
 	enabled := true
 	c := types.ProcessedCluster{Name: "mtls"}
 	c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{
@@ -161,14 +161,14 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 		in := defaultInputs()
 		in.TargetCloud = "aws"
 		d := decideClusterType(c, sizing, cfg, in)
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict)
 	})
 
 	t.Run("azure target forces Dedicated", func(t *testing.T) {
 		in := defaultInputs()
 		in.TargetCloud = "azure"
 		d := decideClusterType(c, sizing, cfg, in)
-		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, ClusterTypeDedicated, d.Verdict)
 		assert.Len(t, d.Triggers, 1)
 		assert.Equal(t, "mtls_on_non_aws_target", d.Triggers[0].RowID)
 		assert.False(t, d.Triggers[0].CustomerDeclared, "mTLS rule is state-derived, not a wrong-click risk")
@@ -179,27 +179,27 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 		in := defaultInputs()
 		in.TargetCloud = "gcp"
 		d := decideClusterType(c2, sizing, cfg, in)
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict)
 	})
 }
 
 func TestDecideClusterType_Topology(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 4}
+	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 4}
 	c := types.ProcessedCluster{Name: "x"}
 
 	t.Run("Enterprise verdict has no topology", func(t *testing.T) {
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
-		assert.Equal(t, types.ClusterTypeEnterprise, d.Verdict)
-		assert.Equal(t, types.TopologyNotApplicable, d.Topology)
+		assert.Equal(t, ClusterTypeEnterprise, d.Verdict)
+		assert.Equal(t, TopologyNotApplicable, d.Topology)
 		assert.Nil(t, d.FinalCKU, "Enterprise clusters are sized in eCKU only — no FinalCKU mirror")
 	})
 
 	t.Run("Dedicated via eCKU cap → Multi-Zone", func(t *testing.T) {
-		big := types.ClusterSizing{ClusterID: "big", FinalECKU: 33}
+		big := ClusterSizing{ClusterID: "big", FinalECKU: 33}
 		d := decideClusterType(c, big, cfg, defaultInputs())
-		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
-		assert.Equal(t, types.TopologyMultiZone, d.Topology)
+		assert.Equal(t, ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, TopologyMultiZone, d.Topology)
 		require.NotNil(t, d.FinalCKU)
 		assert.Equal(t, 33, *d.FinalCKU, "FinalCKU mirrors the sizing's FinalECKU value")
 	})
@@ -208,8 +208,8 @@ func TestDecideClusterType_Topology(t *testing.T) {
 		in := defaultInputs()
 		in.Requires9995SLAWithinSingleZone = true
 		d := decideClusterType(c, sizing, cfg, in)
-		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
-		assert.Equal(t, types.TopologySingleZone, d.Topology)
+		assert.Equal(t, ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, TopologySingleZone, d.Topology)
 		require.NotNil(t, d.FinalCKU)
 		assert.Equal(t, 4, *d.FinalCKU)
 	})
@@ -221,8 +221,8 @@ func TestDecideClusterType_Topology(t *testing.T) {
 		in := defaultInputs()
 		in.Requires9995SLAWithinSingleZone = true
 		d := decideClusterType(c2, sizing, cfg, in)
-		assert.Equal(t, types.ClusterTypeDedicated, d.Verdict)
-		assert.Equal(t, types.TopologySingleZone, d.Topology)
+		assert.Equal(t, ClusterTypeDedicated, d.Verdict)
+		assert.Equal(t, TopologySingleZone, d.Topology)
 		assert.GreaterOrEqual(t, len(d.Triggers), 2, "both rules should have fired")
 	})
 }

--- a/internal/services/plan/cost_reconciliation.go
+++ b/internal/services/plan/cost_reconciliation.go
@@ -54,9 +54,9 @@ func mskUsageTypeRegex(cfg *PlanConfig) *regexp.Regexp {
 // desc; no materiality threshold (the customer decides what's
 // "real"). Returns nil when there are no candidates or no MSK source
 // data — the renderer omits the section in that case.
-func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *types.CostReconciliationSection {
+func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *CostReconciliationSection {
 	re := mskUsageTypeRegex(cfg)
-	var candidates []types.HiddenClusterCandidate
+	var candidates []HiddenClusterCandidate
 	for _, src := range state.Sources {
 		if src.MSKData == nil {
 			continue
@@ -68,7 +68,7 @@ func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *type
 				if _, present := inventory[instType]; present {
 					continue
 				}
-				candidates = append(candidates, types.HiddenClusterCandidate{
+				candidates = append(candidates, HiddenClusterCandidate{
 					Region:         region.Name,
 					InstanceType:   instType,
 					TotalSpend:     agg.totalSpend,
@@ -93,7 +93,7 @@ func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *type
 		}
 		return candidates[i].InstanceType < candidates[j].InstanceType
 	})
-	return &types.CostReconciliationSection{Candidates: candidates}
+	return &CostReconciliationSection{Candidates: candidates}
 }
 
 // inventoryInstanceTypes returns the set of instance types
@@ -194,7 +194,7 @@ func parseMSKInstanceType(usageType string, re *regexp.Regexp) string {
 // data is empty across all regions — the diff isn't actionable
 // without cost data. Returns nil when at least one region has cost
 // data (even if the diff was clean).
-func detectCostReconciliationOpenQuestions(state types.ProcessedState) []types.OpenQuestion {
+func detectCostReconciliationOpenQuestions(state types.ProcessedState) []OpenQuestion {
 	hasCost := false
 	for _, src := range state.Sources {
 		if src.MSKData == nil {
@@ -219,7 +219,7 @@ func detectCostReconciliationOpenQuestions(state types.ProcessedState) []types.O
 	if !hasAnyMSKRegion(state) {
 		return nil
 	}
-	return []types.OpenQuestion{{
+	return []OpenQuestion{{
 		ID:         "cost_data_not_collected",
 		Title:      "Cost-vs-inventory reconciliation skipped — run `kcp report costs`",
 		Body:       "No AWS Cost Explorer data is present in the state file. The cost-vs-inventory diff (which surfaces MSK instance types billed by AWS but NOT discovered by `kcp discover`) needs cost data to run.",

--- a/internal/services/plan/cutover.go
+++ b/internal/services/plan/cutover.go
@@ -40,17 +40,17 @@ const (
 // distinct from "the customer set `prefer_gateway: false`" but
 // indistinguishable at this layer. Callers from tests should construct
 // inputs via the resolver, not by struct literal.
-func decideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.CutoverDecision {
+func decideCutover(clusters []types.ProcessedCluster, inputs PlanInputsResolved) CutoverDecision {
 	style, sub := resolveStyle(inputs)
 
 	// Blue/Green sidesteps the gateway question entirely — the gateway
 	// doesn't sit on a parallel-run cutover step.
-	if style == types.CutoverBlueGreen {
-		return types.CutoverDecision{
+	if style == CutoverBlueGreen {
+		return CutoverDecision{
 			Style:                style,
 			SubPattern:           sub,
-			GatewayMediated:      types.GatewayMediatedNotApplicable,
-			RecommendationStatus: types.RecommendationCustomerChoice,
+			GatewayMediated:      GatewayMediatedNotApplicable,
+			RecommendationStatus: RecommendationCustomerChoice,
 			AlternativesShown:    alternativesShown(style),
 			Prereqs:              prereqsForStyle(style, inputs, fleetUsesIAM(clusters)),
 		}
@@ -60,33 +60,33 @@ func decideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsRes
 	eligible := gatewayEligible(inputs, iamInUse)
 	ambiguous := ambiguousGatewayIntent(inputs, iamInUse)
 
-	var mediated types.GatewayMediated
-	var status types.RecommendationStatus
+	var mediated GatewayMediated
+	var status RecommendationStatus
 	switch {
 	case !inputs.PreferGateway:
-		mediated = types.GatewayMediatedFalse
-		status = types.RecommendationCustomerChoice
+		mediated = GatewayMediatedFalse
+		status = RecommendationCustomerChoice
 	case eligible:
-		mediated = types.GatewayMediatedTrue
-		status = types.RecommendationCanonical
+		mediated = GatewayMediatedTrue
+		status = RecommendationCanonical
 	case ambiguous:
-		mediated = types.GatewayMediatedFalse
-		status = types.RecommendationDegradedAwaitingOQ
+		mediated = GatewayMediatedFalse
+		status = RecommendationDegradedAwaitingOQ
 	default:
 		// `prefer_gateway: true` but at least one prereq is still
 		// `not_started`. Customer has engaged but not finished.
-		mediated = types.GatewayMediatedFalse
-		status = types.RecommendationDegradedPrereqsPending
+		mediated = GatewayMediatedFalse
+		status = RecommendationDegradedPrereqsPending
 	}
 
 	// Suppress the gateway prereq table when the customer opted out of
 	// the gateway — those prereqs aren't needed for plain Cluster
 	// Linking, so showing "not started" against them is misleading.
-	var prereqs []types.Prereq
-	if mediated != types.GatewayMediatedFalse || status != types.RecommendationCustomerChoice {
+	var prereqs []Prereq
+	if mediated != GatewayMediatedFalse || status != RecommendationCustomerChoice {
 		prereqs = prereqsForStyle(style, inputs, iamInUse)
 	}
-	return types.CutoverDecision{
+	return CutoverDecision{
 		Style:                style,
 		SubPattern:           sub,
 		GatewayMediated:      mediated,
@@ -99,37 +99,37 @@ func decideCutover(clusters []types.ProcessedCluster, inputs types.PlanInputsRes
 // resolveStyle maps downtime_tolerance to a CutoverStyle plus optional
 // sub-pattern. sub-pattern is only populated when style is
 // Stop-Restart-Repeat; for everything else it's empty.
-func resolveStyle(inputs types.PlanInputsResolved) (types.CutoverStyle, types.CutoverSubPattern) {
+func resolveStyle(inputs PlanInputsResolved) (CutoverStyle, CutoverSubPattern) {
 	tolerance := inputs.DowntimeTolerance
 	if tolerance == "" {
 		tolerance = DowntimeUnsetFallback
 	}
-	var style types.CutoverStyle
+	var style CutoverStyle
 	switch tolerance {
 	case DowntimeZero:
-		style = types.CutoverBlueGreen
+		style = CutoverBlueGreen
 	case DowntimeSecondsPerService, DowntimeMinutesPerService, DowntimeLetConfluentChoose:
-		style = types.CutoverStopRestartRepeat
+		style = CutoverStopRestartRepeat
 	case DowntimeScheduledWindowSequential:
-		style = types.CutoverStopWaitRestart
+		style = CutoverStopWaitRestart
 	case DowntimeScheduledWindowAllAtOnce:
-		style = types.CutoverRestartAllAtOnce
+		style = CutoverRestartAllAtOnce
 	default:
 		// Unknown value: degrade to the Confluent default rather than
 		// erroring. `detectCutoverOpenQuestions` surfaces an OQ
 		// (`downtime_tolerance_unknown`) so the customer sees the
 		// typo / unrecognised value rather than silently inheriting
 		// the default.
-		style = types.CutoverStopRestartRepeat
+		style = CutoverStopRestartRepeat
 	}
 
-	var sub types.CutoverSubPattern
-	if style == types.CutoverStopRestartRepeat {
+	var sub CutoverSubPattern
+	if style == CutoverStopRestartRepeat {
 		switch inputs.SubPattern {
-		case string(types.SubPatternTopicByTopic):
-			sub = types.SubPatternTopicByTopic
+		case string(SubPatternTopicByTopic):
+			sub = SubPatternTopicByTopic
 		default:
-			sub = types.SubPatternAppByApp
+			sub = SubPatternAppByApp
 		}
 	}
 	return style, sub
@@ -155,8 +155,8 @@ func knownDowntimeTolerance(tolerance string) bool {
 // to app-by-app in resolveStyle).
 func knownCutoverSubPattern(sub string) bool {
 	return knownEnum(sub,
-		string(types.SubPatternAppByApp),
-		string(types.SubPatternTopicByTopic),
+		string(SubPatternAppByApp),
+		string(SubPatternTopicByTopic),
 	)
 }
 
@@ -164,7 +164,7 @@ func knownCutoverSubPattern(sub string) bool {
 // `in_progress` or `complete`. IAM prereq only counts when the fleet
 // actually has IAM enabled (otherwise the IAM-pre-migration constraint
 // is vacuous — there's nothing to pre-migrate).
-func gatewayEligible(inputs types.PlanInputsResolved, iamInUse bool) bool {
+func gatewayEligible(inputs PlanInputsResolved, iamInUse bool) bool {
 	if !prereqAdvanced(inputs.ConfluentForKubernetesStatus) {
 		return false
 	}
@@ -191,7 +191,7 @@ func prereqAdvanced(status string) bool {
 // `iam_pre_migration_status: in_progress` would flip the status from
 // `degraded_awaiting_oq` to `degraded_prereqs_pending` even though the
 // IAM prereq doesn't apply to this fleet.
-func ambiguousGatewayIntent(inputs types.PlanInputsResolved, iamInUse bool) bool {
+func ambiguousGatewayIntent(inputs PlanInputsResolved, iamInUse bool) bool {
 	if !inputs.PreferGateway {
 		return false
 	}
@@ -210,14 +210,14 @@ func ambiguousGatewayIntent(inputs types.PlanInputsResolved, iamInUse bool) bool
 // alternativesShown returns the cutover styles that the renderer
 // should explain for trust ("we considered these and didn't pick
 // them") — every style EXCEPT the recommended one.
-func alternativesShown(recommended types.CutoverStyle) []types.CutoverStyle {
-	all := []types.CutoverStyle{
-		types.CutoverStopRestartRepeat,
-		types.CutoverStopWaitRestart,
-		types.CutoverRestartAllAtOnce,
-		types.CutoverBlueGreen,
+func alternativesShown(recommended CutoverStyle) []CutoverStyle {
+	all := []CutoverStyle{
+		CutoverStopRestartRepeat,
+		CutoverStopWaitRestart,
+		CutoverRestartAllAtOnce,
+		CutoverBlueGreen,
 	}
-	var out []types.CutoverStyle
+	var out []CutoverStyle
 	for _, s := range all {
 		if s != recommended {
 			out = append(out, s)
@@ -231,16 +231,16 @@ func alternativesShown(recommended types.CutoverStyle) []types.CutoverStyle {
 // compatibility are state-derived prereqs surfaced by the renderer
 // based on plan-config; this function only emits the customer-driven
 // gateway prereqs. Blue/Green has no kcp-emitted prereqs.
-func prereqsForStyle(style types.CutoverStyle, inputs types.PlanInputsResolved, iamInUse bool) []types.Prereq {
-	if style == types.CutoverBlueGreen {
+func prereqsForStyle(style CutoverStyle, inputs PlanInputsResolved, iamInUse bool) []Prereq {
+	if style == CutoverBlueGreen {
 		return nil
 	}
-	out := []types.Prereq{
+	out := []Prereq{
 		{Description: "Confluent for Kubernetes (CFK) cluster", Status: prereqStatusFromInput(inputs.ConfluentForKubernetesStatus)},
 		{Description: "Confluent Cloud Gateway Add-On license", Status: prereqStatusFromInput(inputs.CCGatewayLicenseStatus)},
 	}
 	if iamInUse {
-		out = append(out, types.Prereq{
+		out = append(out, Prereq{
 			Description: "IAM clients pre-migrated to SCRAM / mTLS",
 			Status:      prereqStatusFromInput(inputs.IAMPreMigrationStatus),
 		})
@@ -250,15 +250,15 @@ func prereqsForStyle(style types.CutoverStyle, inputs types.PlanInputsResolved, 
 
 // prereqStatusFromInput maps plan-input status tokens to the rendered
 // PrereqStatus enum. Unknown values fall through to `unconfirmed`.
-func prereqStatusFromInput(status string) types.PrereqStatus {
+func prereqStatusFromInput(status string) PrereqStatus {
 	switch status {
 	case PrereqStatusCompleteInput:
-		return types.PrereqMet
+		return PrereqMet
 	case PrereqStatusInProgressInput:
-		return types.PrereqInProgress
+		return PrereqInProgress
 	case PrereqNotStarted:
-		return types.PrereqBlocked
+		return PrereqBlocked
 	default:
-		return types.PrereqUnconfirmed
+		return PrereqUnconfirmed
 	}
 }

--- a/internal/services/plan/cutover_test.go
+++ b/internal/services/plan/cutover_test.go
@@ -13,10 +13,10 @@ import (
 // styleInputs returns a base PlanInputsResolved with the given
 // downtime_tolerance plus sensible defaults (eligible gateway, no IAM).
 // Each test layers its own modifications on top.
-func styleInputs(tolerance string) types.PlanInputsResolved {
-	return types.PlanInputsResolved{
+func styleInputs(tolerance string) PlanInputsResolved {
+	return PlanInputsResolved{
 		DowntimeTolerance:            tolerance,
-		SubPattern:                   string(types.SubPatternAppByApp),
+		SubPattern:                   string(SubPatternAppByApp),
 		PreferGateway:                true,
 		ConfluentForKubernetesStatus: PrereqStatusCompleteInput,
 		CCGatewayLicenseStatus:       PrereqStatusCompleteInput,
@@ -27,14 +27,14 @@ func styleInputs(tolerance string) types.PlanInputsResolved {
 func TestDecideCutover_StyleMapping(t *testing.T) {
 	cases := []struct {
 		tolerance string
-		want      types.CutoverStyle
+		want      CutoverStyle
 	}{
-		{DowntimeZero, types.CutoverBlueGreen},
-		{DowntimeSecondsPerService, types.CutoverStopRestartRepeat},
-		{DowntimeMinutesPerService, types.CutoverStopRestartRepeat},
-		{DowntimeScheduledWindowSequential, types.CutoverStopWaitRestart},
-		{DowntimeScheduledWindowAllAtOnce, types.CutoverRestartAllAtOnce},
-		{DowntimeLetConfluentChoose, types.CutoverStopRestartRepeat},
+		{DowntimeZero, CutoverBlueGreen},
+		{DowntimeSecondsPerService, CutoverStopRestartRepeat},
+		{DowntimeMinutesPerService, CutoverStopRestartRepeat},
+		{DowntimeScheduledWindowSequential, CutoverStopWaitRestart},
+		{DowntimeScheduledWindowAllAtOnce, CutoverRestartAllAtOnce},
+		{DowntimeLetConfluentChoose, CutoverStopRestartRepeat},
 	}
 	for _, tc := range cases {
 		t.Run(tc.tolerance, func(t *testing.T) {
@@ -46,35 +46,35 @@ func TestDecideCutover_StyleMapping(t *testing.T) {
 
 func TestDecideCutover_SubPatternOnlyForSRR(t *testing.T) {
 	srr := styleInputs(DowntimeMinutesPerService)
-	srr.SubPattern = string(types.SubPatternTopicByTopic)
+	srr.SubPattern = string(SubPatternTopicByTopic)
 	d := decideCutover(nil, srr)
-	assert.Equal(t, types.SubPatternTopicByTopic, d.SubPattern, "SRR should carry the sub-pattern")
+	assert.Equal(t, SubPatternTopicByTopic, d.SubPattern, "SRR should carry the sub-pattern")
 
 	bg := styleInputs(DowntimeZero)
-	bg.SubPattern = string(types.SubPatternTopicByTopic)
+	bg.SubPattern = string(SubPatternTopicByTopic)
 	d = decideCutover(nil, bg)
 	assert.Empty(t, d.SubPattern, "non-SRR styles must not surface a sub-pattern")
 }
 
 func TestDecideCutover_Canonical(t *testing.T) {
 	d := decideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
-	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus)
-	assert.Equal(t, types.GatewayMediatedTrue, d.GatewayMediated)
+	assert.Equal(t, RecommendationCanonical, d.RecommendationStatus)
+	assert.Equal(t, GatewayMediatedTrue, d.GatewayMediated)
 }
 
 func TestDecideCutover_CustomerChoiceOptOut(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	inputs.PreferGateway = false
 	d := decideCutover(nil, inputs)
-	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
-	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+	assert.Equal(t, RecommendationCustomerChoice, d.RecommendationStatus)
+	assert.Equal(t, GatewayMediatedFalse, d.GatewayMediated)
 }
 
 func TestDecideCutover_BlueGreenIsCustomerChoice(t *testing.T) {
 	d := decideCutover(nil, styleInputs(DowntimeZero))
-	assert.Equal(t, types.CutoverBlueGreen, d.Style)
-	assert.Equal(t, types.GatewayMediatedNotApplicable, d.GatewayMediated)
-	assert.Equal(t, types.RecommendationCustomerChoice, d.RecommendationStatus)
+	assert.Equal(t, CutoverBlueGreen, d.Style)
+	assert.Equal(t, GatewayMediatedNotApplicable, d.GatewayMediated)
+	assert.Equal(t, RecommendationCustomerChoice, d.RecommendationStatus)
 }
 
 // Ambiguous = prefer_gateway default true + all three prereqs at
@@ -85,8 +85,8 @@ func TestDecideCutover_DegradedAwaitingOQ(t *testing.T) {
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
 	d := decideCutover(nil, inputs)
-	assert.Equal(t, types.RecommendationDegradedAwaitingOQ, d.RecommendationStatus)
-	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+	assert.Equal(t, RecommendationDegradedAwaitingOQ, d.RecommendationStatus)
+	assert.Equal(t, GatewayMediatedFalse, d.GatewayMediated)
 }
 
 // Pending = prefer_gateway true + at least one prereq advanced but
@@ -96,8 +96,8 @@ func TestDecideCutover_DegradedPrereqsPending(t *testing.T) {
 	inputs.ConfluentForKubernetesStatus = PrereqStatusInProgressInput
 	inputs.CCGatewayLicenseStatus = PrereqNotStarted
 	d := decideCutover(nil, inputs)
-	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus)
-	assert.Equal(t, types.GatewayMediatedFalse, d.GatewayMediated)
+	assert.Equal(t, RecommendationDegradedPrereqsPending, d.RecommendationStatus)
+	assert.Equal(t, GatewayMediatedFalse, d.GatewayMediated)
 }
 
 // IAM prereq is only consulted when the fleet actually has IAM enabled.
@@ -108,19 +108,19 @@ func TestDecideCutover_IAMPrereqOnlyMattersWhenIAMInFleet(t *testing.T) {
 
 	// Without IAM in the fleet, still eligible / canonical.
 	d := decideCutover([]types.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
-	assert.Equal(t, types.RecommendationCanonical, d.RecommendationStatus, "no IAM in fleet → IAM prereq irrelevant")
+	assert.Equal(t, RecommendationCanonical, d.RecommendationStatus, "no IAM in fleet → IAM prereq irrelevant")
 
 	// With IAM in the fleet, the IAM-not-started prereq now blocks eligibility.
 	d = decideCutover([]types.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
-	assert.Equal(t, types.RecommendationDegradedPrereqsPending, d.RecommendationStatus, "IAM in fleet → IAM prereq required")
+	assert.Equal(t, RecommendationDegradedPrereqsPending, d.RecommendationStatus, "IAM in fleet → IAM prereq required")
 }
 
 func TestDecideCutover_AlternativesShown(t *testing.T) {
 	d := decideCutover(nil, styleInputs(DowntimeLetConfluentChoose))
-	assert.Equal(t, types.CutoverStopRestartRepeat, d.Style)
+	assert.Equal(t, CutoverStopRestartRepeat, d.Style)
 	assert.Len(t, d.AlternativesShown, 3, "alternatives = all styles except the recommended one")
-	assert.NotContains(t, d.AlternativesShown, types.CutoverStopRestartRepeat)
-	assert.Contains(t, d.AlternativesShown, types.CutoverBlueGreen)
+	assert.NotContains(t, d.AlternativesShown, CutoverStopRestartRepeat)
+	assert.Contains(t, d.AlternativesShown, CutoverBlueGreen)
 }
 
 // IAM prereq row only appears in the rendered prereq table when IAM is
@@ -168,7 +168,7 @@ func withSourceAuth(name, auth string) types.ProcessedCluster {
 // ----- detectCutoverOpenQuestions -----
 
 // hasOQ returns whether any OQ matches the given ID.
-func hasOQ(oqs []types.OpenQuestion, id string) bool {
+func hasOQ(oqs []OpenQuestion, id string) bool {
 	for _, oq := range oqs {
 		if oq.ID == id {
 			return true
@@ -265,8 +265,8 @@ func TestComputeCutoverOverrides_PerClusterDifference(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 	zero := DowntimeZero
 	sched := DowntimeScheduledWindowAllAtOnce
-	inputs.Raw = &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	inputs.Raw = &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"a": {DowntimeTolerance: &zero},  // override → Blue/Green
 			"b": {DowntimeTolerance: &sched}, // override → Restart-All-At-Once
 			"c": {},                          // no cutover override → no entry
@@ -278,10 +278,10 @@ func TestComputeCutoverOverrides_PerClusterDifference(t *testing.T) {
 	out := computeCutoverOverrides(clusters, fleet, inputs)
 	require := []struct {
 		id    string
-		style types.CutoverStyle
+		style CutoverStyle
 	}{
-		{"a", types.CutoverBlueGreen},
-		{"b", types.CutoverRestartAllAtOnce},
+		{"a", CutoverBlueGreen},
+		{"b", CutoverRestartAllAtOnce},
 	}
 	assert.Len(t, out, len(require), "only clusters whose resolved style differs surface")
 	for i, want := range require {
@@ -296,9 +296,9 @@ func TestComputeCutoverOverrides_PerClusterDifference(t *testing.T) {
 // tell why their override didn't take effect.
 func TestDetectClusterCutoverOpenQuestions_TypoPerCluster(t *testing.T) {
 	typo := "zerooo"
-	inputs := types.PlanInputsResolved{
-		Raw: &types.PlanInputs{
-			Clusters: map[string]types.ClusterPlanInputs{
+	inputs := PlanInputsResolved{
+		Raw: &PlanInputs{
+			Clusters: map[string]ClusterPlanInputs{
 				"a": {DowntimeTolerance: &typo},
 			},
 		},
@@ -319,8 +319,8 @@ func TestDetectClusterCutoverOpenQuestions_TypoPerCluster(t *testing.T) {
 func TestPerCluster_AuthAndCutoverOverridesCoexistOnSameCluster(t *testing.T) {
 	zero := DowntimeZero
 	oauth := "oauth"
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {
 				DowntimeTolerance: &zero,
 				TargetAuthMethod:  &oauth,
@@ -337,7 +337,7 @@ func TestPerCluster_AuthAndCutoverOverridesCoexistOnSameCluster(t *testing.T) {
 	fleet := decideCutover([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, base)
 	overrides := computeCutoverOverrides([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, fleet, base)
 	require.Len(t, overrides, 1, "per-cluster downtime_tolerance must produce a cutover override entry")
-	assert.Equal(t, types.CutoverBlueGreen, overrides[0].Style)
+	assert.Equal(t, CutoverBlueGreen, overrides[0].Style)
 
 	auth := decideAuth(withSourceAuth("alpha", SourceAuthSCRAM), defaultCfg(t), resolved)
 	row := requireRow(t, auth, SourceAuthSCRAM)
@@ -350,25 +350,25 @@ func TestPerCluster_AuthAndCutoverOverridesCoexistOnSameCluster(t *testing.T) {
 // computeCutoverOverrides could miss the sub_pattern-only path
 // because `raw.DowntimeTolerance == nil` looks like "no override".
 func TestPerCluster_SubPatternOnlyOverride(t *testing.T) {
-	tbt := string(types.SubPatternTopicByTopic)
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	tbt := string(SubPatternTopicByTopic)
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {SubPattern: &tbt},
 		},
 	}
 	base := styleInputs(DowntimeMinutesPerService)
-	base.SubPattern = string(types.SubPatternAppByApp) // fleet default
+	base.SubPattern = string(SubPatternAppByApp) // fleet default
 	base.Raw = raw
 
 	fleet := decideCutover(nil, base)
-	assert.Equal(t, types.CutoverStopRestartRepeat, fleet.Style, "fleet must still resolve to SRR")
-	assert.Equal(t, types.SubPatternAppByApp, fleet.SubPattern, "fleet sub-pattern unchanged")
+	assert.Equal(t, CutoverStopRestartRepeat, fleet.Style, "fleet must still resolve to SRR")
+	assert.Equal(t, SubPatternAppByApp, fleet.SubPattern, "fleet sub-pattern unchanged")
 
 	overrides := computeCutoverOverrides([]types.ProcessedCluster{{Name: "alpha"}}, fleet, base)
 	require.Len(t, overrides, 1, "sub_pattern-only override must still produce a CutoverOverrides entry")
 	assert.Equal(t, "alpha", overrides[0].ClusterID)
-	assert.Equal(t, types.CutoverStopRestartRepeat, overrides[0].Style, "style inherits the fleet's")
-	assert.Equal(t, types.SubPatternTopicByTopic, overrides[0].SubPattern, "sub-pattern reflects the override")
+	assert.Equal(t, CutoverStopRestartRepeat, overrides[0].Style, "style inherits the fleet's")
+	assert.Equal(t, SubPatternTopicByTopic, overrides[0].SubPattern, "sub-pattern reflects the override")
 }
 
 // Fleet has all 3 gateway prereqs complete (so canonical recommendation
@@ -381,8 +381,8 @@ func TestPerCluster_SubPatternOnlyOverride(t *testing.T) {
 //     and `gateway_prereqs_pending` MUST stay silent.
 func TestPerCluster_BlueGreenOverrideOnIAMClusterWithCompletePrereqs(t *testing.T) {
 	zero := DowntimeZero
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"iam-cluster": {DowntimeTolerance: &zero},
 		},
 	}
@@ -394,13 +394,13 @@ func TestPerCluster_BlueGreenOverrideOnIAMClusterWithCompletePrereqs(t *testing.
 	clusters := []types.ProcessedCluster{withSourceAuth("iam-cluster", SourceAuthIAM)}
 
 	fleet := decideCutover(clusters, base)
-	assert.Equal(t, types.RecommendationCanonical, fleet.RecommendationStatus, "all prereqs complete + IAM in fleet must still resolve canonical")
-	assert.Equal(t, types.GatewayMediatedTrue, fleet.GatewayMediated)
+	assert.Equal(t, RecommendationCanonical, fleet.RecommendationStatus, "all prereqs complete + IAM in fleet must still resolve canonical")
+	assert.Equal(t, GatewayMediatedTrue, fleet.GatewayMediated)
 
 	overrides := computeCutoverOverrides(clusters, fleet, base)
 	require.Len(t, overrides, 1)
-	assert.Equal(t, types.CutoverBlueGreen, overrides[0].Style)
-	assert.Equal(t, types.GatewayMediatedNotApplicable, overrides[0].GatewayMediated, "BG override on IAM cluster still sidesteps the gateway")
+	assert.Equal(t, CutoverBlueGreen, overrides[0].Style)
+	assert.Equal(t, GatewayMediatedNotApplicable, overrides[0].GatewayMediated, "BG override on IAM cluster still sidesteps the gateway")
 
 	oqs := detectCutoverOpenQuestions(fleet, overrides, base, fleetUsesIAM(clusters))
 	for _, oq := range oqs {
@@ -427,9 +427,9 @@ func TestComputeCutoverOverrides_GatewayMediationInheritedFromFleet(t *testing.T
 		withSourceAuth("scram-override", SourceAuthSCRAM),
 	}
 	srr := DowntimeMinutesPerService
-	tbt := string(types.SubPatternTopicByTopic)
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	tbt := string(SubPatternTopicByTopic)
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			// scram-override flips sub-pattern only — same style as fleet.
 			// Pre-fix, decideCutover on a single SCRAM cluster would
 			// IGNORE the IAM prereq (fleetUsesIAM=false for this slice)
@@ -439,7 +439,7 @@ func TestComputeCutoverOverrides_GatewayMediationInheritedFromFleet(t *testing.T
 	}
 	base.Raw = raw
 	fleet := decideCutover(clusters, base)
-	require.NotEqual(t, types.GatewayMediatedTrue, fleet.GatewayMediated, "fleet must be degraded by the IAM-not-started prereq")
+	require.NotEqual(t, GatewayMediatedTrue, fleet.GatewayMediated, "fleet must be degraded by the IAM-not-started prereq")
 
 	overrides := computeCutoverOverrides(clusters, fleet, base)
 	require.Len(t, overrides, 1, "scram-override must surface (sub-pattern differs)")
@@ -455,15 +455,15 @@ func TestComputeCutoverOverrides_GatewayMediationInheritedFromFleet(t *testing.T
 // silently lost.
 func TestPerCluster_SecondsPerServiceWithoutFleetGateway(t *testing.T) {
 	sps := DowntimeSecondsPerService
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {DowntimeTolerance: &sps},
 		},
 	}
 	// Fleet doesn't have any gateway prereqs advanced → plain CL.
-	base := types.PlanInputsResolved{
+	base := PlanInputsResolved{
 		DowntimeTolerance:            DowntimeMinutesPerService,
-		SubPattern:                   string(types.SubPatternAppByApp),
+		SubPattern:                   string(SubPatternAppByApp),
 		PreferGateway:                true,
 		ConfluentForKubernetesStatus: PrereqNotStarted,
 		CCGatewayLicenseStatus:       PrereqNotStarted,
@@ -473,7 +473,7 @@ func TestPerCluster_SecondsPerServiceWithoutFleetGateway(t *testing.T) {
 	clusters := []types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}
 
 	fleet := decideCutover(clusters, base)
-	require.NotEqual(t, types.GatewayMediatedTrue, fleet.GatewayMediated, "fleet must NOT be gateway-mediated for this scenario")
+	require.NotEqual(t, GatewayMediatedTrue, fleet.GatewayMediated, "fleet must NOT be gateway-mediated for this scenario")
 
 	oqs := detectPerClusterGatewayIncompat(clusters, fleet, base)
 	require.Len(t, oqs, 1, "per-cluster seconds_per_service must fire the gateway-incompat OQ when fleet isn't mediated")
@@ -485,6 +485,6 @@ func TestPerCluster_SecondsPerServiceWithoutFleetGateway(t *testing.T) {
 	base.ConfluentForKubernetesStatus = PrereqStatusCompleteInput
 	base.CCGatewayLicenseStatus = PrereqStatusCompleteInput
 	mediatedFleet := decideCutover(clusters, base)
-	require.Equal(t, types.GatewayMediatedTrue, mediatedFleet.GatewayMediated)
+	require.Equal(t, GatewayMediatedTrue, mediatedFleet.GatewayMediated)
 	assert.Empty(t, detectPerClusterGatewayIncompat(clusters, mediatedFleet, base), "mediated fleet → no per-cluster OQ")
 }

--- a/internal/services/plan/effort_signals.go
+++ b/internal/services/plan/effort_signals.go
@@ -31,18 +31,18 @@ const (
 //
 // Returns nil when there are no MSK clusters to evaluate (renderer
 // omits the section).
-func detectEffortSignals(state types.ProcessedState) *types.EffortSignalsSection {
+func detectEffortSignals(state types.ProcessedState) *EffortSignalsSection {
 	clusters := collectClusters(state)
 	if len(clusters) == 0 {
 		return nil
 	}
-	signals := []types.EffortSignal{
+	signals := []EffortSignal{
 		signalIAMClientCount(clusters),
 		signalMM2CheckpointTopics(clusters),
 		signalSelfManagedConnectFleets(clusters),
 		signalGlueSerializerMigration(state, clusters),
 	}
-	return &types.EffortSignalsSection{Signals: signals}
+	return &EffortSignalsSection{Signals: signals}
 }
 
 // intPtr is a tiny constructor for Effort-Signal Counts. nil means
@@ -62,7 +62,7 @@ func intPtr(n int) *int { return &n }
 // Don't be tempted to swap in `types.AuthTypeIAM` from `types.go` —
 // that constant resolves to "SASL/IAM" and would silently mismatch
 // every real state file.
-func signalIAMClientCount(clusters []types.ProcessedCluster) types.EffortSignal {
+func signalIAMClientCount(clusters []types.ProcessedCluster) EffortSignal {
 	// Distinguish "scan ran, found 0 IAM clients" from "scan didn't
 	// run at all": if no cluster has any discovered_clients populated,
 	// the count is structurally unobservable → return nil. Otherwise
@@ -80,7 +80,7 @@ func signalIAMClientCount(clusters []types.ProcessedCluster) types.EffortSignal 
 			}
 		}
 	}
-	sig := types.EffortSignal{
+	sig := EffortSignal{
 		ID:    EffortSignalIDIAMClientCount,
 		Label: "IAM → SCRAM workstream size — clients that need re-credentialing before the CC Gateway path",
 	}
@@ -101,7 +101,7 @@ func signalIAMClientCount(clusters []types.ProcessedCluster) types.EffortSignal 
 // IdentityReplicationPolicy suppress the prefix — those won't show
 // up here. The renderer surfaces the caveat in the Note. Regex lives
 // in topic_patterns.go so red_flags can share it.
-func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) types.EffortSignal {
+func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) EffortSignal {
 	// De-dupe by topic name so a Cluster-Linking mirror that
 	// replicates the same `*.checkpoints.internal` topic across N
 	// clusters doesn't inflate the count to N. Each distinct
@@ -121,7 +121,7 @@ func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) types.EffortSi
 		}
 	}
 	count := len(seen)
-	sig := types.EffortSignal{
+	sig := EffortSignal{
 		ID:    EffortSignalIDMM2CheckpointTopics,
 		Label: "MirrorMaker 2 checkpoint topics — replication fleets to enumerate",
 		Count: intPtr(count),
@@ -138,7 +138,7 @@ func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) types.EffortSi
 // (`connect-offsets`) may not exist with the same prefix, so we
 // require only two of three — AND-of-all-three would miss real
 // fleets per the spec. Regex lives in topic_patterns.go.
-func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) types.EffortSignal {
+func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) EffortSignal {
 	// Walk every topic, group by (cluster, prefix), collect which
 	// suffixes appear. Per-cluster scoping prevents two distinct
 	// fleets that both use the default unprefixed `connect-configs`
@@ -201,7 +201,7 @@ func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) types.Eff
 	if scannerConnectorCount > count {
 		count = scannerConnectorCount
 	}
-	return types.EffortSignal{
+	return EffortSignal{
 		ID:    EffortSignalIDSelfManagedConnectFleets,
 		Label: "Self-managed Connect fleets — review surface area beyond what kcp can describe",
 		Count: intPtr(count),
@@ -217,8 +217,8 @@ func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) types.Eff
 // Server-side schema export is automated by `kcp create-asset
 // migrate-schemas --glue-registry`; this row scopes the *client-side*
 // serializer-swap workstream.
-func signalGlueSerializerMigration(state types.ProcessedState, clusters []types.ProcessedCluster) types.EffortSignal {
-	sig := types.EffortSignal{
+func signalGlueSerializerMigration(state types.ProcessedState, clusters []types.ProcessedCluster) EffortSignal {
+	sig := EffortSignal{
 		ID:    EffortSignalIDGlueSerializerMigration,
 		Label: "Glue → CC SR client serializer migration size — clients that need `AWSKafkaAvroSerializer` → `KafkaAvroSerializer`",
 	}

--- a/internal/services/plan/effort_signals_test.go
+++ b/internal/services/plan/effort_signals_test.go
@@ -10,7 +10,7 @@ import (
 
 // findSignal returns the signal matching `id` so tests don't depend on
 // slice ordering.
-func findSignal(t *testing.T, section *types.EffortSignalsSection, id string) types.EffortSignal {
+func findSignal(t *testing.T, section *EffortSignalsSection, id string) EffortSignal {
 	t.Helper()
 	require.NotNil(t, section)
 	for _, s := range section.Signals {
@@ -19,7 +19,7 @@ func findSignal(t *testing.T, section *types.EffortSignalsSection, id string) ty
 		}
 	}
 	t.Fatalf("effort signal %q not present in section (got %d signals)", id, len(section.Signals))
-	return types.EffortSignal{}
+	return EffortSignal{}
 }
 
 // Signal 1: IAM → SCRAM client count. Counts discovered_clients whose

--- a/internal/services/plan/inputs.go
+++ b/internal/services/plan/inputs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/confluentinc/kcp/internal/types"
 	"github.com/goccy/go-yaml"
 )
 
@@ -14,7 +13,7 @@ const defaultSLATarget = "99.9"
 // is empty (no file supplied is a valid state — the Plan still generates
 // from defaults). Missing fields never fail because no field is required
 // at the YAML schema level.
-func LoadPlanInputs(path string) (*types.PlanInputs, error) {
+func LoadPlanInputs(path string) (*PlanInputs, error) {
 	if path == "" {
 		return nil, nil
 	}
@@ -22,7 +21,7 @@ func LoadPlanInputs(path string) (*types.PlanInputs, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read plan-inputs %s: %w", path, err)
 	}
-	var in types.PlanInputs
+	var in PlanInputs
 	if err := yaml.Unmarshal(data, &in); err != nil {
 		return nil, fmt.Errorf("failed to parse plan-inputs %s: %w", path, err)
 	}
@@ -34,9 +33,9 @@ func LoadPlanInputs(path string) (*types.PlanInputs, error) {
 // falls back to PlanConfig.PlanInputDefaults. Raw is preserved so
 // downstream consumers can detect which sizing fields the customer
 // explicitly set (HeadroomFraction, SLATarget, SizingPercentile, etc.).
-func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsResolved {
+func ResolvePlanInputs(in *PlanInputs, cfg *PlanConfig) PlanInputsResolved {
 	defaults := cfg.PlanInputDefaults
-	out := types.PlanInputsResolved{
+	out := PlanInputsResolved{
 		Raw:                                  in,
 		SizingPercentile:                     defaults.SizingPercentile,
 		HeadroomFraction:                     defaults.HeadroomFraction,
@@ -159,7 +158,7 @@ func ResolvePlanInputs(in *types.PlanInputs, cfg *PlanConfig) types.PlanInputsRe
 // **Hot path note:** when iterating many clusters, prefer
 // `applyClusterOverride` against a pre-resolved global view — this
 // function re-resolves globals on every call.
-func ResolvePlanInputsForCluster(in *types.PlanInputs, cfg *PlanConfig, clusterName string) types.PlanInputsResolved {
+func ResolvePlanInputsForCluster(in *PlanInputs, cfg *PlanConfig, clusterName string) PlanInputsResolved {
 	out := ResolvePlanInputs(in, cfg)
 	return applyClusterOverride(out, in, clusterName)
 }
@@ -170,7 +169,7 @@ func ResolvePlanInputsForCluster(in *types.PlanInputs, cfg *PlanConfig, clusterN
 // avoid re-running the (cheap but non-trivial) global resolution
 // against `in.Raw` for every cluster — the global view is computed
 // once and reused.
-func applyClusterOverride(out types.PlanInputsResolved, in *types.PlanInputs, clusterName string) types.PlanInputsResolved {
+func applyClusterOverride(out PlanInputsResolved, in *PlanInputs, clusterName string) PlanInputsResolved {
 	if in == nil {
 		return out
 	}

--- a/internal/services/plan/inputs_test.go
+++ b/internal/services/plan/inputs_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,7 +70,7 @@ func TestResolvePlanInputsDefaults(t *testing.T) {
 		sla := "99.95"
 		egress := true
 		gateways := 3
-		in := &types.PlanInputs{
+		in := &PlanInputs{
 			HeadroomFraction:         &hf,
 			SLATarget:                &sla,
 			CCEgressRequired:         &egress,
@@ -96,9 +95,9 @@ func TestResolvePlanInputsForCluster_OverrideWins(t *testing.T) {
 	hf := 0.45
 	sla := "99.95"
 	enf := true
-	in := &types.PlanInputs{
+	in := &PlanInputs{
 		HeadroomFraction: &hf, // global override
-		Clusters: map[string]types.ClusterPlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {SLATarget: &sla, EnforceSchemasAtTheBroker: &enf},
 			"beta":  {}, // empty override entry — should still fall back
 		},
@@ -147,9 +146,9 @@ func TestApplyClusterOverride_EquivalentToResolvePlanInputsForCluster(t *testing
 	hf := 0.45
 	sla := "99.95"
 	enf := true
-	in := &types.PlanInputs{
+	in := &PlanInputs{
 		HeadroomFraction: &hf,
-		Clusters: map[string]types.ClusterPlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {SLATarget: &sla, EnforceSchemasAtTheBroker: &enf},
 			"beta":  {},
 		},

--- a/internal/services/plan/networking.go
+++ b/internal/services/plan/networking.go
@@ -2,8 +2,6 @@ package plan
 
 import (
 	"fmt"
-
-	"github.com/confluentinc/kcp/internal/types"
 )
 
 // Customer-set values of `existing_vpc_connectivity` that select a
@@ -18,8 +16,8 @@ const (
 // (peak burst, percentage-of-PL-cap) plus the verdict and reason. Used
 // to keep the 8 decision branches below uniform — every branch must
 // surface peak-burst data for the renderer / OQ detector to consume.
-func netDecision(sizing types.ClusterSizing, verdict types.Networking, reason string) types.NetworkingDecision {
-	return types.NetworkingDecision{
+func netDecision(sizing ClusterSizing, verdict Networking, reason string) NetworkingDecision {
+	return NetworkingDecision{
 		ClusterID:       sizing.ClusterID,
 		Verdict:         verdict,
 		PeakBurstECKU:   sizing.PeakBurstECKU,
@@ -38,11 +36,11 @@ func netDecision(sizing types.ClusterSizing, verdict types.Networking, reason st
 // the verdict deterministic), but detectOpenQuestions surfaces an OQ so
 // the customer can move to Dedicated (which supports PrivateLink at
 // higher CKU).
-func privateLinkSizingExceedsCap(sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, cfg *PlanConfig) bool {
-	if net.Verdict != types.NetworkingPrivateLink {
+func privateLinkSizingExceedsCap(sizing ClusterSizing, ct ClusterTypeDecision, net NetworkingDecision, cfg *PlanConfig) bool {
+	if net.Verdict != NetworkingPrivateLink {
 		return false
 	}
-	if ct.Verdict != types.ClusterTypeEnterprise {
+	if ct.Verdict != ClusterTypeEnterprise {
 		return false
 	}
 	return sizing.FinalECKU > cfg.EnterpriseCaps.PrivateLinkMaxECKU
@@ -62,43 +60,43 @@ func privateLinkSizingExceedsCap(sizing types.ClusterSizing, ct types.ClusterTyp
 //
 // `existing_vpc_connectivity` is only honored on the AWS-Dedicated path —
 // Transit Gateway and VPC Peering are Dedicated-only AWS products.
-func decideNetworking(sizing types.ClusterSizing, ct types.ClusterTypeDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) types.NetworkingDecision {
+func decideNetworking(sizing ClusterSizing, ct ClusterTypeDecision, cfg *PlanConfig, inputs PlanInputsResolved) NetworkingDecision {
 	target := targetCloud(inputs)
 
-	if ct.Verdict == types.ClusterTypeDedicated {
+	if ct.Verdict == ClusterTypeDedicated {
 		// PNI, Transit Gateway, and VPC Peering are AWS-only networking
 		// products. Cross-cloud Dedicated lands on PrivateLink (the
 		// generic private-network option supported across clouds).
 		if target != defaultTargetCloud {
-			return netDecision(sizing, types.NetworkingPrivateLink,
+			return netDecision(sizing, NetworkingPrivateLink,
 				fmt.Sprintf("target_cloud=%q — PNI / TGW / VPC Peering are AWS-only, so cross-cloud Dedicated lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)", target))
 		}
 		switch inputs.ExistingVPCConnectivity {
 		case vpcConnectivityTransitGateway:
-			return netDecision(sizing, types.NetworkingTransitGateway,
+			return netDecision(sizing, NetworkingTransitGateway,
 				"Dedicated cluster + existing_vpc_connectivity=transit_gateway — match the customer's source topology")
 		case vpcConnectivityVPCPeering:
-			return netDecision(sizing, types.NetworkingVPCPeering,
+			return netDecision(sizing, NetworkingVPCPeering,
 				"Dedicated cluster + existing_vpc_connectivity=vpc_peering — match the customer's source topology")
 		}
-		return netDecision(sizing, types.NetworkingPNI,
+		return netDecision(sizing, NetworkingPNI,
 			"Dedicated AWS cluster — PNI required (TGW / VPC Peering are alternatives only when the customer's existing MSK topology already uses them; see `existing_vpc_connectivity` in plan-inputs.yaml)")
 	}
 
 	// Enterprise path: PNI is the default for AWS-to-AWS workloads. The
 	// flip to PrivateLink only fires on one of three explicit triggers.
 	if target != defaultTargetCloud {
-		return netDecision(sizing, types.NetworkingPrivateLink,
+		return netDecision(sizing, NetworkingPrivateLink,
 			fmt.Sprintf("target_cloud=%q — PNI is AWS-to-AWS only, so cross-cloud lands on PrivateLink (set `target_cloud: aws` in `plan-inputs.yaml` to undo)", target))
 	}
 	if inputs.CCEgressRequired {
-		return netDecision(sizing, types.NetworkingPrivateLink,
+		return netDecision(sizing, NetworkingPrivateLink,
 			"cc_egress_required=true — PNI does not natively support egress from CC into customer infrastructure (set `cc_egress_required: false` in `plan-inputs.yaml` if this wasn't intentional)")
 	}
 	if inputs.ProjectedPNIGatewayCount >= cfg.Thresholds.PNIGatewayBreakeven {
-		return netDecision(sizing, types.NetworkingPrivateLink,
+		return netDecision(sizing, NetworkingPrivateLink,
 			fmt.Sprintf("projected_pni_gateway_count=%d (≥ %d) — flip to PrivateLink (lower `projected_pni_gateway_count` in `plan-inputs.yaml` to stay on PNI)", inputs.ProjectedPNIGatewayCount, cfg.Thresholds.PNIGatewayBreakeven))
 	}
-	return netDecision(sizing, types.NetworkingPNI,
+	return netDecision(sizing, NetworkingPNI,
 		fmt.Sprintf("default for AWS Enterprise (scales to %d eCKU vs PrivateLink's %d-eCKU cap)", cfg.EnterpriseCaps.PNIMaxECKU, cfg.EnterpriseCaps.PrivateLinkMaxECKU))
 }

--- a/internal/services/plan/networking_test.go
+++ b/internal/services/plan/networking_test.go
@@ -3,49 +3,48 @@ package plan
 import (
 	"testing"
 
-	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDecideNetworking_DedicatedDefaultsToPNI(t *testing.T) {
 	// Dedicated + no `existing_vpc_connectivity` override → PNI.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeDedicated}
 	d := decideNetworking(sizing, ct, cfg, defaultInputs())
-	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Equal(t, NetworkingPNI, d.Verdict)
 	assert.Contains(t, d.Reason, "Dedicated")
 }
 
 func TestDecideNetworking_DedicatedTransitGateway(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeDedicated}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "transit_gateway"
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingTransitGateway, d.Verdict)
+	assert.Equal(t, NetworkingTransitGateway, d.Verdict)
 	assert.Contains(t, d.Reason, "transit_gateway")
 }
 
 func TestDecideNetworking_DedicatedVPCPeering(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeDedicated}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeDedicated}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "vpc_peering"
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingVPCPeering, d.Verdict)
+	assert.Equal(t, NetworkingVPCPeering, d.Verdict)
 	assert.Contains(t, d.Reason, "vpc_peering")
 }
 
 func TestDecideNetworking_EnterpriseDefaultsToPNI(t *testing.T) {
 	// AWS Enterprise default verdict is PNI when no trigger fires.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	d := decideNetworking(sizing, ct, cfg, defaultInputs())
-	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Equal(t, NetworkingPNI, d.Verdict)
 	assert.Contains(t, d.Reason, "default for AWS Enterprise")
 }
 
@@ -54,57 +53,57 @@ func TestDecideNetworking_EnterpriseIgnoresVPCConnectivity(t *testing.T) {
 	// with `existing_vpc_connectivity: transit_gateway` falls back to the
 	// PNI-default flow, not TGW.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ExistingVPCConnectivity = "transit_gateway"
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Equal(t, NetworkingPNI, d.Verdict)
 }
 
 func TestDecideNetworking_EnterpriseCrossCloudFlipsToPrivateLink(t *testing.T) {
 	// PNI is AWS-to-AWS only — non-AWS target lands on PrivateLink.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.TargetCloud = "azure"
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Equal(t, NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "AWS-to-AWS only")
 }
 
 func TestDecideNetworking_EnterpriseCCEgressRequiredFlipsToPrivateLink(t *testing.T) {
 	// CCEgressRequired=true → PrivateLink (PNI lacks native CC→customer egress).
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.CCEgressRequired = true
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Equal(t, NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "cc_egress_required")
 }
 
 func TestDecideNetworking_EnterpriseTwoPNIGatewaysFlipsToPrivateLink(t *testing.T) {
 	// ≥2 PNI gateways → PrivateLink (per-gateway PNI cost crosses breakeven).
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ProjectedPNIGatewayCount = 2
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPrivateLink, d.Verdict)
+	assert.Equal(t, NetworkingPrivateLink, d.Verdict)
 	assert.Contains(t, d.Reason, "projected_pni_gateway_count=2")
 }
 
 func TestDecideNetworking_EnterpriseOneGatewayStaysPNI(t *testing.T) {
 	// Single gateway is below the breakeven — PNI default.
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
-	ct := types.ClusterTypeDecision{ClusterID: "x", Verdict: types.ClusterTypeEnterprise}
+	sizing := ClusterSizing{ClusterID: "x", PeakBurstECKU: 1, PeakBurstPctOfPLCap: 10}
+	ct := ClusterTypeDecision{ClusterID: "x", Verdict: ClusterTypeEnterprise}
 	in := defaultInputs()
 	in.ProjectedPNIGatewayCount = 1
 	d := decideNetworking(sizing, ct, cfg, in)
-	assert.Equal(t, types.NetworkingPNI, d.Verdict)
+	assert.Equal(t, NetworkingPNI, d.Verdict)
 }

--- a/internal/services/plan/plan.go
+++ b/internal/services/plan/plan.go
@@ -1,4 +1,4 @@
-package types
+package plan
 
 import "time"
 

--- a/internal/services/plan/plan_inputs.go
+++ b/internal/services/plan/plan_inputs.go
@@ -1,4 +1,4 @@
-package types
+package plan
 
 // PlanInputs is the parsed plan-inputs.yaml. Pointers distinguish "unset"
 // from the zero value so the loader can echo only the fields the customer

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -52,7 +52,7 @@ func NewPlanService(cfg *PlanConfig, now func() time.Time) *PlanService {
 // Build produces a Plan from a ProcessedState and resolved plan-inputs.
 // Each step is a pure function so the test surface is the orchestration,
 // not its parts.
-func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsResolved, stateFilePath string) (*types.Plan, error) {
+func (s *PlanService) Build(state types.ProcessedState, inputs PlanInputsResolved, stateFilePath string) (*Plan, error) {
 	// Backfill `ClusterMetrics.Aggregates` once, in-place, against the
 	// canonical state. Every downstream caller (the per-cluster Build
 	// loop, plus every fleet-wide detector that re-runs
@@ -72,8 +72,8 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		return clusters[i].Arn < clusters[j].Arn
 	})
 
-	plan := &types.Plan{
-		Header: types.PlanHeader{
+	plan := &Plan{
+		Header: PlanHeader{
 			Source:            "Amazon MSK",
 			StateFilePath:     stateFilePath,
 			KCPVersion:        build_info.Version,
@@ -112,7 +112,7 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 		plan.ClusterTypeDecision = append(plan.ClusterTypeDecision, ct)
 		plan.NetworkingDecision = append(plan.NetworkingDecision, net)
 		plan.Auth = append(plan.Auth, auth)
-		plan.SourceEnvironment.Clusters = append(plan.SourceEnvironment.Clusters, types.SourceClusterSummary{
+		plan.SourceEnvironment.Clusters = append(plan.SourceEnvironment.Clusters, SourceClusterSummary{
 			ClusterID:    c.Name,
 			Region:       c.Region,
 			TopicCount:   topicCount(c),
@@ -144,7 +144,7 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 	// the strategy-typo / strategy-unknown signals are valuable even
 	// when the verdict resolves to no recommendation.
 	schema := decideSchema(state, s.cfg, inputs)
-	if schema != nil && !hasPath(schema, types.SchemaPathSchemaless) {
+	if schema != nil && !hasPath(schema, SchemaPathSchemaless) {
 		plan.Schema = schema
 	}
 	plan.OpenQuestions = append(plan.OpenQuestions, detectSchemaOpenQuestions(schema, s.cfg, inputs)...)
@@ -204,8 +204,8 @@ func (s *PlanService) Build(state types.ProcessedState, inputs types.PlanInputsR
 // will upgrade that recommendation. SERVERLESS-specific suppressions for
 // "ACLs not populated" and "0 brokers" live in cluster_signals.go so the
 // same logic is shared with the rule evaluator.
-func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, ct types.ClusterTypeDecision, net types.NetworkingDecision, auth types.AuthDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
-	var oqs []types.OpenQuestion
+func detectOpenQuestions(c types.ProcessedCluster, sizing ClusterSizing, ct ClusterTypeDecision, net NetworkingDecision, auth AuthDecision, cfg *PlanConfig, inputs PlanInputsResolved) []OpenQuestion {
+	var oqs []OpenQuestion
 	// Auth posture undetectable. Fires whenever the source has no
 	// detected auth methods — auth is its own concern, surfaced
 	// independently of topic / ACL inventory gaps (those have their
@@ -214,7 +214,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	// Provisioned needs an admin re-scan; Serverless needs the
 	// Serverless.ClientAuthentication block populated.
 	if len(auth.SourceAuths) == 0 {
-		oq := types.OpenQuestion{
+		oq := OpenQuestion{
 			ID:        "auth_posture_unknown",
 			ClusterID: c.Name,
 			Title:     "No client-authentication methods detected on the source — auth migration recommendation is unconfirmed",
@@ -240,7 +240,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	if inputs.TargetAuthMethod != "" && inputs.PreferGateway && knownTargetAuthMethod(inputs.TargetAuthMethod) {
 		for _, row := range auth.TargetMappings {
 			if !row.GatewayCompatible {
-				oqs = append(oqs, types.OpenQuestion{
+				oqs = append(oqs, OpenQuestion{
 					ID:         "auth_target_gateway_incompatible",
 					ClusterID:  c.Name,
 					Title:      fmt.Sprintf("`target_auth_method: %s` set but source auth `%s` is gateway-incompatible", inputs.TargetAuthMethod, row.SourceAuth),
@@ -261,7 +261,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 			// declare throughput or consult the account team.
 			howToClose = "Serverless throughput isn't auto-populated by `kcp discover` — supply ingress/egress targets via `plan-inputs.yaml` (or work with your Confluent account team to size against actual workload rates)."
 		}
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "missing_p95_metrics",
 			ClusterID:  c.Name,
 			Title:      fmt.Sprintf("No %s throughput metrics — sizing fell back to SLA floor", percentileHeader(inputs.SizingPercentile)),
@@ -270,7 +270,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		})
 	}
 	if !aclScanRan(c) && !isServerless(c) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:        "acls_not_scanned",
 			ClusterID: c.Name,
 			Title:     "Admin scan didn't populate ACLs — cap-vs-Enterprise rule was skipped",
@@ -280,7 +280,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		})
 	}
 	if brokerInventoryGap(c) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "broker_inventory_empty",
 			ClusterID:  c.Name,
 			Title:      "Source environment shows 0 brokers — likely an incomplete scan",
@@ -305,7 +305,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		default:
 			body = "`KafkaAdminClientInformation.Topics.Summary.Topics` is 0. The Source Environment table reads as `Topics: 0`, which is almost certainly wrong for a real MSK cluster (system topics alone usually push the count above zero)."
 		}
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "topic_inventory_empty",
 			ClusterID:  c.Name,
 			Title:      "Source environment shows 0 topics — likely an incomplete scan",
@@ -314,7 +314,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 		})
 	}
 	if hasUnknownClusterType(c) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "cluster_type_unrecognised",
 			ClusterID:  c.Name,
 			Title:      "MSK cluster discriminator unrecognised — Plan treated as Provisioned with empty fields",
@@ -324,7 +324,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 	}
 	if privateLinkSizingExceedsCap(sizing, ct, net, cfg) {
 		cap := cfg.EnterpriseCaps.PrivateLinkMaxECKU
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "networking_privatelink_over_cap",
 			ClusterID:  c.Name,
 			Title:      fmt.Sprintf("PrivateLink trigger fired but cluster sizing exceeds the %d-eCKU PrivateLink cap on Enterprise", cap),
@@ -345,7 +345,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing types.ClusterSizing, c
 // state file contains OSK (open-source Kafka, on-prem) clusters.
 // `kcp report plan` covers MSK only today; without this OQ those
 // clusters would be silently dropped from the plan.
-func detectOSKSourceOpenQuestion(state types.ProcessedState) []types.OpenQuestion {
+func detectOSKSourceOpenQuestion(state types.ProcessedState) []OpenQuestion {
 	var oskCount int
 	for _, src := range state.Sources {
 		if src.OSKData != nil {
@@ -359,7 +359,7 @@ func detectOSKSourceOpenQuestion(state types.ProcessedState) []types.OpenQuestio
 	if oskCount == 1 {
 		noun, verb = "cluster", "isn't"
 	}
-	return []types.OpenQuestion{{
+	return []OpenQuestion{{
 		ID:         "osk_source_unsupported",
 		Title:      fmt.Sprintf("%d on-prem Kafka %s in the state file %s covered by `kcp report plan`", oskCount, noun, verb),
 		Body:       "The state file includes `osk_sources` clusters (open-source Kafka, e.g. on-prem deployments). `kcp report plan` currently scopes to MSK source clusters only — the OSK clusters are silently dropped from every section above. The MSK-shaped recommendations still stand for any MSK clusters in the same state file.",
@@ -372,7 +372,7 @@ func detectOSKSourceOpenQuestion(state types.ProcessedState) []types.OpenQuestio
 // Plan's GeneratedAt time; if the state was empty (zero timestamp) the
 // OQ is suppressed because there's nothing to compare against.
 // `staleDays` comes from plan-config.yaml `thresholds.stale_state_days`.
-func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDays int) []types.OpenQuestion {
+func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDays int) []OpenQuestion {
 	if stateTimestamp.IsZero() {
 		return nil
 	}
@@ -386,7 +386,7 @@ func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDa
 	// "7 days old" reads as wrong-by-a-day). Math.Round avoids
 	// truncation toward zero.
 	days := int(math.Round(age.Hours() / 24))
-	return []types.OpenQuestion{{
+	return []OpenQuestion{{
 		ID:         "state_file_stale",
 		Title:      fmt.Sprintf("State file is %d days old — verdicts may not reflect current source state", days),
 		Body:       fmt.Sprintf("The source state file is dated `%s`; this Plan was generated `%s` (%d days later). Verdicts above (ACL-cap, broker counts, throughput sizing) are computed against the state file as-is, but the source environment may have drifted since.", stateTimestamp.UTC().Format("2006-01-02 15:04:05 UTC"), generatedAt.UTC().Format("2006-01-02 15:04:05 UTC"), days),
@@ -406,10 +406,10 @@ func detectStaleStateOQ(stateTimestamp time.Time, generatedAt time.Time, staleDa
 // overrides to Blue/Green, the gateway-intent / prereq OQs add a note
 // that those clusters are exempt — otherwise the OQ reads as if it
 // applies to the entire fleet.
-func detectCutoverOpenQuestions(cutover types.CutoverDecision, overrides []types.ClusterCutoverOverride, inputs types.PlanInputsResolved, iamInUse bool) []types.OpenQuestion {
-	var oqs []types.OpenQuestion
+func detectCutoverOpenQuestions(cutover CutoverDecision, overrides []ClusterCutoverOverride, inputs PlanInputsResolved, iamInUse bool) []OpenQuestion {
+	var oqs []OpenQuestion
 	if !knownDowntimeTolerance(inputs.DowntimeTolerance) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "downtime_tolerance_unknown",
 			Title:      fmt.Sprintf("`downtime_tolerance: %s` is not a recognised value — defaulted to Stop-Restart-Repeat", inputs.DowntimeTolerance),
 			Body:       "The Plan only recognises `zero | seconds_per_service | minutes_per_service | scheduled_window_sequential | scheduled_window_all_at_once | let_confluent_choose`. The current value falls outside the enum, so the Plan inherits the Confluent default (Stop-Restart-Repeat) silently — which is probably not what you intended.",
@@ -427,15 +427,15 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, overrides []types
 		exemptSuffix = fmt.Sprintf(" Per-cluster Blue/Green overrides (`%s`) sidestep the gateway question — this OQ applies to the rest of the fleet.", strings.Join(gatewayExempt, "`, `"))
 	}
 	switch cutover.RecommendationStatus {
-	case types.RecommendationDegradedAwaitingOQ:
-		oqs = append(oqs, types.OpenQuestion{
+	case RecommendationDegradedAwaitingOQ:
+		oqs = append(oqs, OpenQuestion{
 			ID:         "gateway_intent_unconfirmed",
 			Title:      "Gateway intent — pick CC Gateway or plain Cluster Linking",
 			Body:       "`prefer_gateway: true` (default) AND all three gateway prereqs (`confluent_for_kubernetes_status`, `cc_gateway_license_status`, `iam_pre_migration_status`) are at `not_started`. Both paths are fully supported — the Plan just needs you to pick. Plain Cluster Linking applies while this is open." + exemptSuffix,
 			HowToClose: "In `plan-inputs.yaml`, either (a) set `prefer_gateway: false` to commit to plain Cluster Linking, OR (b) move at least one gateway prereq to `in_progress` to commit to the gateway path. Re-run `kcp report plan` to clear the OQ.",
 		})
-	case types.RecommendationDegradedPrereqsPending:
-		oqs = append(oqs, types.OpenQuestion{
+	case RecommendationDegradedPrereqsPending:
+		oqs = append(oqs, OpenQuestion{
 			ID:         "gateway_prereqs_pending",
 			Title:      "Gateway prereqs — pending items before the gateway path can be recommended",
 			Body:       fmt.Sprintf("`prefer_gateway: true` and at least one gateway prereq is still at `not_started`: %s. The gateway-mediated path needs all applicable prereqs at `in_progress` or `complete`. Plain Cluster Linking applies until they advance.%s", pendingPrereqList(inputs, iamInUse), exemptSuffix),
@@ -446,17 +446,17 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, overrides []types
 	// gateway. If the customer asks for it but mediation isn't possible
 	// (opt-out OR ambiguous OR prereqs pending), surface a cause-specific
 	// OQ. Blue/Green sidesteps the gateway entirely and never trips this.
-	if inputs.DowntimeTolerance == DowntimeSecondsPerService && cutover.GatewayMediated != types.GatewayMediatedTrue && cutover.Style != types.CutoverBlueGreen {
+	if inputs.DowntimeTolerance == DowntimeSecondsPerService && cutover.GatewayMediated != GatewayMediatedTrue && cutover.Style != CutoverBlueGreen {
 		body := "seconds_per_service downtime tolerance requires CC-Gateway mediation (the gateway's 30–90s `BROKER_NOT_AVAILABLE` window is what makes sub-minute cutovers possible). The current Plan doesn't mediate via the gateway because: "
 		switch {
 		case !inputs.PreferGateway:
 			body += "`prefer_gateway: false`. Set `prefer_gateway: true` OR relax `downtime_tolerance` to `minutes_per_service` (plain Cluster Linking)."
-		case cutover.RecommendationStatus == types.RecommendationDegradedAwaitingOQ:
+		case cutover.RecommendationStatus == RecommendationDegradedAwaitingOQ:
 			body += "gateway intent is unconfirmed (see the related Open Question above). Commit to the gateway path or relax `downtime_tolerance`."
 		default:
 			body += "one or more gateway prereqs are still at `not_started`. Move pending prereqs to `in_progress`/`complete`, OR relax `downtime_tolerance` to `minutes_per_service`."
 		}
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "downtime_tolerance_requires_gateway",
 			Title:      "`downtime_tolerance: seconds_per_service` requires the gateway but the recommendation is plain Cluster Linking",
 			Body:       body,
@@ -473,10 +473,10 @@ func detectCutoverOpenQuestions(cutover types.CutoverDecision, overrides []types
 // affected cluster is obvious). Per-cluster typos silently fall back
 // to the per-source default in decideAuth via effectiveTarget, so
 // without this detector they're invisible to the customer.
-func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
-	var oqs []types.OpenQuestion
+func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
+	var oqs []OpenQuestion
 	if !knownTargetAuthMethod(inputs.TargetAuthMethod) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "target_auth_method_unknown",
 			Title:      fmt.Sprintf("`target_auth_method: %s` is not a recognised value — per-source defaults applied instead", inputs.TargetAuthMethod),
 			Body:       fmt.Sprintf("The Plan only recognises `%s | %s | %s`. The current value falls outside the enum; the per-source `auth_mapping` default is used silently for every cluster.", TargetAuthAPIKeys, TargetAuthMTLS, TargetAuthOAuth),
@@ -492,7 +492,7 @@ func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs type
 		if knownTargetAuthMethod(value) {
 			continue
 		}
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "target_auth_method_unknown",
 			ClusterID:  name,
 			Title:      fmt.Sprintf("`clusters[%s].target_auth_method: %s` is not a recognised value — per-source default applied for this cluster", name, value),
@@ -508,7 +508,7 @@ func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs type
 // stable alphabetical order. Unknown-cluster overrides are filtered
 // out here; `detectUnknownClusterOverrides` handles surfacing them as
 // their own OQ. Returns nil when no Raw inputs exist.
-func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []string {
+func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []string {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
@@ -532,7 +532,7 @@ func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs t
 // cluster. Without this, a typo'd cluster name (e.g. `clusters[trust]`
 // against a fleet with no `trust` cluster) silently produces no
 // override and the reader has no signal that their input was rejected.
-func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
+func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
@@ -551,9 +551,9 @@ func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs typ
 		return nil
 	}
 	sort.Strings(unknown)
-	oqs := make([]types.OpenQuestion, 0, len(unknown))
+	oqs := make([]OpenQuestion, 0, len(unknown))
 	for _, name := range unknown {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "cluster_override_unknown_cluster",
 			Title:      fmt.Sprintf("`clusters[%s]` in `plan-inputs.yaml` doesn't match any scanned cluster — override silently ignored", name),
 			Body:       fmt.Sprintf("The plan-inputs `clusters:` map names `%s`, but the state file contains no cluster with that name. The override block has no effect; either the cluster name is a typo, or the state file is from a different source than expected.", name),
@@ -572,11 +572,11 @@ func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs typ
 // When the override value isn't in the recognised enum, the entry
 // carries OverrideRejected + RejectedOverrideValue so a JSON consumer
 // can detect rejected overrides structurally (mirrors AuthDecision).
-func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.CutoverDecision, inputs types.PlanInputsResolved) []types.ClusterCutoverOverride {
+func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []ClusterCutoverOverride {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
-	var out []types.ClusterCutoverOverride
+	var out []ClusterCutoverOverride
 	for _, c := range clusters {
 		raw, ok := inputs.Raw.Clusters[c.Name]
 		if !ok || (raw.DowntimeTolerance == nil && raw.SubPattern == nil) {
@@ -595,15 +595,15 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.Cuto
 		// IAM / non-IAM fleets. (See `detectPerClusterGatewayIncompat`
 		// for the separate OQ that surfaces the cross-check.)
 		mediated := fleet.GatewayMediated
-		if dec.Style == types.CutoverBlueGreen {
-			mediated = types.GatewayMediatedNotApplicable
+		if dec.Style == CutoverBlueGreen {
+			mediated = GatewayMediatedNotApplicable
 		}
 		rejected, rejectedValue := rejectedCutoverOverride(raw)
 		styleMatchesFleet := dec.Style == fleet.Style && dec.SubPattern == fleet.SubPattern && mediated == fleet.GatewayMediated
 		if styleMatchesFleet && !rejected {
 			continue
 		}
-		out = append(out, types.ClusterCutoverOverride{
+		out = append(out, ClusterCutoverOverride{
 			ClusterID:             c.Name,
 			Style:                 dec.Style,
 			SubPattern:            dec.SubPattern,
@@ -622,17 +622,17 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet types.Cuto
 // this, the customer's per-cluster choice is silently lost — the
 // cluster falls back to the fleet's plain Cluster Linking shape and
 // the reader has no signal.
-func detectPerClusterGatewayIncompat(clusters []types.ProcessedCluster, fleet types.CutoverDecision, inputs types.PlanInputsResolved) []types.OpenQuestion {
-	if fleet.GatewayMediated == types.GatewayMediatedTrue {
+func detectPerClusterGatewayIncompat(clusters []types.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []OpenQuestion {
+	if fleet.GatewayMediated == GatewayMediatedTrue {
 		return nil
 	}
-	var oqs []types.OpenQuestion
+	var oqs []OpenQuestion
 	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
 		cluster := inputs.Raw.Clusters[name]
 		if cluster.DowntimeTolerance == nil || *cluster.DowntimeTolerance != DowntimeSecondsPerService {
 			continue
 		}
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:        "downtime_tolerance_requires_gateway",
 			ClusterID: name,
 			Title:     fmt.Sprintf("`clusters[%s].downtime_tolerance: seconds_per_service` requires the gateway but the fleet's recommendation is plain Cluster Linking", name),
@@ -649,10 +649,10 @@ func detectPerClusterGatewayIncompat(clusters []types.ProcessedCluster, fleet ty
 // question. Used by detectCutoverOpenQuestions to add a clarifying
 // note to fleet-wide gateway OQs so the reader doesn't think the OQ
 // applies to gateway-exempt clusters too.
-func bgOverrideClusterNames(overrides []types.ClusterCutoverOverride) []string {
+func bgOverrideClusterNames(overrides []ClusterCutoverOverride) []string {
 	var out []string
 	for _, o := range overrides {
-		if o.Style == types.CutoverBlueGreen {
+		if o.Style == CutoverBlueGreen {
 			out = append(out, o.ClusterID)
 		}
 	}
@@ -663,7 +663,7 @@ func bgOverrideClusterNames(overrides []types.ClusterCutoverOverride) []string {
 // values are outside the recognised enum. Returns the first rejected
 // value found (downtime_tolerance takes precedence over sub_pattern)
 // for the renderer / JSON consumer to display.
-func rejectedCutoverOverride(raw types.ClusterPlanInputs) (bool, string) {
+func rejectedCutoverOverride(raw ClusterPlanInputs) (bool, string) {
 	if raw.DowntimeTolerance != nil && !knownDowntimeTolerance(*raw.DowntimeTolerance) {
 		return true, *raw.DowntimeTolerance
 	}
@@ -681,14 +681,14 @@ func rejectedCutoverOverride(raw types.ClusterPlanInputs) (bool, string) {
 // for cluster names that match an actual scanned cluster;
 // unknown-name overrides are handled by
 // detectUnknownClusterOverrides.
-func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) []types.OpenQuestion {
-	var oqs []types.OpenQuestion
+func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
+	var oqs []OpenQuestion
 	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
 		cluster := inputs.Raw.Clusters[name]
 		if cluster.DowntimeTolerance != nil {
 			value := *cluster.DowntimeTolerance
 			if !knownDowntimeTolerance(value) {
-				oqs = append(oqs, types.OpenQuestion{
+				oqs = append(oqs, OpenQuestion{
 					ID:         "downtime_tolerance_unknown",
 					ClusterID:  name,
 					Title:      fmt.Sprintf("`clusters[%s].downtime_tolerance: %s` is not a recognised value — treated as `let_confluent_choose` (Stop-Restart-Repeat) for this cluster", name, value),
@@ -700,7 +700,7 @@ func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs
 		if cluster.SubPattern != nil {
 			value := *cluster.SubPattern
 			if !knownCutoverSubPattern(value) {
-				oqs = append(oqs, types.OpenQuestion{
+				oqs = append(oqs, OpenQuestion{
 					ID:         "sub_pattern_unknown",
 					ClusterID:  name,
 					Title:      fmt.Sprintf("`clusters[%s].sub_pattern: %s` is not a recognised value — `app-by-app` applied for this cluster", name, value),
@@ -716,7 +716,7 @@ func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs
 // pendingPrereqList renders the list of gateway prereqs still at
 // `not_started`, for inclusion in an OQ body. Inline rather than a
 // helper-with-cases because the body string is one-shot per Plan.
-func pendingPrereqList(inputs types.PlanInputsResolved, iamInUse bool) string {
+func pendingPrereqList(inputs PlanInputsResolved, iamInUse bool) string {
 	var pending []string
 	if inputs.ConfluentForKubernetesStatus == PrereqNotStarted {
 		pending = append(pending, "`confluent_for_kubernetes_status`")
@@ -810,14 +810,14 @@ func brokerCount(c types.ProcessedCluster) int {
 	return len(c.AWSClientInformation.Nodes)
 }
 
-func buildSizingAppendix(sizings []types.ClusterSizing, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.SizingMathDetail {
+func buildSizingAppendix(sizings []ClusterSizing, cfg *PlanConfig, inputs PlanInputsResolved) []SizingMathDetail {
 	caps := cfg.EnterpriseCaps
-	out := make([]types.SizingMathDetail, 0, len(sizings))
+	out := make([]SizingMathDetail, 0, len(sizings))
 	for _, s := range sizings {
 		if s.Degraded {
 			continue
 		}
-		out = append(out, types.SizingMathDetail{
+		out = append(out, SizingMathDetail{
 			ClusterID: s.ClusterID,
 			Formula: fmt.Sprintf("CEIL(max(%sIn/%d, %sOut/%d, partitions/%d) * (1 + %.2f headroom))",
 				percentileHeader(inputs.SizingPercentile), caps.PerECKUIngressMBps,

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -141,22 +141,22 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c.KafkaAdminClientInformation.Acls = []types.Acls{} // non-nil means "scan ran" under aclScanRan's current heuristic
 		return c
 	}
-	ent := types.ClusterTypeDecision{Verdict: types.ClusterTypeEnterprise}
-	pniNet := func(id string) types.NetworkingDecision {
-		return types.NetworkingDecision{ClusterID: id, Verdict: types.NetworkingPNI}
+	ent := ClusterTypeDecision{Verdict: ClusterTypeEnterprise}
+	pniNet := func(id string) NetworkingDecision {
+		return NetworkingDecision{ClusterID: id, Verdict: NetworkingPNI}
 	}
 	// scramAuth is the default test fixture for AuthDecision — a single
 	// SCRAM source. Non-empty SourceAuths suppresses the
 	// `auth_posture_unknown` OQ, which is what every test here cares
 	// about (those tests assert on other OQ IDs).
-	scramAuth := func(id string) types.AuthDecision {
-		return types.AuthDecision{ClusterID: id, SourceAuths: []string{SourceAuthSCRAM}}
+	scramAuth := func(id string) AuthDecision {
+		return AuthDecision{ClusterID: id, SourceAuths: []string{SourceAuthSCRAM}}
 	}
 
 	t.Run("missing P95 metrics → missing_p95_metrics OQ", func(t *testing.T) {
 		c := provisioned("noMetrics")
-		sizing := types.ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
-		oqs := detectOpenQuestions(c, sizing, ent, pniNet("noMetrics"), scramAuth("noMetrics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		sizing := ClusterSizing{ClusterID: "noMetrics", Degraded: true, DegradedReason: "no BytesInPerSec p95"}
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("noMetrics"), scramAuth("noMetrics"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		// Metrics are collected by `kcp discover` (not a separate `scan metrics` subcommand).
 		assertContainsOQ(t, oqs, "missing_p95_metrics", "kcp discover")
 	})
@@ -167,7 +167,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		// trustworthy "scan ran" signal — aclScanRan returns true and
 		// the OQ is suppressed.
 		c := provisioned("provisioned-zero-acls") // helper sets Acls = []types.Acls{}
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-zero-acls", FinalECKU: 1}, ent, pniNet("provisioned-zero-acls"), scramAuth("provisioned-zero-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "provisioned-zero-acls", FinalECKU: 1}, ent, pniNet("provisioned-zero-acls"), scramAuth("provisioned-zero-acls"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "acls_not_scanned", oq.ID, "scan-ran-with-0 must NOT emit the OQ")
 		}
@@ -179,7 +179,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		// the customer can rule out the ACL-cap risk.
 		c := provisioned("provisioned-nil-acls")
 		c.KafkaAdminClientInformation.Acls = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "provisioned-nil-acls", FinalECKU: 1}, ent, pniNet("provisioned-nil-acls"), scramAuth("provisioned-nil-acls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "provisioned-nil-acls", FinalECKU: 1}, ent, pniNet("provisioned-nil-acls"), scramAuth("provisioned-nil-acls"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "acls_not_scanned", "--skip-acls")
 	})
 
@@ -188,7 +188,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		// Topics nil → scan didn't run; ACLs nil follows from same gap
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noAcls", FinalECKU: 1}, ent, pniNet("noAcls"), scramAuth("noAcls"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "noAcls", FinalECKU: 1}, ent, pniNet("noAcls"), scramAuth("noAcls"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "acls_not_scanned", "admin Kafka credentials")
 	})
 
@@ -198,7 +198,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		c.KafkaAdminClientInformation.Acls = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "serverless", FinalECKU: 1}, ent, pniNet("serverless"), scramAuth("serverless"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "serverless", FinalECKU: 1}, ent, pniNet("serverless"), scramAuth("serverless"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "acls_not_scanned", oq.ID, "serverless does not expose ACLs via this API")
 			assert.NotEqual(t, "broker_inventory_empty", oq.ID, "serverless has no broker nodes by design")
@@ -208,14 +208,14 @@ func TestDetectOpenQuestions(t *testing.T) {
 	t.Run("zero brokers on PROVISIONED → broker_inventory_empty OQ", func(t *testing.T) {
 		c := provisioned("noBrokers")
 		c.AWSClientInformation.Nodes = nil
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1}, ent, pniNet("noBrokers"), scramAuth("noBrokers"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "noBrokers", FinalECKU: 1}, ent, pniNet("noBrokers"), scramAuth("noBrokers"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "broker_inventory_empty", "kcp discover")
 	})
 
 	t.Run("zero topics → topic_inventory_empty OQ", func(t *testing.T) {
 		c := provisioned("noTopics")
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 0}}
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "noTopics", FinalECKU: 1}, ent, pniNet("noTopics"), scramAuth("noTopics"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "noTopics", FinalECKU: 1}, ent, pniNet("noTopics"), scramAuth("noTopics"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "topic_inventory_empty", "kcp scan clusters")
 	})
 
@@ -226,9 +226,9 @@ func TestDetectOpenQuestions(t *testing.T) {
 			VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}}},
 		}
 		// Topics intentionally left nil.
-		auth := types.AuthDecision{ClusterID: "srv-nil", SourceAuths: []string{SourceAuthIAM}}
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "srv-nil", FinalECKU: 1}, ent, pniNet("srv-nil"), auth, cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
-		var topicOQ *types.OpenQuestion
+		auth := AuthDecision{ClusterID: "srv-nil", SourceAuths: []string{SourceAuthIAM}}
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "srv-nil", FinalECKU: 1}, ent, pniNet("srv-nil"), auth, cfg, PlanInputsResolved{SizingPercentile: "p95"})
+		var topicOQ *OpenQuestion
 		for i, oq := range oqs {
 			if oq.ID == "topic_inventory_empty" {
 				topicOQ = &oqs[i]
@@ -242,17 +242,17 @@ func TestDetectOpenQuestions(t *testing.T) {
 
 	t.Run("PrivateLink trigger + sized > cap → networking_privatelink_over_cap OQ", func(t *testing.T) {
 		c := provisioned("overCap")
-		sizing := types.ClusterSizing{ClusterID: "overCap", FinalECKU: 15} // > 10 eCKU PL cap
-		net := types.NetworkingDecision{ClusterID: "overCap", Verdict: types.NetworkingPrivateLink}
-		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		sizing := ClusterSizing{ClusterID: "overCap", FinalECKU: 15} // > 10 eCKU PL cap
+		net := NetworkingDecision{ClusterID: "overCap", Verdict: NetworkingPrivateLink}
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assertContainsOQ(t, oqs, "networking_privatelink_over_cap", "account team")
 	})
 
 	t.Run("PrivateLink with sized <= cap → no over-cap OQ", func(t *testing.T) {
 		c := provisioned("underCap")
-		sizing := types.ClusterSizing{ClusterID: "underCap", FinalECKU: 5}
-		net := types.NetworkingDecision{ClusterID: "underCap", Verdict: types.NetworkingPrivateLink}
-		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		sizing := ClusterSizing{ClusterID: "underCap", FinalECKU: 5}
+		net := NetworkingDecision{ClusterID: "underCap", Verdict: NetworkingPrivateLink}
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
 		}
@@ -260,9 +260,9 @@ func TestDetectOpenQuestions(t *testing.T) {
 
 	t.Run("PNI with any sizing → no over-cap OQ (only fires on PrivateLink verdict)", func(t *testing.T) {
 		c := provisioned("pniBig")
-		sizing := types.ClusterSizing{ClusterID: "pniBig", FinalECKU: 25}
-		net := types.NetworkingDecision{ClusterID: "pniBig", Verdict: types.NetworkingPNI}
-		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		sizing := ClusterSizing{ClusterID: "pniBig", FinalECKU: 25}
+		net := NetworkingDecision{ClusterID: "pniBig", Verdict: NetworkingPNI}
+		oqs := detectOpenQuestions(c, sizing, ent, net, scramAuth(c.Name), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		for _, oq := range oqs {
 			assert.NotEqual(t, "networking_privatelink_over_cap", oq.ID)
 		}
@@ -270,19 +270,19 @@ func TestDetectOpenQuestions(t *testing.T) {
 
 	t.Run("spiky workload does NOT generate an OQ (FYI only)", func(t *testing.T) {
 		c := provisioned("spiky")
-		sizing := types.ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
-		oqs := detectOpenQuestions(c, sizing, ent, pniNet("spiky"), scramAuth("spiky"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		sizing := ClusterSizing{ClusterID: "spiky", FinalECKU: 2, SpikyIngress: true}
+		oqs := detectOpenQuestions(c, sizing, ent, pniNet("spiky"), scramAuth("spiky"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "spiky clusters should NOT emit an OQ — informational only")
 	})
 
 	t.Run("fully populated cluster emits no OQs", func(t *testing.T) {
 		c := provisioned("complete")
-		oqs := detectOpenQuestions(c, types.ClusterSizing{ClusterID: "complete", FinalECKU: 2}, ent, pniNet("complete"), scramAuth("complete"), cfg, types.PlanInputsResolved{SizingPercentile: "p95"})
+		oqs := detectOpenQuestions(c, ClusterSizing{ClusterID: "complete", FinalECKU: 2}, ent, pniNet("complete"), scramAuth("complete"), cfg, PlanInputsResolved{SizingPercentile: "p95"})
 		assert.Empty(t, oqs, "happy-path clusters should not surface OQs")
 	})
 }
 
-func assertContainsOQ(t *testing.T, oqs []types.OpenQuestion, id, expectedSubstring string) {
+func assertContainsOQ(t *testing.T, oqs []OpenQuestion, id, expectedSubstring string) {
 	t.Helper()
 	for _, oq := range oqs {
 		if oq.ID == id {
@@ -467,7 +467,7 @@ func TestInputsMissing_AllSignalsTracked(t *testing.T) {
 
 func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 	cfg := defaultCfg(t)
-	sizing := types.ClusterSizing{ClusterID: "x", FinalECKU: 5}
+	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 5}
 
 	t.Run("nil-Acls PROVISIONED: skipped rule has SkipReason", func(t *testing.T) {
 		c := provisionedClusterWithScan("nil-acls", nil)
@@ -475,7 +475,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 		require.Len(t, d.EvaluatedRules, len(hardLimitCatalog), "EvaluatedRules must carry every catalog entry")
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleACLCountExceedsCap {
-				assert.Equal(t, types.RuleSkipped, r.Outcome)
+				assert.Equal(t, RuleSkipped, r.Outcome)
 				assert.NotEmpty(t, r.SkipReason, "skipped rule must carry a SkipReason")
 				assert.Empty(t, r.Evidence, "skipped rule must NOT carry Evidence")
 				return
@@ -488,7 +488,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleACLCountExceedsCap {
-				assert.Equal(t, types.RuleNotFired, r.Outcome)
+				assert.Equal(t, RuleNotFired, r.Outcome)
 				assert.Contains(t, r.Evidence, "≤", "not_fired rule must surface negative evidence")
 				return
 			}
@@ -503,7 +503,7 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 		var found bool
 		for _, r := range d.EvaluatedRules {
 			if r.RowID == ruleBrokerSideSchemaValidation {
-				assert.Equal(t, types.RuleFired, r.Outcome)
+				assert.Equal(t, RuleFired, r.Outcome)
 				assert.NotEmpty(t, r.Evidence)
 				found = true
 				break
@@ -533,8 +533,8 @@ func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T
 		}},
 	}
 	flag := true
-	rawInputs := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	rawInputs := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {Requires9995SLAWithinSingleZone: &flag}, // SZ for alpha only
 		},
 	}
@@ -544,14 +544,14 @@ func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, p.ClusterTypeDecision, 2)
 
-	byID := map[string]types.ClusterTypeDecision{}
+	byID := map[string]ClusterTypeDecision{}
 	for _, d := range p.ClusterTypeDecision {
 		byID[d.ClusterID] = d
 	}
 
-	assert.Equal(t, types.ClusterTypeDedicated, byID["alpha"].Verdict, "per-cluster override must flip alpha to Dedicated")
-	assert.Equal(t, types.TopologySingleZone, byID["alpha"].Topology, "SLA flag drives SZ topology")
-	assert.Equal(t, types.ClusterTypeEnterprise, byID["bravo"].Verdict, "non-overridden cluster must keep the global default (Enterprise)")
+	assert.Equal(t, ClusterTypeDedicated, byID["alpha"].Verdict, "per-cluster override must flip alpha to Dedicated")
+	assert.Equal(t, TopologySingleZone, byID["alpha"].Topology, "SLA flag drives SZ topology")
+	assert.Equal(t, ClusterTypeEnterprise, byID["bravo"].Verdict, "non-overridden cluster must keep the global default (Enterprise)")
 }
 
 // Per-cluster target_auth_method override flips the effective target
@@ -573,8 +573,8 @@ func TestPlanServiceBuild_PerClusterTargetAuthOverride(t *testing.T) {
 		}},
 	}
 	oauth := TargetAuthOAuth
-	rawInputs := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	rawInputs := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {TargetAuthMethod: &oauth},
 		},
 	}
@@ -584,7 +584,7 @@ func TestPlanServiceBuild_PerClusterTargetAuthOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, p.Auth, 2)
 
-	byID := map[string]types.AuthDecision{}
+	byID := map[string]AuthDecision{}
 	for _, a := range p.Auth {
 		byID[a.ClusterID] = a
 	}
@@ -616,7 +616,7 @@ func TestDetectStaleStateOQ_HonorsThreshold(t *testing.T) {
 // the global override is a typo, and stays silent for the recognised
 // values + the empty default.
 func TestDetectAuthFleetOpenQuestions_TargetAuthMethodTypo(t *testing.T) {
-	resolved := types.PlanInputsResolved{TargetAuthMethod: "oauthhh"}
+	resolved := PlanInputsResolved{TargetAuthMethod: "oauthhh"}
 	oqs := detectAuthFleetOpenQuestions(nil, resolved)
 	require.Len(t, oqs, 1)
 	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
@@ -636,14 +636,14 @@ func TestDetectAuthFleetOpenQuestions_TargetAuthMethodTypo(t *testing.T) {
 func TestDetectAuthFleetOpenQuestions_PerClusterTargetAuthTypo(t *testing.T) {
 	typo := "oauthhh"
 	good := TargetAuthOAuth
-	raw := &types.PlanInputs{
-		Clusters: map[string]types.ClusterPlanInputs{
+	raw := &PlanInputs{
+		Clusters: map[string]ClusterPlanInputs{
 			"alpha": {TargetAuthMethod: &typo},
 			"bravo": {TargetAuthMethod: &good},
 		},
 	}
 	clusters := []types.ProcessedCluster{{Name: "alpha"}, {Name: "bravo"}}
-	resolved := types.PlanInputsResolved{Raw: raw}
+	resolved := PlanInputsResolved{Raw: raw}
 	oqs := detectAuthFleetOpenQuestions(clusters, resolved)
 	require.Len(t, oqs, 1, "only the typo cluster should emit an OQ")
 	assert.Equal(t, "target_auth_method_unknown", oqs[0].ID)
@@ -655,7 +655,7 @@ func TestDetectAuthFleetOpenQuestions_PerClusterTargetAuthTypo(t *testing.T) {
 // that don't use IAM — otherwise a non-IAM fleet that accidentally
 // flipped that prereq would lose the `gateway_intent_unconfirmed` OQ.
 func TestAmbiguousGatewayIntent_IgnoresIAMPrereqWhenNoIAM(t *testing.T) {
-	inputs := types.PlanInputsResolved{
+	inputs := PlanInputsResolved{
 		PreferGateway:                true,
 		ConfluentForKubernetesStatus: PrereqNotStarted,
 		CCGatewayLicenseStatus:       PrereqNotStarted,

--- a/internal/services/plan/plan_test.go
+++ b/internal/services/plan/plan_test.go
@@ -1,4 +1,4 @@
-package types
+package plan
 
 import (
 	"encoding/json"

--- a/internal/services/plan/red_flags.go
+++ b/internal/services/plan/red_flags.go
@@ -59,12 +59,12 @@ var broadTopicPatterns = []struct {
 // independently and produces a {Status, Evidence} pair — Triggered
 // rows render at the top of §Red Flags, with NotTriggered / Unknown
 // collapsed into a tail summary.
-func detectRedFlags(state types.ProcessedState, plan *types.Plan, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.RedFlagsSection {
+func detectRedFlags(state types.ProcessedState, plan *Plan, cfg *PlanConfig, inputs PlanInputsResolved) *RedFlagsSection {
 	clusters := collectClusters(state)
 	if len(clusters) == 0 {
 		return nil
 	}
-	rows := []types.RedFlag{
+	rows := []RedFlag{
 		evalSchemalessSource(plan, inputs),
 		evalKafkaVersionBelowFloor(clusters, cfg),
 		evalIAMAuthEnabled(clusters),
@@ -81,7 +81,7 @@ func detectRedFlags(state types.ProcessedState, plan *types.Plan, cfg *PlanConfi
 		evalKafkaStreamsInUse(clusters, inputs),
 		evalBroadTopicPatternMatch(clusters),
 	}
-	return &types.RedFlagsSection{Rows: rows}
+	return &RedFlagsSection{Rows: rows}
 }
 
 // ----- Row 1: schemaless source -----
@@ -89,11 +89,11 @@ func detectRedFlags(state types.ProcessedState, plan *types.Plan, cfg *PlanConfi
 // Triggered when no Schema Registry was detected AND the customer
 // declared a non-unknown schema_strategy. While `schema_strategy ==
 // unknown` the row is suppressed to avoid a spurious first-run warning.
-func evalSchemalessSource(plan *types.Plan, inputs types.PlanInputsResolved) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDSchemalessSource, Title: "Schemaless source (no Schema Registry detected)"}
+func evalSchemalessSource(plan *Plan, inputs PlanInputsResolved) RedFlag {
+	rf := RedFlag{ID: RedFlagIDSchemalessSource, Title: "Schemaless source (no Schema Registry detected)"}
 	strategy := inputs.SchemaStrategy
 	if strategy == "" || strategy == SchemaStrategyUnknown {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "`schema_strategy` not yet declared — set it in `plan-inputs.yaml` to evaluate this row"
 		return rf
 	}
@@ -104,17 +104,17 @@ func evalSchemalessSource(plan *types.Plan, inputs types.PlanInputsResolved) typ
 	// (§5 says "you have an SR but we couldn't see it"; §6 would
 	// say "you don't have an SR"). Resolve as NotTriggered so the
 	// scan-gap copy in §5 is the single source of truth.
-	noScanSource := plan.Schema == nil || plan.Schema.Source == types.SchemaSourceNone
+	noScanSource := plan.Schema == nil || plan.Schema.Source == SchemaSourceNone
 	if noScanSource && strategy == SchemaStrategyMigrateExistingSchemaRegistry {
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 		return rf
 	}
 	if noScanSource {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = fmt.Sprintf("`schema_strategy: %s`, no Schema Registry detected by `kcp scan schema-registry` / `kcp scan glue-schema-registry`", strategy)
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -124,8 +124,8 @@ func evalSchemalessSource(plan *types.Plan, inputs types.PlanInputsResolved) typ
 // Versions are dot-separated integer segments; the comparator
 // (`versionAtLeast`) already strips pre-release suffixes and handles
 // the "latest" alias.
-func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConfig) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDKafkaVersionBelowCLFloor, Title: "Kafka version below the Cluster Linking floor"}
+func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConfig) RedFlag {
+	rf := RedFlag{ID: RedFlagIDKafkaVersionBelowCLFloor, Title: "Kafka version below the Cluster Linking floor"}
 	floor := cfg.ClusterLinking.SourceMinKafkaVersion
 	type versionHit struct {
 		Cluster string `json:"cluster"`
@@ -153,17 +153,17 @@ func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConf
 	}
 	switch {
 	case len(below) > 0:
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = fmt.Sprintf("clusters below floor `%s`: %s", floor, strings.Join(belowStrs, ", "))
 		rf.EvidenceFields = map[string]any{
 			"floor":    floor,
 			"clusters": below,
 		}
 	case len(unparseable) > 0:
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = fmt.Sprintf("kafka_version missing for: %s — re-run `kcp discover`", strings.Join(unparseable, ", "))
 	default:
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 	}
 	return rf
 }
@@ -185,8 +185,8 @@ func kafkaVersionOf(c types.ProcessedCluster) string {
 
 // ----- Row 3: IAM auth enabled -----
 
-func evalIAMAuthEnabled(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDIAMAuthEnabled, Title: "IAM authentication enabled on the source"}
+func evalIAMAuthEnabled(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDIAMAuthEnabled, Title: "IAM authentication enabled on the source"}
 	var hits []string
 	for _, c := range clusters {
 		for _, a := range sourceAuthsDetected(c) {
@@ -197,31 +197,31 @@ func evalIAMAuthEnabled(clusters []types.ProcessedCluster) types.RedFlag {
 		}
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "IAM detected on: " + strings.Join(hits, ", ")
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
 // ----- Row 4: AWS Glue Schema Registry in use -----
 
-func evalGlueSRInUse(plan *types.Plan) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDGlueSRInUse, Title: "AWS Glue Schema Registry in use"}
+func evalGlueSRInUse(plan *Plan) RedFlag {
+	rf := RedFlag{ID: RedFlagIDGlueSRInUse, Title: "AWS Glue Schema Registry in use"}
 	if plan.Schema == nil {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "schema migration verdict unavailable"
 		return rf
 	}
-	if hasPath(plan.Schema, types.SchemaPathMigrateGlue) ||
-		plan.Schema.Source == types.SchemaSourceGlue ||
-		plan.Schema.Source == types.SchemaSourceConfluentAndGlue {
-		rf.Status = types.RedFlagTriggered
+	if hasPath(plan.Schema, SchemaPathMigrateGlue) ||
+		plan.Schema.Source == SchemaSourceGlue ||
+		plan.Schema.Source == SchemaSourceConfluentAndGlue {
+		rf.Status = RedFlagTriggered
 		rf.Evidence = fmt.Sprintf("Glue registries detected: %s", strings.Join(plan.Schema.GlueRegistries, ", "))
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -231,10 +231,10 @@ func evalGlueSRInUse(plan *types.Plan) types.RedFlag {
 // sized eCKU's per-eCKU partition cap. Dynamic to the cluster's
 // sized footprint, not the Enterprise PNI ceiling — so a 5-eCKU
 // cluster trips at 4,500 partitions; a 32-eCKU cluster at 28,800.
-func evalPartitionApproachingCap(plan *types.Plan, cfg *PlanConfig) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDPartitionApproachingCap, Title: "Partition count approaching the cluster's sized partition ceiling"}
+func evalPartitionApproachingCap(plan *Plan, cfg *PlanConfig) RedFlag {
+	rf := RedFlag{ID: RedFlagIDPartitionApproachingCap, Title: "Partition count approaching the cluster's sized partition ceiling"}
 	if cfg.EnterpriseCaps.PerECKUPartitionRate <= 0 {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "config: per_eCKU_partition_rate missing"
 		return rf
 	}
@@ -252,11 +252,11 @@ func evalPartitionApproachingCap(plan *types.Plan, cfg *PlanConfig) types.RedFla
 		}
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = strings.Join(hits, "; ")
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -267,8 +267,8 @@ func evalPartitionApproachingCap(plan *types.Plan, cfg *PlanConfig) types.RedFla
 // topic-population + cluster type per the spec: a PROVISIONED cluster
 // with topics populated AND an empty `connectors` slice counts as
 // "actually zero".
-func evalMSKConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDMSKConnectPresent, Title: "MSK Connect managed connectors present"}
+func evalMSKConnectPresent(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDMSKConnectPresent, Title: "MSK Connect managed connectors present"}
 	var triggered []string
 	var unscanned []string
 	for _, c := range clusters {
@@ -290,13 +290,13 @@ func evalMSKConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
 	}
 	switch {
 	case len(triggered) > 0:
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = strings.Join(triggered, ", ")
 	case len(unscanned) > 0:
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "scan inconclusive for: " + strings.Join(unscanned, ", ")
 	default:
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 	}
 	return rf
 }
@@ -307,8 +307,8 @@ func evalMSKConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
 // Same nil-vs-empty disambiguation as row 6: empty struct with topics
 // populated counts as "no Connect clusters"; nil struct = scan didn't
 // run.
-func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDSelfManagedConnectPresent, Title: "Self-managed Connect clusters present"}
+func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDSelfManagedConnectPresent, Title: "Self-managed Connect clusters present"}
 	var triggered []string
 	var unscanned []string
 	for _, c := range clusters {
@@ -331,21 +331,21 @@ func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) types.RedF
 	}
 	switch {
 	case len(triggered) > 0:
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = strings.Join(triggered, ", ")
 	case len(unscanned) > 0:
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "scan inconclusive for: " + strings.Join(unscanned, ", ")
 	default:
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 	}
 	return rf
 }
 
 // ----- Row 8: multi-region source -----
 
-func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDMultiRegionSource, Title: "Source clusters span multiple AWS regions"}
+func evalMultiRegionSource(state types.ProcessedState) RedFlag {
+	rf := RedFlag{ID: RedFlagIDMultiRegionSource, Title: "Source clusters span multiple AWS regions"}
 	regions := map[string]struct{}{}
 	for _, src := range state.Sources {
 		if src.MSKData == nil {
@@ -366,7 +366,7 @@ func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
 		// load-bearing for the "same state file + same plan-inputs
 		// → byte-identical plan" guarantee.
 		sort.Strings(names)
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = fmt.Sprintf("%d regions: %s", len(regions), strings.Join(names, ", "))
 		rf.EvidenceFields = map[string]any{
 			"region_count": len(names),
@@ -374,7 +374,7 @@ func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
 		}
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -389,8 +389,8 @@ func evalMultiRegionSource(state types.ProcessedState) types.RedFlag {
 // cluster_signals.go) so semantics stay in lockstep with V1 — when
 // `aclScanRan` returns true the scan succeeded; an empty slice in
 // that case is "actually zero", not "scan didn't run".
-func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDZeroACLsWithIAM, Title: "Zero ACLs with IAM auth enabled — verify SE expected behavior"}
+func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDZeroACLsWithIAM, Title: "Zero ACLs with IAM auth enabled — verify SE expected behavior"}
 	var hits []string
 	var serverlessIAM []string // Serverless+IAM clusters can't expose ACLs via the kcp scan path
 	var unscannedIAM []string  // Provisioned+IAM clusters where the ACL scan didn't run (nil ACLs)
@@ -431,25 +431,25 @@ func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) types.RedFlag {
 		excludedNote = fmt.Sprintf(" (Provisioned+IAM clusters %s excluded — ACL scan didn't populate; see `acls_not_scanned` OQ to re-scan)", strings.Join(unscannedIAM, ", "))
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "IAM + 0 ACLs on: " + strings.Join(hits, ", ") + excludedNote
 		return rf
 	}
 	// No Provisioned hits but at least one IAM cluster the row can't
 	// evaluate — Serverless or --skip-acls. Don't claim "Not triggered".
 	if len(serverlessIAM) > 0 || len(unscannedIAM) > 0 {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "Row can't evaluate for one or more IAM clusters" + excludedNote + ". Verify ACL posture manually."
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
 // ----- Row 10: client inventory gap -----
 
-func evalClientInventoryGap(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDClientInventoryGap, Title: "Client inventory not populated"}
+func evalClientInventoryGap(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDClientInventoryGap, Title: "Client inventory not populated"}
 	var hits []string
 	for _, c := range clusters {
 		if len(c.DiscoveredClients) == 0 {
@@ -457,23 +457,23 @@ func evalClientInventoryGap(clusters []types.ProcessedCluster) types.RedFlag {
 		}
 	}
 	if len(hits) == 0 {
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 		return rf
 	}
 	if len(hits) == len(clusters) {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "no `discovered_clients` on any cluster — run `kcp scan client-inventory`"
 		return rf
 	}
-	rf.Status = types.RedFlagTriggered
+	rf.Status = RedFlagTriggered
 	rf.Evidence = "missing on: " + strings.Join(hits, ", ")
 	return rf
 }
 
 // ----- Row 11: MSK Express broker tier -----
 
-func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDMSKExpressBrokerTier, Title: "MSK Express broker tier in use"}
+func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDMSKExpressBrokerTier, Title: "MSK Express broker tier in use"}
 	type expressHit struct {
 		Cluster      string `json:"cluster"`
 		InstanceType string `json:"instance_type"`
@@ -502,12 +502,12 @@ func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) types.RedFlag {
 		}
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "Express tier on: " + strings.Join(hitStrs, ", ")
 		rf.EvidenceFields = map[string]any{"clusters": hits}
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -530,8 +530,8 @@ func brokerInstanceType(c types.ProcessedCluster) string {
 
 // ----- Row 12: tiered storage in use -----
 
-func evalTieredStorageInUse(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDTieredStorageInUse, Title: "Tiered storage in use on the source"}
+func evalTieredStorageInUse(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDTieredStorageInUse, Title: "Tiered storage in use on the source"}
 	var hits []string
 	for _, c := range clusters {
 		// Serverless has no `StorageMode` concept — the elastic
@@ -544,12 +544,12 @@ func evalTieredStorageInUse(clusters []types.ProcessedCluster) types.RedFlag {
 		}
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "TIERED on: " + strings.Join(hits, ", ") + " — Cluster Linking does NOT carry historical tiered data forward; see Tiered Storage section"
 		rf.EvidenceFields = map[string]any{"clusters": hits}
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -558,19 +558,19 @@ func evalTieredStorageInUse(clusters []types.ProcessedCluster) types.RedFlag {
 // No state signal exists for EOS / transactions; returns Unknown
 // unless the customer flags it. Surfaces as "not scanned" rather
 // than firing false.
-func evalEOSInUse(inputs types.PlanInputsResolved) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDEOSInUse, Title: "Exactly-once semantics (EOS) / Kafka transactions in use"}
+func evalEOSInUse(inputs PlanInputsResolved) RedFlag {
+	rf := RedFlag{ID: RedFlagIDEOSInUse, Title: "Exactly-once semantics (EOS) / Kafka transactions in use"}
 	if inputs.ExactlyOnceTransactionsInUse == nil {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "no state signal; declare `exactly_once_transactions_in_use: true|false` in `plan-inputs.yaml`"
 		return rf
 	}
 	if *inputs.ExactlyOnceTransactionsInUse {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "`exactly_once_transactions_in_use: true` declared in plan-inputs"
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -579,10 +579,10 @@ func evalEOSInUse(inputs types.PlanInputsResolved) types.RedFlag {
 // Two signals: explicit customer declaration OR topic-pattern scan
 // for `-changelog` / `-repartition` artifacts. Either one fires the
 // row; the evidence string names which signal won.
-func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs types.PlanInputsResolved) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDKafkaStreamsInUse, Title: "Kafka Streams apps consuming from the source"}
+func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs PlanInputsResolved) RedFlag {
+	rf := RedFlag{ID: RedFlagIDKafkaStreamsInUse, Title: "Kafka Streams apps consuming from the source"}
 	if inputs.KafkaStreamsInUse != nil && *inputs.KafkaStreamsInUse {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "`kafka_streams_in_use: true` declared in plan-inputs"
 		return rf
 	}
@@ -595,7 +595,7 @@ func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs types.PlanI
 		}
 	}
 	if len(hits) > 0 {
-		rf.Status = types.RedFlagTriggered
+		rf.Status = RedFlagTriggered
 		rf.Evidence = "Streams topic pattern detected on: " + strings.Join(hits, ", ")
 		return rf
 	}
@@ -605,11 +605,11 @@ func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs types.PlanI
 	// suffixes. Customer declaration of `kafka_streams_in_use: false`
 	// flips this to NotTriggered explicitly.
 	if inputs.KafkaStreamsInUse == nil {
-		rf.Status = types.RedFlagUnknown
+		rf.Status = RedFlagUnknown
 		rf.Evidence = "no state signal — declare `kafka_streams_in_use: true|false` in `plan-inputs.yaml` if you know"
 		return rf
 	}
-	rf.Status = types.RedFlagNotTriggered
+	rf.Status = RedFlagNotTriggered
 	return rf
 }
 
@@ -619,8 +619,8 @@ func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs types.PlanI
 // changelog/repartition, transactions, heartbeats) against every
 // topic on every cluster. Surfaces deployments with custom prefixes
 // that the structured rows above might miss.
-func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) types.RedFlag {
-	rf := types.RedFlag{ID: RedFlagIDBroadTopicPatternMatch, Title: "Broad topic-name pattern scan — items the structured rows might miss"}
+func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) RedFlag {
+	rf := RedFlag{ID: RedFlagIDBroadTopicPatternMatch, Title: "Broad topic-name pattern scan — items the structured rows might miss"}
 	hitsByPattern := map[string][]string{}
 	anyHits := false
 	for _, c := range clusters {
@@ -637,7 +637,7 @@ func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) types.RedFlag
 		}
 	}
 	if !anyHits {
-		rf.Status = types.RedFlagNotTriggered
+		rf.Status = RedFlagNotTriggered
 		return rf
 	}
 	var parts []string
@@ -659,7 +659,7 @@ func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) types.RedFlag
 		}
 		parts = append(parts, fmt.Sprintf("%s — %s", p.label, strings.Join(shown, ", ")))
 	}
-	rf.Status = types.RedFlagTriggered
+	rf.Status = RedFlagTriggered
 	rf.Evidence = strings.Join(parts, "; ")
 	return rf
 }

--- a/internal/services/plan/red_flags_test.go
+++ b/internal/services/plan/red_flags_test.go
@@ -12,7 +12,7 @@ import (
 
 // findRow returns the row matching `id` so tests don't depend on slice
 // ordering. Fails the test when the row is missing.
-func findRow(t *testing.T, section *types.RedFlagsSection, id string) types.RedFlag {
+func findRow(t *testing.T, section *RedFlagsSection, id string) RedFlag {
 	t.Helper()
 	require.NotNil(t, section)
 	for _, r := range section.Rows {
@@ -21,7 +21,7 @@ func findRow(t *testing.T, section *types.RedFlagsSection, id string) types.RedF
 		}
 	}
 	t.Fatalf("red flag row %q not present in section (got %d rows)", id, len(section.Rows))
-	return types.RedFlag{}
+	return RedFlag{}
 }
 
 // Row 1 — schemaless source. Suppressed when `schema_strategy` is
@@ -38,13 +38,13 @@ func TestRedFlags_SchemalessSource(t *testing.T) {
 	inputs := schemaInputs(SchemaStrategyUnknown)
 	plan := buildPlanForRedFlags(t, state, cfg, inputs)
 	row := findRow(t, plan.RedFlags, RedFlagIDSchemalessSource)
-	assert.Equal(t, types.RedFlagUnknown, row.Status, "strategy=unknown must not fire row 1")
+	assert.Equal(t, RedFlagUnknown, row.Status, "strategy=unknown must not fire row 1")
 
 	// strategy = adopt_schemas_during_migration → row fires.
 	inputs = schemaInputs(SchemaStrategyAdoptSchemasDuringMigration)
 	plan = buildPlanForRedFlags(t, state, cfg, inputs)
 	row = findRow(t, plan.RedFlags, RedFlagIDSchemalessSource)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "adopt_schemas_during_migration")
 }
 
@@ -55,7 +55,7 @@ func TestRedFlags_KafkaVersionBelowFloor(t *testing.T) {
 	state := wrapClusters(below, above)
 	plan := buildPlanForRedFlags(t, state, defaultCfg(t), defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "old-cluster=2.2.1")
 	assert.NotContains(t, row.Evidence, "new-cluster")
 }
@@ -66,7 +66,7 @@ func TestRedFlags_ExpressBrokerTier(t *testing.T) {
 	standardCluster := redFlagCluster("standard-cluster", "3.5.0", "kafka.m5.large", "")
 	plan := buildPlanForRedFlags(t, wrapClusters(expressCluster, standardCluster), defaultCfg(t), defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "express-cluster=express.m7g.large")
 }
 
@@ -76,7 +76,7 @@ func TestRedFlags_TieredStorageInUse(t *testing.T) {
 	local := redFlagCluster("local-cluster", "3.5.0", "", string(kafkatypes.StorageModeLocal))
 	plan := buildPlanForRedFlags(t, wrapClusters(tiered, local), defaultCfg(t), defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "tiered-cluster")
 }
 
@@ -88,20 +88,20 @@ func TestRedFlags_EOSInUse(t *testing.T) {
 	// nil → Unknown
 	plan := buildPlanForRedFlags(t, state, cfg, defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
-	assert.Equal(t, types.RedFlagUnknown, row.Status)
+	assert.Equal(t, RedFlagUnknown, row.Status)
 
 	// true → Triggered
 	inputs := defaultInputs()
 	inputs.ExactlyOnceTransactionsInUse = ptrBool(true)
 	plan = buildPlanForRedFlags(t, state, cfg, inputs)
 	row = findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 
 	// false → NotTriggered
 	inputs.ExactlyOnceTransactionsInUse = ptrBool(false)
 	plan = buildPlanForRedFlags(t, state, cfg, inputs)
 	row = findRow(t, plan.RedFlags, RedFlagIDEOSInUse)
-	assert.Equal(t, types.RedFlagNotTriggered, row.Status)
+	assert.Equal(t, RedFlagNotTriggered, row.Status)
 }
 
 // Row 15 — broad topic-name pattern scan: catches MM2 / Connect /
@@ -115,7 +115,7 @@ func TestRedFlags_BroadTopicPatternMatch(t *testing.T) {
 	}}
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDBroadTopicPatternMatch)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "mm2-source-data")
 	assert.Contains(t, row.Evidence, "events-changelog")
 }
@@ -123,7 +123,7 @@ func TestRedFlags_BroadTopicPatternMatch(t *testing.T) {
 // Empty fleet (no MSK clusters) → detectRedFlags returns nil so the
 // renderer omits the §Red Flags section entirely.
 func TestDetectRedFlags_EmptyFleetReturnsNil(t *testing.T) {
-	assert.Nil(t, detectRedFlags(types.ProcessedState{}, &types.Plan{}, defaultCfg(t), defaultInputs()))
+	assert.Nil(t, detectRedFlags(types.ProcessedState{}, &Plan{}, defaultCfg(t), defaultInputs()))
 }
 
 // ----- helpers -----
@@ -168,7 +168,7 @@ func wrapClusters(clusters ...types.ProcessedCluster) types.ProcessedState {
 // the full integration (V2 detector + V1 plumbing) rather than
 // calling detectRedFlags in isolation. Same default time / cfg used
 // by the rest of the plan tests.
-func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.Plan {
+func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *Plan {
 	t.Helper()
 	svc := NewPlanService(cfg, fixedNow)
 	p, err := svc.Build(state, inputs, "redflags-test.json")
@@ -205,13 +205,13 @@ func TestRedFlags_ServerlessSkipsProvisionedOnlyRows(t *testing.T) {
 	require.NotNil(t, plan.RedFlags)
 
 	kafkaRow := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
-	assert.Equal(t, types.RedFlagNotTriggered, kafkaRow.Status, "Serverless has no Kafka version — row must NOT fire Unknown")
+	assert.Equal(t, RedFlagNotTriggered, kafkaRow.Status, "Serverless has no Kafka version — row must NOT fire Unknown")
 
 	expressRow := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
-	assert.Equal(t, types.RedFlagNotTriggered, expressRow.Status, "Serverless is a distinct tier from Express")
+	assert.Equal(t, RedFlagNotTriggered, expressRow.Status, "Serverless is a distinct tier from Express")
 
 	tieredRow := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
-	assert.Equal(t, types.RedFlagNotTriggered, tieredRow.Status, "Serverless has no StorageMode concept")
+	assert.Equal(t, RedFlagNotTriggered, tieredRow.Status, "Serverless has no StorageMode concept")
 }
 
 // Mixed-fleet variant: Serverless cluster alongside a Provisioned
@@ -226,7 +226,7 @@ func TestRedFlags_ServerlessDoesntPolluteVersionEvidence(t *testing.T) {
 	require.NotNil(t, plan.RedFlags)
 
 	row := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
-	assert.Equal(t, types.RedFlagTriggered, row.Status)
+	assert.Equal(t, RedFlagTriggered, row.Status)
 	assert.Contains(t, row.Evidence, "old-provisioned")
 	assert.NotContains(t, row.Evidence, "serverless-mixed", "Serverless cluster must not appear in version-row evidence")
 }
@@ -247,7 +247,7 @@ func TestRedFlags_ServerlessNoClientAuthentication(t *testing.T) {
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
 	require.NotNil(t, plan.RedFlags)
 	iamRow := findRow(t, plan.RedFlags, RedFlagIDIAMAuthEnabled)
-	assert.Equal(t, types.RedFlagNotTriggered, iamRow.Status, "no auth block → no IAM detected")
+	assert.Equal(t, RedFlagNotTriggered, iamRow.Status, "no auth block → no IAM detected")
 	// Cluster surfaces as Serverless and the auth fallback is empty.
 	require.Len(t, plan.Auth, 1)
 	assert.Empty(t, plan.Auth[0].SourceAuths)
@@ -277,10 +277,10 @@ func TestRedFlags_ServerlessMultiRegion(t *testing.T) {
 	require.NotNil(t, plan.RedFlags)
 
 	multiRegion := findRow(t, plan.RedFlags, RedFlagIDMultiRegionSource)
-	assert.Equal(t, types.RedFlagTriggered, multiRegion.Status, "two regions → multi-region fires")
+	assert.Equal(t, RedFlagTriggered, multiRegion.Status, "two regions → multi-region fires")
 
 	kafkaRow := findRow(t, plan.RedFlags, RedFlagIDKafkaVersionBelowCLFloor)
-	assert.Equal(t, types.RedFlagNotTriggered, kafkaRow.Status, "Serverless-only multi-region must not trip the version row")
+	assert.Equal(t, RedFlagNotTriggered, kafkaRow.Status, "Serverless-only multi-region must not trip the version row")
 }
 
 // Mixed fleet variant for Express + Tiered: a single Provisioned
@@ -295,12 +295,12 @@ func TestRedFlags_ServerlessDoesntPolluteExpressOrTieredEvidence(t *testing.T) {
 	require.NotNil(t, plan.RedFlags)
 
 	exp := findRow(t, plan.RedFlags, RedFlagIDMSKExpressBrokerTier)
-	assert.Equal(t, types.RedFlagTriggered, exp.Status)
+	assert.Equal(t, RedFlagTriggered, exp.Status)
 	assert.Contains(t, exp.Evidence, "prov-express=express.m7g.large")
 	assert.NotContains(t, exp.Evidence, "serverless-mixed")
 
 	tier := findRow(t, plan.RedFlags, RedFlagIDTieredStorageInUse)
-	assert.Equal(t, types.RedFlagTriggered, tier.Status)
+	assert.Equal(t, RedFlagTriggered, tier.Status)
 	assert.Contains(t, tier.Evidence, "prov-express")
 	assert.NotContains(t, tier.Evidence, "serverless-mixed")
 }
@@ -313,7 +313,7 @@ func TestRedFlags_ServerlessIAMMakesZeroACLsRowUnknown(t *testing.T) {
 	plan := buildPlanForRedFlags(t, wrapClusters(srv), defaultCfg(t), defaultInputs())
 	require.NotNil(t, plan.RedFlags)
 	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
-	assert.Equal(t, types.RedFlagUnknown, row.Status, "Serverless+IAM clusters make the ACL row inconclusive — must be Unknown not Not Triggered")
+	assert.Equal(t, RedFlagUnknown, row.Status, "Serverless+IAM clusters make the ACL row inconclusive — must be Unknown not Not Triggered")
 	assert.Contains(t, row.Evidence, "srv-iam")
 }
 
@@ -332,7 +332,7 @@ func TestRedFlags_ZeroACLsWithIAM_MixedFleetSurfacesExclusion(t *testing.T) {
 	plan := buildPlanForRedFlags(t, wrapClusters(provIAM, srv), defaultCfg(t), defaultInputs())
 	require.NotNil(t, plan.RedFlags)
 	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
-	assert.Equal(t, types.RedFlagTriggered, row.Status, "Provisioned IAM + 0 ACLs still triggers the row")
+	assert.Equal(t, RedFlagTriggered, row.Status, "Provisioned IAM + 0 ACLs still triggers the row")
 	assert.Contains(t, row.Evidence, "prov-iam")
 	assert.Contains(t, row.Evidence, "srv-iam", "Serverless+IAM exclusion must be surfaced in the row evidence")
 }
@@ -349,7 +349,7 @@ func TestRedFlags_ServerlessNoAuthFiresAuthPostureOQ(t *testing.T) {
 	}
 	c.KafkaAdminClientInformation.Topics = &types.Topics{Details: []types.TopicDetails{{Name: "t"}}}
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
-	var authOQ *types.OpenQuestion
+	var authOQ *OpenQuestion
 	for i, oq := range plan.OpenQuestions {
 		if oq.ID == "auth_posture_unknown" && oq.ClusterID == "srv-noauth" {
 			authOQ = &plan.OpenQuestions[i]
@@ -372,7 +372,7 @@ func TestRedFlags_ZeroACLs_SkipACLsCaseSurfacesAsUnknown(t *testing.T) {
 	// Acls left nil — simulates --skip-acls / scan-didn't-run case.
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
 	row := findRow(t, plan.RedFlags, RedFlagIDZeroACLsWithIAM)
-	assert.Equal(t, types.RedFlagUnknown, row.Status, "IAM cluster with nil ACLs makes the row Unknown")
+	assert.Equal(t, RedFlagUnknown, row.Status, "IAM cluster with nil ACLs makes the row Unknown")
 	assert.Contains(t, row.Evidence, "prov-iam-skipped")
 }
 
@@ -405,7 +405,7 @@ func TestRedFlags_ServerlessAdminProbeFallback(t *testing.T) {
 	plan := buildPlanForRedFlags(t, wrapClusters(c), defaultCfg(t), defaultInputs())
 	require.NotNil(t, plan.RedFlags)
 	iamRow := findRow(t, plan.RedFlags, RedFlagIDIAMAuthEnabled)
-	assert.Equal(t, types.RedFlagTriggered, iamRow.Status)
+	assert.Equal(t, RedFlagTriggered, iamRow.Status)
 	require.Len(t, plan.Auth, 1)
 	assert.Equal(t, []string{SourceAuthIAM}, plan.Auth[0].SourceAuths)
 }

--- a/internal/services/plan/render_json.go
+++ b/internal/services/plan/render_json.go
@@ -3,14 +3,12 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/confluentinc/kcp/internal/types"
 )
 
 // RenderJSON serialises a Plan to canonical 2-space-indented JSON. Stable
 // key ordering comes for free from struct field order — any map members
 // are encoded by Go's stdlib in sorted key order since Go 1.12.
-func RenderJSON(p *types.Plan) ([]byte, error) {
+func RenderJSON(p *Plan) ([]byte, error) {
 	data, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("render plan as JSON: %w", err)

--- a/internal/services/plan/render_markdown.go
+++ b/internal/services/plan/render_markdown.go
@@ -8,8 +8,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-
-	"github.com/confluentinc/kcp/internal/types"
 )
 
 // regionFlagToken matches the inline `--region <value>` flag that
@@ -27,7 +25,7 @@ var regionFlagToken = regexp.MustCompile(`--region\s+[a-zA-Z0-9-]+`)
 // `cfg` must be the same PlanConfig the PlanService used to build the
 // plan (product-fact numbers in the Definitions block and the partition
 // cap in the appendix read from it).
-func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
+func RenderMarkdown(p *Plan, cfg *PlanConfig) ([]byte, error) {
 	var b bytes.Buffer
 
 	fmt.Fprintf(&b, "# Migration Plan — %s → Confluent Cloud\n\n", p.Header.Source)
@@ -88,7 +86,7 @@ func RenderMarkdown(p *types.Plan, cfg *PlanConfig) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func writeOpenQuestions(b *bytes.Buffer, p *types.Plan, section int) {
+func writeOpenQuestions(b *bytes.Buffer, p *Plan, section int) {
 	if len(p.OpenQuestions) == 0 {
 		fmt.Fprintf(b, "## %d. Actions Needed\n\n", section)
 		b.WriteString("_No actions outstanding — the Plan above renders without unresolved questions._\n\n")
@@ -165,7 +163,7 @@ func severityLegend(present map[string]bool) string {
 // oqIDSet returns a lookup of OQ IDs present in this Plan. Used to
 // drive sibling-aware severity promotions through the OQ registry
 // (see oq_registry.go — `promoteSeverity`).
-func oqIDSet(oqs []types.OpenQuestion) map[string]bool {
+func oqIDSet(oqs []OpenQuestion) map[string]bool {
 	out := make(map[string]bool, len(oqs))
 	for _, oq := range oqs {
 		out[oq.ID] = true
@@ -181,14 +179,14 @@ func oqIDSet(oqs []types.OpenQuestion) map[string]bool {
 // region for a `<region>` placeholder when the collapsed group spans
 // multiple regions, since each cluster lives in exactly one region.
 type oqGroup struct {
-	oq       types.OpenQuestion
+	oq       OpenQuestion
 	clusters []string
 	regions  map[string]struct{}
 }
 
 // groupOpenQuestions returns first-seen-order groups; callers must pass
 // a priority-sorted input slice if they want priority order preserved.
-func groupOpenQuestions(oqs []types.OpenQuestion) []oqGroup {
+func groupOpenQuestions(oqs []OpenQuestion) []oqGroup {
 	groups := make([]oqGroup, 0, len(oqs))
 	byKey := make(map[string]int, len(oqs))
 	for _, oq := range oqs {
@@ -273,7 +271,7 @@ func writeDefinitions(b *bytes.Buffer, cfg *PlanConfig) {
 	b.WriteString("\n</details>\n\n")
 }
 
-func writeSourceEnvironment(b *bytes.Buffer, p *types.Plan, section int) {
+func writeSourceEnvironment(b *bytes.Buffer, p *Plan, section int) {
 	fmt.Fprintf(b, "## %d. Source Environment\n\n", section)
 	if len(p.SourceEnvironment.Clusters) == 0 {
 		b.WriteString("_No clusters found in the state file. Re-run `kcp discover` / `kcp scan ...` and try again._\n\n")
@@ -341,7 +339,7 @@ func sourceAuthCell(auths []string) string {
 	return strings.Join(parts, ", ")
 }
 
-func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, section int) {
+func writeSizingAndDecisions(b *bytes.Buffer, p *Plan, cfg *PlanConfig, section int) {
 	fmt.Fprintf(b, "## %d. Sizing & Cluster Decisions\n\n", section)
 	if len(p.Sizing) == 0 {
 		b.WriteString("_No clusters to size._\n\n")
@@ -353,11 +351,11 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 	// mis-pair a cluster's sizing with another cluster's verdict — earlier
 	// the loop indexed all three slices by `i`, which was correct for plans
 	// built by PlanService.Build() but fragile under any other construction.
-	ctByID := make(map[string]types.ClusterTypeDecision, len(p.ClusterTypeDecision))
+	ctByID := make(map[string]ClusterTypeDecision, len(p.ClusterTypeDecision))
 	for _, d := range p.ClusterTypeDecision {
 		ctByID[d.ClusterID] = d
 	}
-	netByID := make(map[string]types.NetworkingDecision, len(p.NetworkingDecision))
+	netByID := make(map[string]NetworkingDecision, len(p.NetworkingDecision))
 	for _, d := range p.NetworkingDecision {
 		netByID[d.ClusterID] = d
 	}
@@ -415,7 +413,7 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 	// the networking decision. Reads cleanly even for 30+ clusters because
 	// each entry is one or two lines.
 	b.WriteString("### Why These Recommendations\n\n")
-	srcByID := make(map[string]types.SourceClusterSummary, len(p.SourceEnvironment.Clusters))
+	srcByID := make(map[string]SourceClusterSummary, len(p.SourceEnvironment.Clusters))
 	for _, sc := range p.SourceEnvironment.Clusters {
 		srcByID[sc.ClusterID] = sc
 	}
@@ -480,7 +478,7 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 			continue
 		}
 		var pieces []string
-		var customerDeclaredTriggers []types.HardLimitTrigger
+		var customerDeclaredTriggers []HardLimitTrigger
 		skippedRuleCount := countSkippedRules(ct.EvaluatedRules)
 		if len(ct.Triggers) == 0 {
 			noFire := fmt.Sprintf("Cluster type **%s** — no hard-limit rule fired", clusterTypeLabel(ct))
@@ -512,15 +510,15 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 		if len(perClusterTriggers) > 0 {
 			writeCostCallout(&extras, perClusterTriggers, calloutPerCluster)
 		}
-		if !hoistStateDerivedBanner && ct.Verdict == types.ClusterTypeDedicated && len(customerDeclaredTriggers) == 0 && len(ct.Triggers) > 0 {
+		if !hoistStateDerivedBanner && ct.Verdict == ClusterTypeDedicated && len(customerDeclaredTriggers) == 0 && len(ct.Triggers) > 0 {
 			extras.WriteString("  - ℹ **Cost direction:** Dedicated has a higher monthly cost than Enterprise. This verdict is state-derived (a hard-limit rule fired on the cluster as scanned), so the escalation isn't recoverable by editing `plan-inputs.yaml`. Confirm with your Confluent account team that the cluster's capacity reflects your actual workload before committing.\n")
 		}
-		if ct.Verdict == types.ClusterTypeDedicated && ct.Topology == types.TopologySingleZone && !szIsGlobal(globalCustomerTriggers) {
+		if ct.Verdict == ClusterTypeDedicated && ct.Topology == TopologySingleZone && !szIsGlobal(globalCustomerTriggers) {
 			writeSZTradeoff(&extras, cfg, calloutPerCluster)
 		}
 		if (s.SpikyIngress || s.SpikyEgress) && s.FinalECKU > s.SLAFloorECKU {
 			absorbed := "Enterprise elasticity absorbs"
-			if ct.Verdict == types.ClusterTypeDedicated {
+			if ct.Verdict == ClusterTypeDedicated {
 				absorbed = "the sized Dedicated capacity absorbs"
 			}
 			fmt.Fprintf(&extras, "  - _Note: %s. Sizing is P95-based and %s the spike; set `sizing_percentile: p99` in `plan-inputs.yaml` if you'd rather size to the peak._\n", spikyDescription(s), absorbed)
@@ -566,7 +564,7 @@ func writeSizingAndDecisions(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig, se
 // for the FYI note on spiky clusters. Guards against P95==0 (the spiky
 // flag fires for any positive peak when P95 is zero — `peak > 2.0 * 0`)
 // so the ratio doesn't render as +Inf.
-func spikyDescription(s types.ClusterSizing) string {
+func spikyDescription(s ClusterSizing) string {
 	var parts []string
 	if s.SpikyIngress {
 		parts = append(parts, formatSpikeRatio("ingress", s.PeakInMBps, s.SizedInMBps))
@@ -629,7 +627,7 @@ func pluralize(singular string, n int) string {
 // hasProvisional reports whether any cluster has at least one
 // load-bearing scan signal missing — used to decide whether to emit
 // the `*` legend after the Sizing & Cluster Decisions table.
-func hasProvisional(sizings []types.ClusterSizing) bool {
+func hasProvisional(sizings []ClusterSizing) bool {
 	for _, s := range sizings {
 		if len(s.InputsMissing) > 0 || s.Degraded {
 			return true
@@ -643,10 +641,10 @@ func hasProvisional(sizings []types.ClusterSizing) bool {
 // renderer uses this to append a one-liner note to "no hard-limit rule
 // fired" verdicts so the reader doesn't mistake the silence for
 // certainty.
-func countSkippedRules(rules []types.RuleEvaluation) int {
+func countSkippedRules(rules []RuleEvaluation) int {
 	n := 0
 	for _, r := range rules {
-		if r.Outcome == types.RuleSkipped {
+		if r.Outcome == RuleSkipped {
 			n++
 		}
 	}
@@ -674,14 +672,14 @@ func slaFloorList(cfg *PlanConfig) string {
 // finalSizeUnit returns "eCKU" or "CKU" for the given cluster-type
 // verdict so rendered prose matches the unit in the Sizing & Cluster
 // Decisions table.
-func finalSizeUnit(ct types.ClusterTypeDecision) string {
-	if ct.Verdict == types.ClusterTypeDedicated {
+func finalSizeUnit(ct ClusterTypeDecision) string {
+	if ct.Verdict == ClusterTypeDedicated {
 		return "CKU"
 	}
 	return "eCKU"
 }
 
-func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
+func writeSizingAppendix(b *bytes.Buffer, p *Plan, cfg *PlanConfig) {
 	if len(p.SizingAppendix) == 0 {
 		return
 	}
@@ -721,7 +719,7 @@ func writeSizingAppendix(b *bytes.Buffer, p *types.Plan, cfg *PlanConfig) {
 // evidence or skip-reason. Lets a reviewer audit "what would the rules
 // engine have said given this state" without re-running the tool.
 // Collapsed by default since most readers don't need it.
-func writeRulesAppendix(b *bytes.Buffer, p *types.Plan) {
+func writeRulesAppendix(b *bytes.Buffer, p *Plan) {
 	hasAny := false
 	for _, ct := range p.ClusterTypeDecision {
 		if len(ct.EvaluatedRules) > 0 {
@@ -746,7 +744,7 @@ func writeRulesAppendix(b *bytes.Buffer, p *types.Plan) {
 		b.WriteString("| Rule | Outcome | Detail |\n|---|---|---|\n")
 		for _, r := range ct.EvaluatedRules {
 			detail := r.Evidence
-			if r.Outcome == types.RuleSkipped {
+			if r.Outcome == RuleSkipped {
 				detail = r.SkipReason
 			}
 			fmt.Fprintf(b, "| `%s` (%s) | `%s` | %s |\n",
@@ -791,7 +789,7 @@ const szTradeoffBody = "**Single-Zone resilience tradeoff:** the 99.95%% SLA sel
 // writeCostCallout emits the cost-callout block. Global scope renders
 // the top-of-section banner once; per-cluster scope renders the inline
 // nested-list-item version attached to one cluster's bullet.
-func writeCostCallout(b *bytes.Buffer, triggers []types.HardLimitTrigger, scope calloutScope) {
+func writeCostCallout(b *bytes.Buffer, triggers []HardLimitTrigger, scope calloutScope) {
 	labels := formatCustomerTriggerLabels(triggers)
 	switch scope {
 	case calloutGlobal:
@@ -817,8 +815,8 @@ func writeSZTradeoff(b *bytes.Buffer, cfg *PlanConfig, scope calloutScope) {
 // szIsGlobal reports whether the SZ-SLA customer trigger appears in
 // the global-banner set — if it does, per-cluster sites must suppress
 // their inline SZ tradeoff to avoid duplicating the message.
-func szIsGlobal(global []types.HardLimitTrigger) bool {
-	return slices.ContainsFunc(global, func(t types.HardLimitTrigger) bool { return t.RowID == szTriggerRowID })
+func szIsGlobal(global []HardLimitTrigger) bool {
+	return slices.ContainsFunc(global, func(t HardLimitTrigger) bool { return t.RowID == szTriggerRowID })
 }
 
 // detectGlobalCustomerTriggers finds customer-declared triggers that
@@ -833,10 +831,10 @@ func szIsGlobal(global []types.HardLimitTrigger) bool {
 // fleet-level "Cost direction" banner when many clusters share the
 // state-forced escalation — at small N the per-cluster inline note
 // is fine; at fleet scale it becomes noise.
-func countStateDerivedDedicated(decisions []types.ClusterTypeDecision) int {
+func countStateDerivedDedicated(decisions []ClusterTypeDecision) int {
 	n := 0
 	for _, ct := range decisions {
-		if ct.Verdict != types.ClusterTypeDedicated || len(ct.Triggers) == 0 {
+		if ct.Verdict != ClusterTypeDedicated || len(ct.Triggers) == 0 {
 			continue
 		}
 		anyCustomer := false
@@ -853,7 +851,7 @@ func countStateDerivedDedicated(decisions []types.ClusterTypeDecision) int {
 	return n
 }
 
-func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types.HardLimitTrigger {
+func detectGlobalCustomerTriggers(decisions []ClusterTypeDecision) []HardLimitTrigger {
 	if len(decisions) == 0 {
 		return nil
 	}
@@ -863,7 +861,7 @@ func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types
 	// most once) doesn't inflate the count past `len(decisions)` and
 	// fool the "fires on every cluster" check.
 	count := make(map[string]int)
-	firstSeen := make(map[string]types.HardLimitTrigger)
+	firstSeen := make(map[string]HardLimitTrigger)
 	for _, d := range decisions {
 		seen := make(map[string]bool, len(d.Triggers))
 		for _, t := range d.Triggers {
@@ -877,7 +875,7 @@ func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types
 			}
 		}
 	}
-	var global []types.HardLimitTrigger
+	var global []HardLimitTrigger
 	for rowID, n := range count {
 		if n == len(decisions) {
 			global = append(global, firstSeen[rowID])
@@ -893,7 +891,7 @@ func detectGlobalCustomerTriggers(decisions []types.ClusterTypeDecision) []types
 // NOT appear in `global`. Used at the per-cluster cost-callout site
 // so a trigger that already got the top-of-section banner isn't
 // repeated inline.
-func filterNonGlobalTriggers(cluster, global []types.HardLimitTrigger) []types.HardLimitTrigger {
+func filterNonGlobalTriggers(cluster, global []HardLimitTrigger) []HardLimitTrigger {
 	if len(global) == 0 {
 		return cluster
 	}
@@ -901,7 +899,7 @@ func filterNonGlobalTriggers(cluster, global []types.HardLimitTrigger) []types.H
 	for _, t := range global {
 		globalIDs[t.RowID] = struct{}{}
 	}
-	var out []types.HardLimitTrigger
+	var out []HardLimitTrigger
 	for _, t := range cluster {
 		if _, isGlobal := globalIDs[t.RowID]; !isGlobal {
 			out = append(out, t)
@@ -915,7 +913,7 @@ func filterNonGlobalTriggers(cluster, global []types.HardLimitTrigger) []types.H
 // (e.g. "99.95% single-zone SLA required") rather than the raw RowID
 // (e.g. "sla_99_95_single_zone") so a customer sees something they
 // recognise from the YAML comments.
-func formatCustomerTriggerLabels(triggers []types.HardLimitTrigger) string {
+func formatCustomerTriggerLabels(triggers []HardLimitTrigger) string {
 	labels := make([]string, len(triggers))
 	for i, t := range triggers {
 		labels[i] = fmt.Sprintf("%s (`%s`)", t.Description, t.RowID)
@@ -941,14 +939,14 @@ func percentileHeader(percentile string) string {
 // decision. Dedicated clusters carry a topology suffix (MZ vs SZ) so the
 // reader can see at a glance whether the verdict is Multi-Zone or the
 // 99.95%-SLA-driven Single-Zone variant. Enterprise renders as-is.
-func clusterTypeLabel(ct types.ClusterTypeDecision) string {
-	if ct.Verdict != types.ClusterTypeDedicated {
+func clusterTypeLabel(ct ClusterTypeDecision) string {
+	if ct.Verdict != ClusterTypeDedicated {
 		return string(ct.Verdict)
 	}
 	switch ct.Topology {
-	case types.TopologySingleZone:
+	case TopologySingleZone:
 		return "Dedicated Single-Zone (SZ)"
-	case types.TopologyMultiZone:
+	case TopologyMultiZone:
 		return "Dedicated Multi-Zone (MZ)"
 	default:
 		return "Dedicated"
@@ -958,10 +956,10 @@ func clusterTypeLabel(ct types.ClusterTypeDecision) string {
 // formatSizeCell renders the "Final size" column. Enterprise clusters
 // are sized in eCKU; Dedicated clusters are sized in CKU (same integer,
 // different unit per the Confluent product taxonomy).
-func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) string {
+func formatSizeCell(finalECKU int, ct ClusterTypeDecision, degraded bool) string {
 	suffix := "eCKU"
 	value := finalECKU
-	if ct.Verdict == types.ClusterTypeDedicated && ct.FinalCKU != nil {
+	if ct.Verdict == ClusterTypeDedicated && ct.FinalCKU != nil {
 		suffix = "CKU"
 		value = *ct.FinalCKU
 	}
@@ -979,7 +977,7 @@ func formatSizeCell(finalECKU int, ct types.ClusterTypeDecision, degraded bool) 
 // per-cluster exceptions — clusters whose resolved style differs from
 // the fleet default. Skips the section entirely when there's no
 // cutover decision (empty fleet).
-func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, overrides []types.ClusterCutoverOverride, cfg *PlanConfig, section int) {
+func writeCutover(b *bytes.Buffer, c *CutoverDecision, overrides []ClusterCutoverOverride, cfg *PlanConfig, section int) {
 	if c == nil {
 		return
 	}
@@ -1000,7 +998,7 @@ func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, overrides []types.C
 	// orchestration. Promote the runbook hint to its own sub-heading
 	// so the multi-sentence content reads as a separate concern, not
 	// a comically heavy list item.
-	if c.Style == types.CutoverBlueGreen {
+	if c.Style == CutoverBlueGreen {
 		linkingURL := "https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/index.html"
 		if cfg != nil && cfg.ClusterLinking.Source != "" {
 			linkingURL = cfg.ClusterLinking.Source
@@ -1017,23 +1015,23 @@ func writeCutover(b *bytes.Buffer, c *types.CutoverDecision, overrides []types.C
 // cutoverStyleLabel renders the style + sub-pattern label. Stop-Restart-Repeat
 // carries the sub-pattern suffix (app-by-app vs topic-by-topic); other
 // styles render as-is.
-func cutoverStyleLabel(style types.CutoverStyle, sub types.CutoverSubPattern) string {
+func cutoverStyleLabel(style CutoverStyle, sub CutoverSubPattern) string {
 	base := cutoverStyleName(style)
-	if style == types.CutoverStopRestartRepeat && sub != "" {
+	if style == CutoverStopRestartRepeat && sub != "" {
 		return fmt.Sprintf("%s (%s)", base, sub)
 	}
 	return base
 }
 
-func cutoverStyleName(style types.CutoverStyle) string {
+func cutoverStyleName(style CutoverStyle) string {
 	switch style {
-	case types.CutoverStopRestartRepeat:
+	case CutoverStopRestartRepeat:
 		return "Stop-Restart-Repeat"
-	case types.CutoverStopWaitRestart:
+	case CutoverStopWaitRestart:
 		return "Stop-Wait-Restart"
-	case types.CutoverRestartAllAtOnce:
+	case CutoverRestartAllAtOnce:
 		return "Restart-All-At-Once"
-	case types.CutoverBlueGreen:
+	case CutoverBlueGreen:
 		return "Blue/Green"
 	default:
 		return string(style)
@@ -1045,16 +1043,16 @@ func cutoverStyleName(style types.CutoverStyle) string {
 // Plain Cluster Linking gets a tradeoff hint so it doesn't read as
 // second-class — it's a fully supported path that some customers
 // deliberately pick.
-func cutoverGatewayLabel(m types.GatewayMediated, status types.RecommendationStatus) string {
+func cutoverGatewayLabel(m GatewayMediated, status RecommendationStatus) string {
 	switch m {
-	case types.GatewayMediatedTrue:
+	case GatewayMediatedTrue:
 		return "CC Gateway-mediated (transparent per-service cutover, 30–90 s `BROKER_NOT_AVAILABLE` window)"
-	case types.GatewayMediatedFalse:
-		if status == types.RecommendationCustomerChoice {
+	case GatewayMediatedFalse:
+		if status == RecommendationCustomerChoice {
 			return "Plain Cluster Linking (gateway opted out via `prefer_gateway: false`). Simpler ops; requires per-service producer restart at cutover. Pick this when the CFK + Gateway Add-On license aren't justifiable for the fleet's downtime budget."
 		}
 		return "Plain Cluster Linking"
-	case types.GatewayMediatedNotApplicable:
+	case GatewayMediatedNotApplicable:
 		return "Not applicable — Blue/Green doesn't sit on a single cutover step"
 	default:
 		return string(m)
@@ -1067,11 +1065,11 @@ func cutoverGatewayLabel(m types.GatewayMediated, status types.RecommendationSta
 // "Awaiting" framing, not "Degraded" — plain Cluster Linking is a fully
 // supported path; the marker just signals an open decision, not a
 // broken state.
-func recommendationStatusMarker(status types.RecommendationStatus) string {
+func recommendationStatusMarker(status RecommendationStatus) string {
 	switch status {
-	case types.RecommendationDegradedAwaitingOQ:
+	case RecommendationDegradedAwaitingOQ:
 		return "ℹ **Awaiting gateway intent** — no preference declared yet; the Plan uses plain Cluster Linking until you confirm. See **Actions Needed** for how to choose."
-	case types.RecommendationDegradedPrereqsPending:
+	case RecommendationDegradedPrereqsPending:
 		return "ℹ **Awaiting gateway prereqs** — gateway path requested but one or more prereqs are still at `not_started`. See **Actions Needed** for the list. Plain Cluster Linking applies in the meantime."
 	default:
 		return ""
@@ -1081,7 +1079,7 @@ func recommendationStatusMarker(status types.RecommendationStatus) string {
 // writeCutoverAlternatives renders a short bullet list explaining the
 // styles the plan considered and didn't pick. Keeps the reader's trust
 // without forcing them to walk the full decision tree.
-func writeCutoverAlternatives(b *bytes.Buffer, alts []types.CutoverStyle) {
+func writeCutoverAlternatives(b *bytes.Buffer, alts []CutoverStyle) {
 	if len(alts) == 0 {
 		return
 	}
@@ -1093,15 +1091,15 @@ func writeCutoverAlternatives(b *bytes.Buffer, alts []types.CutoverStyle) {
 
 // cutoverAlternativeWhy returns the one-line "why this isn't the
 // recommendation" string for each style.
-func cutoverAlternativeWhy(s types.CutoverStyle) string {
+func cutoverAlternativeWhy(s CutoverStyle) string {
 	switch s {
-	case types.CutoverStopRestartRepeat:
+	case CutoverStopRestartRepeat:
 		return "phased per-service rollout; recoverable steps, longer elapsed time. Pick via `downtime_tolerance: seconds_per_service | minutes_per_service | let_confluent_choose`."
-	case types.CutoverStopWaitRestart:
+	case CutoverStopWaitRestart:
 		return "single coordinated window; needs the window to be long enough for re-mirroring + validation. Pick via `downtime_tolerance: scheduled_window_sequential`."
-	case types.CutoverRestartAllAtOnce:
+	case CutoverRestartAllAtOnce:
 		return "single window; every client reconfigures at the same instant. Highest blast radius. Pick via `downtime_tolerance: scheduled_window_all_at_once`."
-	case types.CutoverBlueGreen:
+	case CutoverBlueGreen:
 		return "parallel run via Cluster Linking; zero downtime, highest operational complexity. Pick via `downtime_tolerance: zero`."
 	default:
 		return ""
@@ -1115,7 +1113,7 @@ func cutoverAlternativeWhy(s types.CutoverStyle) string {
 // whether a row went missing. When IAM prereq is absent from a
 // non-empty list, adds a one-line note clarifying it was suppressed
 // because no IAM source was detected.
-func writeCutoverPrereqs(b *bytes.Buffer, prereqs []types.Prereq) {
+func writeCutoverPrereqs(b *bytes.Buffer, prereqs []Prereq) {
 	if len(prereqs) == 0 {
 		b.WriteString("- **Prerequisites:** _none required for this path._\n")
 		return
@@ -1140,7 +1138,7 @@ func writeCutoverPrereqs(b *bytes.Buffer, prereqs []types.Prereq) {
 // to a different cutover style than the fleet default. Empty slice =
 // homogeneous fleet → nothing emitted. Rejected overrides carry a `*`
 // marker + footnote (mirrors §4 Auth's OverrideRejected handling).
-func writeCutoverOverrides(b *bytes.Buffer, overrides []types.ClusterCutoverOverride) {
+func writeCutoverOverrides(b *bytes.Buffer, overrides []ClusterCutoverOverride) {
 	if len(overrides) == 0 {
 		return
 	}
@@ -1154,9 +1152,9 @@ func writeCutoverOverrides(b *bytes.Buffer, overrides []types.ClusterCutoverOver
 		}
 		fmt.Fprintf(b, "  - `%s` → %s%s", o.ClusterID, cutoverStyleLabel(o.Style, o.SubPattern), marker)
 		switch o.GatewayMediated {
-		case types.GatewayMediatedTrue:
+		case GatewayMediatedTrue:
 			b.WriteString(" (gateway-mediated)")
-		case types.GatewayMediatedNotApplicable:
+		case GatewayMediatedNotApplicable:
 			b.WriteString(" (gateway N/A for this style)")
 		}
 		b.WriteString("\n")
@@ -1167,15 +1165,15 @@ func writeCutoverOverrides(b *bytes.Buffer, overrides []types.ClusterCutoverOver
 	b.WriteString("\n")
 }
 
-func prereqStatusLabel(s types.PrereqStatus) string {
+func prereqStatusLabel(s PrereqStatus) string {
 	switch s {
-	case types.PrereqMet:
+	case PrereqMet:
 		return "✅ met"
-	case types.PrereqInProgress:
+	case PrereqInProgress:
 		return "🚧 in progress"
-	case types.PrereqBlocked:
+	case PrereqBlocked:
 		return "⛔ not started"
-	case types.PrereqUnconfirmed:
+	case PrereqUnconfirmed:
 		return "❓ unconfirmed"
 	default:
 		return string(s)
@@ -1192,7 +1190,7 @@ func prereqStatusLabel(s types.PrereqStatus) string {
 // complete` AND the gateway is mediated, the §4 source row is a
 // pre-migration snapshot and the prereq says clients have already
 // moved off IAM — surface that so §3 and §4 don't read as contradictory.
-func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.CutoverDecision, inputs types.PlanInputsResolved, section int) {
+func writeAuth(b *bytes.Buffer, auths []AuthDecision, cutover *CutoverDecision, inputs PlanInputsResolved, section int) {
 	if len(auths) == 0 {
 		return
 	}
@@ -1240,7 +1238,7 @@ func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.Cutov
 	// IAM-transition footnote — when prereq is `complete` and
 	// gateway is in play, the IAM rows above are a pre-migration
 	// snapshot, not the post-migration auth.
-	if cutover != nil && inputs.IAMPreMigrationStatus == PrereqStatusCompleteInput && cutover.GatewayMediated == types.GatewayMediatedTrue {
+	if cutover != nil && inputs.IAMPreMigrationStatus == PrereqStatusCompleteInput && cutover.GatewayMediated == GatewayMediatedTrue {
 		anyIAM := false
 		for _, a := range auths {
 			for _, row := range a.TargetMappings {
@@ -1262,7 +1260,7 @@ func writeAuth(b *bytes.Buffer, auths []types.AuthDecision, cutover *types.Cutov
 // last_verified date so a reviewer can audit where each auth-mapping
 // recommendation came from. Walks the unique (SourceAuth, Source,
 // LastVerified) tuples and emits one bullet per source row.
-func writeAuthMappingProvenance(b *bytes.Buffer, auths []types.AuthDecision) {
+func writeAuthMappingProvenance(b *bytes.Buffer, auths []AuthDecision) {
 	type provKey struct{ source, lastVerified, sourceAuth string }
 	seen := map[provKey]bool{}
 	var rows []provKey
@@ -1314,7 +1312,7 @@ func gatewayCompatibleLabel(compatible, transparent bool) string {
 // p.Schema in that branch). For mixed Confluent+Glue deployments
 // both verdicts render — Glue Terraform command and a Schema-Linking
 // eligibility table.
-func writeSchema(b *bytes.Buffer, dec *types.SchemaDecision, inputs types.PlanInputsResolved, cfg *PlanConfig, section int) {
+func writeSchema(b *bytes.Buffer, dec *SchemaDecision, inputs PlanInputsResolved, cfg *PlanConfig, section int) {
 	if dec == nil {
 		return
 	}
@@ -1348,13 +1346,13 @@ func writeSchema(b *bytes.Buffer, dec *types.SchemaDecision, inputs types.PlanIn
 	suppressEligibilityTable := strategy == SchemaStrategyNoSchemas
 
 	switch dec.Source {
-	case types.SchemaSourceGlue:
+	case SchemaSourceGlue:
 		writeGluePathCommand(b, dec.GlueRegistries)
-	case types.SchemaSourceConfluent:
+	case SchemaSourceConfluent:
 		if !suppressEligibilityTable {
 			writeSchemaLinkingEligibility(b, dec, cfg)
 		}
-	case types.SchemaSourceConfluentAndGlue:
+	case SchemaSourceConfluentAndGlue:
 		// Both registries present: render each path side-by-side so the
 		// customer sees both recommendations without having to re-run
 		// the Plan against a narrowed scan.
@@ -1371,15 +1369,15 @@ func writeSchema(b *bytes.Buffer, dec *types.SchemaDecision, inputs types.PlanIn
 // the source. Glue-only paths cite the `kcp create-asset migrate-schemas`
 // docs (the active recommendation); Confluent paths cite the Schema
 // Linking docs (the eligibility floor); dual-source cites both.
-func writeSchemaProvenance(b *bytes.Buffer, dec *types.SchemaDecision, cfg *PlanConfig) {
+func writeSchemaProvenance(b *bytes.Buffer, dec *SchemaDecision, cfg *PlanConfig) {
 	const glueRef = "https://confluentinc.github.io/kcp/command-reference/create-asset/migrate-schemas/"
 	switch dec.Source {
-	case types.SchemaSourceGlue:
+	case SchemaSourceGlue:
 		fmt.Fprintf(b, "\n_Mapping provenance: Glue migration command → %s._\n\n", glueRef)
-	case types.SchemaSourceConfluent:
+	case SchemaSourceConfluent:
 		fmt.Fprintf(b, "\n_Mapping provenance: Schema Linking eligibility (CP %s+ %s + outbound reachable) → %s (last verified %s)._\n\n",
 			cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition, cfg.SchemaLinking.Source, cfg.SchemaLinking.LastVerified)
-	case types.SchemaSourceConfluentAndGlue:
+	case SchemaSourceConfluentAndGlue:
 		fmt.Fprintf(b, "\n_Mapping provenance: Glue migration → %s; Schema Linking eligibility (CP %s+ %s + outbound reachable) → %s (last verified %s)._\n\n",
 			glueRef, cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition, cfg.SchemaLinking.Source, cfg.SchemaLinking.LastVerified)
 	default:
@@ -1394,9 +1392,9 @@ func writeSchemaProvenance(b *bytes.Buffer, dec *types.SchemaDecision, cfg *Plan
 // dual-source decisions uniformly. Joiner is " — **also:** " to keep
 // the inline-bold labels readable (each label already ends with `**`,
 // so a `**also**` joiner would collide asterisks).
-func schemaPathsLabel(paths []types.SchemaPath) string {
+func schemaPathsLabel(paths []SchemaPath) string {
 	if len(paths) == 0 {
-		return schemaPathLabel(types.SchemaPathUnknown)
+		return schemaPathLabel(SchemaPathUnknown)
 	}
 	if len(paths) == 1 {
 		return schemaPathLabel(paths[0])
@@ -1420,11 +1418,11 @@ func schemaPathsLabel(paths []types.SchemaPath) string {
 //     one. Don't render "Pending — declare the missing input" (the
 //     declaration is already complete); instead point the reader at
 //     re-running the scan or correcting the strategy.
-func schemaPathsLabelForContext(paths []types.SchemaPath, strategy string, source types.SchemaSource) string {
-	if strategy == SchemaStrategyNoSchemas && source != types.SchemaSourceNone {
+func schemaPathsLabelForContext(paths []SchemaPath, strategy string, source SchemaSource) string {
+	if strategy == SchemaStrategyNoSchemas && source != SchemaSourceNone {
 		return "**Conflict** — strategy declares `no_schemas` but the scan found a Schema Registry; see §Actions Needed for reconciliation"
 	}
-	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && source == types.SchemaSourceNone {
+	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && source == SchemaSourceNone {
 		return "**Scan gap** — strategy declares `migrate_existing_schema_registry` but no SR was found in the state file; re-run `kcp scan schema-registry` / `kcp scan glue-schema-registry` against the source, OR correct `schema_strategy` if the source genuinely has no registry"
 	}
 	return schemaPathsLabel(paths)
@@ -1434,14 +1432,14 @@ func schemaPathsLabelForContext(paths []types.SchemaPath, strategy string, sourc
 // status glyph when the declared value conflicts with what the scan
 // found, so a reader doesn't have to cross-reference §Schema with
 // §Actions Needed to spot the contradiction.
-func schemaStrategyDeclaredLabel(strategy string, dec *types.SchemaDecision) string {
+func schemaStrategyDeclaredLabel(strategy string, dec *SchemaDecision) string {
 	if strategy == "" {
 		strategy = SchemaStrategyUnknown
 	}
-	if strategy == SchemaStrategyNoSchemas && dec.Source != types.SchemaSourceNone {
+	if strategy == SchemaStrategyNoSchemas && dec.Source != SchemaSourceNone {
 		return fmt.Sprintf("`%s` ⚠ (scan found a Schema Registry)", strategy)
 	}
-	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && dec.Source == types.SchemaSourceNone {
+	if strategy == SchemaStrategyMigrateExistingSchemaRegistry && dec.Source == SchemaSourceNone {
 		return fmt.Sprintf("`%s` ⚠ (scan found no Schema Registry — re-scan or correct the strategy)", strategy)
 	}
 	if !knownSchemaStrategy(strategy) && strategy != SchemaStrategyUnknown {
@@ -1450,30 +1448,30 @@ func schemaStrategyDeclaredLabel(strategy string, dec *types.SchemaDecision) str
 	return fmt.Sprintf("`%s`", strategy)
 }
 
-func schemaSourceLabel(src types.SchemaSource, confluentURLs, glueNames []string) string {
+func schemaSourceLabel(src SchemaSource, confluentURLs, glueNames []string) string {
 	switch src {
-	case types.SchemaSourceConfluent:
+	case SchemaSourceConfluent:
 		return fmt.Sprintf("Confluent Schema Registry (%d URL%s: %s)",
 			len(confluentURLs), pluralize("", len(confluentURLs)), strings.Join(quoteAll(confluentURLs), ", "))
-	case types.SchemaSourceGlue:
+	case SchemaSourceGlue:
 		return fmt.Sprintf("AWS Glue Schema Registry (%d %s: %s)",
 			len(glueNames), pluralize("registry", len(glueNames)), strings.Join(quoteAll(glueNames), ", "))
-	case types.SchemaSourceConfluentAndGlue:
+	case SchemaSourceConfluentAndGlue:
 		return "Confluent Schema Registry AND AWS Glue Schema Registry (each handled independently below)"
 	default:
 		return "_none detected_ — neither `kcp scan schema-registry` nor `kcp scan glue-schema-registry` found a registry on the source"
 	}
 }
 
-func schemaPathLabel(p types.SchemaPath) string {
+func schemaPathLabel(p SchemaPath) string {
 	switch p {
-	case types.SchemaPathSchemaLinking:
+	case SchemaPathSchemaLinking:
 		return "**Schema Linking** — source SR pushes schema updates to CC SR over TCP; alternative is manual REST export/import"
-	case types.SchemaPathMigrateGlue:
+	case SchemaPathMigrateGlue:
 		return "**`kcp create-asset migrate-schemas --glue-registry`** — one Terraform apply imports every schema in the Glue registry into CC SR"
-	case types.SchemaPathDeferToAccount:
+	case SchemaPathDeferToAccount:
 		return "**Defer to your Confluent account team** — REST API export/import is possible but not deterministic; see §Actions Needed for the failing constraint"
-	case types.SchemaPathSchemaless:
+	case SchemaPathSchemaless:
 		return "**Schemaless** — `schema_strategy: no_schemas` and no source SR was scanned; this section will not render"
 	default:
 		return "**Pending** — declare the missing input in `plan-inputs.yaml`; see §Actions Needed for the specific field"
@@ -1499,7 +1497,7 @@ func writeGluePathCommand(b *bytes.Buffer, glueNames []string) {
 // table for the Confluent SR path. Verdict comes first so the
 // reader's eye lands on ✅/❌/❔ before the constraint text — at a
 // glance you see whether to read further or fix YAML.
-func writeSchemaLinkingEligibility(b *bytes.Buffer, dec *types.SchemaDecision, cfg *PlanConfig) {
+func writeSchemaLinkingEligibility(b *bytes.Buffer, dec *SchemaDecision, cfg *PlanConfig) {
 	b.WriteString("\n**Schema Linking eligibility (Confluent SR path):** all three rows must be **✅ yes** for the Schema Linking path to apply. Any **❌ no** falls to `defer_to_account_team`; any **❔ unknown** keeps the path at `unknown` until you declare the missing input.\n\n")
 	b.WriteString("| Verdict | Constraint | Input |\n")
 	b.WriteString("|---|---|---|\n")
@@ -1539,18 +1537,18 @@ func quoteAll(values []string) []string {
 // and Unknown rows collapse into a tail summary (count + comma list)
 // so the customer can scan triggered items in one screenful even on
 // a 15-row table.
-func writeRedFlags(b *bytes.Buffer, rf *types.RedFlagsSection, section int) {
+func writeRedFlags(b *bytes.Buffer, rf *RedFlagsSection, section int) {
 	if rf == nil || len(rf.Rows) == 0 {
 		return
 	}
 	fmt.Fprintf(b, "## %d. Red Flags\n\n", section)
 	b.WriteString("Items below aren't blockers — they're things to discuss with your Confluent SE. Each row's evidence is the field path + value from the scan so the conversation grounds in scan facts, not inference.\n\n")
-	var triggered, unknown, notTriggered []types.RedFlag
+	var triggered, unknown, notTriggered []RedFlag
 	for _, r := range rf.Rows {
 		switch r.Status {
-		case types.RedFlagTriggered:
+		case RedFlagTriggered:
 			triggered = append(triggered, r)
-		case types.RedFlagUnknown:
+		case RedFlagUnknown:
 			unknown = append(unknown, r)
 		default:
 			notTriggered = append(notTriggered, r)
@@ -1614,7 +1612,7 @@ func writeRedFlags(b *bytes.Buffer, rf *types.RedFlagsSection, section int) {
 //   - Structurally-unobservable zero (e.g. IAM client count when the
 //     client-inventory scan didn't run) renders as `_unknown_`
 //     instead of `0` so the customer doesn't read it as "no work".
-func writeEffortSignals(b *bytes.Buffer, es *types.EffortSignalsSection, section int) {
+func writeEffortSignals(b *bytes.Buffer, es *EffortSignalsSection, section int) {
 	if es == nil || len(es.Signals) == 0 {
 		return
 	}
@@ -1685,7 +1683,7 @@ func writeEffortSignals(b *bytes.Buffer, es *types.EffortSignalsSection, section
 // run); render it as `_unknown_` so the customer doesn't read it as
 // "no work". Concrete 0 stays as `0` — the scan ran and returned
 // zero hits.
-func effortSignalCountCell(s types.EffortSignal) string {
+func effortSignalCountCell(s EffortSignal) string {
 	if s.Count == nil {
 		return "_unknown_"
 	}
@@ -1708,7 +1706,7 @@ func effortSignalSuperscript(n int) string {
 // dollar estimate, no recommendation — kcp surfaces the mechanism /
 // duration / cost-direction so the customer (and account team) can
 // decide whether the cold data is worth re-fetching.
-func writeTieredStorage(b *bytes.Buffer, ts *types.TieredStorageSection, section int) {
+func writeTieredStorage(b *bytes.Buffer, ts *TieredStorageSection, section int) {
 	if ts == nil || len(ts.Clusters) == 0 {
 		return
 	}
@@ -1784,7 +1782,7 @@ func formatBytesHuman(v float64) string {
 // No materiality threshold — the customer (FinOps / cloud lead /
 // platform engineer) decides which candidates are "real" hidden
 // clusters vs. decommissioned-but-still-billed ones.
-func writeCostReconciliation(b *bytes.Buffer, cr *types.CostReconciliationSection, section int) {
+func writeCostReconciliation(b *bytes.Buffer, cr *CostReconciliationSection, section int) {
 	if cr == nil || len(cr.Candidates) == 0 {
 		return
 	}

--- a/internal/services/plan/render_markdown_test.go
+++ b/internal/services/plan/render_markdown_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,15 +15,15 @@ import (
 // the verdict, not buried in an appendix.
 func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "wrong-click", FinalECKU: 5, SizedInMBps: 10, SizedOutMBps: 10, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
+		ClusterTypeDecision: []ClusterTypeDecision{
 			{
 				ClusterID: "wrong-click",
-				Verdict:   types.ClusterTypeDedicated,
-				Triggers: []types.HardLimitTrigger{
+				Verdict:   ClusterTypeDedicated,
+				Triggers: []HardLimitTrigger{
 					{
 						RowID:            "sla_99_95_single_zone",
 						Description:      "99.95% SLA within a single zone required",
@@ -34,8 +33,8 @@ func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
 				},
 			},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "wrong-click", Verdict: types.NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "wrong-click", Verdict: NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
 		},
 	}
 
@@ -53,12 +52,12 @@ func TestRenderMarkdown_CostCalloutOnCustomerDeclaredDedicated(t *testing.T) {
 // guard the renderer would print "+Inf" or "NaN" as the multiplier.
 func TestRenderMarkdown_SpikyNoteHandlesZeroP95(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "zero-p95", FinalECKU: 1, SizedInMBps: 0, PeakInMBps: 5, SpikyIngress: true, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{{ClusterID: "zero-p95", Verdict: types.ClusterTypeEnterprise}},
-		NetworkingDecision:  []types.NetworkingDecision{{ClusterID: "zero-p95", Verdict: types.NetworkingPrivateLink, Reason: "fits"}},
+		ClusterTypeDecision: []ClusterTypeDecision{{ClusterID: "zero-p95", Verdict: ClusterTypeEnterprise}},
+		NetworkingDecision:  []NetworkingDecision{{ClusterID: "zero-p95", Verdict: NetworkingPrivateLink, Reason: "fits"}},
 	}
 	out, err := RenderMarkdown(p, cfg)
 	require.NoError(t, err)
@@ -75,33 +74,33 @@ func TestRenderMarkdown_SpikyNoteHandlesZeroP95(t *testing.T) {
 func TestRenderMarkdown_DedicatedTopologyAndCKULabel(t *testing.T) {
 	cfg := defaultCfg(t)
 	cku := 4
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "ent-small", FinalECKU: 2, SizedInMBps: 10, SizedOutMBps: 20, MaxRatioDriver: "ingress"},
 			{ClusterID: "ded-mz", FinalECKU: 4, SizedInMBps: 100, SizedOutMBps: 180, MaxRatioDriver: "ingress"},
 			{ClusterID: "ded-sz", FinalECKU: 4, SizedInMBps: 50, SizedOutMBps: 80, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
-			{ClusterID: "ent-small", Verdict: types.ClusterTypeEnterprise},
+		ClusterTypeDecision: []ClusterTypeDecision{
+			{ClusterID: "ent-small", Verdict: ClusterTypeEnterprise},
 			{
 				ClusterID: "ded-mz",
-				Verdict:   types.ClusterTypeDedicated,
-				Topology:  types.TopologyMultiZone,
+				Verdict:   ClusterTypeDedicated,
+				Topology:  TopologyMultiZone,
 				FinalCKU:  &cku,
-				Triggers:  []types.HardLimitTrigger{{RowID: "eCKU_exceeds_pni_cap", Description: "x", Evidence: "y"}},
+				Triggers:  []HardLimitTrigger{{RowID: "eCKU_exceeds_pni_cap", Description: "x", Evidence: "y"}},
 			},
 			{
 				ClusterID: "ded-sz",
-				Verdict:   types.ClusterTypeDedicated,
-				Topology:  types.TopologySingleZone,
+				Verdict:   ClusterTypeDedicated,
+				Topology:  TopologySingleZone,
 				FinalCKU:  &cku,
-				Triggers:  []types.HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95 SZ", Evidence: "flag", CustomerDeclared: true}},
+				Triggers:  []HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95 SZ", Evidence: "flag", CustomerDeclared: true}},
 			},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "ent-small", Verdict: types.NetworkingPrivateLink, Reason: "fits"},
-			{ClusterID: "ded-mz", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
-			{ClusterID: "ded-sz", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "ent-small", Verdict: NetworkingPrivateLink, Reason: "fits"},
+			{ClusterID: "ded-mz", Verdict: NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "ded-sz", Verdict: NetworkingPNI, Reason: "Dedicated"},
 		},
 	}
 
@@ -140,15 +139,15 @@ func splitLine(body, clusterID string) string {
 // recommendation isn't recoverable by flipping a YAML flag.
 func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "real-big", FinalECKU: 50, SizedInMBps: 4000, SizedOutMBps: 4000, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
+		ClusterTypeDecision: []ClusterTypeDecision{
 			{
 				ClusterID: "real-big",
-				Verdict:   types.ClusterTypeDedicated,
-				Triggers: []types.HardLimitTrigger{
+				Verdict:   ClusterTypeDedicated,
+				Triggers: []HardLimitTrigger{
 					{
 						RowID:       "eCKU_exceeds_pni_cap",
 						Description: "Sized eCKU exceeds Enterprise PNI cap",
@@ -158,8 +157,8 @@ func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
 				},
 			},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "real-big", Verdict: types.NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "real-big", Verdict: NetworkingPNI, Reason: "Dedicated cluster — PNI required"},
 		},
 	}
 
@@ -184,20 +183,20 @@ func TestRenderMarkdown_NoCostCalloutOnStateDerivedDedicated(t *testing.T) {
 // sees what to fix.
 func TestRenderMarkdown_InputsMissingMarksProvisional(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "ok", FinalECKU: 1, SizedInMBps: 5, SizedOutMBps: 8, MaxRatioDriver: "ingress"},
 			{ClusterID: "gap", FinalECKU: 1, SLAFloorECKU: 1, MaxRatioDriver: "ingress", InputsMissing: []string{"topics", "acls"}},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
-			{ClusterID: "ok", Verdict: types.ClusterTypeEnterprise},
-			{ClusterID: "gap", Verdict: types.ClusterTypeEnterprise, InputsMissing: []string{"topics", "acls"}},
+		ClusterTypeDecision: []ClusterTypeDecision{
+			{ClusterID: "ok", Verdict: ClusterTypeEnterprise},
+			{ClusterID: "gap", Verdict: ClusterTypeEnterprise, InputsMissing: []string{"topics", "acls"}},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "ok", Verdict: types.NetworkingPNI, Reason: "PNI default"},
-			{ClusterID: "gap", Verdict: types.NetworkingPNI, Reason: "PNI default"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "ok", Verdict: NetworkingPNI, Reason: "PNI default"},
+			{ClusterID: "gap", Verdict: NetworkingPNI, Reason: "PNI default"},
 		},
-		SizingAppendix: []types.SizingMathDetail{
+		SizingAppendix: []SizingMathDetail{
 			{ClusterID: "ok", Formula: "CEIL(max(P95In/60, P95Out/180, partitions/3000) * (1 + 0.30 headroom))"},
 		},
 	}
@@ -232,20 +231,20 @@ func TestRenderMarkdown_InputsMissingMarksProvisional(t *testing.T) {
 // injection vector the code reviewer flagged.
 func TestRenderMarkdown_AppendixA2EscapesPipeInTableCells(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "weird|name", FinalECKU: 1, SizedInMBps: 1, SizedOutMBps: 1, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
+		ClusterTypeDecision: []ClusterTypeDecision{
 			{
 				ClusterID: "weird|name",
-				Verdict:   types.ClusterTypeEnterprise,
-				EvaluatedRules: []types.RuleEvaluation{
-					{RowID: "demo", Description: "Demo rule", Outcome: types.RuleNotFired, Evidence: "value a|b"},
+				Verdict:   ClusterTypeEnterprise,
+				EvaluatedRules: []RuleEvaluation{
+					{RowID: "demo", Description: "Demo rule", Outcome: RuleNotFired, Evidence: "value a|b"},
 				},
 			},
 		},
-		NetworkingDecision: []types.NetworkingDecision{{ClusterID: "weird|name", Verdict: types.NetworkingPNI, Reason: "x"}},
+		NetworkingDecision: []NetworkingDecision{{ClusterID: "weird|name", Verdict: NetworkingPNI, Reason: "x"}},
 	}
 	out, err := RenderMarkdown(p, cfg)
 	require.NoError(t, err)
@@ -261,19 +260,19 @@ func TestRenderMarkdown_AppendixA2EscapesPipeInTableCells(t *testing.T) {
 // appears for each.
 func TestRenderMarkdown_CostCalloutMultipleTriggers(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "combo", FinalECKU: 2, SizedInMBps: 10, SizedOutMBps: 10, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{{
+		ClusterTypeDecision: []ClusterTypeDecision{{
 			ClusterID: "combo",
-			Verdict:   types.ClusterTypeDedicated,
-			Triggers: []types.HardLimitTrigger{
+			Verdict:   ClusterTypeDedicated,
+			Triggers: []HardLimitTrigger{
 				{RowID: "sla_99_95_single_zone", Description: "99.95% single-zone SLA required", CustomerDeclared: true},
 				{RowID: "broker_side_schema_validation_required", Description: "Broker-side schema ID validation required", CustomerDeclared: true},
 			},
 		}},
-		NetworkingDecision: []types.NetworkingDecision{{ClusterID: "combo", Verdict: types.NetworkingPNI, Reason: "Dedicated"}},
+		NetworkingDecision: []NetworkingDecision{{ClusterID: "combo", Verdict: NetworkingPNI, Reason: "Dedicated"}},
 	}
 	out, err := RenderMarkdown(p, cfg)
 	require.NoError(t, err)
@@ -290,12 +289,12 @@ func TestRenderMarkdown_CostCalloutMultipleTriggers(t *testing.T) {
 // the `_Inputs missing_` Why-line note or a `*` provisional marker.
 func TestRenderMarkdown_HealthyClusterHasNoProvisionalMarker(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "ok", FinalECKU: 1, SizedInMBps: 5, SizedOutMBps: 8, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{{ClusterID: "ok", Verdict: types.ClusterTypeEnterprise}},
-		NetworkingDecision:  []types.NetworkingDecision{{ClusterID: "ok", Verdict: types.NetworkingPNI, Reason: "default"}},
+		ClusterTypeDecision: []ClusterTypeDecision{{ClusterID: "ok", Verdict: ClusterTypeEnterprise}},
+		NetworkingDecision:  []NetworkingDecision{{ClusterID: "ok", Verdict: NetworkingPNI, Reason: "default"}},
 	}
 	out, err := RenderMarkdown(p, cfg)
 	require.NoError(t, err)
@@ -310,24 +309,24 @@ func TestRenderMarkdown_HealthyClusterHasNoProvisionalMarker(t *testing.T) {
 // callouts.
 func TestRenderMarkdown_GlobalTriggerCollapsesToBanner(t *testing.T) {
 	cfg := defaultCfg(t)
-	mkTrigger := func(id, desc string) []types.HardLimitTrigger {
-		return []types.HardLimitTrigger{{RowID: id, Description: desc, CustomerDeclared: true}}
+	mkTrigger := func(id, desc string) []HardLimitTrigger {
+		return []HardLimitTrigger{{RowID: id, Description: desc, CustomerDeclared: true}}
 	}
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "a", FinalECKU: 1, MaxRatioDriver: "ingress"},
 			{ClusterID: "b", FinalECKU: 1, MaxRatioDriver: "ingress"},
 			{ClusterID: "c", FinalECKU: 1, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
-			{ClusterID: "a", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
-			{ClusterID: "b", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
-			{ClusterID: "c", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+		ClusterTypeDecision: []ClusterTypeDecision{
+			{ClusterID: "a", Verdict: ClusterTypeDedicated, Topology: TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+			{ClusterID: "b", Verdict: ClusterTypeDedicated, Topology: TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
+			{ClusterID: "c", Verdict: ClusterTypeDedicated, Topology: TopologySingleZone, Triggers: mkTrigger("sla_99_95_single_zone", "99.95% single-zone SLA required")},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "a", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
-			{ClusterID: "b", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
-			{ClusterID: "c", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "a", Verdict: NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "b", Verdict: NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "c", Verdict: NetworkingPNI, Reason: "Dedicated"},
 		},
 	}
 	out, err := RenderMarkdown(p, cfg)
@@ -365,25 +364,25 @@ func TestSlaFloorList_SortedDeterministic(t *testing.T) {
 // firing cluster (the global banner must NOT appear).
 func TestDetectGlobalCustomerTriggers_PartialFireKeepsInline(t *testing.T) {
 	cfg := defaultCfg(t)
-	mkTrigger := func() []types.HardLimitTrigger {
-		return []types.HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95% single-zone SLA required", CustomerDeclared: true}}
+	mkTrigger := func() []HardLimitTrigger {
+		return []HardLimitTrigger{{RowID: "sla_99_95_single_zone", Description: "99.95% single-zone SLA required", CustomerDeclared: true}}
 	}
-	p := &types.Plan{
-		Sizing: []types.ClusterSizing{
+	p := &Plan{
+		Sizing: []ClusterSizing{
 			{ClusterID: "a", FinalECKU: 1, MaxRatioDriver: "ingress"},
 			{ClusterID: "b", FinalECKU: 1, MaxRatioDriver: "ingress"},
 			{ClusterID: "c", FinalECKU: 1, MaxRatioDriver: "ingress"},
 		},
-		ClusterTypeDecision: []types.ClusterTypeDecision{
+		ClusterTypeDecision: []ClusterTypeDecision{
 			// a + b fire; c doesn't (Enterprise default)
-			{ClusterID: "a", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger()},
-			{ClusterID: "b", Verdict: types.ClusterTypeDedicated, Topology: types.TopologySingleZone, Triggers: mkTrigger()},
-			{ClusterID: "c", Verdict: types.ClusterTypeEnterprise},
+			{ClusterID: "a", Verdict: ClusterTypeDedicated, Topology: TopologySingleZone, Triggers: mkTrigger()},
+			{ClusterID: "b", Verdict: ClusterTypeDedicated, Topology: TopologySingleZone, Triggers: mkTrigger()},
+			{ClusterID: "c", Verdict: ClusterTypeEnterprise},
 		},
-		NetworkingDecision: []types.NetworkingDecision{
-			{ClusterID: "a", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
-			{ClusterID: "b", Verdict: types.NetworkingPNI, Reason: "Dedicated"},
-			{ClusterID: "c", Verdict: types.NetworkingPNI, Reason: "default for AWS Enterprise"},
+		NetworkingDecision: []NetworkingDecision{
+			{ClusterID: "a", Verdict: NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "b", Verdict: NetworkingPNI, Reason: "Dedicated"},
+			{ClusterID: "c", Verdict: NetworkingPNI, Reason: "default for AWS Enterprise"},
 		},
 	}
 	out, err := RenderMarkdown(p, cfg)
@@ -408,7 +407,7 @@ func TestDetectGlobalCustomerTriggers_PartialFireKeepsInline(t *testing.T) {
 // swap a `<region>` placeholder once multiple distinct regions exist
 // in the merged group.
 func TestGroupOpenQuestions_RegionFlagNormalizationCollapses(t *testing.T) {
-	oqs := []types.OpenQuestion{
+	oqs := []OpenQuestion{
 		{
 			ID:         "auth_posture_unknown",
 			ClusterID:  "a",
@@ -436,8 +435,8 @@ func TestGroupOpenQuestions_RegionFlagNormalizationCollapses(t *testing.T) {
 // first-seen region.
 func TestActionsNeededRender_MultiRegionGroupSwapsPlaceholder(t *testing.T) {
 	cfg := defaultCfg(t)
-	p := &types.Plan{
-		OpenQuestions: []types.OpenQuestion{
+	p := &Plan{
+		OpenQuestions: []OpenQuestion{
 			{
 				ID:         "auth_posture_unknown",
 				ClusterID:  "a",
@@ -468,7 +467,7 @@ func TestActionsNeededRender_MultiRegionGroupSwapsPlaceholder(t *testing.T) {
 // surface the contradiction so the reader doesn't see a misleading
 // "Pending — declare the missing input".
 func TestSchemaLabels_ScanGapWhenDeclaredButNotScanned(t *testing.T) {
-	dec := &types.SchemaDecision{Source: types.SchemaSourceNone}
+	dec := &SchemaDecision{Source: SchemaSourceNone}
 	pathLabel := schemaPathsLabelForContext(nil, SchemaStrategyMigrateExistingSchemaRegistry, dec.Source)
 	assert.Contains(t, pathLabel, "Scan gap", "recommended-path should call out the scan gap explicitly")
 	assert.Contains(t, pathLabel, "re-run", "scan-gap label must nudge the customer to re-run the scan")

--- a/internal/services/plan/schema.go
+++ b/internal/services/plan/schema.go
@@ -50,14 +50,14 @@ func knownSchemaCPEdition(value string) bool {
 // The result's `Paths` slice carries every verdict that applies —
 // usually one entry, two for the dual-source case so JSON consumers
 // branching on a single slot don't miss the second arm.
-func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.PlanInputsResolved) *types.SchemaDecision {
+func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *SchemaDecision {
 	source, confluentURLs, glueNames := detectSchemaSource(state)
 	strategy := inputs.SchemaStrategy
 	if strategy == "" {
 		strategy = SchemaStrategyUnknown
 	}
 
-	dec := &types.SchemaDecision{
+	dec := &SchemaDecision{
 		Source:          source,
 		ConfluentSRURLs: confluentURLs,
 		GlueRegistries:  glueNames,
@@ -67,7 +67,7 @@ func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 	// (typo wins — emitting a verdict against an unrecognised strategy
 	// would silently override the customer's intent).
 	if !knownSchemaStrategy(strategy) || strategy == SchemaStrategyUnknown {
-		dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+		dec.Paths = []SchemaPath{SchemaPathUnknown}
 		return dec
 	}
 
@@ -79,23 +79,23 @@ func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 	//       skip schemas entirely). The 🟡 schema_state_strategy_mismatch
 	//       OQ carries the message.
 	if strategy == SchemaStrategyNoSchemas {
-		if source == types.SchemaSourceNone {
-			dec.Paths = []types.SchemaPath{types.SchemaPathSchemaless}
+		if source == SchemaSourceNone {
+			dec.Paths = []SchemaPath{SchemaPathSchemaless}
 		} else {
-			dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+			dec.Paths = []SchemaPath{SchemaPathUnknown}
 		}
 		return dec
 	}
 
 	switch source {
-	case types.SchemaSourceGlue:
-		dec.Paths = []types.SchemaPath{types.SchemaPathMigrateGlue}
+	case SchemaSourceGlue:
+		dec.Paths = []SchemaPath{SchemaPathMigrateGlue}
 		return dec
-	case types.SchemaSourceConfluent:
+	case SchemaSourceConfluent:
 		fillConfluentEligibility(dec, cfg, inputs)
-		dec.Paths = []types.SchemaPath{confluentEligibilityPath(dec)}
+		dec.Paths = []SchemaPath{confluentEligibilityPath(dec)}
 		return dec
-	case types.SchemaSourceConfluentAndGlue:
+	case SchemaSourceConfluentAndGlue:
 		// Two arms apply concurrently. Glue first (it's the
 		// automatable path) so the renderer leads with the actionable
 		// command; Confluent verdict second so the customer sees both
@@ -109,8 +109,8 @@ func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 		// from "verdict undecidable" by looking at the slice. The
 		// `schema_linking_eligibility_unknown` OQ carries the gap.
 		fillConfluentEligibility(dec, cfg, inputs)
-		dec.Paths = []types.SchemaPath{types.SchemaPathMigrateGlue}
-		if confluent := confluentEligibilityPath(dec); confluent != types.SchemaPathUnknown {
+		dec.Paths = []SchemaPath{SchemaPathMigrateGlue}
+		if confluent := confluentEligibilityPath(dec); confluent != SchemaPathUnknown {
 			dec.Paths = append(dec.Paths, confluent)
 		}
 		return dec
@@ -121,7 +121,7 @@ func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 	// `migrate_existing_schema_registry`). The customer has declared
 	// intent but no source SR was scanned — the path is unknown until
 	// they either rerun the scan or confirm "no existing SR".
-	dec.Paths = []types.SchemaPath{types.SchemaPathUnknown}
+	dec.Paths = []SchemaPath{SchemaPathUnknown}
 	return dec
 }
 
@@ -129,14 +129,14 @@ func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs types.Plan
 // onto the corresponding SchemaPath. Extracted from decideSchema so
 // both the pure-Confluent and the dual ConfluentAndGlue branches share
 // one rule.
-func confluentEligibilityPath(dec *types.SchemaDecision) types.SchemaPath {
+func confluentEligibilityPath(dec *SchemaDecision) SchemaPath {
 	switch schemaLinkingEligibilityVerdict(dec) {
 	case eligibilityVerdictEligible:
-		return types.SchemaPathSchemaLinking
+		return SchemaPathSchemaLinking
 	case eligibilityVerdictIneligible:
-		return types.SchemaPathDeferToAccount
+		return SchemaPathDeferToAccount
 	default:
-		return types.SchemaPathUnknown
+		return SchemaPathUnknown
 	}
 }
 
@@ -144,9 +144,9 @@ func confluentEligibilityPath(dec *types.SchemaDecision) types.SchemaPath {
 // SchemaPathUnknown if Paths is empty. Package-private — only test
 // assertions care about the leading verdict; production code uses
 // hasPath or reads `dec.Paths` directly.
-func primaryPath(dec *types.SchemaDecision) types.SchemaPath {
+func primaryPath(dec *SchemaDecision) SchemaPath {
 	if dec == nil || len(dec.Paths) == 0 {
-		return types.SchemaPathUnknown
+		return SchemaPathUnknown
 	}
 	return dec.Paths[0]
 }
@@ -155,14 +155,14 @@ func primaryPath(dec *types.SchemaDecision) types.SchemaPath {
 // a Confluent Schema Registry (solo or alongside Glue). Used by the
 // eligibility-OQ detectors and the renderer's preamble gate so the
 // predicate doesn't drift across callsites.
-func sourceTouchesConfluent(s types.SchemaSource) bool {
-	return s == types.SchemaSourceConfluent || s == types.SchemaSourceConfluentAndGlue
+func sourceTouchesConfluent(s SchemaSource) bool {
+	return s == SchemaSourceConfluent || s == SchemaSourceConfluentAndGlue
 }
 
 // hasPath reports whether a SchemaDecision's Paths slice contains `p`.
 // Used by Build to decide whether to suppress the §Schema section
 // (schemaless) and by the renderer for path-specific rendering.
-func hasPath(dec *types.SchemaDecision, p types.SchemaPath) bool {
+func hasPath(dec *SchemaDecision, p SchemaPath) bool {
 	if dec == nil {
 		return false
 	}
@@ -178,10 +178,10 @@ func hasPath(dec *types.SchemaDecision, p types.SchemaPath) bool {
 // (state.SchemaRegistries.ConfluentSchemaRegistry +
 // state.SchemaRegistries.AWSGlue) into a single enum + the lookups the
 // renderer needs (URLs + registry names).
-func detectSchemaSource(state types.ProcessedState) (types.SchemaSource, []string, []string) {
+func detectSchemaSource(state types.ProcessedState) (SchemaSource, []string, []string) {
 	srs := state.SchemaRegistries
 	if srs == nil {
-		return types.SchemaSourceNone, nil, nil
+		return SchemaSourceNone, nil, nil
 	}
 	confluentURLs := make([]string, 0, len(srs.ConfluentSchemaRegistry))
 	for _, sr := range srs.ConfluentSchemaRegistry {
@@ -193,13 +193,13 @@ func detectSchemaSource(state types.ProcessedState) (types.SchemaSource, []strin
 	}
 	switch {
 	case len(confluentURLs) > 0 && len(glueNames) > 0:
-		return types.SchemaSourceConfluentAndGlue, confluentURLs, glueNames
+		return SchemaSourceConfluentAndGlue, confluentURLs, glueNames
 	case len(confluentURLs) > 0:
-		return types.SchemaSourceConfluent, confluentURLs, nil
+		return SchemaSourceConfluent, confluentURLs, nil
 	case len(glueNames) > 0:
-		return types.SchemaSourceGlue, nil, glueNames
+		return SchemaSourceGlue, nil, glueNames
 	default:
-		return types.SchemaSourceNone, nil, nil
+		return SchemaSourceNone, nil, nil
 	}
 }
 
@@ -207,7 +207,7 @@ func detectSchemaSource(state types.ProcessedState) (types.SchemaSource, []strin
 // on `dec` from the customer-declared CP version + edition +
 // reachability inputs. Tri-state (nil = unknown) so the verdict can
 // distinguish "verified false" from "not declared yet" downstream.
-func fillConfluentEligibility(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) {
+func fillConfluentEligibility(dec *SchemaDecision, cfg *PlanConfig, inputs PlanInputsResolved) {
 	if inputs.ConfluentSRCPVersion != "" {
 		v := versionAtLeast(inputs.ConfluentSRCPVersion, cfg.SchemaLinking.MinCPVersion)
 		dec.MeetsCPVersionFloor = &v
@@ -233,7 +233,7 @@ const (
 // schemaLinkingEligibilityVerdict folds the three tri-state flags into
 // one verdict: any "verified false" → ineligible, any nil → unknown,
 // all "verified true" → eligible.
-func schemaLinkingEligibilityVerdict(dec *types.SchemaDecision) eligibilityVerdict {
+func schemaLinkingEligibilityVerdict(dec *SchemaDecision) eligibilityVerdict {
 	flags := []*bool{dec.MeetsCPVersionFloor, dec.MeetsCPEditionRequirement, dec.SourceSROutboundReachable}
 	anyUnknown := false
 	for _, f := range flags {
@@ -258,11 +258,11 @@ func schemaLinkingEligibilityVerdict(dec *types.SchemaDecision) eligibilityVerdi
 // body can quote the configured CP-version floor + edition the same
 // way the rendered eligibility table does — keeps the two surfaces
 // in lockstep if an admin tunes `plan-config.yaml`.
-func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) []types.OpenQuestion {
+func detectSchemaOpenQuestions(dec *SchemaDecision, cfg *PlanConfig, inputs PlanInputsResolved) []OpenQuestion {
 	if dec == nil {
 		return nil
 	}
-	var oqs []types.OpenQuestion
+	var oqs []OpenQuestion
 
 	strategy := inputs.SchemaStrategy
 	if strategy == "" {
@@ -272,7 +272,7 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 	// Strategy typo (recognised values + the explicit `unknown` token
 	// keep this silent; anything else fires).
 	if !knownSchemaStrategy(strategy) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "schema_strategy_invalid",
 			Title:      "`schema_strategy` is not a recognised value — set to one of the four enum tokens",
 			Body:       "Recognised values: `unknown` | `no_schemas` | `adopt_schemas_during_migration` | `migrate_existing_schema_registry`. The current value falls outside the enum, so the Plan treats it as `unknown` and emits this OQ.",
@@ -286,8 +286,8 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 	// migration command decides itself, no strategy declaration
 	// needed. The dual `ConfluentAndGlue` case still fires the OQ
 	// because the Confluent arm requires the strategy.
-	if strategy == SchemaStrategyUnknown && dec.Source != types.SchemaSourceGlue {
-		oqs = append(oqs, types.OpenQuestion{
+	if strategy == SchemaStrategyUnknown && dec.Source != SchemaSourceGlue {
+		oqs = append(oqs, OpenQuestion{
 			ID:         "schema_strategy_unknown",
 			Title:      "Schema migration strategy not declared — set `schema_strategy` in `plan-inputs.yaml`",
 			Body:       "First-run Plans default `schema_strategy: unknown` so we don't silently emit a schemaless verdict (which would suppress the Red Flag for shops that genuinely have a Schema Registry). Pick the strategy that matches your migration: `no_schemas` (workloads carry no schemas), `adopt_schemas_during_migration` (you want CC Schema Registry but don't have one on-prem), or `migrate_existing_schema_registry` (you have an SR and want it mirrored).",
@@ -308,9 +308,9 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 	// The `return oqs` here intentionally drops the eligibility OQs
 	// only; OQs that are independent of the no_schemas contradiction
 	// belong above the mismatch gate so they still fire.
-	mismatch := strategy == SchemaStrategyNoSchemas && dec.Source != types.SchemaSourceNone
+	mismatch := strategy == SchemaStrategyNoSchemas && dec.Source != SchemaSourceNone
 	if mismatch {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "schema_state_strategy_mismatch",
 			Title:      "`schema_strategy: no_schemas` but the scan found a Schema Registry on the source",
 			Body:       "If you intend to retire the source SR during the migration, this is fine — leave the setting and acknowledge this OQ. If the SR was scanned in error (e.g. it belongs to a different team), narrow the scan scope. Otherwise switch `schema_strategy` to `migrate_existing_schema_registry` so the Plan applies the SR-detected path.",
@@ -326,7 +326,7 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 	// customer fills these in.
 	if sourceTouchesConfluent(dec.Source) &&
 		schemaLinkingEligibilityVerdict(dec) == eligibilityVerdictUnknown {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "schema_linking_eligibility_unknown",
 			Title:      "Declare source SR CP version, edition, and outbound reachability in `plan-inputs.yaml`",
 			Body:       fmt.Sprintf("Schema Linking requires the source SR to (1) be on CP %s or later, (2) run the `%s` edition (other editions do not ship Schema Linking), and (3) be able to make outbound TCP connections to your CC Schema Registry endpoint. Until all three are declared, the Plan can't pick between the Schema Linking path and the account-team-handoff path.", cfg.SchemaLinking.MinCPVersion, cfg.SchemaLinking.RequiresCPEdition),
@@ -341,7 +341,7 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 	// accept the manual path.
 	if sourceTouchesConfluent(dec.Source) &&
 		schemaLinkingEligibilityVerdict(dec) == eligibilityVerdictIneligible {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "schema_linking_ineligible",
 			Title:      "Schema Linking blocked — fix the failing constraint or defer to your Confluent account team",
 			Body:       ineligibilityBody(dec, cfg, inputs),
@@ -359,7 +359,7 @@ func detectSchemaOpenQuestions(dec *types.SchemaDecision, cfg *PlanConfig, input
 // so the OQ stays in lockstep with the eligibility table whenever an
 // admin tunes plan-config.yaml. Joins failure reasons with "; " so
 // the list reads as one sentence.
-func ineligibilityBody(dec *types.SchemaDecision, cfg *PlanConfig, inputs types.PlanInputsResolved) string {
+func ineligibilityBody(dec *SchemaDecision, cfg *PlanConfig, inputs PlanInputsResolved) string {
 	var reasons []string
 	if dec.MeetsCPVersionFloor != nil && !*dec.MeetsCPVersionFloor {
 		reasons = append(reasons, fmt.Sprintf("CP version declared as `%s` is below the `%s` floor", inputs.ConfluentSRCPVersion, cfg.SchemaLinking.MinCPVersion))

--- a/internal/services/plan/schema_test.go
+++ b/internal/services/plan/schema_test.go
@@ -26,8 +26,8 @@ func schemaState(confluentURLs, glueNames []string) types.ProcessedState {
 	return types.ProcessedState{SchemaRegistries: srs}
 }
 
-func schemaInputs(strategy string) types.PlanInputsResolved {
-	return types.PlanInputsResolved{SchemaStrategy: strategy}
+func schemaInputs(strategy string) PlanInputsResolved {
+	return PlanInputsResolved{SchemaStrategy: strategy}
 }
 
 func ptrBool(b bool) *bool { return &b }
@@ -37,8 +37,8 @@ func ptrBool(b bool) *bool { return &b }
 func TestDecideSchema_GlueDetected(t *testing.T) {
 	dec := decideSchema(schemaState(nil, []string{"my-glue"}), defaultCfg(t), schemaInputs(SchemaStrategyMigrateExistingSchemaRegistry))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceGlue, dec.Source)
-	assert.Equal(t, types.SchemaPathMigrateGlue, primaryPath(dec))
+	assert.Equal(t, SchemaSourceGlue, dec.Source)
+	assert.Equal(t, SchemaPathMigrateGlue, primaryPath(dec))
 	assert.Equal(t, []string{"my-glue"}, dec.GlueRegistries)
 }
 
@@ -51,8 +51,8 @@ func TestDecideSchema_ConfluentEligible(t *testing.T) {
 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
-	assert.Equal(t, types.SchemaPathSchemaLinking, primaryPath(dec))
+	assert.Equal(t, SchemaSourceConfluent, dec.Source)
+	assert.Equal(t, SchemaPathSchemaLinking, primaryPath(dec))
 	require.NotNil(t, dec.MeetsCPVersionFloor)
 	assert.True(t, *dec.MeetsCPVersionFloor)
 	require.NotNil(t, dec.MeetsCPEditionRequirement)
@@ -68,7 +68,7 @@ func TestDecideSchema_ConfluentBelowCPFloor(t *testing.T) {
 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
+	assert.Equal(t, SchemaPathDeferToAccount, primaryPath(dec))
 	require.NotNil(t, dec.MeetsCPVersionFloor)
 	assert.False(t, *dec.MeetsCPVersionFloor)
 }
@@ -82,7 +82,7 @@ func TestDecideSchema_ConfluentCommunityEdition(t *testing.T) {
 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaPathDeferToAccount, primaryPath(dec))
+	assert.Equal(t, SchemaPathDeferToAccount, primaryPath(dec))
 	require.NotNil(t, dec.MeetsCPEditionRequirement)
 	assert.False(t, *dec.MeetsCPEditionRequirement)
 }
@@ -96,7 +96,7 @@ func TestDecideSchema_ConfluentReachabilityUnknown(t *testing.T) {
 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+	assert.Equal(t, SchemaPathUnknown, primaryPath(dec))
 	assert.Nil(t, dec.SourceSROutboundReachable, "nil tri-state preserved when input is unset")
 }
 
@@ -104,22 +104,22 @@ func TestDecideSchema_ConfluentReachabilityUnknown(t *testing.T) {
 func TestDecideSchema_NoneAndNoSchemas(t *testing.T) {
 	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceNone, dec.Source)
-	assert.Equal(t, types.SchemaPathSchemaless, primaryPath(dec))
+	assert.Equal(t, SchemaSourceNone, dec.Source)
+	assert.Equal(t, SchemaPathSchemaless, primaryPath(dec))
 }
 
 // Strategy=unknown (default) → unknown (OQ asks customer to declare).
 func TestDecideSchema_StrategyUnknown(t *testing.T) {
 	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyUnknown))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+	assert.Equal(t, SchemaPathUnknown, primaryPath(dec))
 }
 
 // Strategy typo'd → unknown (OQ flags the typo before any path applies).
 func TestDecideSchema_StrategyTypo(t *testing.T) {
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs("no_schemaz"))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "typo'd strategy must not select a downstream path")
+	assert.Equal(t, SchemaPathUnknown, primaryPath(dec), "typo'd strategy must not select a downstream path")
 }
 
 // Both Confluent + Glue with eligible flags → Paths carries BOTH
@@ -133,12 +133,12 @@ func TestDecideSchema_ConfluentAndGlue(t *testing.T) {
 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceConfluentAndGlue, dec.Source)
+	assert.Equal(t, SchemaSourceConfluentAndGlue, dec.Source)
 	require.Len(t, dec.Paths, 2, "dual-source must carry both arms in Paths")
-	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0], "Glue path renders first")
-	assert.Equal(t, types.SchemaPathSchemaLinking, dec.Paths[1], "Confluent verdict in second slot")
-	assert.True(t, hasPath(dec, types.SchemaPathSchemaLinking))
-	assert.True(t, hasPath(dec, types.SchemaPathMigrateGlue))
+	assert.Equal(t, SchemaPathMigrateGlue, dec.Paths[0], "Glue path renders first")
+	assert.Equal(t, SchemaPathSchemaLinking, dec.Paths[1], "Confluent verdict in second slot")
+	assert.True(t, hasPath(dec, SchemaPathSchemaLinking))
+	assert.True(t, hasPath(dec, SchemaPathMigrateGlue))
 	require.NotNil(t, dec.MeetsCPVersionFloor, "Confluent eligibility populated even when Glue is the leading verdict")
 }
 
@@ -152,8 +152,8 @@ func TestDecideSchema_ConfluentAndGlue_PendingConfluentArmDropped(t *testing.T) 
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	require.Len(t, dec.Paths, 1, "pending Confluent arm must NOT serialise as Paths[1]==unknown")
-	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
-	assert.False(t, hasPath(dec, types.SchemaPathUnknown))
+	assert.Equal(t, SchemaPathMigrateGlue, dec.Paths[0])
+	assert.False(t, hasPath(dec, SchemaPathUnknown))
 }
 
 // Dual-source with Confluent arm INELIGIBLE (e.g. CP below floor) —
@@ -167,8 +167,8 @@ func TestDecideSchema_ConfluentAndGlue_ConfluentArmIneligible(t *testing.T) {
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, []string{"my-glue"}), defaultCfg(t), inputs)
 	require.NotNil(t, dec)
 	require.Len(t, dec.Paths, 2)
-	assert.Equal(t, types.SchemaPathMigrateGlue, dec.Paths[0])
-	assert.Equal(t, types.SchemaPathDeferToAccount, dec.Paths[1])
+	assert.Equal(t, SchemaPathMigrateGlue, dec.Paths[0])
+	assert.Equal(t, SchemaPathDeferToAccount, dec.Paths[1])
 }
 
 // State has no SR + customer declared `adopt_schemas_during_migration`
@@ -178,8 +178,8 @@ func TestDecideSchema_ConfluentAndGlue_ConfluentArmIneligible(t *testing.T) {
 func TestDecideSchema_NoneWithAdoptStrategy(t *testing.T) {
 	dec := decideSchema(schemaState(nil, nil), defaultCfg(t), schemaInputs(SchemaStrategyAdoptSchemasDuringMigration))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceNone, dec.Source)
-	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec))
+	assert.Equal(t, SchemaSourceNone, dec.Source)
+	assert.Equal(t, SchemaPathUnknown, primaryPath(dec))
 	assert.Nil(t, dec.MeetsCPVersionFloor, "eligibility flags must not be populated when no Confluent SR was scanned")
 }
 
@@ -191,8 +191,8 @@ func TestDecideSchema_NoneWithAdoptStrategy(t *testing.T) {
 func TestDecideSchema_NoSchemasButConfluentDetected(t *testing.T) {
 	dec := decideSchema(schemaState([]string{"https://csr.example.com"}, nil), defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
 	require.NotNil(t, dec)
-	assert.Equal(t, types.SchemaSourceConfluent, dec.Source)
-	assert.Equal(t, types.SchemaPathUnknown, primaryPath(dec), "verdict short-circuits to unknown; OQ carries the message")
+	assert.Equal(t, SchemaSourceConfluent, dec.Source)
+	assert.Equal(t, SchemaPathUnknown, primaryPath(dec), "verdict short-circuits to unknown; OQ carries the message")
 	assert.Nil(t, dec.MeetsCPVersionFloor, "eligibility flags must remain nil on the no_schemas+scanned-SR contradiction")
 	assert.Nil(t, dec.MeetsCPEditionRequirement)
 	assert.Nil(t, dec.SourceSROutboundReachable)
@@ -202,9 +202,9 @@ func TestDecideSchema_NoSchemasButConfluentDetected(t *testing.T) {
 // declared flag is false. The body names the failing constraint AND
 // the declared value the customer can edit.
 func TestDetectSchemaOpenQuestions_IneligibleSurfacesReason(t *testing.T) {
-	dec := &types.SchemaDecision{
-		Source:                    types.SchemaSourceConfluent,
-		Paths:                     []types.SchemaPath{types.SchemaPathDeferToAccount},
+	dec := &SchemaDecision{
+		Source:                    SchemaSourceConfluent,
+		Paths:                     []SchemaPath{SchemaPathDeferToAccount},
 		MeetsCPVersionFloor:       ptrBool(false),
 		MeetsCPEditionRequirement: ptrBool(true),
 		SourceSROutboundReachable: ptrBool(true),
@@ -221,7 +221,7 @@ func TestDetectSchemaOpenQuestions_IneligibleSurfacesReason(t *testing.T) {
 // schema_state_strategy_mismatch fires when no_schemas is declared
 // but the scan found a registry — 🟡, not 🔴 (could be deliberate).
 func TestDetectSchemaOpenQuestions_NoSchemasMismatch(t *testing.T) {
-	dec := &types.SchemaDecision{Source: types.SchemaSourceConfluent, Paths: []types.SchemaPath{types.SchemaPathUnknown}}
+	dec := &SchemaDecision{Source: SchemaSourceConfluent, Paths: []SchemaPath{SchemaPathUnknown}}
 	oqs := detectSchemaOpenQuestions(dec, defaultCfg(t), schemaInputs(SchemaStrategyNoSchemas))
 	require.NotEmpty(t, oqs)
 	found := false

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -26,7 +26,7 @@ const bytesPerMBps = 1_048_576.0
 // FinalECKU = SLA floor and Degraded = true rather than failing the whole
 // plan build. The renderer surfaces the gap so the customer knows the
 // sizing column is a placeholder.
-func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs types.PlanInputsResolved) types.ClusterSizing {
+func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) ClusterSizing {
 	caps := cfg.EnterpriseCaps
 	aggs := c.ClusterMetrics.Aggregates
 
@@ -35,14 +35,14 @@ func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 	p95OutBytes, haveOut := pickPercentile(aggs, "BytesOutPerSec", pct)
 	if !haveIn || !haveOut {
 		slaFloor := slaFloorECKU(inputs.SLATarget, cfg.PlanInputDefaults.SLAFloorECKU)
-		return types.ClusterSizing{
+		return ClusterSizing{
 			ClusterID:      c.Name,
 			UserPartitions: userPartitionsOf(c),
 			SLAFloorECKU:   slaFloor,
 			FinalECKU:      slaFloor,
 			Degraded:       true,
 			DegradedReason: missingMetricsReason(haveIn, haveOut, pct),
-			Citations: []types.FieldCitation{
+			Citations: []FieldCitation{
 				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.%s", c.Name, citationKey(pct)), Value: nil},
 				{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.%s", c.Name, citationKey(pct)), Value: nil},
 			},
@@ -88,7 +88,7 @@ func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 
 	spikyRatio := inputs.SpikyWorkloadRatio
 
-	return types.ClusterSizing{
+	return ClusterSizing{
 		ClusterID:           c.Name,
 		SizedInMBps:         p95InMBps,
 		SizedOutMBps:        p95OutMBps,
@@ -110,7 +110,7 @@ func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs type
 		PeakBurstPctOfPLCap: peakBurstPctOfPLCap,
 		SpikyIngress:        peakInMBps > spikyRatio*p95InMBps,
 		SpikyEgress:         peakOutMBps > spikyRatio*p95OutMBps,
-		Citations: []types.FieldCitation{
+		Citations: []FieldCitation{
 			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.%s", c.Name, citationKey(pct)), Value: p95InBytes},
 			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesOutPerSec.%s", c.Name, citationKey(pct)), Value: p95OutBytes},
 			{Path: fmt.Sprintf("cluster[%s].metrics.aggregates.BytesInPerSec.max", c.Name), Value: peakInBytes},

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -30,8 +30,8 @@ func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMB
 	}
 }
 
-func defaultInputs() types.PlanInputsResolved {
-	return types.PlanInputsResolved{
+func defaultInputs() PlanInputsResolved {
+	return PlanInputsResolved{
 		SLATarget:                "99.9",
 		SizingPercentile:         "p95",
 		HeadroomFraction:         0.30,

--- a/internal/services/plan/tiered_storage.go
+++ b/internal/services/plan/tiered_storage.go
@@ -28,9 +28,9 @@ const (
 // trade-off (mechanism / duration / cost direction) so the customer
 // (and account team) can decide whether the cold data is worth
 // re-fetching.
-func detectTieredStorage(state types.ProcessedState, inputs types.PlanInputsResolved) *types.TieredStorageSection {
+func detectTieredStorage(state types.ProcessedState, inputs PlanInputsResolved) *TieredStorageSection {
 	clusters := collectClusters(state)
-	var tiered []types.TieredStorageCluster
+	var tiered []TieredStorageCluster
 	for _, c := range clusters {
 		// Serverless has no `StorageMode` (Provisioned-only field).
 		// Skip explicitly so the empty `clusterStorageMode` return
@@ -41,7 +41,7 @@ func detectTieredStorage(state types.ProcessedState, inputs types.PlanInputsReso
 		if clusterStorageMode(c) != kafkatypes.StorageModeTiered {
 			continue
 		}
-		tiered = append(tiered, types.TieredStorageCluster{
+		tiered = append(tiered, TieredStorageCluster{
 			ClusterID:          c.Name,
 			StorageMode:        string(kafkatypes.StorageModeTiered),
 			RemoteLogSizeBytes: remoteLogSizeBytesOf(c),
@@ -50,7 +50,7 @@ func detectTieredStorage(state types.ProcessedState, inputs types.PlanInputsReso
 	if len(tiered) == 0 {
 		return nil
 	}
-	return &types.TieredStorageSection{
+	return &TieredStorageSection{
 		Clusters:                   tiered,
 		ConsumerHistoryRequirement: defaultedConsumerHistory(inputs.ConsumerHistoryRequirement),
 		HistoricalDataStrategy:     defaultedHistoricalStrategy(inputs.HistoricalDataStrategy, inputs.ConsumerHistoryRequirement),
@@ -123,13 +123,13 @@ func knownHistoricalStrategy(v string) bool {
 // confidence in the tiered-storage recommendation: typos in the two
 // enums and the "you have tiered storage but haven't picked a
 // strategy" prompt.
-func detectTieredStorageOpenQuestions(section *types.TieredStorageSection, inputs types.PlanInputsResolved) []types.OpenQuestion {
+func detectTieredStorageOpenQuestions(section *TieredStorageSection, inputs PlanInputsResolved) []OpenQuestion {
 	if section == nil {
 		return nil
 	}
-	var oqs []types.OpenQuestion
+	var oqs []OpenQuestion
 	if !knownConsumerHistory(inputs.ConsumerHistoryRequirement) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "tiered_consumer_history_invalid",
 			Title:      "`consumer_history_requirement` is not a recognised value",
 			Body:       "Recognised values: `required` (default) | `not_required` | `unknown`. The current value falls outside the enum; the Plan treats it as `required` until corrected.",
@@ -137,7 +137,7 @@ func detectTieredStorageOpenQuestions(section *types.TieredStorageSection, input
 		})
 	}
 	if inputs.HistoricalDataStrategy != "" && !knownHistoricalStrategy(inputs.HistoricalDataStrategy) {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "tiered_historical_strategy_invalid",
 			Title:      "`historical_data_strategy` is not a recognised value",
 			Body:       "Recognised values: `keep_msk_running_until_data_expires` | `bulk_load_historical_via_external_tool` | `defer_to_account_team`. The current value falls outside the enum; the Plan ignores it and treats the strategy as undeclared.",
@@ -151,7 +151,7 @@ func detectTieredStorageOpenQuestions(section *types.TieredStorageSection, input
 	// stays quiet on that branch.
 	consumerHistory := defaultedConsumerHistory(inputs.ConsumerHistoryRequirement)
 	if section.HistoricalDataStrategy == "" && consumerHistory != ConsumerHistoryNotRequired {
-		oqs = append(oqs, types.OpenQuestion{
+		oqs = append(oqs, OpenQuestion{
 			ID:         "tiered_strategy_undeclared",
 			Title:      "Tiered storage detected — declare `historical_data_strategy` in `plan-inputs.yaml`",
 			Body:       "Cluster Linking does NOT carry historical tiered data forward. Pick the path that matches your operational constraints: keep MSK running until your retention window expires (lowest engineering cost, highest infra cost), bulk-load historical data via an external tool, or defer the cascade to your Confluent account team.",

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -51,9 +51,9 @@ func GeneratePlan(stateJSON, planInputsYAML []byte) (*PlanResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load plan-config: %w", err)
 	}
-	var pi *types.PlanInputs
+	var pi *plan.PlanInputs
 	if len(planInputsYAML) > 0 {
-		var parsed types.PlanInputs
+		var parsed plan.PlanInputs
 		if err := yaml.Unmarshal(planInputsYAML, &parsed); err != nil {
 			return nil, fmt.Errorf("parse plan-inputs: %w", err)
 		}


### PR DESCRIPTION
## Pass 2.3 of the `internal/types` reorg

Third Pass 2 sub-PR, after migration FSM (#326) and gateway (#325). Moves the
**plan domain** into its owning service: the `Plan` output schema (`plan.go`)
and `PlanInputs` (`plan_inputs.go`) are produced solely by
`internal/services/plan` — they are the `kcp report plan` output shape and its
YAML inputs, not source-of-truth state.

### Changes
- `git mv` `plan.go`, `plan_inputs.go`, `plan_test.go` from `internal/types` →
  `internal/services/plan/` (package `types` → `plan`; files otherwise
  unchanged — 99% renames).
- Stripped the `types.` qualifier from the ~40 moved type/const names across the
  `plan` package. Genuinely-shared symbols (`types.ProcessedCluster`,
  `types.Topics`, `types.SchemaRegistriesState`, etc.) are left untouched.
- `pkg/lib/lib.go` is the only external importer: `types.PlanInputs` →
  `plan.PlanInputs` (×2). It keeps its `internal/types` import (still uses
  `types.NewStateFromBytes`).

### Why it's safe
- **Pure relocation, no behaviour change.** The moved files are self-contained
  (`plan.go` imports only `time`; `plan_inputs.go` imports nothing).
- **Cycle-safe** (verified): `internal/types` never referenced these types, and
  `plan` does not import `kafka`.

### Verification
- `go build ./...` ✅
- `go test ./...` → **47 packages pass, 0 failures** ✅

### Pass 2 progress
- ✅ migration FSM → `internal/services/migration` (#326)
- ✅ gateway dead structs removed (#325)
- ✅ **plan schema + inputs → `internal/services/plan` (this PR)**
- ⬜ `terraform.go` → `internal/services/hcl`
- ⬜ `wizard_requests.go` → `cmd/ui/api`
- `schema_registry.go` stays in `internal/types` (validation override — reachable from root `State`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)