### PR TITLE
feat(healthcheck): add kcp healthcheck for live Kafka inventory (MSK + Apache Kafka, hidden)

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confluentinc/kcp/cmd/create_asset"
 	"github.com/confluentinc/kcp/cmd/discover"
 	"github.com/confluentinc/kcp/cmd/docs"
+	"github.com/confluentinc/kcp/cmd/healthcheck"
 	"github.com/confluentinc/kcp/cmd/migration"
 	"github.com/confluentinc/kcp/cmd/report"
 	"github.com/confluentinc/kcp/cmd/scan"
@@ -95,6 +96,7 @@ func init() {
 		report.NewReportCmd(),
 		ui.NewUICmd(),
 		discover.NewDiscoverCmd(),
+		healthcheck.NewHealthcheckCmd(),
 		migration.NewMigrationCmd(),
 		version.NewVersionCmd(),
 		update.NewUpdateCmd(),

--- a/cmd/healthcheck/cmd_healthcheck.go
+++ b/cmd/healthcheck/cmd_healthcheck.go
@@ -2,7 +2,11 @@ package healthcheck
 
 import (
 	"fmt"
+	"log/slog"
+	"path/filepath"
 
+	"github.com/confluentinc/kcp/internal/services/iampolicy"
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -10,9 +14,31 @@ import (
 
 var (
 	sourceType      string
+	stateFile       string
 	credentialsFile string
 	outputFile      string
 )
+
+func healthcheckIAMAnnotation() string {
+	return iampolicy.RenderStatements(
+		"Only required for `--source-type msk`. Apache Kafka healthchecks use credentials from the credentials file, not AWS IAM.",
+		[]iampolicy.Statement{
+			{
+				Sid: "MSKClusterKafkaAccess",
+				Actions: []string{
+					"kafka-cluster:Connect",
+					"kafka-cluster:DescribeCluster",
+					"kafka-cluster:DescribeClusterDynamicConfiguration",
+					"kafka-cluster:DescribeTopic",
+				},
+				Resources: []string{
+					"arn:aws:kafka:<AWS REGION>:<AWS ACCOUNT ID>:topic/<MSK CLUSTER NAME>/<MSK CLUSTER ID>/*",
+					"arn:aws:kafka:<AWS REGION>:<AWS ACCOUNT ID>:cluster/<MSK CLUSTER NAME>/<MSK CLUSTER ID>",
+				},
+			},
+		},
+	)
+}
 
 func NewHealthcheckCmd() *cobra.Command {
 	healthcheckCmd := &cobra.Command{
@@ -22,24 +48,41 @@ func NewHealthcheckCmd() *cobra.Command {
 
 The healthcheck connects to the cluster, inventories topics, ACLs, and broker metadata, and writes a markdown report. A short summary is also printed to stdout.
 
-v1 supports Apache Kafka sources only. MSK support is planned as a follow-up.`,
+Source-specific notes:
+
+- ` + "`--source-type msk`" + ` reads cluster connection details from the ` + "`msk-credentials.yaml`" + ` file produced by ` + "`kcp discover`" + ` and the discovery state file. SCRAM is forced to SHA-512 (the only mechanism MSK supports).
+- ` + "`--source-type apache-kafka`" + ` reads from a hand-authored ` + "`apache-kafka-credentials.yaml`" + ` file.`,
 		Example: `  # Healthcheck an Apache Kafka cluster
   kcp healthcheck --source-type apache-kafka --credentials-file apache-kafka-credentials.yaml
+
+  # Healthcheck an MSK cluster (credentials and state from kcp discover)
+  kcp healthcheck --source-type msk --state-file kcp-state.json --credentials-file msk-credentials.yaml
 
   # Specify the output markdown file
   kcp healthcheck --source-type apache-kafka --credentials-file apache-kafka-credentials.yaml \
       --output ./my-healthcheck.md`,
+		Annotations: map[string]string{
+			iampolicy.AnnotationKey: healthcheckIAMAnnotation(),
+		},
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,
 		PreRunE:       preRunHealthcheck,
 		RunE:          runHealthcheck,
+		// Hidden while we decide on the migration-readiness framing and
+		// the discover-gated vs first-touch invocation model. The
+		// command is wired up and works (so other refactors can rely on
+		// the struct surface), but is intentionally absent from
+		// `kcp --help` and the generated command reference so users
+		// don't discover it before the UX is settled.
+		Hidden: true,
 	}
 
 	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
 	requiredFlags.SortFlags = false
-	requiredFlags.StringVar(&sourceType, "source-type", "", "Source type: 'apache-kafka' (required). MSK support is planned for a future release.")
-	requiredFlags.StringVar(&credentialsFile, "credentials-file", "", "Path to credentials file (e.g. apache-kafka-credentials.yaml)")
+	requiredFlags.StringVar(&sourceType, "source-type", "", "Source type: 'msk' or 'apache-kafka' (required)")
+	requiredFlags.StringVar(&stateFile, "state-file", "kcp-state.json", "Path to the KCP state file (required for --source-type msk)")
+	requiredFlags.StringVar(&credentialsFile, "credentials-file", "", "Path to credentials file (msk-credentials.yaml or apache-kafka-credentials.yaml)")
 	healthcheckCmd.Flags().AddFlagSet(requiredFlags)
 
 	optionalFlags := pflag.NewFlagSet("optional", pflag.ExitOnError)
@@ -58,13 +101,27 @@ func preRunHealthcheck(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	switch sourceType {
-	case "apache-kafka":
-		// supported
-	case "msk":
-		return fmt.Errorf("--source-type msk is not yet supported for healthcheck; v1 supports apache-kafka only")
-	default:
-		return fmt.Errorf("invalid --source-type %q; supported values: apache-kafka", sourceType)
+	// Validate and normalize source type. "apache-kafka" is the user-facing value;
+	// internally the source is represented by the "osk" token.
+	normalizedSourceType, err := types.ParseSourceTypeFlag(sourceType)
+	if err != nil {
+		return err
+	}
+	sourceType = string(normalizedSourceType)
+
+	// Credentials file naming convention — warn rather than reject so a
+	// renamed file still works, mirroring `scan clusters`.
+	if sourceType == "msk" && filepath.Base(credentialsFile) != "msk-credentials.yaml" {
+		slog.Warn("credentials file should be named 'msk-credentials.yaml' for MSK sources", "file", credentialsFile)
+	}
+	if sourceType == "osk" && filepath.Base(credentialsFile) != "apache-kafka-credentials.yaml" {
+		slog.Warn("credentials file should be named 'apache-kafka-credentials.yaml' for Apache Kafka sources", "file", credentialsFile)
+	}
+
+	// MSK requires a populated state file (produced by `kcp discover`) to
+	// resolve broker addresses for each cluster ARN.
+	if sourceType == "msk" && stateFile == "" {
+		return fmt.Errorf("--state-file is required when --source-type msk (run 'kcp discover' first)")
 	}
 
 	return nil

--- a/cmd/healthcheck/cmd_healthcheck.go
+++ b/cmd/healthcheck/cmd_healthcheck.go
@@ -1,0 +1,71 @@
+package healthcheck
+
+import (
+	"fmt"
+
+	"github.com/confluentinc/kcp/internal/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	sourceType      string
+	credentialsFile string
+	outputFile      string
+)
+
+func NewHealthcheckCmd() *cobra.Command {
+	healthcheckCmd := &cobra.Command{
+		Use:   "healthcheck",
+		Short: "Run a live healthcheck against a Kafka cluster",
+		Long: `Run a live operational healthcheck against a Kafka cluster via the Kafka Admin API.
+
+The healthcheck connects to the cluster, inventories topics, ACLs, and broker metadata, and writes a markdown report. A short summary is also printed to stdout.
+
+v1 supports Apache Kafka sources only. MSK support is planned as a follow-up.`,
+		Example: `  # Healthcheck an Apache Kafka cluster
+  kcp healthcheck --source-type apache-kafka --credentials-file apache-kafka-credentials.yaml
+
+  # Specify the output markdown file
+  kcp healthcheck --source-type apache-kafka --credentials-file apache-kafka-credentials.yaml \
+      --output ./my-healthcheck.md`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Args:          cobra.NoArgs,
+		PreRunE:       preRunHealthcheck,
+		RunE:          runHealthcheck,
+	}
+
+	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
+	requiredFlags.SortFlags = false
+	requiredFlags.StringVar(&sourceType, "source-type", "", "Source type: 'apache-kafka' (required). MSK support is planned for a future release.")
+	requiredFlags.StringVar(&credentialsFile, "credentials-file", "", "Path to credentials file (e.g. apache-kafka-credentials.yaml)")
+	healthcheckCmd.Flags().AddFlagSet(requiredFlags)
+
+	optionalFlags := pflag.NewFlagSet("optional", pflag.ExitOnError)
+	optionalFlags.SortFlags = false
+	optionalFlags.StringVar(&outputFile, "output", "", "Path for the generated markdown report. Defaults to ./healthcheck-<cluster-id>-<timestamp>.md.")
+	healthcheckCmd.Flags().AddFlagSet(optionalFlags)
+
+	_ = healthcheckCmd.MarkFlagRequired("source-type")
+	_ = healthcheckCmd.MarkFlagRequired("credentials-file")
+
+	return healthcheckCmd
+}
+
+func preRunHealthcheck(cmd *cobra.Command, args []string) error {
+	if err := utils.BindEnvToFlags(cmd); err != nil {
+		return err
+	}
+
+	switch sourceType {
+	case "apache-kafka":
+		// supported
+	case "msk":
+		return fmt.Errorf("--source-type msk is not yet supported for healthcheck; v1 supports apache-kafka only")
+	default:
+		return fmt.Errorf("invalid --source-type %q; supported values: apache-kafka", sourceType)
+	}
+
+	return nil
+}

--- a/cmd/healthcheck/render.go
+++ b/cmd/healthcheck/render.go
@@ -1,0 +1,169 @@
+package healthcheck
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/confluentinc/kcp/internal/services/markdown"
+	"github.com/confluentinc/kcp/internal/sources"
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// RenderClusterHealthcheck builds a markdown report for a single cluster's
+// healthcheck scan result. It is a pure function — same inputs always
+// produce the same output, which makes it straightforward to test.
+//
+// The timestamp is taken as a parameter (rather than read from time.Now()
+// inside the function) so tests can pin it to a deterministic value.
+func RenderClusterHealthcheck(cluster sources.ClusterScanResult, timestamp time.Time) *markdown.Markdown {
+	m := markdown.New()
+	info := cluster.KafkaAdminInfo
+
+	// --- Header ---
+	m.AddHeading(fmt.Sprintf("Healthcheck Report — %s", cluster.Identifier.Name), 1)
+	m.AddParagraph(fmt.Sprintf("**Generated:** %s", timestamp.UTC().Format(time.RFC3339)))
+	m.AddParagraph(fmt.Sprintf("**KCP version:** %s (%s)", build_info.Version, build_info.Commit))
+	m.AddParagraph(fmt.Sprintf("**Bootstrap servers:** %s", strings.Join(cluster.Identifier.BootstrapServers, ", ")))
+	m.AddParagraph(fmt.Sprintf("**Auth:** %s", describeAuth(info)))
+
+	// --- Cluster ---
+	m.AddHeading("Cluster", 2)
+	m.AddParagraph(fmt.Sprintf("**Cluster ID:** `%s`", info.ClusterID))
+	m.AddParagraph(fmt.Sprintf("**Broker count:** %d", len(info.DiscoveredBrokers)))
+	if len(info.DiscoveredBrokers) > 0 {
+		m.AddParagraph("**Discovered brokers:**")
+		m.AddList(info.DiscoveredBrokers)
+	}
+
+	// --- Topics ---
+	m.AddHeading("Topics", 2)
+	renderTopicsSection(m, info)
+
+	// --- ACLs ---
+	m.AddHeading("ACLs", 2)
+	renderAclsSection(m, info)
+
+	return m
+}
+
+// describeAuth produces a short human-readable auth descriptor from the
+// scan result. KafkaAdminClientInformation only records SaslMechanism, so
+// for non-SASL auth types we fall back to a generic label.
+func describeAuth(info *types.KafkaAdminClientInformation) string {
+	if info.SaslMechanism != "" {
+		return fmt.Sprintf("SASL (%s)", info.SaslMechanism)
+	}
+	return "unspecified"
+}
+
+func renderTopicsSection(m *markdown.Markdown, info *types.KafkaAdminClientInformation) {
+	if info.Topics == nil || len(info.Topics.Details) == 0 {
+		m.AddParagraph("_No topics found._")
+		return
+	}
+
+	summary := info.Topics.Summary
+	m.AddList([]string{
+		fmt.Sprintf("User topics: **%d**", summary.Topics),
+		fmt.Sprintf("Internal topics: **%d**", summary.InternalTopics),
+		fmt.Sprintf("Total user partitions: **%d**", summary.TotalPartitions),
+		fmt.Sprintf("Total internal partitions: **%d**", summary.TotalInternalPartitions),
+		fmt.Sprintf("Compact topics (user): **%d**", summary.CompactTopics),
+		fmt.Sprintf("Remote-storage topics: **%d**", summary.RemoteStorageTopics),
+	})
+
+	// Sort topics by name for deterministic output.
+	topics := make([]types.TopicDetails, len(info.Topics.Details))
+	copy(topics, info.Topics.Details)
+	sort.Slice(topics, func(i, j int) bool { return topics[i].Name < topics[j].Name })
+
+	headers := []string{"Name", "Partitions", "Replication factor", "Internal"}
+	rows := make([][]string, 0, len(topics))
+	for _, t := range topics {
+		internal := "no"
+		if strings.HasPrefix(t.Name, "__") {
+			internal = "yes"
+		}
+		rows = append(rows, []string{
+			t.Name,
+			strconv.Itoa(t.Partitions),
+			strconv.Itoa(t.ReplicationFactor),
+			internal,
+		})
+	}
+	m.AddTable(headers, rows)
+}
+
+func renderAclsSection(m *markdown.Markdown, info *types.KafkaAdminClientInformation) {
+	if len(info.Acls) == 0 {
+		m.AddParagraph("_No ACLs found._")
+		return
+	}
+
+	byPrincipal := make(map[string]int)
+	byResource := make(map[string]int)
+	for _, acl := range info.Acls {
+		byPrincipal[acl.Principal]++
+		byResource[acl.ResourceType]++
+	}
+
+	m.AddParagraph(fmt.Sprintf("**Total ACLs:** %d", len(info.Acls)))
+
+	m.AddHeading("By principal", 3)
+	m.AddTable([]string{"Principal", "Count"}, mapToSortedRows(byPrincipal))
+
+	m.AddHeading("By resource type", 3)
+	m.AddTable([]string{"Resource type", "Count"}, mapToSortedRows(byResource))
+
+	// Sort ACLs deterministically by (principal, resource type, resource name, operation).
+	acls := make([]types.Acls, len(info.Acls))
+	copy(acls, info.Acls)
+	sort.Slice(acls, func(i, j int) bool {
+		if acls[i].Principal != acls[j].Principal {
+			return acls[i].Principal < acls[j].Principal
+		}
+		if acls[i].ResourceType != acls[j].ResourceType {
+			return acls[i].ResourceType < acls[j].ResourceType
+		}
+		if acls[i].ResourceName != acls[j].ResourceName {
+			return acls[i].ResourceName < acls[j].ResourceName
+		}
+		return acls[i].Operation < acls[j].Operation
+	})
+
+	m.AddHeading("Full ACL list", 3)
+	headers := []string{"Principal", "Resource type", "Resource name", "Pattern", "Operation", "Permission", "Host"}
+	rows := make([][]string, 0, len(acls))
+	for _, a := range acls {
+		rows = append(rows, []string{
+			a.Principal,
+			a.ResourceType,
+			a.ResourceName,
+			a.ResourcePatternType,
+			a.Operation,
+			a.PermissionType,
+			a.Host,
+		})
+	}
+	m.AddTable(headers, rows)
+}
+
+// mapToSortedRows converts a count map into table rows sorted by key for
+// deterministic output.
+func mapToSortedRows(counts map[string]int) [][]string {
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	rows := make([][]string, 0, len(keys))
+	for _, k := range keys {
+		rows = append(rows, []string{k, strconv.Itoa(counts[k])})
+	}
+	return rows
+}

--- a/cmd/healthcheck/render_test.go
+++ b/cmd/healthcheck/render_test.go
@@ -1,0 +1,151 @@
+package healthcheck
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/sources"
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+// fixedTime is used across tests so the rendered Generated timestamp is
+// deterministic.
+var fixedTime = time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+
+// stringPtr is a small helper for building TopicDetails.Configurations entries.
+func stringPtr(s string) *string { return &s }
+
+func makeCluster(name string, info *types.KafkaAdminClientInformation, bootstrap []string) sources.ClusterScanResult {
+	return sources.ClusterScanResult{
+		Identifier: sources.ClusterIdentifier{
+			Name:             name,
+			UniqueID:         name,
+			BootstrapServers: bootstrap,
+		},
+		KafkaAdminInfo: info,
+	}
+}
+
+func buildKafkaAdminInfo(topics []types.TopicDetails, acls []types.Acls, brokers []string, clusterID, saslMechanism string) *types.KafkaAdminClientInformation {
+	info := &types.KafkaAdminClientInformation{
+		ClusterID:         clusterID,
+		DiscoveredBrokers: brokers,
+		SaslMechanism:     saslMechanism,
+		Acls:              acls,
+	}
+	if topics != nil {
+		info.SetTopics(topics)
+	}
+	return info
+}
+
+func TestRenderClusterHealthcheck_EmptyCluster(t *testing.T) {
+	info := buildKafkaAdminInfo(nil, nil, []string{"broker1:9092"}, "test-cluster-id", "")
+	cluster := makeCluster("empty-cluster", info, []string{"broker1:9092"})
+
+	out := RenderClusterHealthcheck(cluster, fixedTime).String()
+
+	wantContains := []string{
+		"# Healthcheck Report — empty-cluster",
+		"**Cluster ID:** `test-cluster-id`",
+		"**Broker count:** 1",
+		"_No topics found._",
+		"_No ACLs found._",
+		"**Auth:** unspecified",
+		"2026-06-18T12:00:00Z",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderClusterHealthcheck_TopicsAndAcls(t *testing.T) {
+	topics := []types.TopicDetails{
+		{
+			Name:              "orders",
+			Partitions:        6,
+			ReplicationFactor: 3,
+			Configurations:    map[string]*string{"cleanup.policy": stringPtr("compact")},
+		},
+		{
+			Name:              "events",
+			Partitions:        3,
+			ReplicationFactor: 1,
+			Configurations:    map[string]*string{},
+		},
+		{
+			Name:              "__consumer_offsets",
+			Partitions:        50,
+			ReplicationFactor: 3,
+			Configurations:    map[string]*string{"cleanup.policy": stringPtr("compact")},
+		},
+	}
+
+	acls := []types.Acls{
+		{Principal: "User:alice", ResourceType: "Topic", ResourceName: "orders", ResourcePatternType: "LITERAL", Operation: "Read", PermissionType: "Allow", Host: "*"},
+		{Principal: "User:alice", ResourceType: "Topic", ResourceName: "orders", ResourcePatternType: "LITERAL", Operation: "Describe", PermissionType: "Allow", Host: "*"},
+		{Principal: "User:bob", ResourceType: "Group", ResourceName: "bob-consumer", ResourcePatternType: "LITERAL", Operation: "Read", PermissionType: "Allow", Host: "*"},
+	}
+
+	info := buildKafkaAdminInfo(topics, acls, []string{"broker1:9092", "broker2:9092"}, "real-cluster-id", "SHA256")
+	cluster := makeCluster("prod-kafka", info, []string{"broker1:9092", "broker2:9092"})
+
+	out := RenderClusterHealthcheck(cluster, fixedTime).String()
+
+	wantContains := []string{
+		"# Healthcheck Report — prod-kafka",
+		"**Auth:** SASL (SHA256)",
+		"**Broker count:** 2",
+		// Topic summary stats — 2 user, 1 internal, 9 user partitions
+		"User topics: **2**",
+		"Internal topics: **1**",
+		"Total user partitions: **9**",
+		"Compact topics (user): **1**",
+		// Topic table rows (alphabetical: __consumer_offsets, events, orders)
+		"| __consumer_offsets | 50 | 3 | yes |",
+		"| events | 3 | 1 | no |",
+		"| orders | 6 | 3 | no |",
+		// ACL counts
+		"**Total ACLs:** 3",
+		"| User:alice | 2 |",
+		"| User:bob | 1 |",
+		"| Group | 1 |",
+		"| Topic | 2 |",
+		// Full ACL list rows
+		"| User:alice | Topic | orders | LITERAL | Describe | Allow | * |",
+		"| User:alice | Topic | orders | LITERAL | Read | Allow | * |",
+		"| User:bob | Group | bob-consumer | LITERAL | Read | Allow | * |",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderClusterHealthcheck_IsDeterministic(t *testing.T) {
+	// Same input twice should produce identical output (no map iteration leak).
+	topics := []types.TopicDetails{
+		{Name: "b-topic", Partitions: 1, ReplicationFactor: 1},
+		{Name: "a-topic", Partitions: 1, ReplicationFactor: 1},
+		{Name: "c-topic", Partitions: 1, ReplicationFactor: 1},
+	}
+	acls := []types.Acls{
+		{Principal: "User:z", ResourceType: "Topic", ResourceName: "z", Operation: "Read", PermissionType: "Allow", Host: "*", ResourcePatternType: "LITERAL"},
+		{Principal: "User:a", ResourceType: "Group", ResourceName: "a", Operation: "Read", PermissionType: "Allow", Host: "*", ResourcePatternType: "LITERAL"},
+		{Principal: "User:m", ResourceType: "Topic", ResourceName: "m", Operation: "Read", PermissionType: "Allow", Host: "*", ResourcePatternType: "LITERAL"},
+	}
+	info := buildKafkaAdminInfo(topics, acls, []string{"broker1:9092"}, "det-cluster", "")
+	cluster := makeCluster("det", info, []string{"broker1:9092"})
+
+	first := RenderClusterHealthcheck(cluster, fixedTime).String()
+	for i := 0; i < 5; i++ {
+		again := RenderClusterHealthcheck(cluster, fixedTime).String()
+		if again != first {
+			t.Fatalf("render output is not deterministic\nfirst:\n%s\nlater (iteration %d):\n%s", first, i, again)
+		}
+	}
+}

--- a/cmd/healthcheck/runner.go
+++ b/cmd/healthcheck/runner.go
@@ -1,0 +1,97 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/markdown"
+	"github.com/confluentinc/kcp/internal/sources"
+	"github.com/confluentinc/kcp/internal/sources/osk"
+	"github.com/spf13/cobra"
+)
+
+// filenameSafe matches any character that should be stripped from a cluster
+// identifier when building a default output filename.
+var filenameSafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// runHealthcheck is the entry point invoked by Cobra. It loads credentials
+// via the OSK source, scans each cluster via the Kafka Admin API, renders
+// a markdown report per cluster, and writes it to disk. A per-cluster
+// summary is logged via slog (which fans out to both kcp.log and the
+// console).
+func runHealthcheck(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	source := osk.NewOSKSource()
+
+	if err := source.LoadCredentials(credentialsFile); err != nil {
+		return fmt.Errorf("failed to load credentials: %w", err)
+	}
+
+	clusters := source.GetClusters()
+	slog.Info("clusters to healthcheck", "count", len(clusters))
+	for _, cluster := range clusters {
+		slog.Info("cluster", "name", cluster.Name, "id", cluster.UniqueID)
+	}
+
+	// Reject --output with multiple clusters — there is no sensible way
+	// to write N reports to a single explicit path. The default
+	// per-cluster naming handles multi-cluster automatically.
+	if outputFile != "" && len(clusters) > 1 {
+		return fmt.Errorf("--output cannot be used when the credentials file contains multiple clusters (%d found); omit --output to use per-cluster default filenames", len(clusters))
+	}
+
+	scanOpts := sources.ScanOptions{
+		SkipTopics: false,
+		SkipACLs:   false,
+	}
+
+	slog.Info("starting healthcheck scan")
+	scanResult, err := source.Scan(ctx, scanOpts)
+	if err != nil {
+		return fmt.Errorf("healthcheck scan failed: %w", err)
+	}
+
+	timestamp := time.Now()
+	for _, c := range scanResult.Clusters {
+		path := resolveOutputPath(c, timestamp)
+
+		md := RenderClusterHealthcheck(c, timestamp)
+		if err := md.Print(markdown.PrintOptions{ToTerminal: false, ToFile: path}); err != nil {
+			return fmt.Errorf("failed to write healthcheck report for cluster %s: %w", c.Identifier.Name, err)
+		}
+
+		userTopics := 0
+		internalTopics := 0
+		if c.KafkaAdminInfo.Topics != nil {
+			userTopics = c.KafkaAdminInfo.Topics.Summary.Topics
+			internalTopics = c.KafkaAdminInfo.Topics.Summary.InternalTopics
+		}
+		slog.Info("healthcheck complete",
+			"cluster", c.Identifier.Name,
+			"cluster_id", c.KafkaAdminInfo.ClusterID,
+			"brokers", len(c.KafkaAdminInfo.DiscoveredBrokers),
+			"user_topics", userTopics,
+			"internal_topics", internalTopics,
+			"acls", len(c.KafkaAdminInfo.Acls),
+			"report", path,
+		)
+	}
+
+	return nil
+}
+
+// resolveOutputPath returns the markdown output path for a cluster. When
+// --output is set we honour it verbatim (multi-cluster case is rejected
+// earlier in the runner). Otherwise we generate a default file in the
+// working directory using the cluster name + timestamp.
+func resolveOutputPath(c sources.ClusterScanResult, timestamp time.Time) string {
+	if outputFile != "" {
+		return outputFile
+	}
+	safeID := filenameSafe.ReplaceAllString(c.Identifier.Name, "-")
+	return fmt.Sprintf("./healthcheck-%s-%s.md", safeID, timestamp.UTC().Format("20060102T150405Z"))
+}

--- a/cmd/healthcheck/runner.go
+++ b/cmd/healthcheck/runner.go
@@ -63,6 +63,7 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 	}
 
 	timestamp := time.Now()
+	reportPaths := make([]string, 0, len(scanResult.Clusters))
 	for _, c := range scanResult.Clusters {
 		path := resolveOutputPath(c, timestamp)
 
@@ -70,6 +71,7 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 		if err := md.Print(markdown.PrintOptions{ToTerminal: false, ToFile: path}); err != nil {
 			return fmt.Errorf("failed to write healthcheck report for cluster %s: %w", c.Identifier.Name, err)
 		}
+		reportPaths = append(reportPaths, path)
 
 		userTopics := 0
 		internalTopics := 0
@@ -86,6 +88,28 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 			"acls", len(c.KafkaAdminInfo.Acls),
 			"report", path,
 		)
+
+		// User-facing per-cluster summary. slog.Info above goes to kcp.log
+		// only (the console handler defaults to WARN+); fmt.Printf gives
+		// the operator immediate visible confirmation that the cluster
+		// was scanned and where the report landed. Same pattern as
+		// `scan clusters`.
+		fmt.Printf("   • %s — %d broker(s), %d user topic(s), %d internal topic(s), %d ACL(s)\n",
+			c.Identifier.Name,
+			len(c.KafkaAdminInfo.DiscoveredBrokers),
+			userTopics,
+			internalTopics,
+			len(c.KafkaAdminInfo.Acls),
+		)
+		fmt.Printf("     Report: %s\n", path)
+	}
+
+	fmt.Printf("\n✅ Healthcheck completed successfully\n")
+	fmt.Printf("   Scanned %d cluster(s) (source: %s)\n", len(scanResult.Clusters), sourceType)
+	if len(reportPaths) == 1 {
+		fmt.Printf("   Report: %s\n\n", reportPaths[0])
+	} else {
+		fmt.Printf("   Reports written: %d\n\n", len(reportPaths))
 	}
 
 	return nil

--- a/cmd/healthcheck/runner.go
+++ b/cmd/healthcheck/runner.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/markdown"
 	"github.com/confluentinc/kcp/internal/sources"
+	"github.com/confluentinc/kcp/internal/sources/msk"
 	"github.com/confluentinc/kcp/internal/sources/osk"
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/spf13/cobra"
 )
 
@@ -18,21 +21,24 @@ import (
 var filenameSafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
 // runHealthcheck is the entry point invoked by Cobra. It loads credentials
-// via the OSK source, scans each cluster via the Kafka Admin API, renders
-// a markdown report per cluster, and writes it to disk. A per-cluster
-// summary is logged via slog (which fans out to both kcp.log and the
-// console).
+// via the configured source (OSK or MSK), scans each cluster via the Kafka
+// Admin API, renders a markdown report per cluster, and writes it to disk.
+// A per-cluster summary is logged via slog (which fans out to both kcp.log
+// and the console).
 func runHealthcheck(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	source := osk.NewOSKSource()
+	source, state, err := buildSource(sourceType, stateFile)
+	if err != nil {
+		return err
+	}
 
 	if err := source.LoadCredentials(credentialsFile); err != nil {
 		return fmt.Errorf("failed to load credentials: %w", err)
 	}
 
 	clusters := source.GetClusters()
-	slog.Info("clusters to healthcheck", "count", len(clusters))
+	slog.Info("clusters to healthcheck", "count", len(clusters), "source", sourceType)
 	for _, cluster := range clusters {
 		slog.Info("cluster", "name", cluster.Name, "id", cluster.UniqueID)
 	}
@@ -47,6 +53,7 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 	scanOpts := sources.ScanOptions{
 		SkipTopics: false,
 		SkipACLs:   false,
+		State:      state,
 	}
 
 	slog.Info("starting healthcheck scan")
@@ -82,6 +89,39 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// buildSource constructs the configured Source. For MSK we also load the
+// discovery state file (required to resolve cluster ARNs to broker
+// addresses); OSK does not use the state file.
+func buildSource(sourceType, stateFilePath string) (sources.Source, *types.State, error) {
+	switch sourceType {
+	case "osk":
+		return osk.NewOSKSource(), nil, nil
+	case "msk":
+		state, err := loadStateFile(stateFilePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		return msk.NewMSKSource(), state, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported source type: %s", sourceType)
+	}
+}
+
+// loadStateFile reads the discovery state. Unlike `scan clusters` we do not
+// fall back to creating a fresh state file — healthcheck has nothing to
+// discover; an empty state for MSK means `kcp discover` has not been run.
+func loadStateFile(path string) (*types.State, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("state file %q not found; run 'kcp discover' before healthchecking MSK clusters", path)
+	}
+	state, err := types.NewStateFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load state file %q: %w", path, err)
+	}
+	slog.Info("loaded existing state file", "file", path)
+	return state, nil
 }
 
 // resolveOutputPath returns the markdown output path for a cluster. When


### PR DESCRIPTION
## Summary
- Adds a top-level `kcp healthcheck` command that scans a Kafka cluster via the Kafka Admin API and writes a markdown inventory report per cluster (cluster ID, brokers, topics, ACLs).
- Supports both **Apache Kafka** (`--source-type apache-kafka`, reads `apache-kafka-credentials.yaml`) and **MSK** (`--source-type msk`, reads `msk-credentials.yaml` + `kcp-state.json` populated by `kcp discover`). MSK SCRAM is pinned to SHA-512.
- Raw inventory only — no derived findings / severity. Tier 2 checks (ISR, consumer-group lag, etc.) are deferred.
- Command is **hidden from `--help` and `gen-docs`** while the migration-readiness framing and invocation model are still being decided. Wired up and callable so downstream struct refactors can rely on the surface; users won't discover it organically.
- Prints a per-cluster summary line + ✅ completion block to stdout so the operator sees confirmation in the terminal (same shape for OSK and MSK). Structured `slog.Info` record is also emitted to `kcp.log`.
- Re-uses the existing OSK/MSK sources, IAM-policy annotation helper, and markdown service rather than introducing a parallel scanning path.

## Test plan
- [x] `make test-go` — all packages green, including `cmd/healthcheck/` tests
- [x] End-to-end against `integration-tests/osk-scan` SASL/SCRAM Docker env → valid markdown report + stdout summary
- [x] End-to-end against MSK playground (`kcp discover` → `kcp healthcheck --source-type msk`) → valid markdown report for the discovered cluster
- [x] Missing state file for MSK → friendly error pointing to `kcp discover`
- [x] Command absent from `./kcp --help` output
- [x] Missing required flags produce Cobra's standard error (not a stack trace)
- [ ] Reviewer to spot-check the markdown layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)