### PR TITLE
refactor(types): dedup auth-method behavior onto AuthMethodConfig (Pass A)

### DIFF
--- a/internal/types/auth_method_config_test.go
+++ b/internal/types/auth_method_config_test.go
@@ -1,0 +1,130 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMethodConfig_EnabledAuthMethods(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     AuthMethodConfig
+		includeIAM bool
+		expected   []AuthType
+	}{
+		{
+			name:       "empty config returns no methods",
+			config:     AuthMethodConfig{},
+			includeIAM: true,
+			expected:   []AuthType{},
+		},
+		{
+			name: "single SASL/SCRAM method",
+			config: AuthMethodConfig{
+				SASLScram: &SASLScramConfig{Use: true},
+			},
+			includeIAM: true,
+			expected:   []AuthType{AuthTypeSASLSCRAM},
+		},
+		{
+			name: "IAM included when includeIAM is true",
+			config: AuthMethodConfig{
+				IAM: &IAMConfig{Use: true},
+			},
+			includeIAM: true,
+			expected:   []AuthType{AuthTypeIAM},
+		},
+		{
+			name: "IAM ignored when includeIAM is false (OSK)",
+			config: AuthMethodConfig{
+				IAM: &IAMConfig{Use: true},
+			},
+			includeIAM: false,
+			expected:   []AuthType{},
+		},
+		{
+			name: "disabled methods (Use=false) are excluded",
+			config: AuthMethodConfig{
+				SASLScram: &SASLScramConfig{Use: false},
+				TLS:       &TLSConfig{Use: false},
+			},
+			includeIAM: true,
+			expected:   []AuthType{},
+		},
+		{
+			name: "canonical order preserved across all methods (includeIAM=true)",
+			config: AuthMethodConfig{
+				UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				UnauthenticatedTLS:       &UnauthenticatedTLSConfig{Use: true},
+				IAM:                      &IAMConfig{Use: true},
+				SASLScram:                &SASLScramConfig{Use: true},
+				SASLPlain:                &SASLPlainConfig{Use: true},
+				TLS:                      &TLSConfig{Use: true},
+			},
+			includeIAM: true,
+			expected: []AuthType{
+				AuthTypeUnauthenticatedPlaintext,
+				AuthTypeUnauthenticatedTLS,
+				AuthTypeIAM,
+				AuthTypeSASLSCRAM,
+				AuthTypeSASLPlain,
+				AuthTypeTLS,
+			},
+		},
+		{
+			name: "canonical order with IAM filtered out (includeIAM=false)",
+			config: AuthMethodConfig{
+				UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				UnauthenticatedTLS:       &UnauthenticatedTLSConfig{Use: true},
+				IAM:                      &IAMConfig{Use: true},
+				SASLScram:                &SASLScramConfig{Use: true},
+				SASLPlain:                &SASLPlainConfig{Use: true},
+				TLS:                      &TLSConfig{Use: true},
+			},
+			includeIAM: false,
+			expected: []AuthType{
+				AuthTypeUnauthenticatedPlaintext,
+				AuthTypeUnauthenticatedTLS,
+				AuthTypeSASLSCRAM,
+				AuthTypeSASLPlain,
+				AuthTypeTLS,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.EnabledAuthMethods(tt.includeIAM))
+		})
+	}
+}
+
+func TestAuthMethodConfig_SelectedAuthType(t *testing.T) {
+	t.Run("returns single enabled method", func(t *testing.T) {
+		config := AuthMethodConfig{SASLScram: &SASLScramConfig{Use: true}}
+		got, err := config.SelectedAuthType(false)
+		require.NoError(t, err)
+		assert.Equal(t, AuthTypeSASLSCRAM, got)
+	})
+
+	t.Run("errors when no method enabled", func(t *testing.T) {
+		config := AuthMethodConfig{}
+		_, err := config.SelectedAuthType(true)
+		require.Error(t, err)
+	})
+
+	t.Run("IAM not selectable when includeIAM is false", func(t *testing.T) {
+		config := AuthMethodConfig{IAM: &IAMConfig{Use: true}}
+		_, err := config.SelectedAuthType(false)
+		require.Error(t, err)
+	})
+
+	t.Run("IAM selectable when includeIAM is true", func(t *testing.T) {
+		config := AuthMethodConfig{IAM: &IAMConfig{Use: true}}
+		got, err := config.SelectedAuthType(true)
+		require.NoError(t, err)
+		assert.Equal(t, AuthTypeIAM, got)
+	})
+}

--- a/internal/types/credentials_msk.go
+++ b/internal/types/credentials_msk.go
@@ -162,38 +162,12 @@ type ClusterAuth struct {
 }
 
 func (ce ClusterAuth) GetSelectedAuthType() (AuthType, error) {
-	enabledMethods := ce.GetAuthMethods()
-	if len(enabledMethods) == 0 {
-		return "", fmt.Errorf("no authentication method enabled for cluster")
-	}
-	return enabledMethods[0], nil
-
+	return ce.AuthMethod.SelectedAuthType(true)
 }
 
 // Gets a list of the authentication method(s) selected in the `creds.yaml` file generated during discovery.
 func (ce ClusterAuth) GetAuthMethods() []AuthType {
-	enabledMethods := []AuthType{}
-
-	if ce.AuthMethod.UnauthenticatedPlaintext != nil && ce.AuthMethod.UnauthenticatedPlaintext.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedPlaintext)
-	}
-	if ce.AuthMethod.UnauthenticatedTLS != nil && ce.AuthMethod.UnauthenticatedTLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedTLS)
-	}
-	if ce.AuthMethod.IAM != nil && ce.AuthMethod.IAM.Use {
-		enabledMethods = append(enabledMethods, AuthTypeIAM)
-	}
-	if ce.AuthMethod.SASLScram != nil && ce.AuthMethod.SASLScram.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
-	}
-	if ce.AuthMethod.SASLPlain != nil && ce.AuthMethod.SASLPlain.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLPlain)
-	}
-	if ce.AuthMethod.TLS != nil && ce.AuthMethod.TLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeTLS)
-	}
-
-	return enabledMethods
+	return ce.AuthMethod.EnabledAuthMethods(true)
 }
 
 type AuthMethodConfig struct {
@@ -203,6 +177,40 @@ type AuthMethodConfig struct {
 	TLS                      *TLSConfig                      `yaml:"tls,omitempty"`
 	UnauthenticatedTLS       *UnauthenticatedTLSConfig       `yaml:"unauthenticated_tls,omitempty"`
 	UnauthenticatedPlaintext *UnauthenticatedPlaintextConfig `yaml:"unauthenticated_plaintext,omitempty"`
+}
+
+// EnabledAuthMethods returns the enabled methods in canonical order.
+// includeIAM is false for sources that don't support IAM (Apache Kafka / OSK).
+func (amc AuthMethodConfig) EnabledAuthMethods(includeIAM bool) []AuthType {
+	methods := []AuthType{}
+	if amc.UnauthenticatedPlaintext != nil && amc.UnauthenticatedPlaintext.Use {
+		methods = append(methods, AuthTypeUnauthenticatedPlaintext)
+	}
+	if amc.UnauthenticatedTLS != nil && amc.UnauthenticatedTLS.Use {
+		methods = append(methods, AuthTypeUnauthenticatedTLS)
+	}
+	if includeIAM && amc.IAM != nil && amc.IAM.Use {
+		methods = append(methods, AuthTypeIAM)
+	}
+	if amc.SASLScram != nil && amc.SASLScram.Use {
+		methods = append(methods, AuthTypeSASLSCRAM)
+	}
+	if amc.SASLPlain != nil && amc.SASLPlain.Use {
+		methods = append(methods, AuthTypeSASLPlain)
+	}
+	if amc.TLS != nil && amc.TLS.Use {
+		methods = append(methods, AuthTypeTLS)
+	}
+	return methods
+}
+
+// SelectedAuthType returns the single enabled method, or an error if none.
+func (amc AuthMethodConfig) SelectedAuthType(includeIAM bool) (AuthType, error) {
+	enabled := amc.EnabledAuthMethods(includeIAM)
+	if len(enabled) == 0 {
+		return "", fmt.Errorf("no authentication method enabled for cluster")
+	}
+	return enabled[0], nil
 }
 
 // MergeWith preserves existing auth configurations only for auth methods that still exist in the new config

--- a/internal/types/credentials_osk.go
+++ b/internal/types/credentials_osk.go
@@ -164,37 +164,15 @@ func (c OSKCredentials) Validate() (bool, []error) {
 	return len(errs) == 0, errs
 }
 
-// GetAuthMethods returns the enabled authentication methods for this cluster
+// GetAuthMethods returns the enabled authentication methods for this cluster.
+// IAM is not supported for OSK, so it is excluded (includeIAM=false).
 func (c OSKClusterAuth) GetAuthMethods() []AuthType {
-	enabledMethods := []AuthType{}
-
-	if c.AuthMethod.UnauthenticatedPlaintext != nil && c.AuthMethod.UnauthenticatedPlaintext.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedPlaintext)
-	}
-	if c.AuthMethod.UnauthenticatedTLS != nil && c.AuthMethod.UnauthenticatedTLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedTLS)
-	}
-	if c.AuthMethod.SASLScram != nil && c.AuthMethod.SASLScram.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
-	}
-	if c.AuthMethod.SASLPlain != nil && c.AuthMethod.SASLPlain.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLPlain)
-	}
-	if c.AuthMethod.TLS != nil && c.AuthMethod.TLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeTLS)
-	}
-	// Note: IAM not supported for OSK
-
-	return enabledMethods
+	return c.AuthMethod.EnabledAuthMethods(false)
 }
 
 // GetSelectedAuthType returns the selected auth type for the cluster
 func (c OSKClusterAuth) GetSelectedAuthType() (AuthType, error) {
-	enabledMethods := c.GetAuthMethods()
-	if len(enabledMethods) == 0 {
-		return "", fmt.Errorf("no authentication method enabled for cluster")
-	}
-	return enabledMethods[0], nil
+	return c.AuthMethod.SelectedAuthType(false)
 }
 
 // HasJolokiaConfig returns true if the cluster has Jolokia configuration


### PR DESCRIPTION
## Summary

First of two small, independent, behavior-preserving passes that stop MSK and OSK from maintaining parallel copies of credential auth-method behavior (deferred final follow-up of the `internal/types` reorg).

MSK (`ClusterAuth`) and OSK (`OSKClusterAuth`) each had a near-identical `GetAuthMethods` and an exact-duplicate `GetSelectedAuthType`. This pass moves the canonical-order enumeration and single-method selection onto the **already-shared** `AuthMethodConfig` type and makes the four existing methods thin delegators.

## Changes

- Add `AuthMethodConfig.EnabledAuthMethods(includeIAM bool) []AuthType` — enabled methods in canonical order; `includeIAM=false` for sources without IAM (Apache Kafka / OSK).
- Add `AuthMethodConfig.SelectedAuthType(includeIAM bool) (AuthType, error)` — single enabled method or error.
- `ClusterAuth.GetAuthMethods()` / `GetSelectedAuthType()` → delegate with `includeIAM=true`.
- `OSKClusterAuth.GetAuthMethods()` / `GetSelectedAuthType()` → delegate with `includeIAM=false` (preserves "IAM not supported for OSK").
- New focused unit tests for both methods (both `includeIAM` values, OSK IAM-ignored case, canonical order).

The IAM position (3rd, between unauthenticated-TLS and SASL/SCRAM) is preserved, so output is byte-identical to both prior implementations on every input — valid or invalid.

## No wire-format change

Public signatures and YAML structs/tags are unchanged. This is pure method extraction + delegation.

## Verification

- `go test ./internal/types/` — ok (existing ~60 credentials tests + new tests pass unchanged)
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./...` — **47 packages OK, 0 failures**

## Follow-up

Pass B (extract `New*CredentialsFromFile` / `WriteToFile` file-I/O boilerplate) lands as a separate PR — sequential since it touches the same two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)