### PR TITLE
refactor(types): split processed.go — report shapes to internal/services/report (Pass 2.5)

### DIFF
--- a/cmd/report/costs/cost_reporter.go
+++ b/cmd/report/costs/cost_reporter.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/markdown"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
 type ReportService interface {
-	ProcessState(state types.State) types.ProcessedState
-	FilterRegionCosts(processedState types.ProcessedState, regionName string, startTime, endTime *time.Time) (*types.ProcessedRegionCosts, error)
+	ProcessState(state types.State) report.ProcessedState
+	FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error)
 }
 
 type CostReporterOpts struct {
@@ -48,7 +49,7 @@ func (r *CostReporter) Run() error {
 	fmt.Printf("🔍 Processing regions: %v (from %s to %s)\n", r.regions, r.startDate.Format("2006-01-02"), r.endDate.Format("2006-01-02"))
 
 	processedState := r.reportService.ProcessState(*r.state)
-	regionCostData := []types.ProcessedRegionCosts{}
+	regionCostData := []report.ProcessedRegionCosts{}
 
 	for _, region := range r.regions {
 		regionCosts, err := r.reportService.FilterRegionCosts(processedState, region, r.startDate, r.endDate)
@@ -68,7 +69,7 @@ func (r *CostReporter) Run() error {
 	return nil
 }
 
-func (r *CostReporter) generateReport(regionCostData []types.ProcessedRegionCosts) *markdown.Markdown {
+func (r *CostReporter) generateReport(regionCostData []report.ProcessedRegionCosts) *markdown.Markdown {
 	md := markdown.New()
 	// Add main report header
 	md.AddHeading("AWS Cost Report", 1)
@@ -119,7 +120,7 @@ func (r *CostReporter) generateReport(regionCostData []types.ProcessedRegionCost
 	return md
 }
 
-func (r *CostReporter) addRegionSection(md *markdown.Markdown, regionName string, regionCosts types.ProcessedRegionCosts) {
+func (r *CostReporter) addRegionSection(md *markdown.Markdown, regionName string, regionCosts report.ProcessedRegionCosts) {
 	md.AddHeading(fmt.Sprintf("Region: %s", regionName), 2)
 	md.AddParagraph(fmt.Sprintf("*Detailed cost breakdown for %s region*", regionName))
 	md.AddParagraph("")
@@ -136,7 +137,7 @@ func (r *CostReporter) addRegionSection(md *markdown.Markdown, regionName string
 	md.AddParagraph("")
 }
 
-func (r *CostReporter) addServiceAggregates(md *markdown.Markdown, serviceName string, aggregates types.ServiceCostAggregates) {
+func (r *CostReporter) addServiceAggregates(md *markdown.Markdown, serviceName string, aggregates report.ServiceCostAggregates) {
 	md.AddHeading(fmt.Sprintf("▪ %s", serviceName), 3)
 
 	// Check if this service has any cost data
@@ -152,7 +153,7 @@ func (r *CostReporter) addServiceAggregates(md *markdown.Markdown, serviceName s
 	md.AddParagraph("")
 }
 
-func (r *CostReporter) addServiceCostTable(md *markdown.Markdown, aggregates types.ServiceCostAggregates) {
+func (r *CostReporter) addServiceCostTable(md *markdown.Markdown, aggregates report.ServiceCostAggregates) {
 	// Collect all unique usage types across all cost types
 	usageTypes := make(map[string]bool)
 
@@ -196,7 +197,7 @@ func (r *CostReporter) addServiceCostTable(md *markdown.Markdown, aggregates typ
 
 		for _, costMap := range costTypes {
 			if aggregateData, exists := costMap[usageType]; exists {
-				if costAggregate, ok := aggregateData.(types.CostAggregate); ok {
+				if costAggregate, ok := aggregateData.(report.CostAggregate); ok {
 					value := 0.0
 					if costAggregate.Sum != nil {
 						value = *costAggregate.Sum
@@ -244,7 +245,7 @@ func (r *CostReporter) addServiceCostTable(md *markdown.Markdown, aggregates typ
 	}
 }
 
-func (r *CostReporter) hasServiceData(aggregates types.ServiceCostAggregates) bool {
+func (r *CostReporter) hasServiceData(aggregates report.ServiceCostAggregates) bool {
 	return len(aggregates.UnblendedCost) > 0 ||
 		len(aggregates.BlendedCost) > 0 ||
 		len(aggregates.AmortizedCost) > 0 ||
@@ -252,7 +253,7 @@ func (r *CostReporter) hasServiceData(aggregates types.ServiceCostAggregates) bo
 		len(aggregates.NetUnblendedCost) > 0
 }
 
-func (r *CostReporter) addCostSummary(md *markdown.Markdown, regionCostData []types.ProcessedRegionCosts) {
+func (r *CostReporter) addCostSummary(md *markdown.Markdown, regionCostData []report.ProcessedRegionCosts) {
 	md.AddHeading("Cost Summary", 2)
 	md.AddParagraph("*Overview of total costs across all regions and cost types*")
 	md.AddParagraph("")
@@ -288,11 +289,11 @@ func (r *CostReporter) addCostSummary(md *markdown.Markdown, regionCostData []ty
 	md.AddParagraph("")
 }
 
-func (r *CostReporter) calculateRegionTotalsAllTypes(regionData types.ProcessedRegionCosts) []float64 {
+func (r *CostReporter) calculateRegionTotalsAllTypes(regionData report.ProcessedRegionCosts) []float64 {
 	// Return totals for: Unblended, Blended, Amortized, Net Amortized, Net Unblended
 	totals := make([]float64, 5)
 
-	services := []types.ServiceCostAggregates{
+	services := []report.ServiceCostAggregates{
 		regionData.Aggregates.AmazonManagedStreamingForApacheKafka,
 		regionData.Aggregates.ElasticLoadBalancing,
 		regionData.Aggregates.AmazonVPC,
@@ -311,7 +312,7 @@ func (r *CostReporter) calculateRegionTotalsAllTypes(regionData types.ProcessedR
 
 		for i, costMap := range costMaps {
 			for _, aggregateData := range costMap {
-				if costAggregate, ok := aggregateData.(types.CostAggregate); ok {
+				if costAggregate, ok := aggregateData.(report.CostAggregate); ok {
 					if costAggregate.Sum != nil {
 						totals[i] += *costAggregate.Sum
 					}
@@ -323,7 +324,7 @@ func (r *CostReporter) calculateRegionTotalsAllTypes(regionData types.ProcessedR
 	return totals
 }
 
-func (r *CostReporter) addQueryDetails(md *markdown.Markdown, regionCostData []types.ProcessedRegionCosts) {
+func (r *CostReporter) addQueryDetails(md *markdown.Markdown, regionCostData []report.ProcessedRegionCosts) {
 	// Return early if no region data
 	if len(regionCostData) == 0 {
 		return

--- a/cmd/report/metrics/metric_reporter.go
+++ b/cmd/report/metrics/metric_reporter.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/markdown"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 )
 
 type ReportService interface {
-	ProcessState(state types.State) types.ProcessedState
-	FilterClusterMetrics(processedState types.ProcessedState, clusterArn string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
+	ProcessState(state types.State) report.ProcessedState
+	FilterClusterMetrics(processedState report.ProcessedState, clusterArn string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
 }
 
 type MetricReporterOpts struct {

--- a/cmd/report/metrics/metric_reporter_test.go
+++ b/cmd/report/metrics/metric_reporter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,12 +16,12 @@ type MockReportService struct {
 	mock.Mock
 }
 
-func (m *MockReportService) ProcessState(state types.State) types.ProcessedState {
+func (m *MockReportService) ProcessState(state types.State) report.ProcessedState {
 	args := m.Called(state)
-	return args.Get(0).(types.ProcessedState)
+	return args.Get(0).(report.ProcessedState)
 }
 
-func (m *MockReportService) FilterClusterMetrics(processedState types.ProcessedState, clusterArn string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (m *MockReportService) FilterClusterMetrics(processedState report.ProcessedState, clusterArn string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	args := m.Called(processedState, clusterArn, sourceType, startTime, endTime)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -13,16 +13,17 @@ import (
 	"github.com/confluentinc/kcp/cmd/ui/frontend"
 	"github.com/confluentinc/kcp/internal/services/hcl"
 	"github.com/confluentinc/kcp/internal/services/hcl/hcltypes"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/fatih/color"
 	"github.com/labstack/echo/v4"
 )
 
 type ReportService interface {
-	ProcessState(state types.State) types.ProcessedState
-	FilterRegionCosts(processedState types.ProcessedState, regionName string, startTime, endTime *time.Time) (*types.ProcessedRegionCosts, error)
-	FilterMetrics(processedState types.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
-	FilterClusterMetrics(processedState types.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
+	ProcessState(state types.State) report.ProcessedState
+	FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error)
+	FilterMetrics(processedState report.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
+	FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
 }
 
 type UICmdOpts struct {

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/labstack/echo/v4"
 )
@@ -17,19 +18,19 @@ import (
 // mockReportService satisfies the ReportService interface for testing
 type mockReportService struct{}
 
-func (m *mockReportService) ProcessState(state types.State) types.ProcessedState {
-	return types.ProcessedState{}
+func (m *mockReportService) ProcessState(state types.State) report.ProcessedState {
+	return report.ProcessedState{}
 }
 
-func (m *mockReportService) FilterRegionCosts(processedState types.ProcessedState, regionName string, startTime, endTime *time.Time) (*types.ProcessedRegionCosts, error) {
+func (m *mockReportService) FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error) {
 	return nil, nil
 }
 
-func (m *mockReportService) FilterMetrics(processedState types.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (m *mockReportService) FilterMetrics(processedState report.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	return nil, nil
 }
 
-func (m *mockReportService) FilterClusterMetrics(processedState types.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (m *mockReportService) FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	return nil, nil
 }
 

--- a/internal/services/plan/auth.go
+++ b/internal/services/plan/auth.go
@@ -1,8 +1,6 @@
 package plan
 
-import (
-	"github.com/confluentinc/kcp/internal/types"
-)
+import "github.com/confluentinc/kcp/internal/services/report"
 
 // Target auth method tokens. Customer-facing values written into
 // `plan-inputs.yaml` and rendered back in the AuthDecision JSON.
@@ -30,7 +28,7 @@ func knownTargetAuthMethod(t string) bool {
 // target across all source rows for that cluster — the renderer
 // surfaces the source/target pair and a `Note` so the customer can
 // see the trade-off.
-func decideAuth(c types.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) AuthDecision {
+func decideAuth(c report.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) AuthDecision {
 	sources := sourceAuthsDetected(c)
 	out := AuthDecision{
 		ClusterID:   c.Name,

--- a/internal/services/plan/auth_test.go
+++ b/internal/services/plan/auth_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +17,7 @@ func authInputs() PlanInputsResolved {
 }
 
 func TestDecideAuth_NoSourceAuthsDetected(t *testing.T) {
-	c := types.ProcessedCluster{Name: "blank"}
+	c := report.ProcessedCluster{Name: "blank"}
 	d := decideAuth(c, defaultCfg(t), authInputs())
 	assert.Equal(t, "blank", d.ClusterID)
 	assert.Empty(t, d.SourceAuths, "no auth flags enabled → empty SourceAuths")
@@ -117,7 +117,7 @@ func TestDecideAuth_ServerlessIAM(t *testing.T) {
 // Serverless cluster with no Serverless.ClientAuthentication block.
 // DecideAuth must return empty SourceAuths without panicking.
 func TestDecideAuth_ServerlessNoAuth(t *testing.T) {
-	c := types.ProcessedCluster{Name: "srv-noauth"}
+	c := report.ProcessedCluster{Name: "srv-noauth"}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
 		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}, SecurityGroupIds: []string{"g"}}},

--- a/internal/services/plan/cluster_signals.go
+++ b/internal/services/plan/cluster_signals.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
@@ -29,7 +30,7 @@ func targetCloud(inputs PlanInputsResolved) string {
 // clusters don't have broker nodes and don't expose ACLs through the
 // admin API path used by `kcp scan clusters`, so several "looks like an
 // incomplete scan" signals are actually expected emptiness.
-func isServerless(c types.ProcessedCluster) bool {
+func isServerless(c report.ProcessedCluster) bool {
 	return c.AWSClientInformation.MskClusterConfig.ClusterType == kafkatypes.ClusterTypeServerless
 }
 
@@ -48,7 +49,7 @@ func isServerless(c types.ProcessedCluster) bool {
 // `--skip-acls`, which would recommend Enterprise when Dedicated may
 // actually be required. Serverless clusters don't expose ACLs via this
 // API and are excluded.
-func aclScanRan(c types.ProcessedCluster) bool {
+func aclScanRan(c report.ProcessedCluster) bool {
 	if isServerless(c) {
 		return false
 	}
@@ -61,7 +62,7 @@ func aclScanRan(c types.ProcessedCluster) bool {
 // not a gap; the gap is "MSK PROVISIONED cluster with no Nodes
 // populated" — that's almost certainly a missing or incomplete discover
 // run.
-func brokerInventoryGap(c types.ProcessedCluster) bool {
+func brokerInventoryGap(c report.ProcessedCluster) bool {
 	if isServerless(c) {
 		return false
 	}
@@ -80,7 +81,7 @@ func brokerInventoryGap(c types.ProcessedCluster) bool {
 // that iterate clusters MUST also guard with `isServerless` if they
 // want to skip Serverless explicitly (recommended: silent fall-through
 // is fragile if helper semantics change later).
-func clusterStorageMode(c types.ProcessedCluster) kafkatypes.StorageMode {
+func clusterStorageMode(c report.ProcessedCluster) kafkatypes.StorageMode {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil {
 		return ""
@@ -144,7 +145,7 @@ const (
 //
 // Multiple auths can be enabled simultaneously; the plan renders all
 // detected source auths and never picks one when more than one is on.
-func sourceAuthsDetected(c types.ProcessedCluster) []string {
+func sourceAuthsDetected(c report.ProcessedCluster) []string {
 	if isServerless(c) {
 		return serverlessSourceAuths(c)
 	}
@@ -193,7 +194,7 @@ func authFromSaslMechanism(mech string) string {
 	}
 }
 
-func serverlessSourceAuths(c types.ProcessedCluster) []string {
+func serverlessSourceAuths(c report.ProcessedCluster) []string {
 	srv := c.AWSClientInformation.MskClusterConfig.Serverless
 	if srv == nil || srv.ClientAuthentication == nil || srv.ClientAuthentication.Sasl == nil {
 		return nil
@@ -208,7 +209,7 @@ func serverlessSourceAuths(c types.ProcessedCluster) []string {
 // IAM enabled on the source side. Drives gateway eligibility —
 // IAM clients cannot connect to the CC Gateway and must pre-migrate
 // to SCRAM or mTLS first.
-func fleetUsesIAM(clusters []types.ProcessedCluster) bool {
+func fleetUsesIAM(clusters []report.ProcessedCluster) bool {
 	for _, c := range clusters {
 		for _, auth := range sourceAuthsDetected(c) {
 			if auth == SourceAuthIAM {
@@ -231,7 +232,7 @@ func fleetUsesIAM(clusters []types.ProcessedCluster) bool {
 // inlines directly rather than going through aclScanRan (which
 // returns false for serverless AND for nil-on-provisioned, an
 // ambiguity the caller would have to re-disambiguate).
-func inputsMissing(c types.ProcessedCluster) []string {
+func inputsMissing(c report.ProcessedCluster) []string {
 	var missing []string
 	// MskClusterConfig.Provisioned shape gap — affects every
 	// Provisioned-only helper (kafkaVersionOf, brokerInstanceType,
@@ -259,7 +260,7 @@ func inputsMissing(c types.ProcessedCluster) []string {
 // `Provisioned` block entirely. Both cases mean the Provisioned-only
 // helpers will return empty/false silently. Callers should treat this
 // as an inputs-missing gap and surface a cluster-type OQ.
-func hasUnknownClusterType(c types.ProcessedCluster) bool {
+func hasUnknownClusterType(c report.ProcessedCluster) bool {
 	ct := c.AWSClientInformation.MskClusterConfig.ClusterType
 	if ct == kafkatypes.ClusterTypeServerless {
 		return false

--- a/internal/services/plan/cluster_type.go
+++ b/internal/services/plan/cluster_type.go
@@ -3,7 +3,7 @@ package plan
 import (
 	"fmt"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // hardLimit is one row of the Enterprise → Dedicated escalation catalog.
@@ -15,7 +15,7 @@ type hardLimit struct {
 	id               string
 	description      string
 	customerDeclared bool
-	check            func(cfg *PlanConfig, inputs PlanInputsResolved, cluster types.ProcessedCluster, sizing ClusterSizing) ruleResult
+	check            func(cfg *PlanConfig, inputs PlanInputsResolved, cluster report.ProcessedCluster, sizing ClusterSizing) ruleResult
 }
 
 // ruleResult is one rule's evaluation outcome. Either:
@@ -60,7 +60,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleECKUExceedsPNICap,
 		description: "Sized eCKU exceeds Enterprise PNI cap",
-		check: func(cfg *PlanConfig, _ PlanInputsResolved, _ types.ProcessedCluster, sizing ClusterSizing) ruleResult {
+		check: func(cfg *PlanConfig, _ PlanInputsResolved, _ report.ProcessedCluster, sizing ClusterSizing) ruleResult {
 			pniCap := cfg.EnterpriseCaps.PNIMaxECKU
 			if sizing.FinalECKU > pniCap {
 				return fired(fmt.Sprintf("sized %d eCKU > PNI cap %d eCKU", sizing.FinalECKU, pniCap))
@@ -71,7 +71,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleACLCountExceedsCap,
 		description: "ACL count exceeds Enterprise cap",
-		check: func(cfg *PlanConfig, _ PlanInputsResolved, cluster types.ProcessedCluster, _ ClusterSizing) ruleResult {
+		check: func(cfg *PlanConfig, _ PlanInputsResolved, cluster report.ProcessedCluster, _ ClusterSizing) ruleResult {
 			aclCap := cfg.EnterpriseCaps.ACLCountCap
 			if aclCap <= 0 {
 				return skipped("acl_count_cap not configured")
@@ -93,7 +93,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleBrokerSideSchemaValidation,
 		description:      "Broker-side schema ID validation required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ report.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.EnforceSchemasAtTheBroker {
 				return fired("`enforce_schemas_at_the_broker: true`")
 			}
@@ -104,7 +104,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleRESTProduceHighThroughput,
 		description:      "High-throughput Kafka REST Produce v3 required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ report.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.RequiresHighThroughputRESTProduceAPI {
 				return fired("`requires_high_throughput_rest_produce_api: true`")
 			}
@@ -115,7 +115,7 @@ var hardLimitCatalog = []hardLimit{
 		id:               ruleSLA9995SingleZone,
 		description:      "99.95% single-zone SLA required",
 		customerDeclared: true,
-		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ types.ProcessedCluster, _ ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, _ report.ProcessedCluster, _ ClusterSizing) ruleResult {
 			if inputs.Requires9995SLAWithinSingleZone {
 				return fired("`requires_99_95_sla_within_a_single_zone: true`")
 			}
@@ -125,7 +125,7 @@ var hardLimitCatalog = []hardLimit{
 	{
 		id:          ruleMTLSOnNonAWSTarget,
 		description: "Source uses mTLS, target is non-AWS",
-		check: func(_ *PlanConfig, inputs PlanInputsResolved, cluster types.ProcessedCluster, _ ClusterSizing) ruleResult {
+		check: func(_ *PlanConfig, inputs PlanInputsResolved, cluster report.ProcessedCluster, _ ClusterSizing) ruleResult {
 			usesMTLS := sourceUsesMTLS(cluster)
 			target := targetCloud(inputs)
 			// Punctuation kept identical across branches so the rendered
@@ -149,7 +149,7 @@ var hardLimitCatalog = []hardLimit{
 // Serverless clusters always return false — AWS MSK Serverless supports
 // only IAM SASL (no mTLS); its ClientAuthentication block lives on the
 // `Serverless` struct (not `Provisioned`) and has no TLS field.
-func sourceUsesMTLS(c types.ProcessedCluster) bool {
+func sourceUsesMTLS(c report.ProcessedCluster) bool {
 	if isServerless(c) {
 		return false
 	}
@@ -169,7 +169,7 @@ func sourceUsesMTLS(c types.ProcessedCluster) bool {
 // that Standard doesn't offer. Enterprise is the default; hard-limit
 // rules escalate to Dedicated when a cap is exceeded or a workload
 // constraint can't be served on Enterprise.
-func decideClusterType(c types.ProcessedCluster, sizing ClusterSizing, cfg *PlanConfig, inputs PlanInputsResolved) ClusterTypeDecision {
+func decideClusterType(c report.ProcessedCluster, sizing ClusterSizing, cfg *PlanConfig, inputs PlanInputsResolved) ClusterTypeDecision {
 	var firedTriggers []HardLimitTrigger
 	evaluated := make([]RuleEvaluation, 0, len(hardLimitCatalog))
 	for _, hl := range hardLimitCatalog {

--- a/internal/services/plan/cluster_type_test.go
+++ b/internal/services/plan/cluster_type_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 func TestDecideClusterType_DefaultEnterprise(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 5}
-	d := decideClusterType(types.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
+	d := decideClusterType(report.ProcessedCluster{Name: "x"}, sizing, cfg, defaultInputs())
 	assert.Equal(t, ClusterTypeEnterprise, d.Verdict)
 	assert.Empty(t, d.Triggers)
 }
@@ -21,7 +22,7 @@ func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 	cfg := defaultCfg(t)
 	// pni_max_eCKU = 32; size at 33 to fire the rule.
 	sizing := ClusterSizing{ClusterID: "huge", FinalECKU: 33}
-	d := decideClusterType(types.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
+	d := decideClusterType(report.ProcessedCluster{Name: "huge"}, sizing, cfg, defaultInputs())
 	assert.Equal(t, ClusterTypeDedicated, d.Verdict)
 	assert.Len(t, d.Triggers, 1)
 	assert.Equal(t, "eCKU_exceeds_pni_cap", d.Triggers[0].RowID)
@@ -39,8 +40,8 @@ func TestDecideClusterType_DedicatedWhenSizedOverPNICap(t *testing.T) {
 // model "scan didn't run / --skip-acls" and `[]Acls{}` to model
 // "successful scan with 0 ACLs"). Pass non-empty Acls to exercise rules
 // that need real ACL counts.
-func provisionedClusterWithScan(name string, acls []types.Acls) types.ProcessedCluster {
-	c := types.ProcessedCluster{Name: name}
+func provisionedClusterWithScan(name string, acls []types.Acls) report.ProcessedCluster {
+	c := report.ProcessedCluster{Name: name}
 	c.KafkaAdminClientInformation.Acls = acls
 	c.KafkaAdminClientInformation.Topics = &types.Topics{}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
@@ -93,7 +94,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 	})
 
 	t.Run("SERVERLESS cluster — rule skipped regardless of ACL slice", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "serverless"}
+		c := report.ProcessedCluster{Name: "serverless"}
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		d := decideClusterType(c, sizing, cfg, defaultInputs())
@@ -104,7 +105,7 @@ func TestDecideClusterType_ACLRuleNilVsEmpty(t *testing.T) {
 func TestDecideClusterType_CustomerDeclaredFlags(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := ClusterSizing{ClusterID: "small", FinalECKU: 5}
-	c := types.ProcessedCluster{Name: "small"}
+	c := report.ProcessedCluster{Name: "small"}
 
 	cases := []struct {
 		name        string
@@ -150,7 +151,7 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := ClusterSizing{ClusterID: "mtls", FinalECKU: 5}
 	enabled := true
-	c := types.ProcessedCluster{Name: "mtls"}
+	c := report.ProcessedCluster{Name: "mtls"}
 	c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{
 		ClientAuthentication: &kafkatypes.ClientAuthentication{
 			Tls: &kafkatypes.Tls{Enabled: &enabled},
@@ -175,7 +176,7 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 	})
 
 	t.Run("no mTLS source — rule skipped regardless of target", func(t *testing.T) {
-		c2 := types.ProcessedCluster{Name: "scram"}
+		c2 := report.ProcessedCluster{Name: "scram"}
 		in := defaultInputs()
 		in.TargetCloud = "gcp"
 		d := decideClusterType(c2, sizing, cfg, in)
@@ -186,7 +187,7 @@ func TestDecideClusterType_MTLSOnNonAWSTarget(t *testing.T) {
 func TestDecideClusterType_Topology(t *testing.T) {
 	cfg := defaultCfg(t)
 	sizing := ClusterSizing{ClusterID: "x", FinalECKU: 4}
-	c := types.ProcessedCluster{Name: "x"}
+	c := report.ProcessedCluster{Name: "x"}
 
 	t.Run("Enterprise verdict has no topology", func(t *testing.T) {
 		d := decideClusterType(c, sizing, cfg, defaultInputs())

--- a/internal/services/plan/cost_reconciliation.go
+++ b/internal/services/plan/cost_reconciliation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // mskUsageTypeRegex compiles a usage-string regex from the
@@ -54,7 +54,7 @@ func mskUsageTypeRegex(cfg *PlanConfig) *regexp.Regexp {
 // desc; no materiality threshold (the customer decides what's
 // "real"). Returns nil when there are no candidates or no MSK source
 // data — the renderer omits the section in that case.
-func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *CostReconciliationSection {
+func detectCostReconciliation(state report.ProcessedState, cfg *PlanConfig) *CostReconciliationSection {
 	re := mskUsageTypeRegex(cfg)
 	var candidates []HiddenClusterCandidate
 	for _, src := range state.Sources {
@@ -108,7 +108,7 @@ func detectCostReconciliation(state types.ProcessedState, cfg *PlanConfig) *Cost
 // line as a "hidden cluster".
 const serverlessInventoryType = "kafka.Serverless-Hours"
 
-func inventoryInstanceTypes(region types.ProcessedRegion) map[string]struct{} {
+func inventoryInstanceTypes(region report.ProcessedRegion) map[string]struct{} {
 	out := map[string]struct{}{}
 	for _, c := range region.Clusters {
 		if isServerless(c) {
@@ -136,7 +136,7 @@ type costAgg struct {
 	daysObserved   int
 }
 
-func aggregateCostByInstanceType(costs types.ProcessedRegionCosts, re *regexp.Regexp) map[string]*costAgg {
+func aggregateCostByInstanceType(costs report.ProcessedRegionCosts, re *regexp.Regexp) map[string]*costAgg {
 	out := map[string]*costAgg{}
 	for _, r := range costs.Results {
 		instType := parseMSKInstanceType(r.UsageType, re)
@@ -194,7 +194,7 @@ func parseMSKInstanceType(usageType string, re *regexp.Regexp) string {
 // data is empty across all regions — the diff isn't actionable
 // without cost data. Returns nil when at least one region has cost
 // data (even if the diff was clean).
-func detectCostReconciliationOpenQuestions(state types.ProcessedState) []OpenQuestion {
+func detectCostReconciliationOpenQuestions(state report.ProcessedState) []OpenQuestion {
 	hasCost := false
 	for _, src := range state.Sources {
 		if src.MSKData == nil {
@@ -227,7 +227,7 @@ func detectCostReconciliationOpenQuestions(state types.ProcessedState) []OpenQue
 	}}
 }
 
-func hasAnyMSKRegion(state types.ProcessedState) bool {
+func hasAnyMSKRegion(state report.ProcessedState) bool {
 	for _, src := range state.Sources {
 		if src.MSKData != nil && len(src.MSKData.Regions) > 0 {
 			return true

--- a/internal/services/plan/cost_reconciliation_test.go
+++ b/internal/services/plan/cost_reconciliation_test.go
@@ -3,7 +3,7 @@ package plan
 import (
 	"testing"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,11 +36,11 @@ func TestDetectCostReconciliation_DiffSurfacesHiddenType(t *testing.T) {
 	discovered := redFlagCluster("discovered-cluster", "3.5.0", "kafka.m5.large", "")
 	state := wrapClusters(discovered)
 	// Inject cost data: m5.large (present in inventory) + m7g.large (NOT in inventory)
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.50}},
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.75}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 100.50}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 250.75}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))
@@ -53,12 +53,12 @@ func TestDetectCostReconciliation_DiffSurfacesHiddenType(t *testing.T) {
 // Candidates are sorted by TotalSpend descending.
 func TestDetectCostReconciliation_SortedByTotalSpendDesc(t *testing.T) {
 	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.0}},
-			{Start: "2026-04-01", UsageType: "USE1-Express.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.0}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m5.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 500.0}},
+			{Start: "2026-04-01", UsageType: "USE1-Express.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 250.0}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))
@@ -83,11 +83,11 @@ func TestDetectCostReconciliation_EmptyCostDataEmitsOQ(t *testing.T) {
 // Non-broker usage strings (data transfer, EBS, etc.) are ignored.
 func TestDetectCostReconciliation_NonBrokerRowsIgnored(t *testing.T) {
 	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.0}},
-			{Start: "2026-04-01", UsageType: "USE1-EBS:VolumeUsage.gp3", Values: types.ProcessedCostBreakdown{UnblendedCost: 200.0}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: report.ProcessedCostBreakdown{UnblendedCost: 500.0}},
+			{Start: "2026-04-01", UsageType: "USE1-EBS:VolumeUsage.gp3", Values: report.ProcessedCostBreakdown{UnblendedCost: 200.0}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))
@@ -97,12 +97,12 @@ func TestDetectCostReconciliation_NonBrokerRowsIgnored(t *testing.T) {
 // Months / days observed roll up across distinct timestamps.
 func TestDetectCostReconciliation_ObservationCounts(t *testing.T) {
 	state := wrapClusters(redFlagCluster("only-known", "3.5.0", "kafka.t3.small", ""))
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
-			{Start: "2026-04-02", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
-			{Start: "2026-05-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-04-02", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 100.0}},
+			{Start: "2026-05-01", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 100.0}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))
@@ -123,11 +123,11 @@ func TestDetectCostReconciliation_ServerlessInventoryMatchesCostShape(t *testing
 	state := wrapClusters(srv)
 	// Inject cost data: the Serverless-Hours line should match the
 	// inventory; the m7g.large line should still flag as hidden.
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.Serverless-Hours", Values: types.ProcessedCostBreakdown{UnblendedCost: 500.00}},
-			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: types.ProcessedCostBreakdown{UnblendedCost: 250.00}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.Serverless-Hours", Values: report.ProcessedCostBreakdown{UnblendedCost: 500.00}},
+			{Start: "2026-04-01", UsageType: "USE1-Kafka.m7g.large", Values: report.ProcessedCostBreakdown{UnblendedCost: 250.00}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))

--- a/internal/services/plan/cutover.go
+++ b/internal/services/plan/cutover.go
@@ -1,8 +1,6 @@
 package plan
 
-import (
-	"github.com/confluentinc/kcp/internal/types"
-)
+import "github.com/confluentinc/kcp/internal/services/report"
 
 // downtime_tolerance enum values. Stable identifiers — used as YAML
 // input tokens AND as keys in the style mapping.
@@ -40,7 +38,7 @@ const (
 // distinct from "the customer set `prefer_gateway: false`" but
 // indistinguishable at this layer. Callers from tests should construct
 // inputs via the resolver, not by struct literal.
-func decideCutover(clusters []types.ProcessedCluster, inputs PlanInputsResolved) CutoverDecision {
+func decideCutover(clusters []report.ProcessedCluster, inputs PlanInputsResolved) CutoverDecision {
 	style, sub := resolveStyle(inputs)
 
 	// Blue/Green sidesteps the gateway question entirely — the gateway

--- a/internal/services/plan/cutover_test.go
+++ b/internal/services/plan/cutover_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,11 +107,11 @@ func TestDecideCutover_IAMPrereqOnlyMattersWhenIAMInFleet(t *testing.T) {
 	inputs.IAMPreMigrationStatus = PrereqNotStarted
 
 	// Without IAM in the fleet, still eligible / canonical.
-	d := decideCutover([]types.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
+	d := decideCutover([]report.ProcessedCluster{withSourceAuth("nofleetiam", SourceAuthSCRAM)}, inputs)
 	assert.Equal(t, RecommendationCanonical, d.RecommendationStatus, "no IAM in fleet → IAM prereq irrelevant")
 
 	// With IAM in the fleet, the IAM-not-started prereq now blocks eligibility.
-	d = decideCutover([]types.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
+	d = decideCutover([]report.ProcessedCluster{withSourceAuth("fleetiam", SourceAuthIAM)}, inputs)
 	assert.Equal(t, RecommendationDegradedPrereqsPending, d.RecommendationStatus, "IAM in fleet → IAM prereq required")
 }
 
@@ -128,12 +128,12 @@ func TestDecideCutover_AlternativesShown(t *testing.T) {
 func TestDecideCutover_IAMPrereqRowOnlyWhenIAMInFleet(t *testing.T) {
 	inputs := styleInputs(DowntimeMinutesPerService)
 
-	noIAM := decideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthSCRAM)}, inputs)
+	noIAM := decideCutover([]report.ProcessedCluster{withSourceAuth("c", SourceAuthSCRAM)}, inputs)
 	for _, p := range noIAM.Prereqs {
 		assert.False(t, strings.Contains(p.Description, "IAM"), "IAM prereq must NOT appear when fleet has no IAM")
 	}
 
-	iam := decideCutover([]types.ProcessedCluster{withSourceAuth("c", SourceAuthIAM)}, inputs)
+	iam := decideCutover([]report.ProcessedCluster{withSourceAuth("c", SourceAuthIAM)}, inputs)
 	var sawIAM bool
 	for _, p := range iam.Prereqs {
 		if strings.Contains(p.Description, "IAM") {
@@ -146,8 +146,8 @@ func TestDecideCutover_IAMPrereqRowOnlyWhenIAMInFleet(t *testing.T) {
 // withSourceAuth returns a minimal ProcessedCluster with the named
 // source auth enabled on the AWS-side ClientAuthentication. Used to
 // drive fleetUsesIAM() through decideCutover.
-func withSourceAuth(name, auth string) types.ProcessedCluster {
-	c := types.ProcessedCluster{Name: name}
+func withSourceAuth(name, auth string) report.ProcessedCluster {
+	c := report.ProcessedCluster{Name: name}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 	enabled := true
 	clientAuth := &kafkatypes.ClientAuthentication{}
@@ -272,7 +272,7 @@ func TestComputeCutoverOverrides_PerClusterDifference(t *testing.T) {
 			"c": {},                          // no cutover override → no entry
 		},
 	}
-	clusters := []types.ProcessedCluster{
+	clusters := []report.ProcessedCluster{
 		{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}, // d has no entry in Clusters map
 	}
 	out := computeCutoverOverrides(clusters, fleet, inputs)
@@ -303,7 +303,7 @@ func TestDetectClusterCutoverOpenQuestions_TypoPerCluster(t *testing.T) {
 			},
 		},
 	}
-	oqs := detectClusterCutoverOpenQuestions([]types.ProcessedCluster{{Name: "a"}}, inputs)
+	oqs := detectClusterCutoverOpenQuestions([]report.ProcessedCluster{{Name: "a"}}, inputs)
 	require := 1
 	assert.Len(t, oqs, require)
 	assert.Equal(t, "downtime_tolerance_unknown", oqs[0].ID)
@@ -334,8 +334,8 @@ func TestPerCluster_AuthAndCutoverOverridesCoexistOnSameCluster(t *testing.T) {
 	assert.Equal(t, DowntimeZero, resolved.DowntimeTolerance, "per-cluster downtime_tolerance must layer on top of fleet inputs")
 	assert.Equal(t, "oauth", resolved.TargetAuthMethod, "per-cluster target_auth_method must layer on top of fleet inputs")
 
-	fleet := decideCutover([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, base)
-	overrides := computeCutoverOverrides([]types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, fleet, base)
+	fleet := decideCutover([]report.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, base)
+	overrides := computeCutoverOverrides([]report.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}, fleet, base)
 	require.Len(t, overrides, 1, "per-cluster downtime_tolerance must produce a cutover override entry")
 	assert.Equal(t, CutoverBlueGreen, overrides[0].Style)
 
@@ -364,7 +364,7 @@ func TestPerCluster_SubPatternOnlyOverride(t *testing.T) {
 	assert.Equal(t, CutoverStopRestartRepeat, fleet.Style, "fleet must still resolve to SRR")
 	assert.Equal(t, SubPatternAppByApp, fleet.SubPattern, "fleet sub-pattern unchanged")
 
-	overrides := computeCutoverOverrides([]types.ProcessedCluster{{Name: "alpha"}}, fleet, base)
+	overrides := computeCutoverOverrides([]report.ProcessedCluster{{Name: "alpha"}}, fleet, base)
 	require.Len(t, overrides, 1, "sub_pattern-only override must still produce a CutoverOverrides entry")
 	assert.Equal(t, "alpha", overrides[0].ClusterID)
 	assert.Equal(t, CutoverStopRestartRepeat, overrides[0].Style, "style inherits the fleet's")
@@ -391,7 +391,7 @@ func TestPerCluster_BlueGreenOverrideOnIAMClusterWithCompletePrereqs(t *testing.
 	// so the fleet decision is canonical, not degraded.
 	base.IAMPreMigrationStatus = PrereqStatusCompleteInput
 	base.Raw = raw
-	clusters := []types.ProcessedCluster{withSourceAuth("iam-cluster", SourceAuthIAM)}
+	clusters := []report.ProcessedCluster{withSourceAuth("iam-cluster", SourceAuthIAM)}
 
 	fleet := decideCutover(clusters, base)
 	assert.Equal(t, RecommendationCanonical, fleet.RecommendationStatus, "all prereqs complete + IAM in fleet must still resolve canonical")
@@ -422,7 +422,7 @@ func TestComputeCutoverOverrides_GatewayMediationInheritedFromFleet(t *testing.T
 	base.IAMPreMigrationStatus = PrereqNotStarted // not_started — relevant ONLY if fleet uses IAM
 	// Fleet has an IAM cluster → IAM prereq is consulted → fleet is
 	// degraded (not gateway-mediated).
-	clusters := []types.ProcessedCluster{
+	clusters := []report.ProcessedCluster{
 		withSourceAuth("iam-cluster", SourceAuthIAM),
 		withSourceAuth("scram-override", SourceAuthSCRAM),
 	}
@@ -470,7 +470,7 @@ func TestPerCluster_SecondsPerServiceWithoutFleetGateway(t *testing.T) {
 		IAMPreMigrationStatus:        PrereqNotStarted,
 		Raw:                          raw,
 	}
-	clusters := []types.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}
+	clusters := []report.ProcessedCluster{withSourceAuth("alpha", SourceAuthSCRAM)}
 
 	fleet := decideCutover(clusters, base)
 	require.NotEqual(t, GatewayMediatedTrue, fleet.GatewayMediated, "fleet must NOT be gateway-mediated for this scenario")

--- a/internal/services/plan/effort_signals.go
+++ b/internal/services/plan/effort_signals.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // pluralizeY appends "y" or "ies" based on count — "registry" /
@@ -31,7 +31,7 @@ const (
 //
 // Returns nil when there are no MSK clusters to evaluate (renderer
 // omits the section).
-func detectEffortSignals(state types.ProcessedState) *EffortSignalsSection {
+func detectEffortSignals(state report.ProcessedState) *EffortSignalsSection {
 	clusters := collectClusters(state)
 	if len(clusters) == 0 {
 		return nil
@@ -62,7 +62,7 @@ func intPtr(n int) *int { return &n }
 // Don't be tempted to swap in `types.AuthTypeIAM` from `types.go` —
 // that constant resolves to "SASL/IAM" and would silently mismatch
 // every real state file.
-func signalIAMClientCount(clusters []types.ProcessedCluster) EffortSignal {
+func signalIAMClientCount(clusters []report.ProcessedCluster) EffortSignal {
 	// Distinguish "scan ran, found 0 IAM clients" from "scan didn't
 	// run at all": if no cluster has any discovered_clients populated,
 	// the count is structurally unobservable → return nil. Otherwise
@@ -101,7 +101,7 @@ func signalIAMClientCount(clusters []types.ProcessedCluster) EffortSignal {
 // IdentityReplicationPolicy suppress the prefix — those won't show
 // up here. The renderer surfaces the caveat in the Note. Regex lives
 // in topic_patterns.go so red_flags can share it.
-func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) EffortSignal {
+func signalMM2CheckpointTopics(clusters []report.ProcessedCluster) EffortSignal {
 	// De-dupe by topic name so a Cluster-Linking mirror that
 	// replicates the same `*.checkpoints.internal` topic across N
 	// clusters doesn't inflate the count to N. Each distinct
@@ -138,7 +138,7 @@ func signalMM2CheckpointTopics(clusters []types.ProcessedCluster) EffortSignal {
 // (`connect-offsets`) may not exist with the same prefix, so we
 // require only two of three — AND-of-all-three would miss real
 // fleets per the spec. Regex lives in topic_patterns.go.
-func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) EffortSignal {
+func signalSelfManagedConnectFleets(clusters []report.ProcessedCluster) EffortSignal {
 	// Walk every topic, group by (cluster, prefix), collect which
 	// suffixes appear. Per-cluster scoping prevents two distinct
 	// fleets that both use the default unprefixed `connect-configs`
@@ -217,7 +217,7 @@ func signalSelfManagedConnectFleets(clusters []types.ProcessedCluster) EffortSig
 // Server-side schema export is automated by `kcp create-asset
 // migrate-schemas --glue-registry`; this row scopes the *client-side*
 // serializer-swap workstream.
-func signalGlueSerializerMigration(state types.ProcessedState, clusters []types.ProcessedCluster) EffortSignal {
+func signalGlueSerializerMigration(state report.ProcessedState, clusters []report.ProcessedCluster) EffortSignal {
 	sig := EffortSignal{
 		ID:    EffortSignalIDGlueSerializerMigration,
 		Label: "Glue → CC SR client serializer migration size — clients that need `AWSKafkaAvroSerializer` → `KafkaAvroSerializer`",

--- a/internal/services/plan/effort_signals_test.go
+++ b/internal/services/plan/effort_signals_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,5 +117,5 @@ func TestEffortSignal_GlueAbsent_ZeroWithNote(t *testing.T) {
 // detectEffortSignals returns nil on an empty fleet so the renderer
 // omits §Effort Signals.
 func TestDetectEffortSignals_EmptyFleetReturnsNil(t *testing.T) {
-	assert.Nil(t, detectEffortSignals(types.ProcessedState{}))
+	assert.Nil(t, detectEffortSignals(report.ProcessedState{}))
 }

--- a/internal/services/plan/plan_service.go
+++ b/internal/services/plan/plan_service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/confluentinc/kcp/internal/build_info"
 	"github.com/confluentinc/kcp/internal/services/report"
-	"github.com/confluentinc/kcp/internal/types"
 )
 
 // Function-naming convention across this package:
@@ -52,7 +51,7 @@ func NewPlanService(cfg *PlanConfig, now func() time.Time) *PlanService {
 // Build produces a Plan from a ProcessedState and resolved plan-inputs.
 // Each step is a pure function so the test surface is the orchestration,
 // not its parts.
-func (s *PlanService) Build(state types.ProcessedState, inputs PlanInputsResolved, stateFilePath string) (*Plan, error) {
+func (s *PlanService) Build(state report.ProcessedState, inputs PlanInputsResolved, stateFilePath string) (*Plan, error) {
 	// Backfill `ClusterMetrics.Aggregates` once, in-place, against the
 	// canonical state. Every downstream caller (the per-cluster Build
 	// loop, plus every fleet-wide detector that re-runs
@@ -204,7 +203,7 @@ func (s *PlanService) Build(state types.ProcessedState, inputs PlanInputsResolve
 // will upgrade that recommendation. SERVERLESS-specific suppressions for
 // "ACLs not populated" and "0 brokers" live in cluster_signals.go so the
 // same logic is shared with the rule evaluator.
-func detectOpenQuestions(c types.ProcessedCluster, sizing ClusterSizing, ct ClusterTypeDecision, net NetworkingDecision, auth AuthDecision, cfg *PlanConfig, inputs PlanInputsResolved) []OpenQuestion {
+func detectOpenQuestions(c report.ProcessedCluster, sizing ClusterSizing, ct ClusterTypeDecision, net NetworkingDecision, auth AuthDecision, cfg *PlanConfig, inputs PlanInputsResolved) []OpenQuestion {
 	var oqs []OpenQuestion
 	// Auth posture undetectable. Fires whenever the source has no
 	// detected auth methods — auth is its own concern, surfaced
@@ -345,7 +344,7 @@ func detectOpenQuestions(c types.ProcessedCluster, sizing ClusterSizing, ct Clus
 // state file contains Apache Kafka (self-managed, on-prem) clusters.
 // `kcp report plan` covers MSK only today; without this OQ those
 // clusters would be silently dropped from the plan.
-func detectOSKSourceOpenQuestion(state types.ProcessedState) []OpenQuestion {
+func detectOSKSourceOpenQuestion(state report.ProcessedState) []OpenQuestion {
 	var oskCount int
 	for _, src := range state.Sources {
 		if src.OSKData != nil {
@@ -473,7 +472,7 @@ func detectCutoverOpenQuestions(cutover CutoverDecision, overrides []ClusterCuto
 // affected cluster is obvious). Per-cluster typos silently fall back
 // to the per-source default in decideAuth via effectiveTarget, so
 // without this detector they're invisible to the customer.
-func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
+func detectAuthFleetOpenQuestions(clusters []report.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
 	var oqs []OpenQuestion
 	if !knownTargetAuthMethod(inputs.TargetAuthMethod) {
 		oqs = append(oqs, OpenQuestion{
@@ -508,7 +507,7 @@ func detectAuthFleetOpenQuestions(clusters []types.ProcessedCluster, inputs Plan
 // stable alphabetical order. Unknown-cluster overrides are filtered
 // out here; `detectUnknownClusterOverrides` handles surfacing them as
 // their own OQ. Returns nil when no Raw inputs exist.
-func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []string {
+func sortedKnownClusterOverrideNames(clusters []report.ProcessedCluster, inputs PlanInputsResolved) []string {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
@@ -532,7 +531,7 @@ func sortedKnownClusterOverrideNames(clusters []types.ProcessedCluster, inputs P
 // cluster. Without this, a typo'd cluster name (e.g. `clusters[trust]`
 // against a fleet with no `trust` cluster) silently produces no
 // override and the reader has no signal that their input was rejected.
-func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
+func detectUnknownClusterOverrides(clusters []report.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
@@ -572,7 +571,7 @@ func detectUnknownClusterOverrides(clusters []types.ProcessedCluster, inputs Pla
 // When the override value isn't in the recognised enum, the entry
 // carries OverrideRejected + RejectedOverrideValue so a JSON consumer
 // can detect rejected overrides structurally (mirrors AuthDecision).
-func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []ClusterCutoverOverride {
+func computeCutoverOverrides(clusters []report.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []ClusterCutoverOverride {
 	if inputs.Raw == nil || len(inputs.Raw.Clusters) == 0 {
 		return nil
 	}
@@ -583,7 +582,7 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet CutoverDec
 			continue
 		}
 		clusterInputs := applyClusterOverride(inputs, inputs.Raw, c.Name)
-		dec := decideCutover([]types.ProcessedCluster{c}, clusterInputs)
+		dec := decideCutover([]report.ProcessedCluster{c}, clusterInputs)
 		// Gateway prereqs are fleet-scoped — a per-cluster override
 		// can't earn its own gateway path. Inherit the fleet's
 		// mediation verdict unless the override is Blue/Green, which
@@ -622,7 +621,7 @@ func computeCutoverOverrides(clusters []types.ProcessedCluster, fleet CutoverDec
 // this, the customer's per-cluster choice is silently lost — the
 // cluster falls back to the fleet's plain Cluster Linking shape and
 // the reader has no signal.
-func detectPerClusterGatewayIncompat(clusters []types.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []OpenQuestion {
+func detectPerClusterGatewayIncompat(clusters []report.ProcessedCluster, fleet CutoverDecision, inputs PlanInputsResolved) []OpenQuestion {
 	if fleet.GatewayMediated == GatewayMediatedTrue {
 		return nil
 	}
@@ -681,7 +680,7 @@ func rejectedCutoverOverride(raw ClusterPlanInputs) (bool, string) {
 // for cluster names that match an actual scanned cluster;
 // unknown-name overrides are handled by
 // detectUnknownClusterOverrides.
-func detectClusterCutoverOpenQuestions(clusters []types.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
+func detectClusterCutoverOpenQuestions(clusters []report.ProcessedCluster, inputs PlanInputsResolved) []OpenQuestion {
 	var oqs []OpenQuestion
 	for _, name := range sortedKnownClusterOverrideNames(clusters, inputs) {
 		cluster := inputs.Raw.Clusters[name]
@@ -747,7 +746,7 @@ func openQuestionPriority(id string) int {
 // CalculateMetricsAggregates per invocation. Skips clusters where
 // Aggregates is already populated (e.g. test fixtures that pre-set it)
 // or where there are no raw metrics to fold.
-func backfillAggregates(state *types.ProcessedState) {
+func backfillAggregates(state *report.ProcessedState) {
 	for i := range state.Sources {
 		if state.Sources[i].MSKData == nil {
 			continue
@@ -763,8 +762,8 @@ func backfillAggregates(state *types.ProcessedState) {
 	}
 }
 
-func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
-	var out []types.ProcessedCluster
+func collectClusters(state report.ProcessedState) []report.ProcessedCluster {
+	var out []report.ProcessedCluster
 	for _, src := range state.Sources {
 		if src.MSKData == nil {
 			continue
@@ -776,7 +775,7 @@ func collectClusters(state types.ProcessedState) []types.ProcessedCluster {
 	return out
 }
 
-func countRegions(state types.ProcessedState) int {
+func countRegions(state report.ProcessedState) int {
 	regions := map[string]struct{}{}
 	for _, src := range state.Sources {
 		if src.MSKData != nil {
@@ -799,14 +798,14 @@ func regionFlag(region string) string {
 	return " --region " + region
 }
 
-func topicCount(c types.ProcessedCluster) int {
+func topicCount(c report.ProcessedCluster) int {
 	if c.KafkaAdminClientInformation.Topics == nil {
 		return 0
 	}
 	return c.KafkaAdminClientInformation.Topics.Summary.Topics
 }
 
-func brokerCount(c types.ProcessedCluster) int {
+func brokerCount(c report.ProcessedCluster) int {
 	return len(c.AWSClientInformation.Nodes)
 }
 

--- a/internal/services/plan/plan_service_test.go
+++ b/internal/services/plan/plan_service_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,17 +15,17 @@ func fixedNow() time.Time {
 	return time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
 }
 
-func twoClusterState() types.ProcessedState {
+func twoClusterState() report.ProcessedState {
 	// b-cluster intentionally listed first so the sort proves it works.
-	return types.ProcessedState{
-		Sources: []types.ProcessedSource{
+	return report.ProcessedState{
+		Sources: []report.ProcessedSource{
 			{
 				Type: types.SourceTypeMSK,
-				MSKData: &types.ProcessedMSKSource{
-					Regions: []types.ProcessedRegion{
+				MSKData: &report.ProcessedMSKSource{
+					Regions: []report.ProcessedRegion{
 						{
 							Name: "us-east-1",
-							Clusters: []types.ProcessedCluster{
+							Clusters: []report.ProcessedCluster{
 								fixtureCluster("b-cluster", 100, 5.0, 5.0, 6.0, 6.0),
 								fixtureCluster("a-cluster", 50, 1.0, 1.0, 2.0, 2.0),
 							},
@@ -71,16 +72,16 @@ func TestPlanServiceBuild_DeterministicByteIdenticalJSON(t *testing.T) {
 }
 
 func TestPlanServiceBuild_StableSortAcrossRegions(t *testing.T) {
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{
 					// Same cluster name in two regions to prove (Region, Name) sort.
-					{Name: "us-west-2", Clusters: []types.ProcessedCluster{
+					{Name: "us-west-2", Clusters: []report.ProcessedCluster{
 						withRegion(fixtureCluster("collide", 10, 1.0, 1.0, 1.0, 1.0), "us-west-2"),
 					}},
-					{Name: "us-east-1", Clusters: []types.ProcessedCluster{
+					{Name: "us-east-1", Clusters: []report.ProcessedCluster{
 						withRegion(fixtureCluster("collide", 10, 1.0, 1.0, 1.0, 1.0), "us-east-1"),
 					}},
 				},
@@ -108,12 +109,12 @@ func TestPlanServiceBuild_SourceEnvironmentBrokerAndTopicCount(t *testing.T) {
 	c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 	c.KafkaAdminClientInformation.Topics.Summary.Topics = 42
 
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{
-					{Name: "us-east-1", Clusters: []types.ProcessedCluster{c}},
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{
+					{Name: "us-east-1", Clusters: []report.ProcessedCluster{c}},
 				},
 			},
 		}},
@@ -132,8 +133,8 @@ func TestPlanServiceBuild_SourceEnvironmentBrokerAndTopicCount(t *testing.T) {
 // the action that upgrades it.
 func TestDetectOpenQuestions(t *testing.T) {
 	cfg := defaultCfg(t)
-	provisioned := func(name string) types.ProcessedCluster {
-		c := types.ProcessedCluster{Name: name}
+	provisioned := func(name string) report.ProcessedCluster {
+		c := report.ProcessedCluster{Name: name}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		c.AWSClientInformation.MskClusterConfig.Provisioned = &kafkatypes.Provisioned{} // non-nil to satisfy cluster_type_unrecognised guard
@@ -184,7 +185,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 	})
 
 	t.Run("no topics scan + nil ACLs → acls_not_scanned OQ", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "noAcls"}
+		c := report.ProcessedCluster{Name: "noAcls"}
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		// Topics nil → scan didn't run; ACLs nil follows from same gap
@@ -193,7 +194,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 	})
 
 	t.Run("SERVERLESS cluster suppresses acls_not_scanned and broker_inventory_empty", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "serverless"}
+		c := report.ProcessedCluster{Name: "serverless"}
 		c.AWSClientInformation.Nodes = nil
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
@@ -220,7 +221,7 @@ func TestDetectOpenQuestions(t *testing.T) {
 	})
 
 	t.Run("Serverless with nil Topics → scan-gap body, not 'Summary.Topics is 0'", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "srv-nil"}
+		c := report.ProcessedCluster{Name: "srv-nil"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
 			VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}}},
@@ -297,7 +298,7 @@ func assertContainsOQ(t *testing.T, oqs []OpenQuestion, id, expectedSubstring st
 
 func TestPlanServiceBuild_EmptyState(t *testing.T) {
 	svc := NewPlanService(defaultCfg(t), fixedNow)
-	p, err := svc.Build(types.ProcessedState{}, defaultInputs(), "")
+	p, err := svc.Build(report.ProcessedState{}, defaultInputs(), "")
 	require.NoError(t, err)
 	assert.Empty(t, p.Sizing)
 	assert.Empty(t, p.SourceEnvironment.Clusters)
@@ -305,13 +306,13 @@ func TestPlanServiceBuild_EmptyState(t *testing.T) {
 }
 
 func TestPlanServiceBuild_DegradedClusterStillRenders(t *testing.T) {
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{{
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{{
 					Name: "us-east-1",
-					Clusters: []types.ProcessedCluster{{
+					Clusters: []report.ProcessedCluster{{
 						Name:                        "no-metrics",
 						Region:                      "us-east-1",
 						KafkaAdminClientInformation: types.KafkaAdminClientInformation{Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: 5}}},
@@ -329,7 +330,7 @@ func TestPlanServiceBuild_DegradedClusterStillRenders(t *testing.T) {
 	assert.Empty(t, p.SizingAppendix)
 }
 
-func withRegion(c types.ProcessedCluster, region string) types.ProcessedCluster {
+func withRegion(c report.ProcessedCluster, region string) report.ProcessedCluster {
 	c.Region = region
 	return c
 }
@@ -338,10 +339,10 @@ func withRegion(c types.ProcessedCluster, region string) types.ProcessedCluster 
 // osk_source_unsupported OQ so the customer knows on-prem clusters
 // were silently dropped. Today the plan only covers MSK.
 func TestDetectOSKSourceOpenQuestion_FiresWhenOSKClustersPresent(t *testing.T) {
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{
-			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
-				Clusters: []types.ProcessedOSKCluster{{ID: "onprem-1"}, {ID: "onprem-2"}},
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &report.ProcessedOSKSource{
+				Clusters: []report.ProcessedOSKCluster{{ID: "onprem-1"}, {ID: "onprem-2"}},
 			}},
 		},
 	}
@@ -352,16 +353,16 @@ func TestDetectOSKSourceOpenQuestion_FiresWhenOSKClustersPresent(t *testing.T) {
 }
 
 func TestDetectOSKSourceOpenQuestion_NoOQWhenOSKAbsent(t *testing.T) {
-	state := types.ProcessedState{}
+	state := report.ProcessedState{}
 	assert.Empty(t, detectOSKSourceOpenQuestion(state))
 }
 
 // Singular vs plural verb agreement in the OQ title.
 func TestDetectOSKSourceOpenQuestion_VerbAgreement(t *testing.T) {
 	t.Run("1 cluster → 'isn't' + singular noun", func(t *testing.T) {
-		state := types.ProcessedState{Sources: []types.ProcessedSource{
-			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
-				Clusters: []types.ProcessedOSKCluster{{ID: "solo"}},
+		state := report.ProcessedState{Sources: []report.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &report.ProcessedOSKSource{
+				Clusters: []report.ProcessedOSKCluster{{ID: "solo"}},
 			}},
 		}}
 		oqs := detectOSKSourceOpenQuestion(state)
@@ -369,9 +370,9 @@ func TestDetectOSKSourceOpenQuestion_VerbAgreement(t *testing.T) {
 		assert.Contains(t, oqs[0].Title, "1 on-prem Kafka cluster in the state file isn't")
 	})
 	t.Run("2 clusters → 'aren't' + plural noun", func(t *testing.T) {
-		state := types.ProcessedState{Sources: []types.ProcessedSource{
-			{Type: types.SourceTypeOSK, OSKData: &types.ProcessedOSKSource{
-				Clusters: []types.ProcessedOSKCluster{{ID: "a"}, {ID: "b"}},
+		state := report.ProcessedState{Sources: []report.ProcessedSource{
+			{Type: types.SourceTypeOSK, OSKData: &report.ProcessedOSKSource{
+				Clusters: []report.ProcessedOSKCluster{{ID: "a"}, {ID: "b"}},
 			}},
 		}}
 		oqs := detectOSKSourceOpenQuestion(state)
@@ -386,7 +387,7 @@ func TestDetectOSKSourceOpenQuestion_VerbAgreement(t *testing.T) {
 // empty for that cluster.
 func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
 	t.Run("empty ClusterType → msk_cluster_config", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "no-type"}
+		c := report.ProcessedCluster{Name: "no-type"}
 		// ClusterType left as zero-value
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
 		c.KafkaAdminClientInformation.Acls = []types.Acls{}
@@ -394,7 +395,7 @@ func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
 		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
 	})
 	t.Run("PROVISIONED with nil Provisioned → msk_cluster_config", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "nil-prov"}
+		c := report.ProcessedCluster{Name: "nil-prov"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		// Provisioned block left as nil
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
@@ -403,7 +404,7 @@ func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
 		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
 	})
 	t.Run("Future variant ClusterType → msk_cluster_config", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "future"}
+		c := report.ProcessedCluster{Name: "future"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = "HYBRID"
 		c.KafkaAdminClientInformation.Topics = &types.Topics{}
 		c.KafkaAdminClientInformation.Acls = []types.Acls{}
@@ -411,7 +412,7 @@ func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
 		assert.Contains(t, inputsMissing(c), "msk_cluster_config")
 	})
 	t.Run("Serverless does NOT report msk_cluster_config", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "srv"}
+		c := report.ProcessedCluster{Name: "srv"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
 			VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}}},
@@ -423,7 +424,7 @@ func TestInputsMissing_UnknownClusterTypeReportsGap(t *testing.T) {
 
 func TestInputsMissing_AllSignalsTracked(t *testing.T) {
 	t.Run("fully-scanned PROVISIONED cluster reports no missing inputs", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "ok"}
+		c := report.ProcessedCluster{Name: "ok"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		// Provisioned block must be populated — without it, the
 		// Provisioned-only helpers return empty and the new
@@ -435,21 +436,21 @@ func TestInputsMissing_AllSignalsTracked(t *testing.T) {
 		assert.Empty(t, inputsMissing(c))
 	})
 	t.Run("Topics nil → 'topics' in the list", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "no-topics"}
+		c := report.ProcessedCluster{Name: "no-topics"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.KafkaAdminClientInformation.Acls = []types.Acls{}
 		assert.Contains(t, inputsMissing(c), "topics")
 	})
 	t.Run("Acls nil on PROVISIONED → 'acls' in the list", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "no-acls"}
+		c := report.ProcessedCluster{Name: "no-acls"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		c.AWSClientInformation.Nodes = make([]kafkatypes.NodeInfo, 3)
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		assert.Contains(t, inputsMissing(c), "acls")
 	})
 	t.Run("Serverless suppresses 'acls' and 'brokers'", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "sl"}
+		c := report.ProcessedCluster{Name: "sl"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		missing := inputsMissing(c)
@@ -457,7 +458,7 @@ func TestInputsMissing_AllSignalsTracked(t *testing.T) {
 		assert.NotContains(t, missing, "brokers", "serverless: no broker nodes by design; not a gap")
 	})
 	t.Run("0 broker Nodes on PROVISIONED → 'brokers' in the list", func(t *testing.T) {
-		c := types.ProcessedCluster{Name: "no-brokers"}
+		c := report.ProcessedCluster{Name: "no-brokers"}
 		c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeProvisioned
 		c.KafkaAdminClientInformation.Topics = &types.Topics{Summary: types.TopicSummary{Topics: 5}}
 		c.KafkaAdminClientInformation.Acls = []types.Acls{}
@@ -518,13 +519,13 @@ func TestDecideClusterType_EvaluatedRules_CarriesAllOutcomes(t *testing.T) {
 // despite the global default. This is the regression guard for the
 // heterogeneous-fleet failure mode that motivated A3.
 func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T) {
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{{
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{{
 					Name: "us-east-1",
-					Clusters: []types.ProcessedCluster{
+					Clusters: []report.ProcessedCluster{
 						fixtureCluster("alpha", 100, 5.0, 5.0, 6.0, 6.0),
 						fixtureCluster("bravo", 100, 5.0, 5.0, 6.0, 6.0),
 					},
@@ -558,13 +559,13 @@ func TestPlanServiceBuild_PerClusterOverride_FlipsOnlyTargetCluster(t *testing.T
 // only for the named cluster; everything else stays on the per-source
 // auth_mapping default.
 func TestPlanServiceBuild_PerClusterTargetAuthOverride(t *testing.T) {
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{{
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{{
 					Name: "us-east-1",
-					Clusters: []types.ProcessedCluster{
+					Clusters: []report.ProcessedCluster{
 						attachAuth(fixtureCluster("alpha", 100, 5.0, 5.0, 6.0, 6.0), SourceAuthSCRAM),
 						attachAuth(fixtureCluster("bravo", 100, 5.0, 5.0, 6.0, 6.0), SourceAuthSCRAM),
 					},
@@ -642,7 +643,7 @@ func TestDetectAuthFleetOpenQuestions_PerClusterTargetAuthTypo(t *testing.T) {
 			"bravo": {TargetAuthMethod: &good},
 		},
 	}
-	clusters := []types.ProcessedCluster{{Name: "alpha"}, {Name: "bravo"}}
+	clusters := []report.ProcessedCluster{{Name: "alpha"}, {Name: "bravo"}}
 	resolved := PlanInputsResolved{Raw: raw}
 	oqs := detectAuthFleetOpenQuestions(clusters, resolved)
 	require.Len(t, oqs, 1, "only the typo cluster should emit an OQ")
@@ -706,7 +707,7 @@ func TestSeverityLegend_OnlyPresent(t *testing.T) {
 // attachAuth gives a fixture cluster a SCRAM (or other) source auth so
 // it surfaces in decideAuth output. Mirrors withSourceAuth in
 // cutover_test.go but layers on top of an existing fixtureCluster.
-func attachAuth(c types.ProcessedCluster, sourceAuth string) types.ProcessedCluster {
+func attachAuth(c report.ProcessedCluster, sourceAuth string) report.ProcessedCluster {
 	enabled := true
 	clientAuth := &kafkatypes.ClientAuthentication{}
 	switch sourceAuth {

--- a/internal/services/plan/red_flags.go
+++ b/internal/services/plan/red_flags.go
@@ -6,9 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
-
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // Stable Red Flag IDs. Matches the spec's row numbering — kept stable
@@ -59,7 +58,7 @@ var broadTopicPatterns = []struct {
 // independently and produces a {Status, Evidence} pair — Triggered
 // rows render at the top of §Red Flags, with NotTriggered / Unknown
 // collapsed into a tail summary.
-func detectRedFlags(state types.ProcessedState, plan *Plan, cfg *PlanConfig, inputs PlanInputsResolved) *RedFlagsSection {
+func detectRedFlags(state report.ProcessedState, plan *Plan, cfg *PlanConfig, inputs PlanInputsResolved) *RedFlagsSection {
 	clusters := collectClusters(state)
 	if len(clusters) == 0 {
 		return nil
@@ -124,7 +123,7 @@ func evalSchemalessSource(plan *Plan, inputs PlanInputsResolved) RedFlag {
 // Versions are dot-separated integer segments; the comparator
 // (`versionAtLeast`) already strips pre-release suffixes and handles
 // the "latest" alias.
-func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConfig) RedFlag {
+func evalKafkaVersionBelowFloor(clusters []report.ProcessedCluster, cfg *PlanConfig) RedFlag {
 	rf := RedFlag{ID: RedFlagIDKafkaVersionBelowCLFloor, Title: "Kafka version below the Cluster Linking floor"}
 	floor := cfg.ClusterLinking.SourceMinKafkaVersion
 	type versionHit struct {
@@ -175,7 +174,7 @@ func evalKafkaVersionBelowFloor(clusters []types.ProcessedCluster, cfg *PlanConf
 // version transparently and never populates
 // `Provisioned.CurrentBrokerSoftwareInfo`. Callers MUST guard with
 // `isServerless` before interpreting "" as "scan didn't run".
-func kafkaVersionOf(c types.ProcessedCluster) string {
+func kafkaVersionOf(c report.ProcessedCluster) string {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil || prov.CurrentBrokerSoftwareInfo == nil || prov.CurrentBrokerSoftwareInfo.KafkaVersion == nil {
 		return ""
@@ -185,7 +184,7 @@ func kafkaVersionOf(c types.ProcessedCluster) string {
 
 // ----- Row 3: IAM auth enabled -----
 
-func evalIAMAuthEnabled(clusters []types.ProcessedCluster) RedFlag {
+func evalIAMAuthEnabled(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDIAMAuthEnabled, Title: "IAM authentication enabled on the source"}
 	var hits []string
 	for _, c := range clusters {
@@ -267,7 +266,7 @@ func evalPartitionApproachingCap(plan *Plan, cfg *PlanConfig) RedFlag {
 // topic-population + cluster type per the spec: a PROVISIONED cluster
 // with topics populated AND an empty `connectors` slice counts as
 // "actually zero".
-func evalMSKConnectPresent(clusters []types.ProcessedCluster) RedFlag {
+func evalMSKConnectPresent(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDMSKConnectPresent, Title: "MSK Connect managed connectors present"}
 	var triggered []string
 	var unscanned []string
@@ -307,7 +306,7 @@ func evalMSKConnectPresent(clusters []types.ProcessedCluster) RedFlag {
 // Same nil-vs-empty disambiguation as row 6: empty struct with topics
 // populated counts as "no Connect clusters"; nil struct = scan didn't
 // run.
-func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) RedFlag {
+func evalSelfManagedConnectPresent(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDSelfManagedConnectPresent, Title: "Self-managed Connect clusters present"}
 	var triggered []string
 	var unscanned []string
@@ -344,7 +343,7 @@ func evalSelfManagedConnectPresent(clusters []types.ProcessedCluster) RedFlag {
 
 // ----- Row 8: multi-region source -----
 
-func evalMultiRegionSource(state types.ProcessedState) RedFlag {
+func evalMultiRegionSource(state report.ProcessedState) RedFlag {
 	rf := RedFlag{ID: RedFlagIDMultiRegionSource, Title: "Source clusters span multiple AWS regions"}
 	regions := map[string]struct{}{}
 	for _, src := range state.Sources {
@@ -389,7 +388,7 @@ func evalMultiRegionSource(state types.ProcessedState) RedFlag {
 // cluster_signals.go) so semantics stay in lockstep with V1 — when
 // `aclScanRan` returns true the scan succeeded; an empty slice in
 // that case is "actually zero", not "scan didn't run".
-func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) RedFlag {
+func evalZeroACLsWithIAM(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDZeroACLsWithIAM, Title: "Zero ACLs with IAM auth enabled — verify SE expected behavior"}
 	var hits []string
 	var serverlessIAM []string // Serverless+IAM clusters can't expose ACLs via the kcp scan path
@@ -448,7 +447,7 @@ func evalZeroACLsWithIAM(clusters []types.ProcessedCluster) RedFlag {
 
 // ----- Row 10: client inventory gap -----
 
-func evalClientInventoryGap(clusters []types.ProcessedCluster) RedFlag {
+func evalClientInventoryGap(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDClientInventoryGap, Title: "Client inventory not populated"}
 	var hits []string
 	for _, c := range clusters {
@@ -472,7 +471,7 @@ func evalClientInventoryGap(clusters []types.ProcessedCluster) RedFlag {
 
 // ----- Row 11: MSK Express broker tier -----
 
-func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) RedFlag {
+func evalMSKExpressBrokerTier(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDMSKExpressBrokerTier, Title: "MSK Express broker tier in use"}
 	type expressHit struct {
 		Cluster      string `json:"cluster"`
@@ -520,7 +519,7 @@ func evalMSKExpressBrokerTier(clusters []types.ProcessedCluster) RedFlag {
 // treating "" as "scan didn't run"; for Serverless inventory accounting,
 // see `inventoryInstanceTypes` (cost_reconciliation.go), which registers
 // Serverless clusters under the synthetic `Serverless-Hours` type.
-func brokerInstanceType(c types.ProcessedCluster) string {
+func brokerInstanceType(c report.ProcessedCluster) string {
 	prov := c.AWSClientInformation.MskClusterConfig.Provisioned
 	if prov == nil || prov.BrokerNodeGroupInfo == nil || prov.BrokerNodeGroupInfo.InstanceType == nil {
 		return ""
@@ -530,7 +529,7 @@ func brokerInstanceType(c types.ProcessedCluster) string {
 
 // ----- Row 12: tiered storage in use -----
 
-func evalTieredStorageInUse(clusters []types.ProcessedCluster) RedFlag {
+func evalTieredStorageInUse(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDTieredStorageInUse, Title: "Tiered storage in use on the source"}
 	var hits []string
 	for _, c := range clusters {
@@ -579,7 +578,7 @@ func evalEOSInUse(inputs PlanInputsResolved) RedFlag {
 // Two signals: explicit customer declaration OR topic-pattern scan
 // for `-changelog` / `-repartition` artifacts. Either one fires the
 // row; the evidence string names which signal won.
-func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs PlanInputsResolved) RedFlag {
+func evalKafkaStreamsInUse(clusters []report.ProcessedCluster, inputs PlanInputsResolved) RedFlag {
 	rf := RedFlag{ID: RedFlagIDKafkaStreamsInUse, Title: "Kafka Streams apps consuming from the source"}
 	if inputs.KafkaStreamsInUse != nil && *inputs.KafkaStreamsInUse {
 		rf.Status = RedFlagTriggered
@@ -619,7 +618,7 @@ func evalKafkaStreamsInUse(clusters []types.ProcessedCluster, inputs PlanInputsR
 // changelog/repartition, transactions, heartbeats) against every
 // topic on every cluster. Surfaces deployments with custom prefixes
 // that the structured rows above might miss.
-func evalBroadTopicPatternMatch(clusters []types.ProcessedCluster) RedFlag {
+func evalBroadTopicPatternMatch(clusters []report.ProcessedCluster) RedFlag {
 	rf := RedFlag{ID: RedFlagIDBroadTopicPatternMatch, Title: "Broad topic-name pattern scan — items the structured rows might miss"}
 	hitsByPattern := map[string][]string{}
 	anyHits := false

--- a/internal/services/plan/red_flags_test.go
+++ b/internal/services/plan/red_flags_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,7 +124,7 @@ func TestRedFlags_BroadTopicPatternMatch(t *testing.T) {
 // Empty fleet (no MSK clusters) → detectRedFlags returns nil so the
 // renderer omits the §Red Flags section entirely.
 func TestDetectRedFlags_EmptyFleetReturnsNil(t *testing.T) {
-	assert.Nil(t, detectRedFlags(types.ProcessedState{}, &Plan{}, defaultCfg(t), defaultInputs()))
+	assert.Nil(t, detectRedFlags(report.ProcessedState{}, &Plan{}, defaultCfg(t), defaultInputs()))
 }
 
 // ----- helpers -----
@@ -131,8 +132,8 @@ func TestDetectRedFlags_EmptyFleetReturnsNil(t *testing.T) {
 // redFlagCluster constructs a ProcessedCluster with the AWS SDK
 // MskClusterConfig fields the Red Flag detectors read. Pass empty
 // strings to leave a field unset.
-func redFlagCluster(name, kafkaVersion, instanceType, storageMode string) types.ProcessedCluster {
-	c := types.ProcessedCluster{Name: name, Region: "us-east-1"}
+func redFlagCluster(name, kafkaVersion, instanceType, storageMode string) report.ProcessedCluster {
+	c := report.ProcessedCluster{Name: name, Region: "us-east-1"}
 	prov := &kafkatypes.Provisioned{}
 	if kafkaVersion != "" {
 		v := kafkaVersion
@@ -153,12 +154,12 @@ func redFlagCluster(name, kafkaVersion, instanceType, storageMode string) types.
 	return c
 }
 
-func wrapClusters(clusters ...types.ProcessedCluster) types.ProcessedState {
-	return types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+func wrapClusters(clusters ...report.ProcessedCluster) report.ProcessedState {
+	return report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{{Name: "us-east-1", Clusters: clusters}},
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{{Name: "us-east-1", Clusters: clusters}},
 			},
 		}},
 	}
@@ -168,7 +169,7 @@ func wrapClusters(clusters ...types.ProcessedCluster) types.ProcessedState {
 // the full integration (V2 detector + V1 plumbing) rather than
 // calling detectRedFlags in isolation. Same default time / cfg used
 // by the rest of the plan tests.
-func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *Plan {
+func buildPlanForRedFlags(t *testing.T, state report.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *Plan {
 	t.Helper()
 	svc := NewPlanService(cfg, fixedNow)
 	p, err := svc.Build(state, inputs, "redflags-test.json")
@@ -180,8 +181,8 @@ func buildPlanForRedFlags(t *testing.T, state types.ProcessedState, cfg *PlanCon
 // Serverless cluster: ClusterType=Serverless, `Provisioned` left nil,
 // and the Serverless block carries the (IAM-only) ClientAuthentication.
 // Mirrors the JSON shape AWS returns — see PR #317 review by adrian-januzi.
-func serverlessCluster(name string) types.ProcessedCluster {
-	c := types.ProcessedCluster{Name: name, Region: "us-east-1"}
+func serverlessCluster(name string) report.ProcessedCluster {
+	c := report.ProcessedCluster{Name: name, Region: "us-east-1"}
 	enabled := true
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
@@ -237,7 +238,7 @@ func TestRedFlags_ServerlessDoesntPolluteVersionEvidence(t *testing.T) {
 // Environment table with `_none detected_` rather than crashing or
 // being silently dropped.
 func TestRedFlags_ServerlessNoClientAuthentication(t *testing.T) {
-	c := types.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
+	c := report.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
 		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"subnet-x"}, SecurityGroupIds: []string{"sg-x"}}},
@@ -262,13 +263,13 @@ func TestRedFlags_ServerlessMultiRegion(t *testing.T) {
 	srvEast.Region = "us-east-1"
 	srvWest := serverlessCluster("srv-west")
 	srvWest.Region = "us-west-2"
-	state := types.ProcessedState{
-		Sources: []types.ProcessedSource{{
+	state := report.ProcessedState{
+		Sources: []report.ProcessedSource{{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
-				Regions: []types.ProcessedRegion{
-					{Name: "us-east-1", Clusters: []types.ProcessedCluster{srvEast}},
-					{Name: "us-west-2", Clusters: []types.ProcessedCluster{srvWest}},
+			MSKData: &report.ProcessedMSKSource{
+				Regions: []report.ProcessedRegion{
+					{Name: "us-east-1", Clusters: []report.ProcessedCluster{srvEast}},
+					{Name: "us-west-2", Clusters: []report.ProcessedCluster{srvWest}},
 				},
 			},
 		}},
@@ -342,7 +343,7 @@ func TestRedFlags_ZeroACLsWithIAM_MixedFleetSurfacesExclusion(t *testing.T) {
 // Pre-fix, the OQ was suppressed entirely for Serverless, leaving §4's
 // "see Actions Needed" pointer dangling.
 func TestRedFlags_ServerlessNoAuthFiresAuthPostureOQ(t *testing.T) {
-	c := types.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
+	c := report.ProcessedCluster{Name: "srv-noauth", Region: "us-east-1"}
 	c.AWSClientInformation.MskClusterConfig.ClusterType = kafkatypes.ClusterTypeServerless
 	c.AWSClientInformation.MskClusterConfig.Serverless = &kafkatypes.Serverless{
 		VpcConfigs: []kafkatypes.VpcConfig{{SubnetIds: []string{"s"}, SecurityGroupIds: []string{"g"}}},
@@ -383,10 +384,10 @@ func TestRedFlags_ZeroACLs_SkipACLsCaseSurfacesAsUnknown(t *testing.T) {
 func TestDetectCostReconciliation_ServerlessClusterWithoutMatchingCostLine(t *testing.T) {
 	srv := serverlessCluster("srv-no-billing")
 	state := wrapClusters(srv)
-	state.Sources[0].MSKData.Regions[0].Costs = types.ProcessedRegionCosts{
+	state.Sources[0].MSKData.Regions[0].Costs = report.ProcessedRegionCosts{
 		Region: "us-east-1",
-		Results: []types.ProcessedCost{
-			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: types.ProcessedCostBreakdown{UnblendedCost: 12.50}},
+		Results: []report.ProcessedCost{
+			{Start: "2026-04-01", UsageType: "USE1-DataTransfer-Out-Bytes", Values: report.ProcessedCostBreakdown{UnblendedCost: 12.50}},
 		},
 	}
 	section := detectCostReconciliation(state, defaultCfg(t))

--- a/internal/services/plan/schema.go
+++ b/internal/services/plan/schema.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // Plan-input enum tokens for schema migration. Stable customer-facing
@@ -50,7 +50,7 @@ func knownSchemaCPEdition(value string) bool {
 // The result's `Paths` slice carries every verdict that applies —
 // usually one entry, two for the dual-source case so JSON consumers
 // branching on a single slot don't miss the second arm.
-func decideSchema(state types.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *SchemaDecision {
+func decideSchema(state report.ProcessedState, cfg *PlanConfig, inputs PlanInputsResolved) *SchemaDecision {
 	source, confluentURLs, glueNames := detectSchemaSource(state)
 	strategy := inputs.SchemaStrategy
 	if strategy == "" {
@@ -178,7 +178,7 @@ func hasPath(dec *SchemaDecision, p SchemaPath) bool {
 // (state.SchemaRegistries.ConfluentSchemaRegistry +
 // state.SchemaRegistries.AWSGlue) into a single enum + the lookups the
 // renderer needs (URLs + registry names).
-func detectSchemaSource(state types.ProcessedState) (SchemaSource, []string, []string) {
+func detectSchemaSource(state report.ProcessedState) (SchemaSource, []string, []string) {
 	srs := state.SchemaRegistries
 	if srs == nil {
 		return SchemaSourceNone, nil, nil

--- a/internal/services/plan/schema_test.go
+++ b/internal/services/plan/schema_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,9 +13,9 @@ import (
 // registries. nil omits the SchemaRegistries block entirely (the
 // `source = none` case); empty slices model a scanner that ran but
 // found nothing (still resolves to `none`).
-func schemaState(confluentURLs, glueNames []string) types.ProcessedState {
+func schemaState(confluentURLs, glueNames []string) report.ProcessedState {
 	if confluentURLs == nil && glueNames == nil {
-		return types.ProcessedState{}
+		return report.ProcessedState{}
 	}
 	srs := &types.SchemaRegistriesState{}
 	for _, u := range confluentURLs {
@@ -23,7 +24,7 @@ func schemaState(confluentURLs, glueNames []string) types.ProcessedState {
 	for _, n := range glueNames {
 		srs.AWSGlue = append(srs.AWSGlue, types.GlueSchemaRegistryInformation{RegistryName: n})
 	}
-	return types.ProcessedState{SchemaRegistries: srs}
+	return report.ProcessedState{SchemaRegistries: srs}
 }
 
 func schemaInputs(strategy string) PlanInputsResolved {

--- a/internal/services/plan/sizing.go
+++ b/internal/services/plan/sizing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -26,7 +27,7 @@ const bytesPerMBps = 1_048_576.0
 // FinalECKU = SLA floor and Degraded = true rather than failing the whole
 // plan build. The renderer surfaces the gap so the customer knows the
 // sizing column is a placeholder.
-func computeClusterSizing(c types.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) ClusterSizing {
+func computeClusterSizing(c report.ProcessedCluster, cfg *PlanConfig, inputs PlanInputsResolved) ClusterSizing {
 	caps := cfg.EnterpriseCaps
 	aggs := c.ClusterMetrics.Aggregates
 
@@ -159,7 +160,7 @@ func pickMaxDriver(ingress, egress, partitions float64) (float64, string) {
 	return maxR, driver
 }
 
-func userPartitionsOf(c types.ProcessedCluster) int {
+func userPartitionsOf(c report.ProcessedCluster) int {
 	if c.KafkaAdminClientInformation.Topics == nil {
 		return 0
 	}

--- a/internal/services/plan/sizing_test.go
+++ b/internal/services/plan/sizing_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/services/report"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,12 +11,12 @@ import (
 
 // fixtureCluster builds a ProcessedCluster with the metric aggregates that
 // drive the sizing formula. Caller passes in P95/peak values in MBps.
-func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMBps, peakOutMBps float64) types.ProcessedCluster {
+func fixtureCluster(name string, partitions int, p95InMBps, p95OutMBps, peakInMBps, peakOutMBps float64) report.ProcessedCluster {
 	p95In := p95InMBps * bytesPerMBps
 	p95Out := p95OutMBps * bytesPerMBps
 	peakIn := peakInMBps * bytesPerMBps
 	peakOut := peakOutMBps * bytesPerMBps
-	return types.ProcessedCluster{
+	return report.ProcessedCluster{
 		Name:   name,
 		Region: "us-east-1",
 		ClusterMetrics: types.ProcessedClusterMetrics{
@@ -78,7 +79,7 @@ func TestComputeClusterSizing_SLAFloorBinds(t *testing.T) {
 func TestComputeClusterSizing_DegradedOnMissingP95(t *testing.T) {
 	// State file that has zero metric aggregates (kcp discover ran without
 	// kcp scan metrics) should not abort — surface a degraded sizing.
-	c := types.ProcessedCluster{
+	c := report.ProcessedCluster{
 		Name:                        "no-metrics",
 		ClusterMetrics:              types.ProcessedClusterMetrics{Aggregates: map[string]types.MetricAggregate{}},
 		KafkaAdminClientInformation: types.KafkaAdminClientInformation{Topics: &types.Topics{Summary: types.TopicSummary{TotalPartitions: 50}}},

--- a/internal/services/plan/tiered_storage.go
+++ b/internal/services/plan/tiered_storage.go
@@ -1,9 +1,8 @@
 package plan
 
 import (
-	"github.com/confluentinc/kcp/internal/types"
-
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // Plan-input enum tokens for tiered-storage knobs. Stable
@@ -28,7 +27,7 @@ const (
 // trade-off (mechanism / duration / cost direction) so the customer
 // (and account team) can decide whether the cold data is worth
 // re-fetching.
-func detectTieredStorage(state types.ProcessedState, inputs PlanInputsResolved) *TieredStorageSection {
+func detectTieredStorage(state report.ProcessedState, inputs PlanInputsResolved) *TieredStorageSection {
 	clusters := collectClusters(state)
 	var tiered []TieredStorageCluster
 	for _, c := range clusters {
@@ -67,7 +66,7 @@ func detectTieredStorage(state types.ProcessedState, inputs PlanInputsResolved) 
 // whereas Average over a 30-day window for a fixed 7-day retention
 // would report ~half the real current footprint. Falls back to
 // Average when Maximum isn't populated.
-func remoteLogSizeBytesOf(c types.ProcessedCluster) float64 {
+func remoteLogSizeBytesOf(c report.ProcessedCluster) float64 {
 	agg, ok := c.ClusterMetrics.Aggregates["RemoteLogSizeBytes"]
 	if !ok {
 		return 0

--- a/internal/services/plan/topic_patterns.go
+++ b/internal/services/plan/topic_patterns.go
@@ -3,7 +3,7 @@ package plan
 import (
 	"regexp"
 
-	"github.com/confluentinc/kcp/internal/types"
+	"github.com/confluentinc/kcp/internal/services/report"
 )
 
 // Shared topic-name regexes used by both the Red Flags detector
@@ -70,7 +70,7 @@ var (
 // evidence. Returns (false, "") when the topics scan didn't populate
 // — the upstream `topic_inventory_empty` OQ already surfaces that
 // gap, so callers shouldn't conflate "no match" with "no scan".
-func topicPatternFound(c types.ProcessedCluster, re *regexp.Regexp) (bool, string) {
+func topicPatternFound(c report.ProcessedCluster, re *regexp.Regexp) (bool, string) {
 	if c.KafkaAdminClientInformation.Topics == nil {
 		return false, ""
 	}

--- a/internal/services/report/processed.go
+++ b/internal/services/report/processed.go
@@ -1,20 +1,21 @@
-package types
+package report
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
+
+	"github.com/confluentinc/kcp/internal/types"
 )
 
 // ProcessedState represents the transformed output data structure
 // This is what comes OUT of the frontend/API after processing the raw State data
 // Same structure as State but with costs and metrics flattened for easier frontend consumption
 type ProcessedState struct {
-	Sources          []ProcessedSource      `json:"sources"`
-	SchemaRegistries *SchemaRegistriesState `json:"schema_registries,omitempty"`
-	KcpBuildInfo     interface{}            `json:"kcp_build_info,omitempty"`
-	Timestamp        time.Time              `json:"timestamp"`
+	Sources          []ProcessedSource            `json:"sources"`
+	SchemaRegistries *types.SchemaRegistriesState `json:"schema_registries,omitempty"`
+	KcpBuildInfo     interface{}                  `json:"kcp_build_info,omitempty"`
+	Timestamp        time.Time                    `json:"timestamp"`
 }
 
 // ProcessedRegion mirrors DiscoveredRegion but with flattened costs and simplified clusters
@@ -27,21 +28,11 @@ type ProcessedRegion struct {
 
 type ProcessedRegionCosts struct {
 	Region     string              `json:"region"`
-	Metadata   CostMetadata        `json:"metadata"`
+	Metadata   types.CostMetadata  `json:"metadata"`
 	Results    []ProcessedCost     `json:"results"`
 	Aggregates ProcessedAggregates `json:"aggregates"`
-	QueryInfo  CostQueryInfo       `json:"query_info"`
+	QueryInfo  types.CostQueryInfo `json:"query_info"`
 }
-
-// AWS service name constants — single source of truth for Cost Explorer service filters.
-// Frontend constants (cmd/ui/frontend/src/constants/index.ts AWS_SERVICES) should mirror these.
-const (
-	ServiceAWSCertificateManager = "AWS Certificate Manager"
-	ServiceMSK                   = "Amazon Managed Streaming for Apache Kafka"
-	ServiceEC2Other              = "EC2 - Other"
-	ServiceELB                   = "Amazon Elastic Load Balancing"
-	ServiceVPC                   = "Amazon Virtual Private Cloud"
-)
 
 // newServiceCostAggregates creates a ServiceCostAggregates with all maps initialized
 func newServiceCostAggregates() ServiceCostAggregates {
@@ -58,15 +49,15 @@ func newServiceCostAggregates() ServiceCostAggregates {
 // or nil if the service is not recognized.
 func (a *ProcessedAggregates) ForService(name string) *ServiceCostAggregates {
 	switch name {
-	case ServiceAWSCertificateManager:
+	case types.ServiceAWSCertificateManager:
 		return &a.AWSCertificateManager
-	case ServiceMSK:
+	case types.ServiceMSK:
 		return &a.AmazonManagedStreamingForApacheKafka
-	case ServiceEC2Other:
+	case types.ServiceEC2Other:
 		return &a.EC2Other
-	case ServiceELB:
+	case types.ServiceELB:
 		return &a.ElasticLoadBalancing
-	case ServiceVPC:
+	case types.ServiceVPC:
 		return &a.AmazonVPC
 	}
 	return nil
@@ -111,44 +102,13 @@ type ProcessedCostBreakdown struct {
 // ProcessedCluster contains the complete cluster data with flattened metrics
 // This is the full cluster information with processed metrics, unlike the simplified version in types.go
 type ProcessedCluster struct {
-	Name                        string                      `json:"name"`
-	Arn                         string                      `json:"arn"`
-	Region                      string                      `json:"region"`
-	ClusterMetrics              ProcessedClusterMetrics     `json:"metrics"` // Flattened from raw CloudWatch metrics
-	AWSClientInformation        AWSClientInformation        `json:"aws_client_information"`
-	KafkaAdminClientInformation KafkaAdminClientInformation `json:"kafka_admin_client_information"`
-	DiscoveredClients           []DiscoveredClient          `json:"discovered_clients"`
-}
-
-type ProcessedClusterMetrics struct {
-	Region     string                     `json:"region"`
-	ClusterArn string                     `json:"cluster_arn"`
-	Metadata   MetricMetadata             `json:"metadata"`
-	Metrics    []ProcessedMetric          `json:"results"`
-	Aggregates map[string]MetricAggregate `json:"aggregates"`
-	QueryInfo  []MetricQueryInfo          `json:"query_info"`
-	// OSK-specific fields (optional, omitempty for MSK clusters)
-	Environment string `json:"environment,omitempty"`
-	Location    string `json:"location,omitempty"`
-}
-
-type ProcessedMetric struct {
-	Start string   `json:"start"`
-	End   string   `json:"end"`
-	Label string   `json:"label"`
-	Value *float64 `json:"value"`
-}
-
-type MetricAggregate struct {
-	Average *float64 `json:"avg"`
-	Maximum *float64 `json:"max"`
-	Minimum *float64 `json:"min"`
-	P95     *float64 `json:"p95"`
-	P99     *float64 `json:"p99"`
-	// Count is the sample size of the aggregate. With `omitempty`,
-	// "unknown" and "exactly 0 samples" both render as absent — treat
-	// absence as "no sample data".
-	Count int `json:"count,omitempty"`
+	Name                        string                            `json:"name"`
+	Arn                         string                            `json:"arn"`
+	Region                      string                            `json:"region"`
+	ClusterMetrics              types.ProcessedClusterMetrics     `json:"metrics"` // Flattened from raw CloudWatch metrics
+	AWSClientInformation        types.AWSClientInformation        `json:"aws_client_information"`
+	KafkaAdminClientInformation types.KafkaAdminClientInformation `json:"kafka_admin_client_information"`
+	DiscoveredClients           []types.DiscoveredClient          `json:"discovered_clients"`
 }
 
 type CostAggregate struct {
@@ -168,31 +128,9 @@ type ServiceCostAggregates struct {
 	NetUnblendedCost map[string]any `json:"net_unblended_cost"`
 }
 
-// SourceType represents the type of Kafka source
-type SourceType string
-
-const (
-	SourceTypeMSK SourceType = "msk"
-	SourceTypeOSK SourceType = "osk"
-)
-
-// ParseSourceTypeFlag maps a user-facing --source-type flag value to the internal
-// SourceType token. The Apache Kafka source is "apache-kafka" to users but is
-// represented internally as "osk".
-func ParseSourceTypeFlag(flag string) (SourceType, error) {
-	switch flag {
-	case "msk":
-		return SourceTypeMSK, nil
-	case "apache-kafka":
-		return SourceTypeOSK, nil
-	default:
-		return "", fmt.Errorf("invalid source-type %q: must be 'msk' or 'apache-kafka'", flag)
-	}
-}
-
 // ProcessedSource represents a unified source (MSK or OSK) with discriminated union
 type ProcessedSource struct {
-	Type    SourceType          `json:"type"`
+	Type    types.SourceType    `json:"type"`
 	MSKData *ProcessedMSKSource `json:"msk_data,omitempty"`
 	OSKData *ProcessedOSKSource `json:"osk_data,omitempty"`
 }
@@ -209,10 +147,10 @@ type ProcessedOSKSource struct {
 
 // ProcessedOSKCluster represents an OSK cluster in the API response
 type ProcessedOSKCluster struct {
-	ID                          string                      `json:"id"`
-	BootstrapServers            []string                    `json:"bootstrap_servers"`
-	KafkaAdminClientInformation KafkaAdminClientInformation `json:"kafka_admin_client_information"`
-	ClusterMetrics              *ProcessedClusterMetrics    `json:"metrics,omitempty"`
-	DiscoveredClients           []DiscoveredClient          `json:"discovered_clients"`
-	Metadata                    OSKClusterMetadata          `json:"metadata"`
+	ID                          string                            `json:"id"`
+	BootstrapServers            []string                          `json:"bootstrap_servers"`
+	KafkaAdminClientInformation types.KafkaAdminClientInformation `json:"kafka_admin_client_information"`
+	ClusterMetrics              *types.ProcessedClusterMetrics    `json:"metrics,omitempty"`
+	DiscoveredClients           []types.DiscoveredClient          `json:"discovered_clients"`
+	Metadata                    types.OSKClusterMetadata          `json:"metadata"`
 }

--- a/internal/services/report/processed_test.go
+++ b/internal/services/report/processed_test.go
@@ -1,0 +1,37 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+func TestProcessedSource_TypeDiscrimination(t *testing.T) {
+	// Test MSK source
+	mskSource := ProcessedSource{
+		Type: types.SourceTypeMSK,
+		MSKData: &ProcessedMSKSource{
+			Regions: []ProcessedRegion{},
+		},
+	}
+	if mskSource.Type != types.SourceTypeMSK {
+		t.Errorf("Expected MSK type, got %s", mskSource.Type)
+	}
+	if mskSource.MSKData == nil {
+		t.Error("MSKData should not be nil for MSK source")
+	}
+
+	// Test OSK source
+	oskSource := ProcessedSource{
+		Type: types.SourceTypeOSK,
+		OSKData: &ProcessedOSKSource{
+			Clusters: []ProcessedOSKCluster{},
+		},
+	}
+	if oskSource.Type != types.SourceTypeOSK {
+		t.Errorf("Expected OSK type, got %s", oskSource.Type)
+	}
+	if oskSource.OSKData == nil {
+		t.Error("OSKData should not be nil for OSK source")
+	}
+}

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -23,24 +23,24 @@ func NewReportService() *ReportService {
 	return &ReportService{}
 }
 
-func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
-	sources := []types.ProcessedSource{}
+func (rs *ReportService) ProcessState(state types.State) ProcessedState {
+	sources := []ProcessedSource{}
 
 	// Process MSK if present
 	if state.MSKSources != nil && len(state.MSKSources.Regions) > 0 {
-		processedRegions := []types.ProcessedRegion{}
+		processedRegions := []ProcessedRegion{}
 
 		for _, region := range state.MSKSources.Regions {
 			// Flatten cost data from nested AWS Cost Explorer format
 			processedCosts := rs.flattenCosts(region)
 
 			// Process each cluster's metrics
-			processedClusters := []types.ProcessedCluster{}
+			processedClusters := []ProcessedCluster{}
 			for _, cluster := range region.Clusters {
 				// Flatten metrics data from nested CloudWatch format
 				processedMetrics := rs.flattenMetrics(cluster)
 
-				processedClusters = append(processedClusters, types.ProcessedCluster{
+				processedClusters = append(processedClusters, ProcessedCluster{
 					Name:                        cluster.Name,
 					Arn:                         cluster.Arn,
 					Region:                      cluster.Region,
@@ -51,7 +51,7 @@ func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
 				})
 			}
 
-			processedRegions = append(processedRegions, types.ProcessedRegion{
+			processedRegions = append(processedRegions, ProcessedRegion{
 				Name:           region.Name,
 				Configurations: region.Configurations,
 				Costs:          processedCosts,
@@ -59,9 +59,9 @@ func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
 			})
 		}
 
-		mskSource := types.ProcessedSource{
+		mskSource := ProcessedSource{
 			Type: types.SourceTypeMSK,
-			MSKData: &types.ProcessedMSKSource{
+			MSKData: &ProcessedMSKSource{
 				Regions: processedRegions,
 			},
 		}
@@ -70,10 +70,10 @@ func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
 
 	// Process OSK if present
 	if state.OSKSources != nil && len(state.OSKSources.Clusters) > 0 {
-		processedOSKClusters := []types.ProcessedOSKCluster{}
+		processedOSKClusters := []ProcessedOSKCluster{}
 
 		for _, cluster := range state.OSKSources.Clusters {
-			processedOSKClusters = append(processedOSKClusters, types.ProcessedOSKCluster{
+			processedOSKClusters = append(processedOSKClusters, ProcessedOSKCluster{
 				ID:                          cluster.ID,
 				BootstrapServers:            cluster.BootstrapServers,
 				KafkaAdminClientInformation: cluster.KafkaAdminClientInformation,
@@ -83,9 +83,9 @@ func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
 			})
 		}
 
-		oskSource := types.ProcessedSource{
+		oskSource := ProcessedSource{
 			Type: types.SourceTypeOSK,
-			OSKData: &types.ProcessedOSKSource{
+			OSKData: &ProcessedOSKSource{
 				Clusters: processedOSKClusters,
 			},
 		}
@@ -93,7 +93,7 @@ func (rs *ReportService) ProcessState(state types.State) types.ProcessedState {
 	}
 
 	// Return the processed state with unified sources
-	processedState := types.ProcessedState{
+	processedState := ProcessedState{
 		Sources:          sources,
 		SchemaRegistries: state.SchemaRegistries,
 		KcpBuildInfo:     state.KcpBuildInfo,
@@ -136,9 +136,9 @@ func (rs *ReportService) filterMetricsByDateRange(metrics []types.ProcessedMetri
 }
 
 // FilterRegionCosts filters the processed state to return cost data for a specific region
-func (rs *ReportService) FilterRegionCosts(processedState types.ProcessedState, regionName string, startTime, endTime *time.Time) (*types.ProcessedRegionCosts, error) {
+func (rs *ReportService) FilterRegionCosts(processedState ProcessedState, regionName string, startTime, endTime *time.Time) (*ProcessedRegionCosts, error) {
 	// Find the MSK source and the specified region
-	var targetRegion *types.ProcessedRegion
+	var targetRegion *ProcessedRegion
 	for _, source := range processedState.Sources {
 		if source.Type == types.SourceTypeMSK && source.MSKData != nil {
 			for _, r := range source.MSKData.Regions {
@@ -160,7 +160,7 @@ func (rs *ReportService) FilterRegionCosts(processedState types.ProcessedState, 
 	regionCosts := targetRegion.Costs
 
 	// If no date filters, use all costs but still calculate aggregates
-	var filteredCosts []types.ProcessedCost
+	var filteredCosts []ProcessedCost
 	if startTime == nil && endTime == nil {
 		filteredCosts = regionCosts.Results
 	} else {
@@ -193,7 +193,7 @@ func (rs *ReportService) FilterRegionCosts(processedState types.ProcessedState, 
 	// Calculate aggregates from filtered costs
 	aggregates := rs.calculateCostAggregates(filteredCosts)
 
-	return &types.ProcessedRegionCosts{
+	return &ProcessedRegionCosts{
 		Region:     regionName,
 		Metadata:   regionCosts.Metadata,
 		Results:    filteredCosts,
@@ -204,7 +204,7 @@ func (rs *ReportService) FilterRegionCosts(processedState types.ProcessedState, 
 
 // filterClusterMetrics filters the processed state by cluster ID and date range
 // sourceType can be "msk", "osk", or "auto" (auto-detects based on identifier pattern)
-func (rs *ReportService) FilterClusterMetrics(processedState types.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (rs *ReportService) FilterClusterMetrics(processedState ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	if sourceType == "" || sourceType == "auto" {
 		if strings.HasPrefix(clusterID, "arn:") {
 			sourceType = "msk"
@@ -223,9 +223,9 @@ func (rs *ReportService) FilterClusterMetrics(processedState types.ProcessedStat
 	}
 }
 
-func (rs *ReportService) filterMSKClusterMetrics(processedState types.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (rs *ReportService) filterMSKClusterMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	var regionName string
-	var targetCluster *types.ProcessedCluster
+	var targetCluster *ProcessedCluster
 
 	for _, source := range processedState.Sources {
 		if source.Type == types.SourceTypeMSK && source.MSKData != nil {
@@ -276,8 +276,8 @@ func (rs *ReportService) filterMSKClusterMetrics(processedState types.ProcessedS
 }
 
 // filterOSKClusterMetrics filters OSK cluster metrics by cluster ID
-func (rs *ReportService) filterOSKClusterMetrics(processedState types.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
-	var targetCluster *types.ProcessedOSKCluster
+func (rs *ReportService) filterOSKClusterMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+	var targetCluster *ProcessedOSKCluster
 
 	// Find the cluster in OSK sources
 	for _, source := range processedState.Sources {
@@ -331,9 +331,9 @@ func (rs *ReportService) filterOSKClusterMetrics(processedState types.ProcessedS
 }
 
 // filterMetrics filters the processed state by region, cluster, and date range
-func (rs *ReportService) FilterMetrics(processedState types.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (rs *ReportService) FilterMetrics(processedState ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
 	// Find the specified region in MSK sources
-	var targetRegion *types.ProcessedRegion
+	var targetRegion *ProcessedRegion
 	for _, source := range processedState.Sources {
 		if source.Type == types.SourceTypeMSK && source.MSKData != nil {
 			for _, r := range source.MSKData.Regions {
@@ -352,7 +352,7 @@ func (rs *ReportService) FilterMetrics(processedState types.ProcessedState, regi
 	}
 
 	// Find the specified cluster within the region
-	var targetCluster *types.ProcessedCluster
+	var targetCluster *ProcessedCluster
 	for _, c := range targetRegion.Clusters {
 		if strings.EqualFold(c.Name, clusterName) {
 			targetCluster = &c
@@ -379,8 +379,8 @@ func (rs *ReportService) FilterMetrics(processedState types.ProcessedState, regi
 
 // calculateCostAggregates takes raw cost data and calculates statistics for each unique combination
 // of service + metric type + usage type, then organizes it into the final nested structure
-func (rs *ReportService) calculateCostAggregates(costs []types.ProcessedCost) types.ProcessedAggregates {
-	aggregates := types.NewProcessedAggregates()
+func (rs *ReportService) calculateCostAggregates(costs []ProcessedCost) ProcessedAggregates {
+	aggregates := NewProcessedAggregates()
 
 	if len(costs) == 0 {
 		return aggregates
@@ -459,7 +459,7 @@ func (rs *ReportService) calculateCostAggregates(costs []types.ProcessedCost) ty
 		avg := sum / float64(len(data.Values)) // Calculate average
 
 		// Create the final aggregate structure with all statistics
-		costAggregate := types.CostAggregate{
+		costAggregate := CostAggregate{
 			Sum:     &sum,
 			Average: &avg,
 			Maximum: &max,
@@ -495,7 +495,7 @@ func (rs *ReportService) calculateCostAggregates(costs []types.ProcessedCost) ty
 }
 
 // assignToServiceMetric assigns a cost aggregate to the correct metric field
-func (rs *ReportService) assignToServiceMetric(service *types.ServiceCostAggregates, metricName, usageType string, aggregate types.CostAggregate) {
+func (rs *ReportService) assignToServiceMetric(service *ServiceCostAggregates, metricName, usageType string, aggregate CostAggregate) {
 	switch metricName {
 	case "unblended_cost":
 		service.UnblendedCost[usageType] = aggregate
@@ -511,7 +511,7 @@ func (rs *ReportService) assignToServiceMetric(service *types.ServiceCostAggrega
 }
 
 // assignServiceTotal assigns a service total to the correct metric field
-func (rs *ReportService) assignServiceTotal(service *types.ServiceCostAggregates, metricName string, total float64) {
+func (rs *ReportService) assignServiceTotal(service *ServiceCostAggregates, metricName string, total float64) {
 	switch metricName {
 	case "unblended_cost":
 		service.UnblendedCost["total"] = total
@@ -526,8 +526,8 @@ func (rs *ReportService) assignServiceTotal(service *types.ServiceCostAggregates
 	}
 }
 
-func (rs *ReportService) flattenCosts(region types.DiscoveredRegion) types.ProcessedRegionCosts {
-	var processedCosts []types.ProcessedCost
+func (rs *ReportService) flattenCosts(region types.DiscoveredRegion) ProcessedRegionCosts {
+	var processedCosts []ProcessedCost
 
 	for _, result := range region.Costs.CostResults {
 		if result.TimePeriod == nil {
@@ -545,7 +545,7 @@ func (rs *ReportService) flattenCosts(region types.DiscoveredRegion) types.Proce
 			service := aws.ToString(&group.Keys[0])
 			lineItem := aws.ToString(&group.Keys[1])
 
-			var costBreakdown types.ProcessedCostBreakdown
+			var costBreakdown ProcessedCostBreakdown
 
 			if metric, exists := group.Metrics["UnblendedCost"]; exists && metric.Amount != nil {
 				if costFloat, err := strconv.ParseFloat(aws.ToString(metric.Amount), 64); err == nil {
@@ -573,7 +573,7 @@ func (rs *ReportService) flattenCosts(region types.DiscoveredRegion) types.Proce
 				}
 			}
 
-			processedCosts = append(processedCosts, types.ProcessedCost{
+			processedCosts = append(processedCosts, ProcessedCost{
 				Start:     start,
 				End:       end,
 				Service:   service,
@@ -583,7 +583,7 @@ func (rs *ReportService) flattenCosts(region types.DiscoveredRegion) types.Proce
 		}
 	}
 
-	return types.ProcessedRegionCosts{
+	return ProcessedRegionCosts{
 		Metadata:  region.Costs.CostMetadata,
 		Results:   processedCosts,
 		QueryInfo: region.Costs.QueryInfo,

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -20,31 +20,31 @@ func TestCalculateCostAggregates(t *testing.T) {
 	})
 
 	t.Run("routes costs to correct service aggregates", func(t *testing.T) {
-		costs := []types.ProcessedCost{
+		costs := []ProcessedCost{
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceMSK, UsageType: "USE1-Kafka.m5.large",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 10.0, BlendedCost: 10.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 10.0, BlendedCost: 10.0},
 			},
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceELB, UsageType: "USE1-LoadBalancerUsage",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 5.0, BlendedCost: 5.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 5.0, BlendedCost: 5.0},
 			},
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceVPC, UsageType: "USE1-VpcEndpoint-Hours",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 3.0, BlendedCost: 3.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 3.0, BlendedCost: 3.0},
 			},
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceEC2Other, UsageType: "USE1-NatGateway-Hours",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 2.0, BlendedCost: 2.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 2.0, BlendedCost: 2.0},
 			},
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceAWSCertificateManager, UsageType: "USE1-FreePrivateCA",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 1.0, BlendedCost: 1.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 1.0, BlendedCost: 1.0},
 			},
 		}
 
@@ -66,23 +66,23 @@ func TestCalculateCostAggregates(t *testing.T) {
 	})
 
 	t.Run("aggregates multiple entries for same service and usage type", func(t *testing.T) {
-		costs := []types.ProcessedCost{
+		costs := []ProcessedCost{
 			{
 				Start: "2025-01-01", End: "2025-01-02",
 				Service: types.ServiceELB, UsageType: "USE1-LoadBalancerUsage",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 5.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 5.0},
 			},
 			{
 				Start: "2025-01-02", End: "2025-01-03",
 				Service: types.ServiceELB, UsageType: "USE1-LoadBalancerUsage",
-				Values: types.ProcessedCostBreakdown{UnblendedCost: 7.0},
+				Values: ProcessedCostBreakdown{UnblendedCost: 7.0},
 			},
 		}
 
 		aggregates := rs.calculateCostAggregates(costs)
 
 		// Sum should be 12.0
-		agg, ok := aggregates.ElasticLoadBalancing.UnblendedCost["USE1-LoadBalancerUsage"].(types.CostAggregate)
+		agg, ok := aggregates.ElasticLoadBalancing.UnblendedCost["USE1-LoadBalancerUsage"].(CostAggregate)
 		require.True(t, ok)
 		require.NotNil(t, agg.Sum)
 		assert.InDelta(t, 12.0, *agg.Sum, 0.001)
@@ -93,7 +93,7 @@ func TestCalculateCostAggregates(t *testing.T) {
 }
 
 func TestForService(t *testing.T) {
-	aggregates := types.NewProcessedAggregates()
+	aggregates := NewProcessedAggregates()
 
 	assert.Equal(t, &aggregates.AmazonManagedStreamingForApacheKafka, aggregates.ForService(types.ServiceMSK))
 	assert.Equal(t, &aggregates.ElasticLoadBalancing, aggregates.ForService(types.ServiceELB))
@@ -103,13 +103,13 @@ func TestForService(t *testing.T) {
 	assert.Nil(t, aggregates.ForService("Unknown Service"))
 }
 
-func assertHasUsageType(t *testing.T, svc types.ServiceCostAggregates, usageType string) {
+func assertHasUsageType(t *testing.T, svc ServiceCostAggregates, usageType string) {
 	t.Helper()
 	_, ok := svc.UnblendedCost[usageType]
 	assert.True(t, ok, "expected usage type %q in UnblendedCost", usageType)
 }
 
-func assertServiceTotal(t *testing.T, svc types.ServiceCostAggregates, expectedTotal float64) {
+func assertServiceTotal(t *testing.T, svc ServiceCostAggregates, expectedTotal float64) {
 	t.Helper()
 	total, ok := svc.UnblendedCost["total"].(float64)
 	require.True(t, ok, "expected 'total' key in UnblendedCost")
@@ -358,16 +358,16 @@ func TestFilterClusterMetrics_SourceAware(t *testing.T) {
 	rs := NewReportService()
 
 	// Create a test state with both MSK and OSK clusters
-	processedState := types.ProcessedState{
-		Sources: []types.ProcessedSource{
+	processedState := ProcessedState{
+		Sources: []ProcessedSource{
 			// MSK source with cluster
 			{
 				Type: types.SourceTypeMSK,
-				MSKData: &types.ProcessedMSKSource{
-					Regions: []types.ProcessedRegion{
+				MSKData: &ProcessedMSKSource{
+					Regions: []ProcessedRegion{
 						{
 							Name: "us-east-1",
-							Clusters: []types.ProcessedCluster{
+							Clusters: []ProcessedCluster{
 								{
 									Name: "test-msk-cluster",
 									Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/test-msk-cluster/abc-123",
@@ -391,8 +391,8 @@ func TestFilterClusterMetrics_SourceAware(t *testing.T) {
 			// OSK source with cluster
 			{
 				Type: types.SourceTypeOSK,
-				OSKData: &types.ProcessedOSKSource{
-					Clusters: []types.ProcessedOSKCluster{
+				OSKData: &ProcessedOSKSource{
+					Clusters: []ProcessedOSKCluster{
 						{
 							ID:               "my-osk-cluster",
 							BootstrapServers: []string{"broker1:9092"},
@@ -544,12 +544,12 @@ func TestFilterClusterMetrics_SourceAware(t *testing.T) {
 
 	t.Run("OSK cluster without metrics returns cluster with nil metrics", func(t *testing.T) {
 		// Create state with OSK cluster that has no metrics
-		stateWithoutMetrics := types.ProcessedState{
-			Sources: []types.ProcessedSource{
+		stateWithoutMetrics := ProcessedState{
+			Sources: []ProcessedSource{
 				{
 					Type: types.SourceTypeOSK,
-					OSKData: &types.ProcessedOSKSource{
-						Clusters: []types.ProcessedOSKCluster{
+					OSKData: &ProcessedOSKSource{
+						Clusters: []ProcessedOSKCluster{
 							{
 								ID:               "no-metrics-cluster",
 								BootstrapServers: []string{"broker1:9092"},
@@ -596,12 +596,12 @@ func TestFilterOSKClusterMetrics_PopulatesMetadata(t *testing.T) {
 	rs := NewReportService()
 
 	t.Run("OSK cluster with metadata populates Environment and Location", func(t *testing.T) {
-		processedState := types.ProcessedState{
-			Sources: []types.ProcessedSource{
+		processedState := ProcessedState{
+			Sources: []ProcessedSource{
 				{
 					Type: types.SourceTypeOSK,
-					OSKData: &types.ProcessedOSKSource{
-						Clusters: []types.ProcessedOSKCluster{
+					OSKData: &ProcessedOSKSource{
+						Clusters: []ProcessedOSKCluster{
 							{
 								ID:               "prod-cluster",
 								BootstrapServers: []string{"broker1:9092"},
@@ -636,12 +636,12 @@ func TestFilterOSKClusterMetrics_PopulatesMetadata(t *testing.T) {
 	})
 
 	t.Run("OSK cluster without metadata fields has empty Environment and Location", func(t *testing.T) {
-		processedState := types.ProcessedState{
-			Sources: []types.ProcessedSource{
+		processedState := ProcessedState{
+			Sources: []ProcessedSource{
 				{
 					Type: types.SourceTypeOSK,
-					OSKData: &types.ProcessedOSKSource{
-						Clusters: []types.ProcessedOSKCluster{
+					OSKData: &ProcessedOSKSource{
+						Clusters: []ProcessedOSKCluster{
 							{
 								ID:               "no-metadata-cluster",
 								BootstrapServers: []string{"broker1:9092"},
@@ -668,12 +668,12 @@ func TestFilterOSKClusterMetrics_PopulatesMetadata(t *testing.T) {
 	})
 
 	t.Run("OSK cluster with nil metrics still populates metadata", func(t *testing.T) {
-		processedState := types.ProcessedState{
-			Sources: []types.ProcessedSource{
+		processedState := ProcessedState{
+			Sources: []ProcessedSource{
 				{
 					Type: types.SourceTypeOSK,
-					OSKData: &types.ProcessedOSKSource{
-						Clusters: []types.ProcessedOSKCluster{
+					OSKData: &ProcessedOSKSource{
+						Clusters: []ProcessedOSKCluster{
 							{
 								ID:               "no-metrics-cluster",
 								BootstrapServers: []string{"broker1:9092"},
@@ -700,15 +700,15 @@ func TestFilterOSKClusterMetrics_PopulatesMetadata(t *testing.T) {
 	})
 
 	t.Run("MSK cluster has empty Environment and Location", func(t *testing.T) {
-		processedState := types.ProcessedState{
-			Sources: []types.ProcessedSource{
+		processedState := ProcessedState{
+			Sources: []ProcessedSource{
 				{
 					Type: types.SourceTypeMSK,
-					MSKData: &types.ProcessedMSKSource{
-						Regions: []types.ProcessedRegion{
+					MSKData: &ProcessedMSKSource{
+						Regions: []ProcessedRegion{
 							{
 								Name: "us-east-1",
-								Clusters: []types.ProcessedCluster{
+								Clusters: []ProcessedCluster{
 									{
 										Name: "msk-cluster",
 										Arn:  "arn:aws:kafka:us-east-1:123456789012:cluster/msk-cluster/abc",
@@ -749,12 +749,12 @@ func TestFilterClusterMetrics_DateFiltering(t *testing.T) {
 		return &t
 	}
 
-	oskState := types.ProcessedState{
-		Sources: []types.ProcessedSource{
+	oskState := ProcessedState{
+		Sources: []ProcessedSource{
 			{
 				Type: types.SourceTypeOSK,
-				OSKData: &types.ProcessedOSKSource{
-					Clusters: []types.ProcessedOSKCluster{
+				OSKData: &ProcessedOSKSource{
+					Clusters: []ProcessedOSKCluster{
 						{
 							ID:               "date-test-cluster",
 							BootstrapServers: []string{"broker1:9092"},

--- a/internal/types/costs.go
+++ b/internal/types/costs.go
@@ -38,3 +38,13 @@ type CostMetadata struct {
 	Tags        map[string][]string `json:"tags"`
 	Services    []string            `json:"services"`
 }
+
+// AWS service name constants — single source of truth for Cost Explorer service filters.
+// Frontend constants (cmd/ui/frontend/src/constants/index.ts AWS_SERVICES) should mirror these.
+const (
+	ServiceAWSCertificateManager = "AWS Certificate Manager"
+	ServiceMSK                   = "Amazon Managed Streaming for Apache Kafka"
+	ServiceEC2Other              = "EC2 - Other"
+	ServiceELB                   = "Amazon Elastic Load Balancing"
+	ServiceVPC                   = "Amazon Virtual Private Cloud"
+)

--- a/internal/types/metrics.go
+++ b/internal/types/metrics.go
@@ -119,3 +119,34 @@ func FormatQueryDuration(d time.Duration) string {
 		return fmt.Sprintf("%dd", days)
 	}
 }
+
+type ProcessedClusterMetrics struct {
+	Region     string                     `json:"region"`
+	ClusterArn string                     `json:"cluster_arn"`
+	Metadata   MetricMetadata             `json:"metadata"`
+	Metrics    []ProcessedMetric          `json:"results"`
+	Aggregates map[string]MetricAggregate `json:"aggregates"`
+	QueryInfo  []MetricQueryInfo          `json:"query_info"`
+	// OSK-specific fields (optional, omitempty for MSK clusters)
+	Environment string `json:"environment,omitempty"`
+	Location    string `json:"location,omitempty"`
+}
+
+type ProcessedMetric struct {
+	Start string   `json:"start"`
+	End   string   `json:"end"`
+	Label string   `json:"label"`
+	Value *float64 `json:"value"`
+}
+
+type MetricAggregate struct {
+	Average *float64 `json:"avg"`
+	Maximum *float64 `json:"max"`
+	Minimum *float64 `json:"min"`
+	P95     *float64 `json:"p95"`
+	P99     *float64 `json:"p99"`
+	// Count is the sample size of the aggregate. With `omitempty`,
+	// "unknown" and "exactly 0 samples" both render as absent — treat
+	// absence as "no sample data".
+	Count int `json:"count,omitempty"`
+}

--- a/internal/types/source.go
+++ b/internal/types/source.go
@@ -1,0 +1,25 @@
+package types
+
+import "fmt"
+
+// SourceType represents the type of Kafka source
+type SourceType string
+
+const (
+	SourceTypeMSK SourceType = "msk"
+	SourceTypeOSK SourceType = "osk"
+)
+
+// ParseSourceTypeFlag maps a user-facing --source-type flag value to the internal
+// SourceType token. The Apache Kafka source is "apache-kafka" to users but is
+// represented internally as "osk".
+func ParseSourceTypeFlag(flag string) (SourceType, error) {
+	switch flag {
+	case "msk":
+		return SourceTypeMSK, nil
+	case "apache-kafka":
+		return SourceTypeOSK, nil
+	default:
+		return "", fmt.Errorf("invalid source-type %q: must be 'msk' or 'apache-kafka'", flag)
+	}
+}

--- a/internal/types/state_test.go
+++ b/internal/types/state_test.go
@@ -825,36 +825,6 @@ func TestNewStateFrom_PreservesExistingOSKData(t *testing.T) {
 	}
 }
 
-func TestProcessedSource_TypeDiscrimination(t *testing.T) {
-	// Test MSK source
-	mskSource := ProcessedSource{
-		Type: SourceTypeMSK,
-		MSKData: &ProcessedMSKSource{
-			Regions: []ProcessedRegion{},
-		},
-	}
-	if mskSource.Type != SourceTypeMSK {
-		t.Errorf("Expected MSK type, got %s", mskSource.Type)
-	}
-	if mskSource.MSKData == nil {
-		t.Error("MSKData should not be nil for MSK source")
-	}
-
-	// Test OSK source
-	oskSource := ProcessedSource{
-		Type: SourceTypeOSK,
-		OSKData: &ProcessedOSKSource{
-			Clusters: []ProcessedOSKCluster{},
-		},
-	}
-	if oskSource.Type != SourceTypeOSK {
-		t.Errorf("Expected OSK type, got %s", oskSource.Type)
-	}
-	if oskSource.OSKData == nil {
-		t.Error("OSKData should not be nil for OSK source")
-	}
-}
-
 func TestGetOSKClusterByID_Found(t *testing.T) {
 	state := &State{
 		OSKSources: &OSKSourcesState{


### PR DESCRIPTION
## Summary

Pass 2.5 of the `internal/types` reorg. Splits the `processed.go` grab-bag three ways by ownership, and deletes `internal/types/processed.go`.

The plan slated the `Processed*` family for `internal/services/report`, but the import graph showed two pieces that **must stay** in `internal/types` to avoid inverting layering — so this is a precise three-way split, not a wholesale move.

## The split

**Move → `internal/services/report/processed.go`** (report-aggregation output shapes):
`ProcessedState`, `ProcessedRegion`, `ProcessedRegionCosts`, `ProcessedAggregates` (+ `ForService`/`NewProcessedAggregates`), `ProcessedCost`, `ProcessedCostBreakdown`, `ProcessedCluster`, `CostAggregate`, `ServiceCostAggregates`, `ProcessedSource`/`ProcessedMSKSource`/`ProcessedOSKSource`, `ProcessedOSKCluster`.
→ `report` is their sole producer (`ReportService.ProcessState`); `plan` already imports `report`, and `report` imports neither `plan` nor `cmd`, so no cycle.

**Stay in `internal/types`** (relocated to cohesive files):
- `ProcessedClusterMetrics` / `ProcessedMetric` / `MetricAggregate` → `metrics.go` — embedded in persisted discovery state (`OSKDiscoveredCluster`, `self_managed_connect`, `discovery_common`).
- `SourceType` + `SourceTypeMSK/OSK` → new `source.go` — low-level discriminator used by `internal/sources/*`, `internal/utils`, `cmd/scan`; moving to `report` would invert layering.
- `ServiceAWS*` Cost Explorer service-name consts → `costs.go` — used by `internal/services/cost`; same inversion risk.

## Changes

- Rewrote `types.<shape>` → `report.<shape>` across consumers (`plan`, `cmd/report`, `cmd/ui/api`); stripped the qualifier within the `report` package.
- Moved `TestProcessedSource_TypeDiscrimination` from `internal/types` to `report` (it exercises the moved shapes).

## Safety

- **Cycle-safe** — nothing in `internal/types` references a moved shape; `report` imports neither `plan` nor `cmd`.
- No name collisions; pure relocation + qualifier edits.

## Verification

- `go build ./...` ✅ · `go vet` clean ✅
- `go test ./...` → **47 packages pass, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)