### PR TITLE
refactor(types): dedup MSK/OSK credentials auth-method + file-I/O

### DIFF
--- a/internal/types/auth_method_config_test.go
+++ b/internal/types/auth_method_config_test.go
@@ -1,0 +1,130 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMethodConfig_EnabledAuthMethods(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     AuthMethodConfig
+		includeIAM bool
+		expected   []AuthType
+	}{
+		{
+			name:       "empty config returns no methods",
+			config:     AuthMethodConfig{},
+			includeIAM: true,
+			expected:   []AuthType{},
+		},
+		{
+			name: "single SASL/SCRAM method",
+			config: AuthMethodConfig{
+				SASLScram: &SASLScramConfig{Use: true},
+			},
+			includeIAM: true,
+			expected:   []AuthType{AuthTypeSASLSCRAM},
+		},
+		{
+			name: "IAM included when includeIAM is true",
+			config: AuthMethodConfig{
+				IAM: &IAMConfig{Use: true},
+			},
+			includeIAM: true,
+			expected:   []AuthType{AuthTypeIAM},
+		},
+		{
+			name: "IAM ignored when includeIAM is false (OSK)",
+			config: AuthMethodConfig{
+				IAM: &IAMConfig{Use: true},
+			},
+			includeIAM: false,
+			expected:   []AuthType{},
+		},
+		{
+			name: "disabled methods (Use=false) are excluded",
+			config: AuthMethodConfig{
+				SASLScram: &SASLScramConfig{Use: false},
+				TLS:       &TLSConfig{Use: false},
+			},
+			includeIAM: true,
+			expected:   []AuthType{},
+		},
+		{
+			name: "canonical order preserved across all methods (includeIAM=true)",
+			config: AuthMethodConfig{
+				UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				UnauthenticatedTLS:       &UnauthenticatedTLSConfig{Use: true},
+				IAM:                      &IAMConfig{Use: true},
+				SASLScram:                &SASLScramConfig{Use: true},
+				SASLPlain:                &SASLPlainConfig{Use: true},
+				TLS:                      &TLSConfig{Use: true},
+			},
+			includeIAM: true,
+			expected: []AuthType{
+				AuthTypeUnauthenticatedPlaintext,
+				AuthTypeUnauthenticatedTLS,
+				AuthTypeIAM,
+				AuthTypeSASLSCRAM,
+				AuthTypeSASLPlain,
+				AuthTypeTLS,
+			},
+		},
+		{
+			name: "canonical order with IAM filtered out (includeIAM=false)",
+			config: AuthMethodConfig{
+				UnauthenticatedPlaintext: &UnauthenticatedPlaintextConfig{Use: true},
+				UnauthenticatedTLS:       &UnauthenticatedTLSConfig{Use: true},
+				IAM:                      &IAMConfig{Use: true},
+				SASLScram:                &SASLScramConfig{Use: true},
+				SASLPlain:                &SASLPlainConfig{Use: true},
+				TLS:                      &TLSConfig{Use: true},
+			},
+			includeIAM: false,
+			expected: []AuthType{
+				AuthTypeUnauthenticatedPlaintext,
+				AuthTypeUnauthenticatedTLS,
+				AuthTypeSASLSCRAM,
+				AuthTypeSASLPlain,
+				AuthTypeTLS,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.EnabledAuthMethods(tt.includeIAM))
+		})
+	}
+}
+
+func TestAuthMethodConfig_SelectedAuthType(t *testing.T) {
+	t.Run("returns single enabled method", func(t *testing.T) {
+		config := AuthMethodConfig{SASLScram: &SASLScramConfig{Use: true}}
+		got, err := config.SelectedAuthType(false)
+		require.NoError(t, err)
+		assert.Equal(t, AuthTypeSASLSCRAM, got)
+	})
+
+	t.Run("errors when no method enabled", func(t *testing.T) {
+		config := AuthMethodConfig{}
+		_, err := config.SelectedAuthType(true)
+		require.Error(t, err)
+	})
+
+	t.Run("IAM not selectable when includeIAM is false", func(t *testing.T) {
+		config := AuthMethodConfig{IAM: &IAMConfig{Use: true}}
+		_, err := config.SelectedAuthType(false)
+		require.Error(t, err)
+	})
+
+	t.Run("IAM selectable when includeIAM is true", func(t *testing.T) {
+		config := AuthMethodConfig{IAM: &IAMConfig{Use: true}}
+		got, err := config.SelectedAuthType(true)
+		require.NoError(t, err)
+		assert.Equal(t, AuthTypeIAM, got)
+	})
+}

--- a/internal/types/credentials_io.go
+++ b/internal/types/credentials_io.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/goccy/go-yaml"
+)
+
+// writeYAMLFile marshals v to YAML and writes it to path with 0600 permissions.
+// Shared by Credentials.WriteToFile and OSKCredentials.WriteToFile.
+func writeYAMLFile(path string, v any) error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write YAML file: %w", err)
+	}
+	return nil
+}
+
+// loadCredentialsFile reads a YAML credentials file at path, unmarshals it into T,
+// and runs its Validate method. Returns the parsed value or the collected errors.
+// Shared by NewCredentialsFromFile and NewOSKCredentialsFromFile.
+func loadCredentialsFile[T interface{ Validate() (bool, []error) }](path string) (*T, []error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, []error{fmt.Errorf("failed to read %s: %w", path, err)}
+	}
+
+	var out T
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, []error{fmt.Errorf("failed to unmarshal YAML: %w", err)}
+	}
+
+	if valid, errs := out.Validate(); !valid {
+		return nil, errs
+	}
+
+	return &out, nil
+}

--- a/internal/types/credentials_io_test.go
+++ b/internal/types/credentials_io_test.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shared loader reports the real path in its read error (previously MSK
+// hardcoded "creds.yaml file" regardless of the path passed in).
+func TestNewCredentialsFromFile_ReadErrorIncludesPath(t *testing.T) {
+	missing := "/nonexistent/dir/my-creds.yaml"
+	_, errs := NewCredentialsFromFile(missing)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), missing)
+}
+
+func TestNewOSKCredentialsFromFile_ReadErrorIncludesPath(t *testing.T) {
+	missing := "/nonexistent/dir/my-apache-kafka-credentials.yaml"
+	_, errs := NewOSKCredentialsFromFile(missing)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), missing)
+}

--- a/internal/types/credentials_msk.go
+++ b/internal/types/credentials_msk.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/goccy/go-yaml"
 )
@@ -27,21 +26,7 @@ func NewCredentialsFrom(fromCredentials *Credentials) *Credentials {
 }
 
 func NewCredentialsFromFile(credentialsYamlPath string) (*Credentials, []error) {
-	data, err := os.ReadFile(credentialsYamlPath)
-	if err != nil {
-		return nil, []error{fmt.Errorf("failed to read creds.yaml file: %w", err)}
-	}
-
-	var credsFile Credentials
-	if err := yaml.Unmarshal(data, &credsFile); err != nil {
-		return nil, []error{fmt.Errorf("failed to unmarshal YAML: %w", err)}
-	}
-
-	if valid, errs := credsFile.Validate(); !valid {
-		return nil, errs
-	}
-
-	return &credsFile, nil
+	return loadCredentialsFile[Credentials](credentialsYamlPath)
 }
 
 // UpsertTargetedClusters creates or replaces only the clusters present in newRegion.Clusters,
@@ -75,14 +60,7 @@ func (c *Credentials) UpsertRegion(newRegion RegionAuth) {
 }
 
 func (c *Credentials) WriteToFile(filePath string) error {
-	yamlData, err := c.ToYaml()
-	if err != nil {
-		return fmt.Errorf("failed to marshal YAML: %w", err)
-	}
-	if err := os.WriteFile(filePath, yamlData, 0600); err != nil {
-		return fmt.Errorf("failed to write YAML file: %w", err)
-	}
-	return nil
+	return writeYAMLFile(filePath, c)
 }
 
 func (c *Credentials) ToYaml() ([]byte, error) {

--- a/internal/types/credentials_msk.go
+++ b/internal/types/credentials_msk.go
@@ -162,38 +162,12 @@ type ClusterAuth struct {
 }
 
 func (ce ClusterAuth) GetSelectedAuthType() (AuthType, error) {
-	enabledMethods := ce.GetAuthMethods()
-	if len(enabledMethods) == 0 {
-		return "", fmt.Errorf("no authentication method enabled for cluster")
-	}
-	return enabledMethods[0], nil
-
+	return ce.AuthMethod.SelectedAuthType(true)
 }
 
 // Gets a list of the authentication method(s) selected in the `creds.yaml` file generated during discovery.
 func (ce ClusterAuth) GetAuthMethods() []AuthType {
-	enabledMethods := []AuthType{}
-
-	if ce.AuthMethod.UnauthenticatedPlaintext != nil && ce.AuthMethod.UnauthenticatedPlaintext.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedPlaintext)
-	}
-	if ce.AuthMethod.UnauthenticatedTLS != nil && ce.AuthMethod.UnauthenticatedTLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedTLS)
-	}
-	if ce.AuthMethod.IAM != nil && ce.AuthMethod.IAM.Use {
-		enabledMethods = append(enabledMethods, AuthTypeIAM)
-	}
-	if ce.AuthMethod.SASLScram != nil && ce.AuthMethod.SASLScram.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
-	}
-	if ce.AuthMethod.SASLPlain != nil && ce.AuthMethod.SASLPlain.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLPlain)
-	}
-	if ce.AuthMethod.TLS != nil && ce.AuthMethod.TLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeTLS)
-	}
-
-	return enabledMethods
+	return ce.AuthMethod.EnabledAuthMethods(true)
 }
 
 type AuthMethodConfig struct {
@@ -203,6 +177,40 @@ type AuthMethodConfig struct {
 	TLS                      *TLSConfig                      `yaml:"tls,omitempty"`
 	UnauthenticatedTLS       *UnauthenticatedTLSConfig       `yaml:"unauthenticated_tls,omitempty"`
 	UnauthenticatedPlaintext *UnauthenticatedPlaintextConfig `yaml:"unauthenticated_plaintext,omitempty"`
+}
+
+// EnabledAuthMethods returns the enabled methods in canonical order.
+// includeIAM is false for sources that don't support IAM (Apache Kafka / OSK).
+func (amc AuthMethodConfig) EnabledAuthMethods(includeIAM bool) []AuthType {
+	methods := []AuthType{}
+	if amc.UnauthenticatedPlaintext != nil && amc.UnauthenticatedPlaintext.Use {
+		methods = append(methods, AuthTypeUnauthenticatedPlaintext)
+	}
+	if amc.UnauthenticatedTLS != nil && amc.UnauthenticatedTLS.Use {
+		methods = append(methods, AuthTypeUnauthenticatedTLS)
+	}
+	if includeIAM && amc.IAM != nil && amc.IAM.Use {
+		methods = append(methods, AuthTypeIAM)
+	}
+	if amc.SASLScram != nil && amc.SASLScram.Use {
+		methods = append(methods, AuthTypeSASLSCRAM)
+	}
+	if amc.SASLPlain != nil && amc.SASLPlain.Use {
+		methods = append(methods, AuthTypeSASLPlain)
+	}
+	if amc.TLS != nil && amc.TLS.Use {
+		methods = append(methods, AuthTypeTLS)
+	}
+	return methods
+}
+
+// SelectedAuthType returns the single enabled method, or an error if none.
+func (amc AuthMethodConfig) SelectedAuthType(includeIAM bool) (AuthType, error) {
+	enabled := amc.EnabledAuthMethods(includeIAM)
+	if len(enabled) == 0 {
+		return "", fmt.Errorf("no authentication method enabled for cluster")
+	}
+	return enabled[0], nil
 }
 
 // MergeWith preserves existing auth configurations only for auth methods that still exist in the new config

--- a/internal/types/credentials_osk.go
+++ b/internal/types/credentials_osk.go
@@ -164,37 +164,15 @@ func (c OSKCredentials) Validate() (bool, []error) {
 	return len(errs) == 0, errs
 }
 
-// GetAuthMethods returns the enabled authentication methods for this cluster
+// GetAuthMethods returns the enabled authentication methods for this cluster.
+// IAM is not supported for OSK, so it is excluded (includeIAM=false).
 func (c OSKClusterAuth) GetAuthMethods() []AuthType {
-	enabledMethods := []AuthType{}
-
-	if c.AuthMethod.UnauthenticatedPlaintext != nil && c.AuthMethod.UnauthenticatedPlaintext.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedPlaintext)
-	}
-	if c.AuthMethod.UnauthenticatedTLS != nil && c.AuthMethod.UnauthenticatedTLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeUnauthenticatedTLS)
-	}
-	if c.AuthMethod.SASLScram != nil && c.AuthMethod.SASLScram.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLSCRAM)
-	}
-	if c.AuthMethod.SASLPlain != nil && c.AuthMethod.SASLPlain.Use {
-		enabledMethods = append(enabledMethods, AuthTypeSASLPlain)
-	}
-	if c.AuthMethod.TLS != nil && c.AuthMethod.TLS.Use {
-		enabledMethods = append(enabledMethods, AuthTypeTLS)
-	}
-	// Note: IAM not supported for OSK
-
-	return enabledMethods
+	return c.AuthMethod.EnabledAuthMethods(false)
 }
 
 // GetSelectedAuthType returns the selected auth type for the cluster
 func (c OSKClusterAuth) GetSelectedAuthType() (AuthType, error) {
-	enabledMethods := c.GetAuthMethods()
-	if len(enabledMethods) == 0 {
-		return "", fmt.Errorf("no authentication method enabled for cluster")
-	}
-	return enabledMethods[0], nil
+	return c.AuthMethod.SelectedAuthType(false)
 }
 
 // HasJolokiaConfig returns true if the cluster has Jolokia configuration

--- a/internal/types/credentials_osk.go
+++ b/internal/types/credentials_osk.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-
-	"github.com/goccy/go-yaml"
 )
 
 // OSKCredentials represents the apache-kafka-credentials.yaml file
@@ -79,21 +77,7 @@ type PrometheusTLSConfig struct {
 
 // NewOSKCredentialsFromFile loads OSK credentials from a YAML file
 func NewOSKCredentialsFromFile(credentialsYamlPath string) (*OSKCredentials, []error) {
-	data, err := os.ReadFile(credentialsYamlPath)
-	if err != nil {
-		return nil, []error{fmt.Errorf("failed to read apache-kafka-credentials.yaml file: %w", err)}
-	}
-
-	var credsFile OSKCredentials
-	if err := yaml.Unmarshal(data, &credsFile); err != nil {
-		return nil, []error{fmt.Errorf("failed to unmarshal YAML: %w", err)}
-	}
-
-	if valid, errs := credsFile.Validate(); !valid {
-		return nil, errs
-	}
-
-	return &credsFile, nil
+	return loadCredentialsFile[OSKCredentials](credentialsYamlPath)
 }
 
 // Validate checks that the credentials file is valid
@@ -187,14 +171,7 @@ func (c OSKClusterAuth) HasPrometheusConfig() bool {
 
 // WriteToFile writes the credentials to a YAML file
 func (c *OSKCredentials) WriteToFile(filePath string) error {
-	yamlData, err := yaml.Marshal(c)
-	if err != nil {
-		return fmt.Errorf("failed to marshal YAML: %w", err)
-	}
-	if err := os.WriteFile(filePath, yamlData, 0600); err != nil {
-		return fmt.Errorf("failed to write YAML file: %w", err)
-	}
-	return nil
+	return writeYAMLFile(filePath, c)
 }
 
 // isValidBootstrapServer checks if a bootstrap server string is valid (host:port format).


### PR DESCRIPTION
## Summary

Two small, independent, behavior-preserving commits that stop MSK and OSK from maintaining parallel copies of credential auth-method behavior and file-I/O boilerplate. Deferred final follow-up of the `internal/types` reorg. No YAML wire-format change.

The top-level `Credentials` (region/ARN-nested) vs `OSKCredentials` (flat + bootstrap + monitoring) shapes are **not** unified here — that is YAML-compat-sensitive and deferred to its own future plan.

## Commit 1 — dedup auth-method behavior onto `AuthMethodConfig`

MSK (`ClusterAuth`) and OSK (`OSKClusterAuth`) each had a near-identical `GetAuthMethods` and an exact-duplicate `GetSelectedAuthType`. Moved the canonical-order enumeration and single-method selection onto the **already-shared** `AuthMethodConfig`:

- `EnabledAuthMethods(includeIAM bool) []AuthType` — enabled methods in canonical order; `includeIAM=false` for sources without IAM (Apache Kafka / OSK).
- `SelectedAuthType(includeIAM bool) (AuthType, error)` — single enabled method or error.
- `ClusterAuth` delegates with `includeIAM=true`; `OSKClusterAuth` with `includeIAM=false` (preserves "IAM not supported for OSK").

IAM position (3rd) is preserved, so output is byte-identical to both prior implementations on every input.

## Commit 2 — extract credentials file-I/O boilerplate

`New*CredentialsFromFile` and the two `WriteToFile` methods duplicated the same read→unmarshal→`Validate` and marshal→`WriteFile(0600)` boilerplate. Extracted two shared helpers in new `credentials_io.go`:

- `writeYAMLFile(path, v)` — marshal + `os.WriteFile(…, 0600)`.
- `loadCredentialsFile[T interface{ Validate() (bool, []error) }](path)` — read + unmarshal + `Validate`. Both credential types satisfy the value-receiver constraint.

The four functions become one-line wrappers; public signatures unchanged. `Credentials.ToYaml()` retained.

**Intentional behavior change:** MSK's read error previously hardcoded `"failed to read creds.yaml file"` regardless of the actual path (a latent bug); the shared helper reports the real `path`. YAML output bytes and `0600` perms are unchanged.

## Verification

- `go test ./internal/types/` — ok (existing ~60 credentials tests + new focused tests pass unchanged)
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./...` — **47 packages OK, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)