### PR TITLE
fix(metrics): chunk CloudWatch GetMetricData to avoid 100,800-point truncation

### DIFF
--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -1,7 +1,10 @@
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,5 +129,112 @@ func TestResultStitcher_MarkPartial(t *testing.T) {
 	s.markPartial()
 	if !s.partial {
 		t.Error("expected partial after markPartial")
+	}
+}
+
+// completeResult returns a single complete series with n points for an Id.
+func completeResult(id string, n int) []cloudwatchtypes.MetricDataResult {
+	vals := make([]float64, n)
+	ts := make([]time.Time, n)
+	for i := 0; i < n; i++ {
+		vals[i] = float64(i)
+		ts[i] = time.Unix(int64(i*60), 0)
+	}
+	return []cloudwatchtypes.MetricDataResult{{
+		Id: aws.String(id), Values: vals, Timestamps: ts, StatusCode: cloudwatchtypes.StatusCodeComplete,
+	}}
+}
+
+func TestExecuteChunkedQuery_SingleCallWhenUnderBudget(t *testing.T) {
+	fake := &fakeCWClient{respond: func(_ int, _ *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		return &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", 10)}, nil
+	}}
+	ms := &MetricService{client: fake}
+	start, end := time.Unix(0, 0), time.Unix(600, 0) // 10 points at 60s
+	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, 60, 4, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.calls))
+	}
+	if len(out.MetricDataResults[0].Values) != 10 {
+		t.Errorf("expected 10 stitched values, got %d", len(out.MetricDataResults[0].Values))
+	}
+}
+
+func TestExecuteChunkedQuery_ChunksAndStaysUnderCap(t *testing.T) {
+	// period 60s, seriesEstimate 250 => chunkSeconds = (100000/250)*60 = 24000s (400 pts).
+	// total window 96000s (1600 pts) => ceil(96000/24000) = 4 chunks.
+	period := int32(60)
+	seriesEst := 250
+	start := time.Unix(0, 0)
+	end := time.Unix(96000, 0)
+	cs := chunkSeconds(period, seriesEst)
+
+	fake := &fakeCWClient{respond: func(_ int, in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		win := int64(in.EndTime.Sub(*in.StartTime).Seconds())
+		if win > cs {
+			t.Errorf("chunk window %d exceeds chunkSeconds %d", win, cs)
+		}
+		return &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", int(win/int64(period)))}, nil
+	}}
+	ms := &MetricService{client: fake}
+	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, period, seriesEst, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.calls) != 4 {
+		t.Fatalf("expected 4 chunks, got %d", len(fake.calls))
+	}
+	if got := len(out.MetricDataResults[0].Values); got != 1600 {
+		t.Errorf("expected 1600 stitched values, got %d", got)
+	}
+}
+
+func TestExecuteChunkedQuery_BisectsOnPartialData(t *testing.T) {
+	// seriesEstimate 0 => no deterministic chunking; full window returns PartialData,
+	// each half returns Complete. Bisection should recover full data.
+	start, end := time.Unix(0, 0), time.Unix(120, 0) // 2 periods at 60s
+	fake := &fakeCWClient{respond: func(_ int, in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		win := int64(in.EndTime.Sub(*in.StartTime).Seconds())
+		if win > 60 {
+			return &cloudwatch.GetMetricDataOutput{MetricDataResults: []cloudwatchtypes.MetricDataResult{
+				{Id: aws.String("sum_x"), StatusCode: cloudwatchtypes.StatusCodePartialData, Values: []float64{0}, Timestamps: []time.Time{time.Unix(60, 0)}},
+			}}, nil
+		}
+		return &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", 1)}, nil
+	}}
+	ms := &MetricService{client: fake}
+	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, 60, 0, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.calls) != 3 {
+		t.Fatalf("expected 3 calls (1 partial + 2 halves), got %d", len(fake.calls))
+	}
+	if got := len(out.MetricDataResults[0].Values); got != 2 {
+		t.Errorf("expected 2 recovered values, got %d", got)
+	}
+}
+
+func TestExecuteChunkedQuery_WarnsAtFloor(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	fake := &fakeCWClient{respond: func(_ int, _ *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		return &cloudwatch.GetMetricDataOutput{MetricDataResults: []cloudwatchtypes.MetricDataResult{
+			{Id: aws.String("sum_x"), StatusCode: cloudwatchtypes.StatusCodePartialData, Values: []float64{0}, Timestamps: []time.Time{time.Unix(0, 0)}},
+		}}, nil
+	}}
+	ms := &MetricService{client: fake}
+	_, err := ms.executeChunkedQuery(context.Background(), nil, time.Unix(0, 0), time.Unix(60, 0), 60, 0, "broker metrics for cluster c1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "metrics may be incomplete") || !strings.Contains(buf.String(), "broker metrics for cluster c1") {
+		t.Errorf("expected one incomplete-metrics warning mentioning the label, got: %q", buf.String())
 	}
 }

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -245,6 +245,26 @@ func TestExecuteChunkedQuery_WarnsAtFloor(t *testing.T) {
 	}
 }
 
+func TestExecuteChunkedQuery_NonPositivePeriodErrors(t *testing.T) {
+	fake := &fakeCWClient{respond: func(_ int, _ *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		t.Fatal("client should not be called for a non-positive period")
+		return nil, nil
+	}}
+	ms := &MetricService{client: fake}
+	for _, period := range []int32{0, -60} {
+		out, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), time.Unix(0, 0), time.Unix(600, 0), period, 4, "test")
+		if err == nil {
+			t.Errorf("period %d: expected error, got nil", period)
+		}
+		if out != nil {
+			t.Errorf("period %d: expected nil output on error, got %+v", period, out)
+		}
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("expected no client calls, got %d", len(fake.calls))
+	}
+}
+
 func TestExecuteChunkedQuery_EmptyQueriesReturnsEmpty(t *testing.T) {
 	fake := &fakeCWClient{respond: func(_ int, _ *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
 		t.Fatal("client should not be called for empty queries")

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -89,3 +89,42 @@ func TestExecuteWindow_SetsAscendingScanAndPaginates(t *testing.T) {
 		t.Errorf("expected 2 stitched page results, got %d", len(out.MetricDataResults))
 	}
 }
+
+func TestResultStitcher_ConcatenatesPerIdPreservingOrder(t *testing.T) {
+	s := newResultStitcher()
+	t0, t1, t2 := time.Unix(0, 0), time.Unix(60, 0), time.Unix(120, 0)
+
+	s.add([]cloudwatchtypes.MetricDataResult{
+		{Id: aws.String("sum_a"), Label: aws.String("A"), Timestamps: []time.Time{t0}, Values: []float64{1}},
+		{Id: aws.String("sum_b"), Label: aws.String("B"), Timestamps: []time.Time{t0}, Values: []float64{10}},
+	})
+	s.add([]cloudwatchtypes.MetricDataResult{
+		{Id: aws.String("sum_a"), Timestamps: []time.Time{t1, t2}, Values: []float64{2, 3}},
+	})
+
+	out := s.output()
+	if len(out.MetricDataResults) != 2 {
+		t.Fatalf("expected 2 ids, got %d", len(out.MetricDataResults))
+	}
+	if aws.ToString(out.MetricDataResults[0].Id) != "sum_a" {
+		t.Errorf("expected first-seen order sum_a first, got %s", aws.ToString(out.MetricDataResults[0].Id))
+	}
+	a := out.MetricDataResults[0]
+	if len(a.Values) != 3 || a.Values[0] != 1 || a.Values[2] != 3 {
+		t.Errorf("sum_a values not concatenated in order: %v", a.Values)
+	}
+	if aws.ToString(a.Label) != "A" {
+		t.Errorf("expected label preserved, got %s", aws.ToString(a.Label))
+	}
+}
+
+func TestResultStitcher_MarkPartial(t *testing.T) {
+	s := newResultStitcher()
+	if s.partial {
+		t.Fatal("expected not partial initially")
+	}
+	s.markPartial()
+	if !s.partial {
+		t.Error("expected partial after markPartial")
+	}
+}

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -259,3 +259,48 @@ func TestExecuteChunkedQuery_EmptyQueriesReturnsEmpty(t *testing.T) {
 		t.Errorf("expected no calls and empty results, got %d calls / %d results", len(fake.calls), len(out.MetricDataResults))
 	}
 }
+
+func TestExecuteChunkedQuery_StitchesContiguousTimestampsAcrossSeams(t *testing.T) {
+	period := int32(60)
+	seriesEst := 250 // chunkSeconds = (100000/250)*60 = 24000s = 400 pts/chunk
+	start := time.Unix(0, 0)
+	end := time.Unix(96000, 0) // 1600 pts across 4 chunks
+	fake := &fakeCWClient{respond: func(_ int, in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		var ts []time.Time
+		var vals []float64
+		for s := in.StartTime.Unix(); s < in.EndTime.Unix(); s += int64(period) {
+			ts = append(ts, time.Unix(s, 0))
+			vals = append(vals, float64(s))
+		}
+		return &cloudwatch.GetMetricDataOutput{MetricDataResults: []cloudwatchtypes.MetricDataResult{
+			{Id: aws.String("sum_x"), Timestamps: ts, Values: vals, StatusCode: cloudwatchtypes.StatusCodeComplete},
+		}}, nil
+	}}
+	ms := &MetricService{client: fake}
+	out, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), start, end, period, seriesEst, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	res := out.MetricDataResults[0]
+	if len(res.Timestamps) != 1600 {
+		t.Fatalf("expected 1600 timestamps, got %d", len(res.Timestamps))
+	}
+	for i := 1; i < len(res.Timestamps); i++ {
+		if diff := res.Timestamps[i].Unix() - res.Timestamps[i-1].Unix(); diff != int64(period) {
+			t.Fatalf("non-contiguous timestamps at index %d: diff %d, want %d", i, diff, period)
+		}
+	}
+}
+
+func TestIsPartial_DetectsMaxMetricsExceededMessage(t *testing.T) {
+	out := &cloudwatch.GetMetricDataOutput{
+		Messages: []cloudwatchtypes.MessageData{{Code: aws.String("MaxMetricsExceeded"), Value: aws.String("limit hit")}},
+	}
+	if !isPartial(out) {
+		t.Error("expected isPartial=true for MaxMetricsExceeded message code")
+	}
+	clean := &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", 1)}
+	if isPartial(clean) {
+		t.Error("expected isPartial=false for a complete result")
+	}
+}

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -30,17 +30,33 @@ func TestFakeClientSatisfiesInterface(t *testing.T) {
 	}
 }
 
-// TestChunkingConstantsDefined verifies the chunking constants are declared with
-// the expected values. The constants are consumed by chunking logic added in
-// later tasks; this test keeps them reachable so the linter does not flag them.
-func TestChunkingConstantsDefined(t *testing.T) {
-	const wantBudget = 100_000
-	if datapointBudget != wantBudget {
-		t.Errorf("datapointBudget = %d, want %d", datapointBudget, wantBudget)
+func TestChunkSeconds(t *testing.T) {
+	// 100_000 budget / 12 series = 8333 pts; * 60s period = per-chunk seconds.
+	if got := chunkSeconds(60, 12); got != int64(100_000/12)*60 {
+		t.Errorf("got %d, want %d", got, int64(100_000/12)*60)
 	}
-	const wantAuthTypes = 4
-	if maxClientAuthTypes != wantAuthTypes {
-		t.Errorf("maxClientAuthTypes = %d, want %d", maxClientAuthTypes, wantAuthTypes)
+	// Unknown estimate or non-positive period => 0 (caller uses full window).
+	if got := chunkSeconds(60, 0); got != 0 {
+		t.Errorf("seriesEstimate 0 => 0, got %d", got)
+	}
+	if got := chunkSeconds(0, 12); got != 0 {
+		t.Errorf("period 0 => 0, got %d", got)
+	}
+	// Huge series count clamps to >= 1 point per series (one period).
+	if got := chunkSeconds(60, 1_000_000); got != 60 {
+		t.Errorf("expected floor of one period (60), got %d", got)
+	}
+}
+
+func TestSeriesEstimates(t *testing.T) {
+	if got := brokerSeriesEstimate(3); got != 4*(3+1) {
+		t.Errorf("broker: got %d, want %d", got, 4*(3+1))
+	}
+	if got := clientConnSeriesEstimate(3); got != 2*(3*maxClientAuthTypes+1) {
+		t.Errorf("clientconn: got %d, want %d", got, 2*(3*maxClientAuthTypes+1))
+	}
+	if got := storageSeriesEstimate(3); got != 3+2 {
+		t.Errorf("storage: got %d, want %d", got, 3+2)
 	}
 }
 

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -132,6 +132,12 @@ func TestResultStitcher_MarkPartial(t *testing.T) {
 	}
 }
 
+// dummyQueries returns a minimal non-empty queries slice for tests where the
+// fake client ignores the query content entirely.
+func dummyQueries() []cloudwatchtypes.MetricDataQuery {
+	return []cloudwatchtypes.MetricDataQuery{{Id: aws.String("q")}}
+}
+
 // completeResult returns a single complete series with n points for an Id.
 func completeResult(id string, n int) []cloudwatchtypes.MetricDataResult {
 	vals := make([]float64, n)
@@ -151,7 +157,7 @@ func TestExecuteChunkedQuery_SingleCallWhenUnderBudget(t *testing.T) {
 	}}
 	ms := &MetricService{client: fake}
 	start, end := time.Unix(0, 0), time.Unix(600, 0) // 10 points at 60s
-	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, 60, 4, "test")
+	out, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), start, end, 60, 4, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -180,7 +186,7 @@ func TestExecuteChunkedQuery_ChunksAndStaysUnderCap(t *testing.T) {
 		return &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", int(win/int64(period)))}, nil
 	}}
 	ms := &MetricService{client: fake}
-	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, period, seriesEst, "test")
+	out, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), start, end, period, seriesEst, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -206,7 +212,7 @@ func TestExecuteChunkedQuery_BisectsOnPartialData(t *testing.T) {
 		return &cloudwatch.GetMetricDataOutput{MetricDataResults: completeResult("sum_x", 1)}, nil
 	}}
 	ms := &MetricService{client: fake}
-	out, err := ms.executeChunkedQuery(context.Background(), nil, start, end, 60, 0, "test")
+	out, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), start, end, 60, 0, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -230,11 +236,26 @@ func TestExecuteChunkedQuery_WarnsAtFloor(t *testing.T) {
 		}}, nil
 	}}
 	ms := &MetricService{client: fake}
-	_, err := ms.executeChunkedQuery(context.Background(), nil, time.Unix(0, 0), time.Unix(60, 0), 60, 0, "broker metrics for cluster c1")
+	_, err := ms.executeChunkedQuery(context.Background(), dummyQueries(), time.Unix(0, 0), time.Unix(60, 0), 60, 0, "broker metrics for cluster c1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "metrics may be incomplete") || !strings.Contains(buf.String(), "broker metrics for cluster c1") {
 		t.Errorf("expected one incomplete-metrics warning mentioning the label, got: %q", buf.String())
+	}
+}
+
+func TestExecuteChunkedQuery_EmptyQueriesReturnsEmpty(t *testing.T) {
+	fake := &fakeCWClient{respond: func(_ int, _ *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+		t.Fatal("client should not be called for empty queries")
+		return nil, nil
+	}}
+	ms := &MetricService{client: fake}
+	out, err := ms.executeChunkedQuery(context.Background(), nil, time.Unix(0, 0), time.Unix(600, 0), 60, 4, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.MetricDataResults) != 0 || len(fake.calls) != 0 {
+		t.Errorf("expected no calls and empty results, got %d calls / %d results", len(fake.calls), len(out.MetricDataResults))
 	}
 }

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+)
+
+// fakeCWClient is an in-memory cloudWatchGetMetricDataAPI for tests.
+type fakeCWClient struct {
+	calls   []cloudwatch.GetMetricDataInput
+	respond func(call int, in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+func (f *fakeCWClient) GetMetricData(_ context.Context, in *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	idx := len(f.calls)
+	f.calls = append(f.calls, *in)
+	return f.respond(idx, in)
+}
+
+func TestFakeClientSatisfiesInterface(t *testing.T) {
+	var _ cloudWatchGetMetricDataAPI = &fakeCWClient{}
+	ms := &MetricService{client: &fakeCWClient{}}
+	if ms.client == nil {
+		t.Fatal("expected client to be set")
+	}
+}
+
+// TestChunkingConstantsDefined verifies the chunking constants are declared with
+// the expected values. The constants are consumed by chunking logic added in
+// later tasks; this test keeps them reachable so the linter does not flag them.
+func TestChunkingConstantsDefined(t *testing.T) {
+	const wantBudget = 100_000
+	if datapointBudget != wantBudget {
+		t.Errorf("datapointBudget = %d, want %d", datapointBudget, wantBudget)
+	}
+	const wantAuthTypes = 4
+	if maxClientAuthTypes != wantAuthTypes {
+		t.Errorf("maxClientAuthTypes = %d, want %d", maxClientAuthTypes, wantAuthTypes)
+	}
+}

--- a/internal/services/metrics/metric_chunking_test.go
+++ b/internal/services/metrics/metric_chunking_test.go
@@ -3,8 +3,11 @@ package metrics
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 )
 
 // fakeCWClient is an in-memory cloudWatchGetMetricDataAPI for tests.
@@ -38,5 +41,35 @@ func TestChunkingConstantsDefined(t *testing.T) {
 	const wantAuthTypes = 4
 	if maxClientAuthTypes != wantAuthTypes {
 		t.Errorf("maxClientAuthTypes = %d, want %d", maxClientAuthTypes, wantAuthTypes)
+	}
+}
+
+func TestExecuteWindow_SetsAscendingScanAndPaginates(t *testing.T) {
+	fake := &fakeCWClient{
+		respond: func(call int, in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+			if call == 0 {
+				return &cloudwatch.GetMetricDataOutput{
+					MetricDataResults: []cloudwatchtypes.MetricDataResult{{Id: aws.String("sum_x"), Values: []float64{1}}},
+					NextToken:         aws.String("page2"),
+				}, nil
+			}
+			return &cloudwatch.GetMetricDataOutput{
+				MetricDataResults: []cloudwatchtypes.MetricDataResult{{Id: aws.String("sum_y"), Values: []float64{2}}},
+			}, nil
+		},
+	}
+	ms := &MetricService{client: fake}
+	out, err := ms.executeWindow(context.Background(), nil, time.Unix(0, 0), time.Unix(3600, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.calls) != 2 {
+		t.Fatalf("expected 2 paginated calls, got %d", len(fake.calls))
+	}
+	if fake.calls[0].ScanBy != cloudwatchtypes.ScanByTimestampAscending {
+		t.Errorf("expected ScanBy ascending, got %v", fake.calls[0].ScanBy)
+	}
+	if len(out.MetricDataResults) != 2 {
+		t.Errorf("expected 2 stitched page results, got %d", len(out.MetricDataResults))
 	}
 }

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -811,6 +811,12 @@ func (ms *MetricService) collectWindow(ctx context.Context, queries []cloudwatch
 // Results are stitched per Id; a single warning is emitted if any data remained
 // partial. label identifies the query group/cluster in that warning.
 func (ms *MetricService) executeChunkedQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time, period int32, seriesEstimate int, label string) (*cloudwatch.GetMetricDataOutput, error) {
+	// period drives the bisection's integer division in collectWindow; reject a
+	// non-positive period up front so an invalid caller fails fast rather than
+	// panicking on divide-by-zero (or behaving oddly for negatives) deeper down.
+	if period <= 0 {
+		return nil, fmt.Errorf("executeChunkedQuery: period must be positive, got %d", period)
+	}
 	if len(queries) == 0 || !endTime.After(startTime) {
 		return &cloudwatch.GetMetricDataOutput{}, nil
 	}

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -722,6 +722,9 @@ func (s *resultStitcher) add(results []cloudwatchtypes.MetricDataResult) {
 	}
 }
 
+// output returns the stitched results. Per-window Messages are intentionally not
+// carried through (they are consumed during collection via isPartial); current
+// callers only read MetricDataResults.
 func (s *resultStitcher) output() *cloudwatch.GetMetricDataOutput {
 	results := make([]cloudwatchtypes.MetricDataResult, 0, len(s.order))
 	for _, id := range s.order {
@@ -760,6 +763,8 @@ func getBrokerType(instanceType string) types.BrokerType {
 }
 
 // isPartial reports whether a window response was truncated by the datapoint cap.
+// The per-result PartialData status is the primary, reliable signal; the
+// MaxMetricsExceeded top-level message is a documented secondary signal.
 func isPartial(out *cloudwatch.GetMetricDataOutput) bool {
 	for _, r := range out.MetricDataResults {
 		if r.StatusCode == cloudwatchtypes.StatusCodePartialData {
@@ -767,8 +772,7 @@ func isPartial(out *cloudwatch.GetMetricDataOutput) bool {
 		}
 	}
 	for _, m := range out.Messages {
-		switch aws.ToString(m.Code) {
-		case "MaxMetricsExceeded", "TooManyDatapoints", "Paginated":
+		if aws.ToString(m.Code) == "MaxMetricsExceeded" {
 			return true
 		}
 	}
@@ -785,8 +789,13 @@ func (ms *MetricService) collectWindow(ctx context.Context, queries []cloudwatch
 	}
 	if isPartial(out) {
 		windowSeconds := int64(end.Sub(start).Seconds())
-		if windowSeconds > int64(period) {
-			mid := start.Add(time.Duration(windowSeconds/2) * time.Second)
+		// Snap the split to a period boundary so neither half re-buckets the
+		// datapoint straddling mid (CloudWatch aligns buckets from each call's
+		// StartTime). If the window is too small to split into two period-aligned
+		// halves, we can't reduce further — record partial and keep what we got.
+		halfPeriods := (windowSeconds / 2) / int64(period)
+		if windowSeconds > int64(period) && halfPeriods >= 1 {
+			mid := start.Add(time.Duration(halfPeriods*int64(period)) * time.Second)
 			if mid.After(start) && mid.Before(end) {
 				if err := ms.collectWindow(ctx, queries, start, mid, period, st); err != nil {
 					return err

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -108,21 +108,23 @@ func (ms *MetricService) ProcessProvisionedCluster(ctx context.Context, cluster 
 	}
 
 	metricsMetadata := buildProvisionedMetadata(cluster, timeWindow, followerFetching)
+	numBrokers := metricsMetadata.NumberOfBrokerNodes
+	clusterName := aws.ToString(cluster.ClusterName)
 
-	brokerQueries, brokerQueryInfos := ms.buildBrokerMetricQueries(aws.ToString(cluster.ClusterName), timeWindow.Period)
-	brokerQueryResult, err := ms.executeMetricQuery(ctx, brokerQueries, timeWindow.StartTime, timeWindow.EndTime)
+	brokerQueries, brokerQueryInfos := ms.buildBrokerMetricQueries(clusterName, timeWindow.Period)
+	brokerQueryResult, err := ms.executeChunkedQuery(ctx, brokerQueries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, brokerSeriesEstimate(numBrokers), "broker metrics for "+clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	clientConnectionQueries, clientConnQueryInfos := ms.buildClientConnectionQueries(aws.ToString(cluster.ClusterName), timeWindow.Period)
-	clientConnectionQueryResult, err := ms.executeMetricQuery(ctx, clientConnectionQueries, timeWindow.StartTime, timeWindow.EndTime)
+	clientConnectionQueries, clientConnQueryInfos := ms.buildClientConnectionQueries(clusterName, timeWindow.Period)
+	clientConnectionQueryResult, err := ms.executeChunkedQuery(ctx, clientConnectionQueries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, clientConnSeriesEstimate(numBrokers), "client-connection metrics for "+clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterQueries, clusterQueryInfos := ms.buildClusterMetricQueries(aws.ToString(cluster.ClusterName), timeWindow.Period)
-	clusterQueryResult, err := ms.executeMetricQuery(ctx, clusterQueries, timeWindow.StartTime, timeWindow.EndTime)
+	clusterQueries, clusterQueryInfos := ms.buildClusterMetricQueries(clusterName, timeWindow.Period)
+	clusterQueryResult, err := ms.executeChunkedQuery(ctx, clusterQueries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, 1, "cluster metrics for "+clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -154,14 +156,14 @@ func (ms *MetricService) ProcessProvisionedCluster(ctx context.Context, cluster 
 	} else {
 		slog.Warn("EBS volume size unavailable, local storage metrics may be inaccurate", "cluster", aws.ToString(cluster.ClusterName))
 	}
-	localStorageQueries, localStorageQueryInfos := ms.buildLocalStorageUsageQuery(aws.ToString(cluster.ClusterName), timeWindow.Period, clusterVolumeSizeGB)
-	storageQueryResult, err := ms.executeMetricQuery(ctx, localStorageQueries, timeWindow.StartTime, timeWindow.EndTime)
+	localStorageQueries, localStorageQueryInfos := ms.buildLocalStorageUsageQuery(clusterName, timeWindow.Period, clusterVolumeSizeGB)
+	storageQueryResult, err := ms.executeChunkedQuery(ctx, localStorageQueries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, storageSeriesEstimate(numBrokers), "local-storage metrics for "+clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	remoteStorageQueries, remoteStorageQueryInfos := ms.buildRemoteStorageUsageQuery(aws.ToString(cluster.ClusterName), timeWindow.Period)
-	remoteStorageQueryResult, err := ms.executeMetricQuery(ctx, remoteStorageQueries, timeWindow.StartTime, timeWindow.EndTime)
+	remoteStorageQueries, remoteStorageQueryInfos := ms.buildRemoteStorageUsageQuery(clusterName, timeWindow.Period)
+	remoteStorageQueryResult, err := ms.executeChunkedQuery(ctx, remoteStorageQueries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, storageSeriesEstimate(numBrokers), "remote-storage metrics for "+clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +228,7 @@ func (ms *MetricService) ProcessServerlessCluster(ctx context.Context, cluster k
 	populateCLICommands(queryInfos, queries, timeWindow.StartTime, timeWindow.EndTime, regionFromArn(cluster.ClusterArn))
 
 	// Execute the metric query
-	queryResult, err := ms.executeMetricQuery(ctx, queries, timeWindow.StartTime, timeWindow.EndTime)
+	queryResult, err := ms.executeChunkedQuery(ctx, queries, timeWindow.StartTime, timeWindow.EndTime, timeWindow.Period, 0, "serverless metrics for "+aws.ToString(cluster.ClusterName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute serverless metric queries: %w", err)
 	}
@@ -679,12 +681,6 @@ func (ms *MetricService) executeWindow(ctx context.Context, queries []cloudwatch
 	}
 
 	return &cloudwatch.GetMetricDataOutput{MetricDataResults: allResults, Messages: allMessages}, nil
-}
-
-// executeMetricQuery is the legacy single-window entrypoint; retained until
-// callers migrate to executeChunkedQuery (a later task).
-func (ms *MetricService) executeMetricQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
-	return ms.executeWindow(ctx, queries, startTime, endTime)
 }
 
 // resultStitcher concatenates MetricDataResult points per Id across sub-window

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -687,6 +687,28 @@ func (ms *MetricService) executeMetricQuery(ctx context.Context, queries []cloud
 	return ms.executeWindow(ctx, queries, startTime, endTime)
 }
 
+// chunkSeconds returns the maximum sub-window length (seconds) that keeps a
+// request under datapointBudget for the given period and series count. Returns
+// 0 when the estimate is unknown (<=0) or period is non-positive, signalling the
+// caller to use the full window and rely on the partial-data fallback.
+func chunkSeconds(period int32, seriesEstimate int) int64 {
+	if period <= 0 || seriesEstimate <= 0 {
+		return 0
+	}
+	maxPtsPerSeries := datapointBudget / seriesEstimate
+	if maxPtsPerSeries < 1 {
+		maxPtsPerSeries = 1
+	}
+	return int64(maxPtsPerSeries) * int64(period)
+}
+
+// Series-count estimates count fan-out series (one per broker) PLUS the returned
+// math-result series, since both consume the datapoint budget. They err high so
+// chunks never exceed the cap; the fallback splitter self-heals any under-estimate.
+func brokerSeriesEstimate(numBrokers int) int     { return 4 * (numBrokers + 1) }                    // 4 metrics
+func clientConnSeriesEstimate(numBrokers int) int { return 2 * (numBrokers*maxClientAuthTypes + 1) } // 2 stats
+func storageSeriesEstimate(numBrokers int) int    { return numBrokers + 2 }                          // 1 returned + 1 intermediate
+
 func getBrokerType(instanceType string) types.BrokerType {
 	if strings.HasPrefix(instanceType, "express.") {
 		return types.BrokerTypeExpress

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -806,7 +806,7 @@ func (ms *MetricService) collectWindow(ctx context.Context, queries []cloudwatch
 // Results are stitched per Id; a single warning is emitted if any data remained
 // partial. label identifies the query group/cluster in that warning.
 func (ms *MetricService) executeChunkedQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time, period int32, seriesEstimate int, label string) (*cloudwatch.GetMetricDataOutput, error) {
-	if !endTime.After(startTime) {
+	if len(queries) == 0 || !endTime.After(startTime) {
 		return &cloudwatch.GetMetricDataOutput{}, nil
 	}
 

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -465,7 +465,10 @@ func newSearchMetricQueryInfo(metricName, searchExpr, mathExpr, stat string, per
 		Period:           period,
 		SearchExpression: searchExpr,
 		MathExpression:   mathExpr,
-		AggregationNote:  fmt.Sprintf("Uses SEARCH to find %s across all %s, then aggregates with %s.", metricName, dimensions, mathExpr),
+		AggregationNote: fmt.Sprintf("Uses SEARCH to find %s across all %s, then aggregates with %s. "+
+			"kcp fetches this metric in time-chunked GetMetricData sub-windows to stay under CloudWatch's 100,800-datapoint per-request limit; "+
+			"the single CLI command above queries the whole window in one request and may return only the most-recent data for large windows or "+
+			"many-broker clusters — split --start-time/--end-time into smaller sub-windows to reproduce the complete series.", metricName, dimensions, mathExpr),
 	}
 }
 

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -758,3 +758,82 @@ func getBrokerType(instanceType string) types.BrokerType {
 	}
 	return types.BrokerTypeStandard
 }
+
+// isPartial reports whether a window response was truncated by the datapoint cap.
+func isPartial(out *cloudwatch.GetMetricDataOutput) bool {
+	for _, r := range out.MetricDataResults {
+		if r.StatusCode == cloudwatchtypes.StatusCodePartialData {
+			return true
+		}
+	}
+	for _, m := range out.Messages {
+		switch aws.ToString(m.Code) {
+		case "MaxMetricsExceeded", "TooManyDatapoints", "Paginated":
+			return true
+		}
+	}
+	return false
+}
+
+// collectWindow fetches one window into the stitcher. If the response is partial
+// and the window spans more than one period, it bisects and recurses; at the
+// one-period floor it records a partial flag (warned once by executeChunkedQuery).
+func (ms *MetricService) collectWindow(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, start, end time.Time, period int32, st *resultStitcher) error {
+	out, err := ms.executeWindow(ctx, queries, start, end)
+	if err != nil {
+		return err
+	}
+	if isPartial(out) {
+		windowSeconds := int64(end.Sub(start).Seconds())
+		if windowSeconds > int64(period) {
+			mid := start.Add(time.Duration(windowSeconds/2) * time.Second)
+			if mid.After(start) && mid.Before(end) {
+				if err := ms.collectWindow(ctx, queries, start, mid, period, st); err != nil {
+					return err
+				}
+				return ms.collectWindow(ctx, queries, mid, end, period, st)
+			}
+		}
+		st.markPartial()
+	}
+	st.add(out.MetricDataResults)
+	return nil
+}
+
+// executeChunkedQuery fetches metrics across [startTime, endTime), splitting into
+// sub-windows sized to stay under datapointBudget for seriesEstimate series at the
+// given period (seriesEstimate <= 0 means "unknown" -> full window + fallback).
+// Results are stitched per Id; a single warning is emitted if any data remained
+// partial. label identifies the query group/cluster in that warning.
+func (ms *MetricService) executeChunkedQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time, period int32, seriesEstimate int, label string) (*cloudwatch.GetMetricDataOutput, error) {
+	if !endTime.After(startTime) {
+		return &cloudwatch.GetMetricDataOutput{}, nil
+	}
+
+	st := newResultStitcher()
+	cs := chunkSeconds(period, seriesEstimate)
+	totalSeconds := int64(endTime.Sub(startTime).Seconds())
+
+	if cs <= 0 || totalSeconds <= cs {
+		if err := ms.collectWindow(ctx, queries, startTime, endTime, period, st); err != nil {
+			return nil, err
+		}
+	} else {
+		for chunkStart := startTime; chunkStart.Before(endTime); {
+			chunkEnd := chunkStart.Add(time.Duration(cs) * time.Second)
+			if chunkEnd.After(endTime) {
+				chunkEnd = endTime
+			}
+			if err := ms.collectWindow(ctx, queries, chunkStart, chunkEnd, period, st); err != nil {
+				return nil, err
+			}
+			chunkStart = chunkEnd
+		}
+	}
+
+	if st.partial {
+		slog.Warn("metrics may be incomplete: CloudWatch returned partial data at the minimum window",
+			"query", label, "period", period, "start", startTime, "end", endTime)
+	}
+	return st.output(), nil
+}

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -15,8 +15,25 @@ import (
 	"github.com/confluentinc/kcp/internal/types"
 )
 
+// cloudWatchGetMetricDataAPI is the subset of the CloudWatch client used by
+// MetricService. It exists so the chunking/stitching logic can be unit-tested
+// with a fake. *cloudwatch.Client satisfies it.
+type cloudWatchGetMetricDataAPI interface {
+	GetMetricData(ctx context.Context, in *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+const (
+	// datapointBudget is CloudWatch's per-request GetMetricData limit (100,800)
+	// with a safety margin. Chunk windows are sized so the datapoints from all
+	// series in a request (fan-out + returned math) stay under it.
+	datapointBudget = 100_000
+	// maxClientAuthTypes bounds the "Client Authentication" dimension cardinality
+	// (TLS, SASL/SCRAM, IAM, Unauthenticated) for the ClientConnectionCount estimate.
+	maxClientAuthTypes = 4
+)
+
 type MetricService struct {
-	client *cloudwatch.Client
+	client cloudWatchGetMetricDataAPI
 }
 
 func NewMetricService(client *cloudwatch.Client) *MetricService {

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -666,12 +666,18 @@ func (ms *MetricService) executeWindow(ctx context.Context, queries []cloudwatch
 	var allResults []cloudwatchtypes.MetricDataResult
 	var allMessages []cloudwatchtypes.MessageData
 	var nextToken *string
+	pages := 0
 	for {
 		input.NextToken = nextToken
 		result, err := ms.client.GetMetricData(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get metric data: %w", err)
 		}
+		pages++
+		slog.Debug("GetMetricData request",
+			"start", startTime, "end", endTime, "page", pages,
+			"continuation", nextToken != nil, "resultSeries", len(result.MetricDataResults),
+			"morePages", result.NextToken != nil)
 		allResults = append(allResults, result.MetricDataResults...)
 		allMessages = append(allMessages, result.Messages...)
 		if result.NextToken == nil {
@@ -680,6 +686,7 @@ func (ms *MetricService) executeWindow(ctx context.Context, queries []cloudwatch
 		nextToken = result.NextToken
 	}
 
+	slog.Debug("fetched metric window", "start", startTime, "end", endTime, "pages", pages, "resultSeries", len(allResults))
 	return &cloudwatch.GetMetricDataOutput{MetricDataResults: allResults, Messages: allMessages}, nil
 }
 
@@ -793,12 +800,14 @@ func (ms *MetricService) collectWindow(ctx context.Context, queries []cloudwatch
 		if windowSeconds > int64(period) && halfPeriods >= 1 {
 			mid := start.Add(time.Duration(halfPeriods*int64(period)) * time.Second)
 			if mid.After(start) && mid.Before(end) {
+				slog.Debug("partial metric window, bisecting", "start", start, "mid", mid, "end", end, "windowSeconds", windowSeconds)
 				if err := ms.collectWindow(ctx, queries, start, mid, period, st); err != nil {
 					return err
 				}
 				return ms.collectWindow(ctx, queries, mid, end, period, st)
 			}
 		}
+		slog.Debug("partial metric window at minimum resolution, keeping partial data", "start", start, "end", end, "windowSeconds", windowSeconds)
 		st.markPartial()
 	}
 	st.add(out.MetricDataResults)
@@ -825,6 +834,20 @@ func (ms *MetricService) executeChunkedQuery(ctx context.Context, queries []clou
 	cs := chunkSeconds(period, seriesEstimate)
 	totalSeconds := int64(endTime.Sub(startTime).Seconds())
 
+	chunked := cs > 0 && totalSeconds > cs
+	numChunks := 1
+	if chunked {
+		numChunks = int((totalSeconds + cs - 1) / cs)
+	}
+	slog.Debug("executing chunked metric query",
+		"query", label, "period", period, "seriesEstimate", seriesEstimate,
+		"start", startTime, "end", endTime, "chunkSeconds", cs, "chunked", chunked, "chunks", numChunks)
+	for _, q := range queries {
+		slog.Debug("metric query expression",
+			"query", label, "id", aws.ToString(q.Id), "label", aws.ToString(q.Label),
+			"expression", aws.ToString(q.Expression), "returnData", aws.ToBool(q.ReturnData))
+	}
+
 	if cs <= 0 || totalSeconds <= cs {
 		if err := ms.collectWindow(ctx, queries, startTime, endTime, period, st); err != nil {
 			return nil, err
@@ -842,9 +865,17 @@ func (ms *MetricService) executeChunkedQuery(ctx context.Context, queries []clou
 		}
 	}
 
+	out := st.output()
+	datapoints := 0
+	for _, r := range out.MetricDataResults {
+		datapoints += len(r.Values)
+	}
+	slog.Debug("completed chunked metric query",
+		"query", label, "series", len(out.MetricDataResults), "datapoints", datapoints, "partial", st.partial)
+
 	if st.partial {
 		slog.Warn("metrics may be incomplete: CloudWatch returned partial data at the minimum window",
 			"query", label, "period", period, "start", startTime, "end", endTime)
 	}
-	return st.output(), nil
+	return out, nil
 }

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -651,35 +651,40 @@ func regionFromArn(arn *string) string {
 
 // Private Helper Functions - Query Execution
 
-func (ms *MetricService) executeMetricQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
+// executeWindow fetches one [startTime, endTime) window, following NextToken
+// pagination. ScanBy is ascending so callers can concatenate windows in time order.
+func (ms *MetricService) executeWindow(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
 	input := &cloudwatch.GetMetricDataInput{
 		MetricDataQueries: queries,
 		StartTime:         aws.Time(startTime),
 		EndTime:           aws.Time(endTime),
+		ScanBy:            cloudwatchtypes.ScanByTimestampAscending,
 	}
 
 	var allResults []cloudwatchtypes.MetricDataResult
+	var allMessages []cloudwatchtypes.MessageData
 	var nextToken *string
-
 	for {
 		input.NextToken = nextToken
 		result, err := ms.client.GetMetricData(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get metric data: %w", err)
 		}
-
 		allResults = append(allResults, result.MetricDataResults...)
-
+		allMessages = append(allMessages, result.Messages...)
 		if result.NextToken == nil {
 			break
 		}
 		nextToken = result.NextToken
 	}
 
-	// Return a consolidated result with all metric data
-	return &cloudwatch.GetMetricDataOutput{
-		MetricDataResults: allResults,
-	}, nil
+	return &cloudwatch.GetMetricDataOutput{MetricDataResults: allResults, Messages: allMessages}, nil
+}
+
+// executeMetricQuery is the legacy single-window entrypoint; retained until
+// callers migrate to executeChunkedQuery (a later task).
+func (ms *MetricService) executeMetricQuery(ctx context.Context, queries []cloudwatchtypes.MetricDataQuery, startTime, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
+	return ms.executeWindow(ctx, queries, startTime, endTime)
 }
 
 func getBrokerType(instanceType string) types.BrokerType {

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -687,6 +687,49 @@ func (ms *MetricService) executeMetricQuery(ctx context.Context, queries []cloud
 	return ms.executeWindow(ctx, queries, startTime, endTime)
 }
 
+// resultStitcher concatenates MetricDataResult points per Id across sub-window
+// calls, preserving first-seen Id order and tracking whether any chunk was partial.
+type resultStitcher struct {
+	order   []string
+	byID    map[string]*cloudwatchtypes.MetricDataResult
+	partial bool
+}
+
+func newResultStitcher() *resultStitcher {
+	return &resultStitcher{byID: map[string]*cloudwatchtypes.MetricDataResult{}}
+}
+
+func (s *resultStitcher) markPartial() { s.partial = true }
+
+func (s *resultStitcher) add(results []cloudwatchtypes.MetricDataResult) {
+	for _, r := range results {
+		id := aws.ToString(r.Id)
+		existing, ok := s.byID[id]
+		if !ok {
+			cp := r
+			s.byID[id] = &cp
+			s.order = append(s.order, id)
+			continue
+		}
+		existing.Timestamps = append(existing.Timestamps, r.Timestamps...)
+		existing.Values = append(existing.Values, r.Values...)
+		if r.Label != nil {
+			existing.Label = r.Label
+		}
+		if r.StatusCode == cloudwatchtypes.StatusCodePartialData {
+			existing.StatusCode = cloudwatchtypes.StatusCodePartialData
+		}
+	}
+}
+
+func (s *resultStitcher) output() *cloudwatch.GetMetricDataOutput {
+	results := make([]cloudwatchtypes.MetricDataResult, 0, len(s.order))
+	for _, id := range s.order {
+		results = append(results, *s.byID[id])
+	}
+	return &cloudwatch.GetMetricDataOutput{MetricDataResults: results}
+}
+
 // chunkSeconds returns the maximum sub-window length (seconds) that keeps a
 // request under datapointBudget for the given period and series count. Returns
 // 0 when the estimate is unknown (<=0) or period is non-positive, signalling the

--- a/internal/services/metrics/metric_service_test.go
+++ b/internal/services/metrics/metric_service_test.go
@@ -152,6 +152,9 @@ func TestNewSearchMetricQueryInfo(t *testing.T) {
 	assert.Equal(t, "SUM(m_bytesinpersec)", info.MathExpression)
 	assert.Contains(t, info.AggregationNote, "BytesInPerSec")
 	assert.Contains(t, info.AggregationNote, "SUM(m_bytesinpersec)")
+	// The note must disclose that the captured single-window CLI command may truncate,
+	// because kcp actually chunks the request under CloudWatch's 100,800 limit.
+	assert.Contains(t, info.AggregationNote, "100,800")
 }
 
 func TestBuildBrokerMetricQueries(t *testing.T) {


### PR DESCRIPTION
## Problem

`kcp discover` collected MSK metrics via a single `GetMetricData` call per group with no `MaxDatapoints`/`ScanBy`, so CloudWatch applied its defaults (**100,800 datapoints/request, newest-first**). Each query is metric-math `SUM(SEARCH(...))` whose `SEARCH` fans out to one series per broker (× client-auth for `ClientConnectionCount`); those fan-out series count toward the cap even at `ReturnData=false`. Broker queries batch 4 metrics in one request → `4 × brokers` series. At 60s over 15 days each series wants 21,600 points, so once `series × pts > 100,800` CloudWatch returns `PartialData` and keeps only the newest points — and the math result can't be recovered via `NextToken`. Result: throughput charts silently showed only the most recent ~5–6 days of a 15-day scan.

## Fix

Time-window **chunking + per-`Id` stitching**, all in `internal/services/metrics/metric_service.go`:

- **Client interface seam** (`cloudWatchGetMetricDataAPI`) so the logic is unit-testable with a fake.
- **`executeWindow`** — one window, `ScanBy=TimestampAscending`, follows `NextToken`.
- **`chunkSeconds` + series estimators** — size each chunk from the cluster's broker count (counting fan-out + returned math series; budget 100,000) to make the fewest calls that stay under the cap.
- **`resultStitcher`** — concatenates points per `Id` across chunks in chronological order.
- **`isPartial` + `collectWindow`** — partial-data fallback that bisects a window (snapped to a period boundary) down to a one-period floor, then **`executeChunkedQuery`** emits one aggregated `slog.Warn` if data is still partial.
- Wired into `ProcessProvisionedCluster` (per-group estimates) and `ProcessServerlessCluster` (estimate 0 → fallback, since topic cardinality isn't known cheaply). Single-series `GlobalPartitionCount` never chunks.

## Testing

- New unit tests (fake CloudWatch client, no AWS): chunk-count/under-cap math, per-`Id` stitching, contiguous timestamps across seams, partial-data bisection recovery, warn-at-floor, empty-queries guard, `isPartial` message detection.
- `make test-go GOTEST_FLAGS="-p 1 -parallel 4 -count=1"` → all pass.
- `golangci-lint run --config .golangci.yml ./...` → 0 issues.
- **Pending:** real multi-broker MSK smoke (`kcp discover --cluster-arn <arn> --metrics-granularity 60s`) to confirm the full 15 days at 60s (~21,600 pts) with no ~5–6 day cliff — before/after point counts to be added here.

Spec & plan: `~/claude-plans/kcp/2026-06-18-cloudwatch-metrics-truncation-{design,plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)