### PR TITLE
fix(security): write kcp state files with 0600 permissions

### DIFF
--- a/internal/services/migration/migration_state_test.go
+++ b/internal/services/migration/migration_state_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -268,4 +269,75 @@ func TestMigrationConfig_PauseConsumerOffsetSync_ForwardCompat(t *testing.T) {
 
 	assert.Contains(t, contents, `"pause_consumer_offset_sync"`, "field should be present in JSON even when false")
 	assert.Contains(t, contents, `"pause_consumer_offset_sync_flipped"`, "flipped field should be present in JSON even when false")
+}
+
+// skipIfWindows skips file-mode assertions on Windows, where POSIX permission
+// bits are not meaningfully enforced.
+func skipIfWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file-mode semantics do not apply on Windows")
+	}
+}
+
+// TestMigrationState_WriteToFile_NewFileHasOwnerOnlyPerms verifies the migration
+// state file is written 0600 (owner read/write only), since it holds sensitive
+// migration metadata. (R2)
+func TestMigrationState_WriteToFile_NewFileHasOwnerOnlyPerms(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
+	require.NoError(t, NewMigrationState().WriteToFile(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "migration state file should be 0600")
+}
+
+// TestMigrationState_WriteToFile_StaleLooseTempDoesNotLeak verifies a leftover
+// legacy fixed-name temp (<path>.tmp) at 0644 from a crashed run cannot cause
+// the final migration state file to be world/group readable. (R3 abuse case)
+func TestMigrationState_WriteToFile_StaleLooseTempDoesNotLeak(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
+	require.NoError(t, os.WriteFile(path+".tmp", []byte("{}"), 0644))
+
+	require.NoError(t, NewMigrationState().WriteToFile(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "stale 0644 temp must not leak into result")
+}
+
+// TestMigrationState_WriteToFile_SecondWritePreservesPerms verifies a rewrite of
+// an existing migration state file keeps mode 0600 rather than loosening it back
+// to 0644. (R4 regression guard)
+func TestMigrationState_WriteToFile_SecondWritePreservesPerms(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
+	for i := 0; i < 2; i++ {
+		require.NoError(t, NewMigrationState().WriteToFile(path))
+	}
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "perms should stay 0600 after second write")
+}
+
+// TestMigrationState_WriteToFile_TightensExistingLooseFile verifies an existing
+// migration state file at 0644 is tightened to 0600 on the next write. (R5
+// regression guard)
+func TestMigrationState_WriteToFile_TightensExistingLooseFile(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0644))
+
+	require.NoError(t, NewMigrationState().WriteToFile(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "existing 0644 file should be tightened to 0600")
 }

--- a/internal/services/migration/migration_state_test.go
+++ b/internal/services/migration/migration_state_test.go
@@ -76,10 +76,12 @@ func TestMigrationState_WriteToFile_AtomicWrite(t *testing.T) {
 	_, err := os.Stat(filePath)
 	require.NoError(t, err, "expected state file to exist")
 
-	// Verify no .tmp file remains after successful write
-	tmpFile := filePath + ".tmp"
-	_, err = os.Stat(tmpFile)
-	assert.True(t, os.IsNotExist(err), "expected .tmp file to not exist after successful write")
+	// Verify no temp file remains after successful write. The writer uses a
+	// uniquely-named temp (..migration-state.json.tmp-*), so match its glob
+	// rather than the legacy fixed name the code no longer creates.
+	matches, err := filepath.Glob(filepath.Join(dir, "."+filepath.Base(filePath)+".tmp-*"))
+	require.NoError(t, err)
+	assert.Empty(t, matches, "expected no temp file to remain after successful write")
 }
 
 func TestMigrationState_UpsertMigration_Insert(t *testing.T) {
@@ -294,20 +296,41 @@ func TestMigrationState_WriteToFile_NewFileHasOwnerOnlyPerms(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "migration state file should be 0600")
 }
 
-// TestMigrationState_WriteToFile_StaleLooseTempDoesNotLeak verifies a leftover
-// legacy fixed-name temp (<path>.tmp) at 0644 from a crashed run cannot cause
-// the final migration state file to be world/group readable. (R3 abuse case)
+// TestMigrationState_WriteToFile_StaleLooseTempDoesNotLeak guards against
+// regressing to the old fixed-name temp scheme, whose bug was that a leftover
+// <path>.tmp at 0644 from a crashed run kept its loose mode and the rename
+// carried it through. We seed that exact condition and assert (a) the final
+// migration state file is still 0600, (b) the stale fixed-name temp is left
+// untouched -- proving the writer created its own unique temp rather than reusing
+// the leftover one -- and (c) the writer's own unique temp is cleaned up on
+// success. (R3 abuse case)
 func TestMigrationState_WriteToFile_StaleLooseTempDoesNotLeak(t *testing.T) {
 	skipIfWindows(t)
 
-	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
-	require.NoError(t, os.WriteFile(path+".tmp", []byte("{}"), 0644))
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".kcp-migration-state.json")
+	// Simulate a crash leaving a fixed-name temp at loose perms -- the exact
+	// condition the old os.WriteFile(path+".tmp", ...) code mishandled.
+	stale := path + ".tmp"
+	require.NoError(t, os.WriteFile(stale, []byte("{}"), 0644))
 
 	require.NoError(t, NewMigrationState().WriteToFile(path))
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "stale 0644 temp must not leak into result")
+
+	// The writer must not reuse the stale fixed-name temp: it should still exist,
+	// untouched at 0644, proving a fresh unique temp was used instead.
+	staleInfo, err := os.Stat(stale)
+	require.NoError(t, err, "stale fixed-name temp should be left untouched")
+	assert.Equal(t, os.FileMode(0o644), staleInfo.Mode().Perm(), "writer must not reuse the fixed-name temp")
+
+	// The writer's own unique temp (..kcp-migration-state.json.tmp-*) must be
+	// cleaned up on success.
+	matches, err := filepath.Glob(filepath.Join(dir, "."+filepath.Base(path)+".tmp-*"))
+	require.NoError(t, err)
+	assert.Empty(t, matches, "unique temp file(s) left behind after success")
 }
 
 // TestMigrationState_WriteToFile_SecondWritePreservesPerms verifies a rewrite of

--- a/internal/services/migration/state.go
+++ b/internal/services/migration/state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/build_info"
@@ -120,14 +121,35 @@ func (ms *MigrationState) WriteToFile(filePath string) error {
 		return fmt.Errorf("failed to marshal migration state: %w", err)
 	}
 
-	// Atomic write: write to temp file first, then rename
-	tmpFile := filePath + ".tmp"
-	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+	// Atomic write: write to a uniquely-named temp file (created at mode 0600 by
+	// os.CreateTemp and pinned explicitly), then rename it onto the target. The
+	// migration state holds sensitive metadata, so it must never be group/world
+	// readable, even briefly or under an unusual umask. The real file is only
+	// ever replaced by the rename and is never deleted directly, so a crash
+	// before the rename leaves the previous migration state intact.
+	tmpFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+
+	if err := tmpFile.Chmod(0600); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to set temp file permissions: %w", err)
+	}
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
 
-	if err := os.Rename(tmpFile, filePath); err != nil {
-		_ = os.Remove(tmpFile) // best-effort cleanup of temp file on error
+	if err := os.Rename(tmpName, filePath); err != nil {
+		_ = os.Remove(tmpName) // best-effort cleanup of temp file on error
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 

--- a/internal/services/migration/state_umask_unix_test.go
+++ b/internal/services/migration/state_umask_unix_test.go
@@ -1,0 +1,31 @@
+//go:build unix
+
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrationState_WriteToFile_UmaskCannotLoosen verifies the file is written
+// exactly 0600 even under a permissive umask. It lives in a unix-only file
+// because syscall.Umask is not defined on Windows; on Windows the umask guard is
+// moot (POSIX permission bits are not enforced) and the rest of the permission
+// tests skip via skipIfWindows. umask is process-global, so this test must not
+// run in parallel. (umask regression guard)
+func TestMigrationState_WriteToFile_UmaskCannotLoosen(t *testing.T) {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	path := filepath.Join(t.TempDir(), ".kcp-migration-state.json")
+	require.NoError(t, NewMigrationState().WriteToFile(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "perms under umask 0 should be exactly 0600")
+}

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -115,15 +116,37 @@ func (s *State) WriteToFile(filePath string) error {
 		return fmt.Errorf("failed to marshal state: %v", err)
 	}
 
-	// Write to temporary file first for atomic operation
-	tmpFile := filePath + ".tmp"
-	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+	// Write to a uniquely-named temp file in the same directory, then atomically
+	// rename it onto the target. os.CreateTemp creates the file with mode 0600,
+	// and we pin it explicitly so the state file (which holds sensitive
+	// infrastructure metadata) is never group/world readable, even briefly and
+	// even under an unusual umask. The real file is only ever replaced by the
+	// rename and is never deleted directly, so a crash before the rename leaves
+	// the previous state file intact.
+	tmpFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+
+	if err := tmpFile.Chmod(0600); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to set temp file permissions: %w", err)
+	}
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 
 	// Atomic rename (on most filesystems)
-	if err := os.Rename(tmpFile, filePath); err != nil {
-		os.Remove(tmpFile) // Clean up temp file
+	if err := os.Rename(tmpName, filePath); err != nil {
+		_ = os.Remove(tmpName) // Clean up temp file
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -113,7 +113,7 @@ func NewStateFromBytes(data []byte) (*State, error) {
 func (s *State) WriteToFile(filePath string) error {
 	data, err := json.Marshal(s)
 	if err != nil {
-		return fmt.Errorf("failed to marshal state: %v", err)
+		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
 	// Write to a uniquely-named temp file in the same directory, then atomically

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1239,5 +1241,126 @@ func TestFormatQueryDuration(t *testing.T) {
 				t.Errorf("FormatQueryDuration(%v) = %q, want %q", tt.d, got, tt.expected)
 			}
 		})
+	}
+}
+
+// skipIfWindows skips file-mode assertions on Windows, where POSIX permission
+// bits are not meaningfully enforced.
+func skipIfWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file-mode semantics do not apply on Windows")
+	}
+}
+
+// TestWriteToFile_NewFileHasOwnerOnlyPerms verifies a freshly written state
+// file is created with mode 0600 (owner read/write only), not world/group
+// readable. (R1)
+func TestWriteToFile_NewFileHasOwnerOnlyPerms(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	if err := (&State{}).WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file perms = %#o, want 0600", got)
+	}
+}
+
+// TestWriteToFile_StaleLooseTempDoesNotLeak verifies that a leftover legacy
+// fixed-name temp file (<path>.tmp) at 0644 from a crashed run cannot cause the
+// final state file to be written world/group readable. (R3 abuse case)
+func TestWriteToFile_StaleLooseTempDoesNotLeak(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	// Simulate a crash leaving a fixed-name temp at loose perms.
+	if err := os.WriteFile(path+".tmp", []byte("{}"), 0644); err != nil {
+		t.Fatalf("seed stale temp: %v", err)
+	}
+
+	if err := (&State{}).WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file perms = %#o, want 0600 (stale 0644 temp leaked into result)", got)
+	}
+}
+
+// TestWriteToFile_SecondWritePreservesPerms verifies a rewrite of an existing
+// state file keeps mode 0600 rather than loosening it back to 0644 -- so the
+// hardening holds across every command that persists state, not just the first.
+// (R4 regression guard)
+func TestWriteToFile_SecondWritePreservesPerms(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	for i := 0; i < 2; i++ {
+		if err := (&State{}).WriteToFile(path); err != nil {
+			t.Fatalf("WriteToFile (write %d): %v", i+1, err)
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file perms after second write = %#o, want 0600", got)
+	}
+}
+
+// TestWriteToFile_TightensExistingLooseFile verifies that an existing state
+// file already at 0644 (e.g. created by an older kcp build) is tightened to
+// 0600 on the next write -- no separate migration step required. (R5 regression
+// guard)
+func TestWriteToFile_TightensExistingLooseFile(t *testing.T) {
+	skipIfWindows(t)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+		t.Fatalf("seed legacy 0644 state file: %v", err)
+	}
+
+	if err := (&State{}).WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file perms = %#o, want 0600 (existing 0644 file not tightened)", got)
+	}
+}
+
+// TestWriteToFile_RoundTripsContent verifies the permission change did not break
+// the write/load round trip -- content is still valid JSON and reloads via the
+// existing loader. (R6 regression guard)
+func TestWriteToFile_RoundTripsContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	want := "round-trip-test-1.2.3"
+	if err := (&State{KcpBuildInfo: KcpBuildInfo{Version: want}}).WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+
+	got, err := NewStateFromFile(path)
+	if err != nil {
+		t.Fatalf("NewStateFromFile: %v", err)
+	}
+	if got.KcpBuildInfo.Version != want {
+		t.Fatalf("reloaded version = %q, want %q", got.KcpBuildInfo.Version, want)
 	}
 }

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -1273,15 +1273,22 @@ func TestWriteToFile_NewFileHasOwnerOnlyPerms(t *testing.T) {
 	}
 }
 
-// TestWriteToFile_StaleLooseTempDoesNotLeak verifies that a leftover legacy
-// fixed-name temp file (<path>.tmp) at 0644 from a crashed run cannot cause the
-// final state file to be written world/group readable. (R3 abuse case)
+// TestWriteToFile_StaleLooseTempDoesNotLeak guards against regressing to the old
+// fixed-name temp scheme, whose bug was that a leftover <path>.tmp at 0644 from a
+// crashed run kept its loose mode and the rename carried it through. We seed that
+// exact condition and assert (a) the final state file is still 0600, (b) the
+// stale fixed-name temp is left untouched -- proving the writer created its own
+// unique temp rather than reusing the leftover one -- and (c) the writer's own
+// unique temp is cleaned up on success. (R3 abuse case)
 func TestWriteToFile_StaleLooseTempDoesNotLeak(t *testing.T) {
 	skipIfWindows(t)
 
-	path := filepath.Join(t.TempDir(), "kcp-state.json")
-	// Simulate a crash leaving a fixed-name temp at loose perms.
-	if err := os.WriteFile(path+".tmp", []byte("{}"), 0644); err != nil {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kcp-state.json")
+	// Simulate a crash leaving a fixed-name temp at loose perms -- the exact
+	// condition the old os.WriteFile(path+".tmp", ...) code mishandled.
+	stale := path + ".tmp"
+	if err := os.WriteFile(stale, []byte("{}"), 0644); err != nil {
 		t.Fatalf("seed stale temp: %v", err)
 	}
 
@@ -1295,6 +1302,25 @@ func TestWriteToFile_StaleLooseTempDoesNotLeak(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("state file perms = %#o, want 0600 (stale 0644 temp leaked into result)", got)
+	}
+
+	// The writer must not reuse the stale fixed-name temp: it should still exist,
+	// untouched at 0644, proving a fresh unique temp was used instead.
+	staleInfo, err := os.Stat(stale)
+	if err != nil {
+		t.Fatalf("stale fixed-name temp should be left untouched, but stat failed: %v", err)
+	}
+	if got := staleInfo.Mode().Perm(); got != 0o644 {
+		t.Fatalf("stale fixed-name temp perms = %#o, want 0644 untouched (writer must not reuse the fixed name)", got)
+	}
+
+	// The writer's own unique temp (.kcp-state.json.tmp-*) must be cleaned up on success.
+	matches, err := filepath.Glob(filepath.Join(dir, ".kcp-state.json.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob unique temp: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("unique temp file(s) left behind after success: %v", matches)
 	}
 }
 

--- a/internal/types/state_umask_unix_test.go
+++ b/internal/types/state_umask_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestWriteToFile_UmaskCannotLoosen verifies that even under a permissive umask
+// the state file is written exactly 0600 and never more permissive. It lives in
+// a unix-only file because syscall.Umask is not defined on Windows; on Windows
+// the umask guard is moot (POSIX permission bits are not enforced) and the rest
+// of the permission tests skip via skipIfWindows. umask is process-global, so
+// this test must not run in parallel. (umask regression guard)
+func TestWriteToFile_UmaskCannotLoosen(t *testing.T) {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	if err := (&State{}).WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file perms under umask 0 = %#o, want exactly 0600", got)
+	}
+}


### PR DESCRIPTION
## What & why

`kcp` wrote its state files — `kcp-state.json` and `.kcp-migration-state.json` — with mode **0644** (group/world-readable). These hold infrastructure-reconnaissance metadata: broker bootstrap endpoints, cluster topology, ACL principals/rules, topic and consumer-group names, metrics, and migration progress. On a shared host — notably the bastion hosts `kcp` itself provisions to reach private clusters — any other local account could read them.

The credentials YAMLs were already `0600`, so the state files were the odd ones out. This change writes both at **0600** (owner read/write only), closing unauthorized local reads of the infra map.

## How

Both writes funnel through two central choke points — `State.WriteToFile` (`internal/types/state.go`) and `MigrationState.WriteToFile` (`internal/services/migration/state.go`) — so every command that persists state (`discover`, `scan clusters` / `client-inventory` / `schema-registry`, `migration init` / `execute`) inherits the hardening with no call-site changes.

Each writer now:
1. creates the temp file via `os.CreateTemp` — a uniquely-named file created with `O_EXCL` at `0600`,
2. pins the mode with an explicit `Chmod(0600)`, then
3. atomically `os.Rename`s it onto the target.

Why not just flip the `0644` literal to `0600`? The old code wrote to a fixed-name `<path>.tmp`, and `os.WriteFile`'s mode only applies when it *creates* the file — so a stale temp from a crashed run would keep its old `0644` mode and the rename would carry that through. `os.CreateTemp` sidesteps this (fresh unique file at `0600`) and also eliminates the transient world-readable window a chmod-after-write would leave. The real state file is only ever swapped by the atomic rename and is never deleted directly, so a crash before the rename leaves the previous file intact.

## Impact / compatibility

- **Same user, no change:** `0600` keeps the owner's read/write; the atomic rename still works.
- **No migration needed:** an existing `0644` state file is tightened to `0600` on the next write.
- **Out of scope (intentional):** generated Terraform/HCL, report-command text, and docs stay `0644` — they are artifacts meant to be applied/shared, not secrets.

## Testing

Test-first (TDD). RED-verified the happy path (`0644 != 0600`) and the stale-temp abuse case (which forced the `os.CreateTemp` design). Coverage across `state_test.go`, `migration_state_test.go`, and the new `*_umask_unix_test.go` files:

- new file is `0600`
- a second write preserves `0600` (does not loosen back to `0644`)
- a stale `0644` temp does not leak into the result
- an existing `0644` file is tightened to `0600`
- umask cannot loosen the result below `0600`
- content still round-trips through the loader

Verification: full suite green (**46 ok, 0 fail**), `go vet` clean, `gofmt` clean, cross-platform build OK (darwin / linux / windows). On-disk behavior confirmed — a real `WriteToFile` produces `-rw-------`, and a second write keeps it `-rw-------`.

## Notes for reviewers

- The umask regression tests use `syscall.Umask` (unix-only) and live behind a `//go:build unix` constraint, so `go test` still compiles on Windows (kcp ships a `build-windows` target).
- Security review: no Critical/High/Medium findings — net improvement. One informational note: on a shared host where `--state-file` points at a world-writable directory, generic directory-level TOCTOU is a pre-existing environmental condition, neither introduced nor worsened here (posture strictly improves `0644` → `0600`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
