### PR TITLE
feat(scan): Connect-specific metrics metadata

### DIFF
--- a/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/confluentinc/kcp/internal/redact"
@@ -105,6 +106,53 @@ func TestMskConnectorMigrator_Run_GeneratedTerraformIsLeakFree(t *testing.T) {
 	// (fail-closed) rather than as a working credential.
 	assert.Contains(t, string(tf), fmt.Sprintf("%q = %q", "database.password", redact.Placeholder),
 		"sensitive field must render as the redaction placeholder in the generated Terraform")
+}
+
+// Path traversal: a connector name carrying "../" (attacker-controllable via a
+// hostile state file even though AWS constrains MSK Connect names server-side) must
+// not let the generated .tf escape OutputDir. Mirrors the self-managed migrator test
+// so the security-critical write-containment is asserted on both identical paths.
+func TestMskConnectorMigrator_Run_HostileNameStaysInOutputDir(t *testing.T) {
+	server := echoTranslateServer(t)
+	defer server.Close()
+
+	root := t.TempDir()
+	outDir := filepath.Join(root, "out")
+
+	migrator := NewMskConnectorMigrator(MigrateMskConnectorOpts{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+		Connectors: []types.ConnectorSummary{
+			{
+				ConnectorName: "../escaped",
+				ConnectorConfiguration: map[string]string{
+					"connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+				},
+			},
+		},
+		OutputDir: outDir,
+	})
+	migrator.baseURL = server.URL
+
+	require.NoError(t, migrator.Run())
+
+	// The traversal target the unsanitized name would have produced must not exist.
+	_, err := os.Stat(filepath.Join(root, "escaped-connector.tf"))
+	assert.True(t, os.IsNotExist(err), "connector must not be written outside OutputDir")
+
+	// Every file the run produced must live inside OutputDir.
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	var connectorFiles int
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), string(filepath.Separator))
+		if strings.HasSuffix(e.Name(), "-connector.tf") {
+			connectorFiles++
+		}
+	}
+	assert.Equal(t, 1, connectorFiles, "exactly one connector .tf must be written inside OutputDir")
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator.go
+++ b/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator.go
@@ -208,7 +208,17 @@ func (mc *SelfManagedConnectorMigrator) translateConnectorConfig(connector types
 		return nil, nil, fmt.Errorf("'connector.class' not found in config")
 	}
 
-	pluginName, err := connector_utils.InferPluginName(connectorClass.(string))
+	// connector.Config is map[string]any (JSON-decoded from the Connect REST API
+	// or rehydrated from the state file), so connector.class can deserialize to a
+	// non-string (number/bool/object/null) on a malformed or tampered source. A
+	// bare type assertion would panic and crash the whole migrate-connectors run;
+	// the comma-ok form turns it into a per-connector error the Run loop skips.
+	connectorClassStr, ok := connectorClass.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("'connector.class' is not a string")
+	}
+
+	pluginName, err := connector_utils.InferPluginName(connectorClassStr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to determine plugin name: %w", err)
 	}

--- a/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
@@ -444,6 +444,66 @@ func TestSelfManagedConnectorMigrator_TranslateConnectorConfig_UnsupportedConnec
 	assert.Contains(t, err.Error(), "failed to determine plugin name")
 }
 
+// Regression: connector.Config is map[string]any, so connector.class can arrive as
+// a non-string (a JSON number/bool/object from a malformed Connect response or a
+// tampered state file). The translate path must return an error rather than panic on
+// a bare type assertion, which would crash the whole migrate-connectors run.
+func TestSelfManagedConnectorMigrator_TranslateConnectorConfig_NonStringConnectorClass(t *testing.T) {
+	migrator := &SelfManagedConnectorMigrator{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+	}
+
+	connector := types.SelfManagedConnector{
+		Name: "test-connector",
+		Config: map[string]any{
+			"connector.class": 42, // not a string
+			"topics":          "test-topic",
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		_, _, err := migrator.translateConnectorConfig(connector)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "'connector.class' is not a string")
+	})
+}
+
+// Run() must survive a connector whose connector.class is non-string: the per-connector
+// translate error is logged and skipped, the run completes without panicking, and no
+// .tf is written for the bad connector.
+func TestSelfManagedConnectorMigrator_Run_NonStringConnectorClassIsSkipped(t *testing.T) {
+	server := echoTranslateServer(t)
+	defer server.Close()
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	migrator := NewSelfManagedConnectorMigrator(MigrateSelfManagedConnectorOpts{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+		Connectors: []types.SelfManagedConnector{
+			{
+				Name: "bad-class",
+				Config: map[string]any{
+					"connector.class": map[string]any{"nested": "object"}, // not a string
+				},
+			},
+		},
+		OutputDir: outDir,
+	})
+	migrator.baseURL = server.URL
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, migrator.Run())
+	})
+
+	_, err := os.Stat(filepath.Join(outDir, "bad-class-connector.tf"))
+	assert.True(t, os.IsNotExist(err), "no .tf should be written for a connector with a non-string connector.class")
+}
+
 func TestSelfManagedConnectorMigrator_Run_WritesProvidersTfAndVariablesTf(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "connectors-output")

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -297,11 +297,20 @@ func connectorAuthType(connector kafkaconnecttypes.ConnectorSummary) (types.Auth
 	}
 }
 
-// bootstrapMatches reports whether any cluster broker address appears in the
-// connector's bootstrap-server string.
+// bootstrapMatches reports whether the connector and the cluster share at least one
+// bootstrap broker. Both sides are comma-separated host:port lists; we compare by exact
+// host:port equality (after splitting and trimming) rather than substring containment,
+// so a broker address can't spuriously match by being a substring of an unrelated
+// connector's bootstrap string (e.g. a host that merely shares a DNS prefix/suffix).
 func bootstrapMatches(connectorBootstrap string, brokerAddresses []string) bool {
+	connectorHosts := make(map[string]struct{})
+	for _, addr := range strings.Split(connectorBootstrap, ",") {
+		if trimmed := strings.TrimSpace(addr); trimmed != "" {
+			connectorHosts[trimmed] = struct{}{}
+		}
+	}
 	for _, brokerAddress := range brokerAddresses {
-		if strings.Contains(connectorBootstrap, brokerAddress) {
+		if _, ok := connectorHosts[strings.TrimSpace(brokerAddress)]; ok {
 			return true
 		}
 	}

--- a/cmd/discover/connector_discoverer_test.go
+++ b/cmd/discover/connector_discoverer_test.go
@@ -255,3 +255,34 @@ func TestDiscoverMatchingConnectors_DoesNotLogRawSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, logBuf.String(), "hunter2", "raw secret must never be logged")
 }
+
+// bootstrapMatches must compare host:port entries by exact equality, not substring
+// containment, so a cluster broker address can't spuriously match an unrelated
+// connector whose bootstrap host merely shares a DNS prefix/suffix.
+func TestBootstrapMatches_ExactHostPortOnly(t *testing.T) {
+	brokers := []string{
+		"b-1.test.kafka.us-east-1.amazonaws.com:9098",
+		"b-2.test.kafka.us-east-1.amazonaws.com:9098",
+	}
+
+	t.Run("substring of a connector host is not a match", func(t *testing.T) {
+		// The broker host:port is a substring of this connector's host but is not an
+		// exact entry — must not match.
+		connector := "b-1.test.kafka.us-east-1.amazonaws.com.attacker.example:9098"
+		assert.False(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("a different cluster does not match", func(t *testing.T) {
+		connector := "b-9.other.kafka.us-east-1.amazonaws.com:9098"
+		assert.False(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("exact host:port matches (including whitespace tolerance)", func(t *testing.T) {
+		connector := "b-1.test.kafka.us-east-1.amazonaws.com:9098, b-2.test.kafka.us-east-1.amazonaws.com:9098"
+		assert.True(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("empty connector bootstrap never matches", func(t *testing.T) {
+		assert.False(t, bootstrapMatches("", brokers))
+	})
+}

--- a/cmd/scan/self_managed_connectors/connect_metrics_mapping_test.go
+++ b/cmd/scan/self_managed_connectors/connect_metrics_mapping_test.go
@@ -1,0 +1,52 @@
+package self_managed_connectors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// U3: the boundary mapper converts the shared collector output
+// (*types.ProcessedClusterMetrics) into the Connect-specific
+// *types.ConnectClusterMetrics, injecting the backend that produced it and
+// carrying the consumable fields through unchanged.
+func TestToConnectClusterMetrics_InjectsSourceAndCopiesFields(t *testing.T) {
+	start := time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	v := 4.0
+	pcm := &types.ProcessedClusterMetrics{
+		// Broker-only fields are present on the source but must be dropped.
+		Region:     "us-east-1",
+		ClusterArn: "arn:aws:kafka:...",
+		Metadata: types.MetricMetadata{
+			StartDate:           start,
+			EndDate:             end,
+			Period:              60,
+			NumberOfBrokerNodes: 3,
+			KafkaVersion:        "3.5.1",
+		},
+		Metrics:    []types.ProcessedMetric{{Label: "connector-count", Value: &v}},
+		Aggregates: map[string]types.MetricAggregate{"connector-count": {Average: &v}},
+		QueryInfo:  []types.MetricQueryInfo{{MetricName: "connector-count"}},
+	}
+
+	got := toConnectClusterMetrics(pcm, "prometheus")
+
+	require.NotNil(t, got)
+	assert.Equal(t, "prometheus", got.Metadata.MetricsSource, "backend must be injected")
+	assert.True(t, start.Equal(got.Metadata.StartDate))
+	assert.True(t, end.Equal(got.Metadata.EndDate))
+	assert.Equal(t, int32(60), got.Metadata.Period)
+	assert.Equal(t, pcm.Metrics, got.Metrics, "metric series carried through")
+	assert.Equal(t, pcm.Aggregates, got.Aggregates, "aggregates carried through")
+	assert.Equal(t, pcm.QueryInfo, got.QueryInfo, "query info carried through")
+}
+
+// Edge: a nil collector result maps to nil (the collect path returns an error
+// before mapping, but the mapper must not panic if handed nil).
+func TestToConnectClusterMetrics_Nil(t *testing.T) {
+	assert.Nil(t, toConnectClusterMetrics(nil, "jolokia"))
+}

--- a/cmd/scan/self_managed_connectors/connect_metrics_mapping_test.go
+++ b/cmd/scan/self_managed_connectors/connect_metrics_mapping_test.go
@@ -33,10 +33,10 @@ func TestToConnectClusterMetrics_InjectsSourceAndCopiesFields(t *testing.T) {
 		QueryInfo:  []types.MetricQueryInfo{{MetricName: "connector-count"}},
 	}
 
-	got := toConnectClusterMetrics(pcm, "prometheus")
+	got := toConnectClusterMetrics(pcm, types.MetricBackendPrometheus)
 
 	require.NotNil(t, got)
-	assert.Equal(t, "prometheus", got.Metadata.MetricsSource, "backend must be injected")
+	assert.Equal(t, types.MetricBackendPrometheus, got.Metadata.MetricsSource, "backend must be injected")
 	assert.True(t, start.Equal(got.Metadata.StartDate))
 	assert.True(t, end.Equal(got.Metadata.EndDate))
 	assert.Equal(t, int32(60), got.Metadata.Period)
@@ -48,5 +48,5 @@ func TestToConnectClusterMetrics_InjectsSourceAndCopiesFields(t *testing.T) {
 // Edge: a nil collector result maps to nil (the collect path returns an error
 // before mapping, but the mapper must not panic if handed nil).
 func TestToConnectClusterMetrics_Nil(t *testing.T) {
-	assert.Nil(t, toConnectClusterMetrics(nil, "jolokia"))
+	assert.Nil(t, toConnectClusterMetrics(nil, types.MetricBackendJolokia))
 }

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -371,7 +371,7 @@ func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context
 // metadata and region/cluster_arn are dropped, and the producing backend
 // (jolokia|prometheus) is recorded as metrics_source. The shared JMX/Prometheus
 // services are left untouched so the broker cluster-scan path is unaffected.
-func toConnectClusterMetrics(pcm *types.ProcessedClusterMetrics, source string) *types.ConnectClusterMetrics {
+func toConnectClusterMetrics(pcm *types.ProcessedClusterMetrics, source types.MetricBackend) *types.ConnectClusterMetrics {
 	if pcm == nil {
 		return nil
 	}
@@ -412,7 +412,7 @@ func (s *SelfManagedConnectorsScanner) collectConnectJolokiaMetrics(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	return toConnectClusterMetrics(pcm, "jolokia"), nil
+	return toConnectClusterMetrics(pcm, types.MetricBackendJolokia), nil
 }
 
 func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx context.Context, creds types.OSKClusterAuth) (*types.ConnectClusterMetrics, error) {
@@ -443,5 +443,5 @@ func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	return toConnectClusterMetrics(pcm, "prometheus"), nil
+	return toConnectClusterMetrics(pcm, types.MetricBackendPrometheus), nil
 }

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -331,7 +331,7 @@ func (s *SelfManagedConnectorsScanner) updateStateWithConnectors(connectors []ty
 // scanner is MSK-only (the OSK branch from 2aaddaaa is deferred — see plan
 // Scope Boundaries). It requires the connectors object to already exist so the
 // metrics have something to hang off; otherwise it returns a clear error.
-func (s *SelfManagedConnectorsScanner) updateStateWithConnectMetrics(metrics *types.ProcessedClusterMetrics) error {
+func (s *SelfManagedConnectorsScanner) updateStateWithConnectMetrics(metrics *types.ConnectClusterMetrics) error {
 	cluster, err := s.State.GetClusterByArn(s.ClusterArn)
 	if err != nil {
 		return err
@@ -350,7 +350,7 @@ func (s *SelfManagedConnectorsScanner) updateStateWithConnectMetrics(metrics *ty
 // metric/query definitions (ConnectMetricDefinitions / ConnectQueryDefinitions)
 // differ. Credentials come from the resolved cluster entry and are never logged
 // or persisted.
-func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context) (*types.ProcessedClusterMetrics, error) {
+func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context) (*types.ConnectClusterMetrics, error) {
 	if s.metricsClusterCreds == nil {
 		return nil, fmt.Errorf("no cluster credentials resolved for metrics collection")
 	}
@@ -365,7 +365,30 @@ func (s *SelfManagedConnectorsScanner) collectConnectMetrics(ctx context.Context
 	}
 }
 
-func (s *SelfManagedConnectorsScanner) collectConnectJolokiaMetrics(ctx context.Context, creds types.OSKClusterAuth) (*types.ProcessedClusterMetrics, error) {
+// toConnectClusterMetrics maps the shared collector output into the
+// Connect-specific envelope. It is the single boundary where the broker-shaped
+// ProcessedClusterMetrics is narrowed to Connect-meaningful fields: the broker
+// metadata and region/cluster_arn are dropped, and the producing backend
+// (jolokia|prometheus) is recorded as metrics_source. The shared JMX/Prometheus
+// services are left untouched so the broker cluster-scan path is unaffected.
+func toConnectClusterMetrics(pcm *types.ProcessedClusterMetrics, source string) *types.ConnectClusterMetrics {
+	if pcm == nil {
+		return nil
+	}
+	return &types.ConnectClusterMetrics{
+		Metadata: types.ConnectMetricMetadata{
+			StartDate:     pcm.Metadata.StartDate,
+			EndDate:       pcm.Metadata.EndDate,
+			Period:        pcm.Metadata.Period,
+			MetricsSource: source,
+		},
+		Metrics:    pcm.Metrics,
+		Aggregates: pcm.Aggregates,
+		QueryInfo:  pcm.QueryInfo,
+	}
+}
+
+func (s *SelfManagedConnectorsScanner) collectConnectJolokiaMetrics(ctx context.Context, creds types.OSKClusterAuth) (*types.ConnectClusterMetrics, error) {
 	if !creds.HasJolokiaConfig() {
 		return nil, fmt.Errorf("no jolokia configuration in credentials for cluster %s", creds.ID)
 	}
@@ -385,10 +408,14 @@ func (s *SelfManagedConnectorsScanner) collectConnectJolokiaMetrics(ctx context.
 	}
 
 	jmxService := jmx.NewJMXService(creds.Jolokia.Endpoints, jmx.ConnectMetricDefinitions(), "worker", jolokiaOpts...)
-	return jmxService.CollectOverDuration(ctx, duration, interval)
+	pcm, err := jmxService.CollectOverDuration(ctx, duration, interval)
+	if err != nil {
+		return nil, err
+	}
+	return toConnectClusterMetrics(pcm, "jolokia"), nil
 }
 
-func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx context.Context, creds types.OSKClusterAuth) (*types.ProcessedClusterMetrics, error) {
+func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx context.Context, creds types.OSKClusterAuth) (*types.ConnectClusterMetrics, error) {
 	if !creds.HasPrometheusConfig() {
 		return nil, fmt.Errorf("no prometheus configuration in credentials for cluster %s", creds.ID)
 	}
@@ -412,5 +439,9 @@ func (s *SelfManagedConnectorsScanner) collectConnectPrometheusMetrics(ctx conte
 
 	promClient := client.NewPrometheusClient(creds.Prometheus.URL, promOpts...)
 	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.ConnectQueryDefinitions(), labels)
-	return promService.CollectMetrics(ctx, queryRange)
+	pcm, err := promService.CollectMetrics(ctx, queryRange)
+	if err != nil {
+		return nil, err
+	}
+	return toConnectClusterMetrics(pcm, "prometheus"), nil
 }

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner_test.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner_test.go
@@ -393,7 +393,7 @@ func TestRun_JolokiaMetricsAttached(t *testing.T) {
 	require.NotNil(t, conns.Metrics, "Connect metrics collected and attached")
 	require.Contains(t, conns.Metrics.Aggregates, "connector-count")
 	// End-to-end: the boundary mapper records the producing backend (U3/R2).
-	require.Equal(t, "jolokia", conns.Metrics.Metadata.MetricsSource, "jolokia run records metrics_source")
+	require.Equal(t, types.MetricBackendJolokia, conns.Metrics.Metadata.MetricsSource, "jolokia run records metrics_source")
 }
 
 func TestRun_PrometheusMetricsAttached(t *testing.T) {
@@ -418,7 +418,7 @@ func TestRun_PrometheusMetricsAttached(t *testing.T) {
 	require.NotNil(t, conns.Metrics, "Connect metrics collected and attached")
 	require.Contains(t, conns.Metrics.Aggregates, "connector-count")
 	// End-to-end: the boundary mapper records the producing backend (U3/R2).
-	require.Equal(t, "prometheus", conns.Metrics.Metadata.MetricsSource, "prometheus run records metrics_source")
+	require.Equal(t, types.MetricBackendPrometheus, conns.Metrics.Metadata.MetricsSource, "prometheus run records metrics_source")
 }
 
 // R1: with no --metrics the scan behaves exactly as before — connectors

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner_test.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner_test.go
@@ -214,7 +214,7 @@ func TestUpdateStateWithConnectMetrics_NoConnectors_Errors(t *testing.T) {
 	// The cluster has no SelfManagedConnectors object yet — attaching metrics
 	// must fail clearly rather than panic on a nil dereference.
 	scanner := &SelfManagedConnectorsScanner{State: stateWithCluster(), ClusterArn: testArn}
-	err := scanner.updateStateWithConnectMetrics(&types.ProcessedClusterMetrics{})
+	err := scanner.updateStateWithConnectMetrics(&types.ConnectClusterMetrics{})
 	require.Error(t, err)
 }
 
@@ -225,7 +225,7 @@ func TestUpdateStateWithConnectMetrics_AttachesMetrics(t *testing.T) {
 	cluster.KafkaAdminClientInformation.SetSelfManagedConnectors([]types.SelfManagedConnector{{Name: "pg-sink"}})
 
 	scanner := &SelfManagedConnectorsScanner{State: st, ClusterArn: testArn}
-	m := &types.ProcessedClusterMetrics{}
+	m := &types.ConnectClusterMetrics{}
 	require.NoError(t, scanner.updateStateWithConnectMetrics(m))
 
 	got, err := st.GetClusterByArn(testArn)
@@ -392,6 +392,8 @@ func TestRun_JolokiaMetricsAttached(t *testing.T) {
 	require.Len(t, conns.Connectors, 1)
 	require.NotNil(t, conns.Metrics, "Connect metrics collected and attached")
 	require.Contains(t, conns.Metrics.Aggregates, "connector-count")
+	// End-to-end: the boundary mapper records the producing backend (U3/R2).
+	require.Equal(t, "jolokia", conns.Metrics.Metadata.MetricsSource, "jolokia run records metrics_source")
 }
 
 func TestRun_PrometheusMetricsAttached(t *testing.T) {
@@ -415,6 +417,8 @@ func TestRun_PrometheusMetricsAttached(t *testing.T) {
 	require.NotNil(t, conns)
 	require.NotNil(t, conns.Metrics, "Connect metrics collected and attached")
 	require.Contains(t, conns.Metrics.Aggregates, "connector-count")
+	// End-to-end: the boundary mapper records the producing backend (U3/R2).
+	require.Equal(t, "prometheus", conns.Metrics.Metadata.MetricsSource, "prometheus run records metrics_source")
 }
 
 // R1: with no --metrics the scan behaves exactly as before — connectors

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -25,7 +25,7 @@ type ReportService interface {
 	FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error)
 	FilterMetrics(processedState report.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
 	FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
-	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
+	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error)
 }
 
 type UICmdOpts struct {

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -25,7 +26,7 @@ type ReportService interface {
 	FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error)
 	FilterMetrics(processedState report.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
 	FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
-	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error)
+	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error)
 }
 
 type UICmdOpts struct {
@@ -118,7 +119,10 @@ func (ui *UI) Run() error {
 
 	e.GET("/metrics/:region/:cluster", ui.handleGetMetrics)
 	e.GET("/metrics/osk/:clusterId", ui.handleGetOSKMetrics)
-	e.GET("/metrics/osk/:clusterId/connect", ui.handleGetOSKConnectMetrics)
+	// Connect is Kafka-distribution agnostic — one route serves both MSK and OSK.
+	// The literal "connect" first segment avoids shadowing by the static "osk" node
+	// and the "/metrics/:region/:cluster" param route.
+	e.GET("/metrics/connect/:sourceType", ui.handleGetConnectMetrics)
 	e.GET("/costs/:region", ui.handleGetCosts)
 
 	e.POST("/upload-state", ui.handleUploadState)
@@ -252,18 +256,36 @@ func (ui *UI) handleGetOSKMetrics(c echo.Context) error {
 	}
 
 	if filteredMetrics.Metrics == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error":   "No metrics available for this cluster",
-			"message": "Run 'kcp scan clusters --source-type apache-kafka --metrics jolokia' or '--metrics prometheus' to collect metrics",
-		})
+		// An empty filtered result is ambiguous: the cluster either never had metrics
+		// collected, or it has metrics but none fall in the selected date range. Only
+		// the former warrants the "run a scan" hint. When a date filter was applied,
+		// re-probe without it (reusing the same lookup) to tell them apart; an
+		// out-of-range window then falls through to a normal empty 200 so the UI shows
+		// an empty chart rather than a misleading error. FilterClusterMetrics is shared
+		// with the `kcp report metrics` CLI, so the distinction is made here in the
+		// handler rather than by changing the filter's contract.
+		neverCollected := true
+		if startTime != nil || endTime != nil {
+			if unfiltered, uErr := ui.reportService.FilterClusterMetrics(processedState, clusterId, "osk", nil, nil); uErr == nil && unfiltered.Metrics != nil {
+				neverCollected = false
+			}
+		}
+		if neverCollected {
+			return c.JSON(http.StatusNotFound, map[string]any{
+				"error":   "No metrics available for this cluster",
+				"message": "Run 'kcp scan clusters --source-type apache-kafka --metrics jolokia' or '--metrics prometheus' to collect metrics",
+			})
+		}
 	}
 
 	return c.JSON(http.StatusOK, filteredMetrics)
 }
 
-func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
-	clusterId := c.Param("clusterId")
-
+// handleGetConnectMetrics serves self-managed Connect metrics for either an MSK or OSK
+// cluster. sourceType is an explicit path param ({msk, osk}); clusterId is a query param
+// (OSK cluster id, or an MSK ARN URL-encoded by the client). The filter searches only the
+// named source set, so a cluster id never resolves across source types.
+func (ui *UI) handleGetConnectMetrics(c echo.Context) error {
 	state, err := ui.getStateBySession(c)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]any{
@@ -272,9 +294,19 @@ func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
 		})
 	}
 
-	if state.OSKSources == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error": "No OSK sources in state",
+	sourceType := c.Param("sourceType")
+	if sourceType != "msk" && sourceType != "osk" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "Invalid source type",
+			"message": fmt.Sprintf("source type %q is not supported (must be 'msk' or 'osk')", sourceType),
+		})
+	}
+
+	clusterId := c.QueryParam("clusterId")
+	if clusterId == "" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "Missing cluster identifier",
+			"message": "clusterId query parameter is required",
 		})
 	}
 
@@ -288,18 +320,21 @@ func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
 
 	processedState := ui.reportService.ProcessState(*state)
 
-	filteredMetrics, err := ui.reportService.FilterConnectMetrics(processedState, clusterId, startTime, endTime)
+	filteredMetrics, err := ui.reportService.FilterConnectMetrics(processedState, clusterId, sourceType, startTime, endTime)
 	if err != nil {
+		// "Never collected" is the only case that warrants the scan-guidance hint.
+		// A cluster that HAS metrics but whose selected date range excludes them all
+		// is not an error — it falls through to a normal (empty) 200 below, so the
+		// user sees an empty chart rather than a misleading "run a scan" message.
+		if errors.Is(err, report.ErrNoConnectMetricsCollected) {
+			return c.JSON(http.StatusNotFound, map[string]any{
+				"error":   "No Connect metrics available for this cluster",
+				"message": "Run 'kcp scan self-managed-connectors --metrics jolokia' or '--metrics prometheus' to collect Connect metrics",
+			})
+		}
 		return c.JSON(http.StatusNotFound, map[string]any{
 			"error":   "Cluster not found or no Connect metrics available",
 			"message": err.Error(),
-		})
-	}
-
-	if filteredMetrics.Metrics == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error":   "No Connect metrics available for this cluster",
-			"message": "Run 'kcp scan self-managed-connectors --metrics jolokia' or '--metrics prometheus' to collect Connect metrics",
 		})
 	}
 

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,8 +16,24 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// mockReportService satisfies the ReportService interface for testing
-type mockReportService struct{}
+// mockReportService satisfies the ReportService interface for testing.
+// The connect* fields configure FilterConnectMetrics and capture the args it was
+// called with, so handler tests can assert source-type/cluster-id passthrough.
+type mockReportService struct {
+	connectMetrics        *types.ConnectClusterMetrics
+	connectErr            error
+	connectCalled         bool
+	lastConnectClusterID  string
+	lastConnectSourceType string
+
+	// clusterMetrics drives FilterClusterMetrics. clusterMetricsUnfiltered is returned
+	// for the handler's no-date-filter re-probe (both startTime and endTime nil) so a
+	// test can model "collected, but out of the selected range"; clusterMetrics is
+	// returned when a date filter is present. clusterErr, if set, is returned for all.
+	clusterMetrics           *types.ProcessedClusterMetrics
+	clusterMetricsUnfiltered *types.ProcessedClusterMetrics
+	clusterErr               error
+}
 
 func (m *mockReportService) ProcessState(state types.State) report.ProcessedState {
 	return report.ProcessedState{}
@@ -31,11 +48,20 @@ func (m *mockReportService) FilterMetrics(processedState report.ProcessedState, 
 }
 
 func (m *mockReportService) FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
-	return nil, nil
+	if m.clusterErr != nil {
+		return nil, m.clusterErr
+	}
+	if startTime == nil && endTime == nil && m.clusterMetricsUnfiltered != nil {
+		return m.clusterMetricsUnfiltered, nil
+	}
+	return m.clusterMetrics, nil
 }
 
-func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
-	return nil, nil
+func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
+	m.connectCalled = true
+	m.lastConnectClusterID = clusterID
+	m.lastConnectSourceType = sourceType
+	return m.connectMetrics, m.connectErr
 }
 
 func newTestUI() *UI {
@@ -298,5 +324,247 @@ func TestGetState_NoStateLoaded_ReturnsNotFound(t *testing.T) {
 	}
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+// connectMetricsTestUI builds a UI with the given mock and a seeded session "s1"
+// so getStateBySession resolves and the connect handler can run.
+func connectMetricsTestUI(mock *mockReportService) *UI {
+	ui := &UI{
+		reportService: mock,
+		states:        make(map[string]*types.State),
+	}
+	ui.states["s1"] = &types.State{}
+	return ui
+}
+
+// callConnectHandler invokes handleGetConnectMetrics with the given path param and
+// query string, returning the recorder for assertions.
+func callConnectHandler(ui *UI, sourceType, query string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/metrics/connect/"+sourceType+query, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("sourceType")
+	c.SetParamValues(sourceType)
+	_ = ui.handleGetConnectMetrics(c)
+	return rec
+}
+
+func TestHandleGetConnectMetrics_OSK_ReturnsMetrics(t *testing.T) {
+	mock := &mockReportService{
+		connectMetrics: &types.ConnectClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "connector-count"}},
+		},
+	}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.lastConnectSourceType != "osk" {
+		t.Errorf("expected sourceType 'osk' passed to filter, got %q", mock.lastConnectSourceType)
+	}
+	if mock.lastConnectClusterID != "osk-kafka" {
+		t.Errorf("expected clusterID 'osk-kafka' passed to filter, got %q", mock.lastConnectClusterID)
+	}
+}
+
+func TestHandleGetConnectMetrics_MSK_ReturnsMetrics(t *testing.T) {
+	mock := &mockReportService{
+		connectMetrics: &types.ConnectClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "connector-count"}},
+		},
+	}
+	ui := connectMetricsTestUI(mock)
+
+	// MSK ARNs contain ':' and '/', so the client URL-encodes them in the query value.
+	arn := "arn%3Aaws%3Akafka%3Aus-east-1%3A123456789012%3Acluster%2Fmsk-kafka%2Fdef-456"
+	rec := callConnectHandler(ui, "msk", "?clusterId="+arn+"&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.lastConnectSourceType != "msk" {
+		t.Errorf("expected sourceType 'msk' passed to filter, got %q", mock.lastConnectSourceType)
+	}
+	if mock.lastConnectClusterID != "arn:aws:kafka:us-east-1:123456789012:cluster/msk-kafka/def-456" {
+		t.Errorf("expected decoded ARN passed to filter, got %q", mock.lastConnectClusterID)
+	}
+}
+
+// Abuse case: an unknown source type is rejected with 4xx and never reaches the filter.
+func TestHandleGetConnectMetrics_UnknownSourceType_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "foo", "?clusterId=whatever&sessionId=s1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown source type, got %d", rec.Code)
+	}
+	if mock.connectCalled {
+		t.Error("filter must not be called for an unknown source type")
+	}
+}
+
+func TestHandleGetConnectMetrics_MissingClusterId_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?sessionId=s1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing clusterId, got %d", rec.Code)
+	}
+	if mock.connectCalled {
+		t.Error("filter must not be called when clusterId is missing")
+	}
+}
+
+// Abuse case: a malformed date range is rejected with 400 (preserved parseDateRange behavior).
+func TestHandleGetConnectMetrics_MalformedDate_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1&startDate=not-a-date")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed date, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetConnectMetrics_MissingSessionId_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing sessionId, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetConnectMetrics_NoMetrics_Returns404WithGuidance(t *testing.T) {
+	// Filter found the cluster but it never had Connect metrics collected, signalled
+	// by the ErrNoConnectMetricsCollected sentinel. Only this case gets scan guidance.
+	mock := &mockReportService{connectErr: report.ErrNoConnectMetricsCollected}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "msk", "?clusterId=some-arn&sessionId=s1")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cluster with no Connect metrics, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "scan self-managed-connectors") {
+		t.Errorf("expected scan-guidance message, got: %s", rec.Body.String())
+	}
+}
+
+// A cluster that HAS Connect metrics but whose selected date range excludes them all
+// must return 200 with an empty result (not the never-collected 404), so the UI shows
+// an empty chart instead of a misleading "run a scan" error.
+func TestHandleGetConnectMetrics_CollectedButOutOfRange_Returns200(t *testing.T) {
+	mock := &mockReportService{connectMetrics: &types.ConnectClusterMetrics{Metrics: nil}}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for collected-but-out-of-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "scan self-managed-connectors") {
+		t.Errorf("must not show scan-guidance when metrics exist but fall outside the date range: %s", rec.Body.String())
+	}
+}
+
+func TestHandleGetConnectMetrics_FilterError_Returns404(t *testing.T) {
+	mock := &mockReportService{connectErr: fmt.Errorf("cluster 'x' not found in msk sources")}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "msk", "?clusterId=x&sessionId=s1")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when filter returns not-found error, got %d", rec.Code)
+	}
+}
+
+// oskMetricsTestUI builds a UI whose seeded session "s1" has a non-nil OSKSources so
+// handleGetOSKMetrics passes its "no Apache Kafka sources" guard and reaches the filter.
+func oskMetricsTestUI(mock *mockReportService) *UI {
+	ui := &UI{
+		reportService: mock,
+		states:        make(map[string]*types.State),
+	}
+	ui.states["s1"] = &types.State{OSKSources: &types.OSKSourcesState{}}
+	return ui
+}
+
+func callOSKMetricsHandler(ui *UI, query string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/metrics/osk/osk-kafka"+query, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("clusterId")
+	c.SetParamValues("osk-kafka")
+	_ = ui.handleGetOSKMetrics(c)
+	return rec
+}
+
+// A cluster that never had metrics collected returns 404 with scan guidance.
+func TestHandleGetOSKMetrics_NeverCollected_Returns404WithGuidance(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics:           &types.ProcessedClusterMetrics{Metrics: nil},
+		clusterMetricsUnfiltered: &types.ProcessedClusterMetrics{Metrics: nil},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1&startDate=2030-01-01T00:00:00Z&endDate=2030-01-02T00:00:00Z")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for never-collected metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "scan clusters") {
+		t.Errorf("expected scan-guidance message, got: %s", rec.Body.String())
+	}
+}
+
+// A cluster that HAS metrics but whose selected date range excludes them all returns
+// 200 with an empty result (not the never-collected 404), so the UI shows an empty
+// chart rather than a misleading "run a scan" error.
+func TestHandleGetOSKMetrics_CollectedButOutOfRange_Returns200(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics: &types.ProcessedClusterMetrics{Metrics: nil}, // filtered window: empty
+		clusterMetricsUnfiltered: &types.ProcessedClusterMetrics{ // unfiltered: has data
+			Metrics: []types.ProcessedMetric{{Label: "BytesInPerSec"}},
+		},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1&startDate=2030-01-01T00:00:00Z&endDate=2030-01-02T00:00:00Z")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for collected-but-out-of-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "scan clusters") {
+		t.Errorf("must not show scan-guidance when metrics exist but fall outside the date range: %s", rec.Body.String())
+	}
+}
+
+// Metrics present within the selected range return 200 with data and no re-probe needed.
+func TestHandleGetOSKMetrics_HasData_Returns200(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics: &types.ProcessedClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "BytesInPerSec"}},
+		},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for in-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
 }

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -34,7 +34,7 @@ func (m *mockReportService) FilterClusterMetrics(processedState report.Processed
 	return nil, nil
 }
 
-func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
 	return nil, nil
 }
 

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterConnectors.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterConnectors.tsx
@@ -61,6 +61,10 @@ interface ClusterConnectorsProps {
     }
   }
   clusterId?: string
+  // Required: a Connect cluster is distribution-agnostic, so every caller must state
+  // which source set the connect-metrics endpoint should search. Leaving it optional
+  // risks an MSK caller silently falling back to the OSK source and 404-ing.
+  sourceType: 'msk' | 'osk'
 }
 
 export const ClusterConnectors = ({
@@ -68,6 +72,7 @@ export const ClusterConnectors = ({
   selfManagedConnectors = [],
   connectMetrics,
   clusterId,
+  sourceType,
 }: ClusterConnectorsProps) => {
   const [activeTab, setActiveTab] = useState<ConnectorTab>(CONNECTOR_TABS.MSK)
   const [copiedConnector, setCopiedConnector] = useState<string | null>(null)
@@ -290,6 +295,7 @@ export const ClusterConnectors = ({
         {connectMetrics?.metadata && clusterId && (
           <ConnectMetrics
             clusterId={clusterId}
+            sourceType={sourceType}
             connectMetricsMetadata={connectMetrics.metadata}
           />
         )}

--- a/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
@@ -21,6 +21,7 @@ interface ConnectMetricsProps {
     start_date?: string
     end_date?: string
     period?: number
+    metrics_source?: string
   }
 }
 

--- a/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
@@ -17,6 +17,7 @@ import type { ApiMetadata } from '@/types/api/common'
 
 interface ConnectMetricsProps {
   clusterId: string
+  sourceType: 'msk' | 'osk'
   connectMetricsMetadata?: {
     start_date?: string
     end_date?: string
@@ -27,6 +28,7 @@ interface ConnectMetricsProps {
 
 export const ConnectMetrics = ({
   clusterId,
+  sourceType,
   connectMetricsMetadata,
 }: ConnectMetricsProps) => {
   const [startDate, setStartDate] = useState<Date | undefined>(undefined)
@@ -35,6 +37,7 @@ export const ConnectMetrics = ({
 
   const { metricsResponse, isLoading, error } = useConnectMetricsFetch({
     clusterId,
+    sourceType,
     startDate,
     endDate,
   })

--- a/cmd/ui/frontend/src/components/explore/views/MSKClusterReport.tsx
+++ b/cmd/ui/frontend/src/components/explore/views/MSKClusterReport.tsx
@@ -121,6 +121,11 @@ export const MSKClusterReport = () => {
                 selfManagedConnectors={
                   cluster.kafka_admin_client_information?.self_managed_connectors?.connectors || []
                 }
+                connectMetrics={
+                  cluster.kafka_admin_client_information?.self_managed_connectors?.metrics
+                }
+                clusterId={getClusterArn(cluster) || cluster.arn || undefined}
+                sourceType="msk"
               />
             </div>
           )}

--- a/cmd/ui/frontend/src/components/explore/views/OSKClusterReport.tsx
+++ b/cmd/ui/frontend/src/components/explore/views/OSKClusterReport.tsx
@@ -86,6 +86,7 @@ export const OSKClusterReport = () => {
                 cluster.kafka_admin_client_information?.self_managed_connectors?.metrics
               }
               clusterId={selectedOSKClusterId ?? undefined}
+              sourceType="osk"
             />
           )}
 

--- a/cmd/ui/frontend/src/hooks/useConnectMetricsFetch.ts
+++ b/cmd/ui/frontend/src/hooks/useConnectMetricsFetch.ts
@@ -5,6 +5,7 @@ import { useSessionId } from '@/stores/store'
 
 interface ConnectMetricsFetchConfig {
   clusterId: string
+  sourceType: 'msk' | 'osk'
   startDate: Date | undefined
   endDate: Date | undefined
 }
@@ -21,6 +22,7 @@ interface ConnectMetricsFetchReturn {
  */
 export const useConnectMetricsFetch = ({
   clusterId,
+  sourceType,
   startDate,
   endDate,
 }: ConnectMetricsFetchConfig): ConnectMetricsFetchReturn => {
@@ -40,7 +42,7 @@ export const useConnectMetricsFetch = ({
       setError(null)
 
       try {
-        const data = await apiClient.metrics.getOSKConnectMetrics(clusterId, sessionId, {
+        const data = await apiClient.metrics.getConnectMetrics(sourceType, clusterId, sessionId, {
           startDate,
           endDate,
         })
@@ -53,7 +55,7 @@ export const useConnectMetricsFetch = ({
     }
 
     fetchMetrics()
-  }, [clusterId, startDate, endDate, sessionId])
+  }, [clusterId, sourceType, startDate, endDate, sessionId])
 
   return {
     metricsResponse,

--- a/cmd/ui/frontend/src/services/apiClient.ts
+++ b/cmd/ui/frontend/src/services/apiClient.ts
@@ -187,15 +187,20 @@ const metrics = {
   },
 
   /**
-   * Get Connect metrics for an OSK cluster
+   * Get self-managed Connect metrics for a cluster. Connect is Kafka-distribution
+   * agnostic, so the same endpoint serves both MSK and OSK; sourceType is an explicit
+   * path segment and clusterId is a query param (OSK cluster id, or an MSK ARN — passed
+   * as a query value so its ':' and '/' characters are URL-encoded rather than breaking
+   * path-segment routing).
    */
-  async getOSKConnectMetrics(
+  async getConnectMetrics(
+    sourceType: 'msk' | 'osk',
     clusterId: string,
     sessionId: string,
     params?: MetricsQueryParams,
     config?: RequestConfig
   ): Promise<MetricsApiResponse> {
-    const queryParams: Record<string, string | Date | undefined> = { sessionId }
+    const queryParams: Record<string, string | Date | undefined> = { sessionId, clusterId }
     if (params?.startDate) {
       queryParams.startDate =
         params.startDate instanceof Date ? params.startDate : new Date(params.startDate)
@@ -205,7 +210,7 @@ const metrics = {
         params.endDate instanceof Date ? params.endDate : new Date(params.endDate)
     }
     return get<MetricsApiResponse>(
-      `${API_ENDPOINTS.METRICS}/osk/${encodeURIComponent(clusterId)}/connect`,
+      `${API_ENDPOINTS.METRICS}/connect/${encodeURIComponent(sourceType)}`,
       queryParams,
       config
     )

--- a/cmd/ui/frontend/src/types/api/common.ts
+++ b/cmd/ui/frontend/src/types/api/common.ts
@@ -17,6 +17,7 @@ export interface ApiMetadata {
   enhanced_monitoring?: string
   period?: number // Period in seconds
   broker_type?: 'express' | 'standard'
+  metrics_source?: string // self-managed Connect only: 'jolokia' | 'prometheus'
 }
 
 /**

--- a/cmd/ui/frontend/src/types/aws/msk.ts
+++ b/cmd/ui/frontend/src/types/aws/msk.ts
@@ -334,6 +334,7 @@ export interface SelfManagedConnectors {
       start_date?: string
       end_date?: string
       period?: number
+      metrics_source?: string
     }
     results?: Array<{
       start: string

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -11,6 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/confluentinc/kcp/internal/types"
 )
+
+// ErrNoConnectMetricsCollected reports that a cluster exists but has never had any
+// self-managed Connect metrics collected. It is deliberately distinct from an empty
+// date-filtered result (a cluster that HAS metrics, none of which fall in the queried
+// window): the former warrants a "run a scan" hint, the latter is a valid empty 200.
+// The API layer maps this sentinel to the scan-guidance response via errors.Is.
+var ErrNoConnectMetricsCollected = errors.New("no Connect metrics collected for cluster")
 
 const (
 	// metricTimestampFormat is the timestamp format used for metric data
@@ -330,33 +338,37 @@ func (rs *ReportService) filterOSKClusterMetrics(processedState ProcessedState, 
 	}, nil
 }
 
-// FilterConnectMetrics filters Connect metrics for an OSK cluster by cluster ID and date range
-func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
-	var targetCluster *ProcessedOSKCluster
+// FilterConnectMetrics filters self-managed Connect metrics for a cluster by cluster ID and
+// date range. Connect is Kafka-distribution agnostic, so the same metrics live on the shared
+// KafkaAdminClientInformation for both MSK and OSK clusters; sourceType selects which source set
+// to search (and which identifier to match: MSK by ARN, OSK by cluster ID). Each branch searches
+// only its own source set, so a cluster identifier never resolves across source types.
+func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
+	var adminInfo *types.KafkaAdminClientInformation
 
-	for _, source := range processedState.Sources {
-		if source.Type == types.SourceTypeOSK && source.OSKData != nil {
-			for _, cluster := range source.OSKData.Clusters {
-				if strings.EqualFold(cluster.ID, clusterID) {
-					targetCluster = &cluster
-					break
-				}
-			}
-		}
-		if targetCluster != nil {
-			break
-		}
+	// Dispatch to the matching source set only — this is what structurally prevents
+	// a cluster identifier resolving across source types. Mirrors the dispatcher
+	// shape of FilterClusterMetrics.
+	switch sourceType {
+	case "osk":
+		adminInfo = findOSKConnectAdminInfo(processedState, clusterID)
+	case "msk":
+		adminInfo = findMSKConnectAdminInfo(processedState, clusterID)
+	default:
+		return nil, fmt.Errorf("invalid source type '%s' (must be 'msk' or 'osk')", sourceType)
 	}
 
-	if targetCluster == nil {
-		return nil, fmt.Errorf("cluster '%s' not found in OSK sources", clusterID)
+	if adminInfo == nil {
+		return nil, fmt.Errorf("cluster '%s' not found in %s sources", clusterID, sourceType)
 	}
 
-	smc := targetCluster.KafkaAdminClientInformation.SelfManagedConnectors
+	smc := adminInfo.SelfManagedConnectors
 	if smc == nil || smc.Metrics == nil {
-		// No Connect metrics collected for this cluster — the handler detects
-		// the nil Metrics slice and returns a "no metrics" response.
-		return &types.ConnectClusterMetrics{}, nil
+		// The cluster exists but no Connect metrics were ever collected. Signal this
+		// distinctly from the empty date-filtered result returned below, so the API
+		// layer shows the "run a scan" hint only when there is genuinely nothing to
+		// collect — not when the user simply picked a window with no data points.
+		return nil, ErrNoConnectMetricsCollected
 	}
 
 	filteredMetrics := rs.filterMetricsByDateRange(smc.Metrics.Metrics, startTime, endTime)
@@ -371,6 +383,42 @@ func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clu
 		Aggregates: aggregates,
 		QueryInfo:  smc.Metrics.QueryInfo,
 	}, nil
+}
+
+// findOSKConnectAdminInfo returns the admin-client info for the OSK cluster matching
+// clusterID (by cluster ID), or nil if no OSK cluster matches.
+func findOSKConnectAdminInfo(processedState ProcessedState, clusterID string) *types.KafkaAdminClientInformation {
+	for _, source := range processedState.Sources {
+		if source.Type != types.SourceTypeOSK || source.OSKData == nil {
+			continue
+		}
+		for _, cluster := range source.OSKData.Clusters {
+			if strings.EqualFold(cluster.ID, clusterID) {
+				info := cluster.KafkaAdminClientInformation
+				return &info
+			}
+		}
+	}
+	return nil
+}
+
+// findMSKConnectAdminInfo returns the admin-client info for the MSK cluster matching
+// clusterID (by ARN), or nil if no MSK cluster matches.
+func findMSKConnectAdminInfo(processedState ProcessedState, clusterID string) *types.KafkaAdminClientInformation {
+	for _, source := range processedState.Sources {
+		if source.Type != types.SourceTypeMSK || source.MSKData == nil {
+			continue
+		}
+		for _, region := range source.MSKData.Regions {
+			for _, cluster := range region.Clusters {
+				if strings.EqualFold(cluster.Arn, clusterID) {
+					info := cluster.KafkaAdminClientInformation
+					return &info
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // filterMetrics filters the processed state by region, cluster, and date range

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -331,7 +331,7 @@ func (rs *ReportService) filterOSKClusterMetrics(processedState ProcessedState, 
 }
 
 // FilterConnectMetrics filters Connect metrics for an OSK cluster by cluster ID and date range
-func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
+func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
 	var targetCluster *ProcessedOSKCluster
 
 	for _, source := range processedState.Sources {
@@ -354,22 +354,22 @@ func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clu
 
 	smc := targetCluster.KafkaAdminClientInformation.SelfManagedConnectors
 	if smc == nil || smc.Metrics == nil {
-		return &types.ProcessedClusterMetrics{
-			ClusterArn: clusterID,
-		}, nil
+		// No Connect metrics collected for this cluster — the handler detects
+		// the nil Metrics slice and returns a "no metrics" response.
+		return &types.ConnectClusterMetrics{}, nil
 	}
 
 	filteredMetrics := rs.filterMetricsByDateRange(smc.Metrics.Metrics, startTime, endTime)
 	aggregates := CalculateMetricsAggregates(filteredMetrics)
 
-	return &types.ProcessedClusterMetrics{
-		ClusterArn:  clusterID,
-		Metadata:    smc.Metrics.Metadata,
-		Metrics:     filteredMetrics,
-		Aggregates:  aggregates,
-		QueryInfo:   smc.Metrics.QueryInfo,
-		Environment: targetCluster.Metadata.Environment,
-		Location:    targetCluster.Metadata.Location,
+	// Connect metrics carry their own metadata (start/end/period/metrics_source);
+	// region/cluster_arn and the broker-only fields have no meaning here and are
+	// intentionally not part of the Connect shape.
+	return &types.ConnectClusterMetrics{
+		Metadata:   smc.Metrics.Metadata,
+		Metrics:    filteredMetrics,
+		Aggregates: aggregates,
+		QueryInfo:  smc.Metrics.QueryInfo,
 	}, nil
 }
 

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -921,13 +921,13 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 func TestFilterConnectMetrics(t *testing.T) {
 	rs := NewReportService()
 
-	connectMetrics := &types.ProcessedClusterMetrics{
+	connectMetrics := &types.ConnectClusterMetrics{
 		Metrics: []types.ProcessedMetric{
 			{Start: "2025-01-01T00:00:00Z", End: "2025-01-01T00:01:00Z", Label: "connector-count", Value: ptr(2.0)},
 			{Start: "2025-01-01T00:01:00Z", End: "2025-01-01T00:02:00Z", Label: "connector-count", Value: ptr(2.0)},
 			{Start: "2025-01-02T00:00:00Z", End: "2025-01-02T00:01:00Z", Label: "connector-count", Value: ptr(3.0)},
 		},
-		Metadata: types.MetricMetadata{Period: 60},
+		Metadata: types.ConnectMetricMetadata{Period: 60, MetricsSource: "jolokia"},
 		QueryInfo: []types.MetricQueryInfo{
 			{MetricName: "connector-count", Statistic: "Point-in-time value (per worker)"},
 		},
@@ -980,9 +980,10 @@ func TestFilterConnectMetrics(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 3)
-		assert.Equal(t, "osk-kafka", result.ClusterArn)
-		assert.Equal(t, "test", result.Environment)
-		assert.Equal(t, "local", result.Location)
+		// The clean Connect shape carries the metadata through; broker-only
+		// ClusterArn/Environment/Location are intentionally absent from the type.
+		assert.Equal(t, int32(60), result.Metadata.Period, "period carried through")
+		assert.Equal(t, "jolokia", result.Metadata.MetricsSource, "metrics_source carried through")
 		assert.Len(t, result.QueryInfo, 1)
 		assert.Equal(t, "connector-count", result.QueryInfo[0].MetricName)
 	})
@@ -1007,7 +1008,6 @@ func TestFilterConnectMetrics(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Nil(t, result.Metrics)
-		assert.Equal(t, "osk-kafka-no-connect", result.ClusterArn)
 	})
 
 	t.Run("case-insensitive cluster ID match", func(t *testing.T) {

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -921,7 +921,7 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 func TestFilterConnectMetrics(t *testing.T) {
 	rs := NewReportService()
 
-	connectMetrics := &types.ConnectClusterMetrics{
+	oskConnectMetrics := &types.ConnectClusterMetrics{
 		Metrics: []types.ProcessedMetric{
 			{Start: "2025-01-01T00:00:00Z", End: "2025-01-01T00:01:00Z", Label: "connector-count", Value: ptr(2.0)},
 			{Start: "2025-01-01T00:01:00Z", End: "2025-01-01T00:02:00Z", Label: "connector-count", Value: ptr(2.0)},
@@ -933,6 +933,21 @@ func TestFilterConnectMetrics(t *testing.T) {
 		},
 	}
 
+	mskConnectMetrics := &types.ConnectClusterMetrics{
+		Metrics: []types.ProcessedMetric{
+			{Start: "2025-01-01T00:00:00Z", End: "2025-01-01T00:01:00Z", Label: "connector-count", Value: ptr(5.0)},
+			{Start: "2025-01-02T00:00:00Z", End: "2025-01-02T00:01:00Z", Label: "connector-count", Value: ptr(7.0)},
+		},
+		Metadata: types.ConnectMetricMetadata{Period: 60, MetricsSource: types.MetricBackendPrometheus},
+		QueryInfo: []types.MetricQueryInfo{
+			{MetricName: "connector-count", Statistic: "Point-in-time value (per worker)"},
+		},
+	}
+
+	const mskArn = "arn:aws:kafka:us-east-1:123456789012:cluster/msk-kafka/def-456"
+
+	// State carries BOTH an OSK and an MSK cluster, each with Connect metrics, so the
+	// source-type branches and cross-source isolation can be exercised against one fixture.
 	stateWithConnect := ProcessedState{
 		Sources: []ProcessedSource{
 			{
@@ -946,12 +961,36 @@ func TestFilterConnectMetrics(t *testing.T) {
 									Connectors: []types.SelfManagedConnector{
 										{Name: "test-connector"},
 									},
-									Metrics: connectMetrics,
+									Metrics: oskConnectMetrics,
 								},
 							},
 							Metadata: types.OSKClusterMetadata{
 								Environment: "test",
 								Location:    "local",
+							},
+						},
+					},
+				},
+			},
+			{
+				Type: types.SourceTypeMSK,
+				MSKData: &ProcessedMSKSource{
+					Regions: []ProcessedRegion{
+						{
+							Name: "us-east-1",
+							Clusters: []ProcessedCluster{
+								{
+									Name: "msk-kafka",
+									Arn:  mskArn,
+									KafkaAdminClientInformation: types.KafkaAdminClientInformation{
+										SelfManagedConnectors: &types.SelfManagedConnectors{
+											Connectors: []types.SelfManagedConnector{
+												{Name: "msk-connector"},
+											},
+											Metrics: mskConnectMetrics,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -975,8 +1014,8 @@ func TestFilterConnectMetrics(t *testing.T) {
 		},
 	}
 
-	t.Run("returns Connect metrics for existing cluster", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", nil, nil)
+	t.Run("returns Connect metrics for existing OSK cluster", func(t *testing.T) {
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 3)
@@ -988,32 +1027,113 @@ func TestFilterConnectMetrics(t *testing.T) {
 		assert.Equal(t, "connector-count", result.QueryInfo[0].MetricName)
 	})
 
+	t.Run("returns Connect metrics for existing MSK cluster", func(t *testing.T) {
+		result, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "msk", nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Metrics, 2)
+		assert.Equal(t, types.MetricBackendPrometheus, result.Metadata.MetricsSource, "MSK metrics_source carried through")
+	})
+
 	t.Run("filters by date range", func(t *testing.T) {
 		start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		end := time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC)
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", &start, &end)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", &start, &end)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 2) // only Jan 1 metrics
 	})
 
 	t.Run("cluster not found returns error", func(t *testing.T) {
-		_, err := rs.FilterConnectMetrics(stateWithConnect, "nonexistent", nil, nil)
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "nonexistent", "osk", nil, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
-	t.Run("cluster without self-managed connectors returns empty metrics", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", nil, nil)
+	t.Run("cluster without self-managed connectors signals never-collected", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", "osk", nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoConnectMetricsCollected)
+	})
+
+	t.Run("collected metrics outside the date range return empty without error", func(t *testing.T) {
+		// Distinct from "never collected": the cluster HAS Connect metrics, the
+		// selected window just excludes them all. This must NOT surface as the
+		// never-collected sentinel — it is a valid empty result the API serves as a
+		// 200, so the user sees an empty chart rather than a "run a scan" message.
+		start := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2030, 1, 2, 0, 0, 0, 0, time.UTC)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", &start, &end)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		assert.Nil(t, result.Metrics)
+		assert.Empty(t, result.Metrics)
+		assert.NotErrorIs(t, err, ErrNoConnectMetricsCollected)
 	})
 
 	t.Run("case-insensitive cluster ID match", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "OSK-KAFKA", nil, nil)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "OSK-KAFKA", "osk", nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 3)
+	})
+
+	// Abuse case: cross-source-type bleed. A cluster identifier that exists under one
+	// source type must never resolve when queried under the other source type.
+	t.Run("OSK cluster id requested as msk does not bleed", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "msk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("MSK cluster arn requested as osk does not bleed", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "osk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	// Abuse case: an unknown source type is rejected, not silently defaulted to a source.
+	t.Run("unknown source type returns error", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "bogus", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source type")
+	})
+
+	// MSK-branch coverage symmetric to the OSK cases above: not-found, no-connectors,
+	// and date filtering must each be exercised through the MSK lookup path.
+	t.Run("MSK cluster not found returns error", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "arn:aws:kafka:us-east-1:000000000000:cluster/nope/zzz", "msk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("MSK cluster without self-managed connectors signals never-collected", func(t *testing.T) {
+		const arn = "arn:aws:kafka:us-east-1:123456789012:cluster/msk-bare/ghi-789"
+		stateMSKNoConnect := ProcessedState{
+			Sources: []ProcessedSource{
+				{
+					Type: types.SourceTypeMSK,
+					MSKData: &ProcessedMSKSource{
+						Regions: []ProcessedRegion{
+							{
+								Name:     "us-east-1",
+								Clusters: []ProcessedCluster{{Name: "msk-bare", Arn: arn}},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := rs.FilterConnectMetrics(stateMSKNoConnect, arn, "msk", nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoConnectMetricsCollected)
+	})
+
+	t.Run("filters by date range on the MSK path", func(t *testing.T) {
+		start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "msk", &start, &end)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Metrics, 1) // only the Jan 1 MSK metric
 	})
 }

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -927,7 +927,7 @@ func TestFilterConnectMetrics(t *testing.T) {
 			{Start: "2025-01-01T00:01:00Z", End: "2025-01-01T00:02:00Z", Label: "connector-count", Value: ptr(2.0)},
 			{Start: "2025-01-02T00:00:00Z", End: "2025-01-02T00:01:00Z", Label: "connector-count", Value: ptr(3.0)},
 		},
-		Metadata: types.ConnectMetricMetadata{Period: 60, MetricsSource: "jolokia"},
+		Metadata: types.ConnectMetricMetadata{Period: 60, MetricsSource: types.MetricBackendJolokia},
 		QueryInfo: []types.MetricQueryInfo{
 			{MetricName: "connector-count", Statistic: "Point-in-time value (per worker)"},
 		},
@@ -983,7 +983,7 @@ func TestFilterConnectMetrics(t *testing.T) {
 		// The clean Connect shape carries the metadata through; broker-only
 		// ClusterArn/Environment/Location are intentionally absent from the type.
 		assert.Equal(t, int32(60), result.Metadata.Period, "period carried through")
-		assert.Equal(t, "jolokia", result.Metadata.MetricsSource, "metrics_source carried through")
+		assert.Equal(t, types.MetricBackendJolokia, result.Metadata.MetricsSource, "metrics_source carried through")
 		assert.Len(t, result.QueryInfo, 1)
 		assert.Equal(t, "connector-count", result.QueryInfo[0].MetricName)
 	})

--- a/internal/types/connect_metrics.go
+++ b/internal/types/connect_metrics.go
@@ -5,14 +5,16 @@ import "time"
 // ConnectMetricMetadata describes a self-managed Kafka Connect metrics collection.
 // Unlike the broker-oriented MetricMetadata, it carries only fields meaningful in
 // the Connect scope: the collection window, the polling granularity, and which
-// backend produced the data. metrics_source is intentionally NOT omitempty — it
-// belongs to every Connect metrics block; legacy state files (collected before this
-// field existed) load with it empty.
+// backend produced the data. MetricsSource reuses the shared MetricBackend type
+// (jolokia|prometheus for Connect) so it stays consistent with QueryInfo.SourceType
+// and the collector dispatch; the JSON wire value is unchanged. metrics_source is
+// intentionally NOT omitempty — it belongs to every Connect metrics block; legacy
+// state files (collected before this field existed) load with it empty.
 type ConnectMetricMetadata struct {
-	StartDate     time.Time `json:"start_date"`
-	EndDate       time.Time `json:"end_date"`
-	Period        int32     `json:"period"`
-	MetricsSource string    `json:"metrics_source"`
+	StartDate     time.Time     `json:"start_date"`
+	EndDate       time.Time     `json:"end_date"`
+	Period        int32         `json:"period"`
+	MetricsSource MetricBackend `json:"metrics_source"`
 }
 
 // ConnectClusterMetrics is the purpose-built metrics envelope for self-managed

--- a/internal/types/connect_metrics.go
+++ b/internal/types/connect_metrics.go
@@ -1,0 +1,27 @@
+package types
+
+import "time"
+
+// ConnectMetricMetadata describes a self-managed Kafka Connect metrics collection.
+// Unlike the broker-oriented MetricMetadata, it carries only fields meaningful in
+// the Connect scope: the collection window, the polling granularity, and which
+// backend produced the data. metrics_source is intentionally NOT omitempty — it
+// belongs to every Connect metrics block; legacy state files (collected before this
+// field existed) load with it empty.
+type ConnectMetricMetadata struct {
+	StartDate     time.Time `json:"start_date"`
+	EndDate       time.Time `json:"end_date"`
+	Period        int32     `json:"period"`
+	MetricsSource string    `json:"metrics_source"`
+}
+
+// ConnectClusterMetrics is the purpose-built metrics envelope for self-managed
+// Kafka Connect. It mirrors the consumable parts of ProcessedClusterMetrics
+// (results, aggregates, query_info) but drops the broker-only metadata and the
+// region/cluster_arn that are meaningless for a Connect cluster.
+type ConnectClusterMetrics struct {
+	Metadata   ConnectMetricMetadata      `json:"metadata"`
+	Metrics    []ProcessedMetric          `json:"results"`
+	Aggregates map[string]MetricAggregate `json:"aggregates"`
+	QueryInfo  []MetricQueryInfo          `json:"query_info"`
+}

--- a/internal/types/connect_metrics_test.go
+++ b/internal/types/connect_metrics_test.go
@@ -1,0 +1,151 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleConnectClusterMetrics builds a fully-populated value for serialization tests.
+func sampleConnectClusterMetrics() ConnectClusterMetrics {
+	start := time.Date(2026, 6, 16, 14, 54, 3, 0, time.UTC)
+	end := time.Date(2026, 6, 23, 14, 54, 3, 0, time.UTC)
+	v := 4.0
+	return ConnectClusterMetrics{
+		Metadata: ConnectMetricMetadata{
+			StartDate:     start,
+			EndDate:       end,
+			Period:        60,
+			MetricsSource: "prometheus",
+		},
+		Metrics: []ProcessedMetric{
+			{Start: start.Format(time.RFC3339), End: end.Format(time.RFC3339), Label: "connector-count", Value: &v},
+		},
+		Aggregates: map[string]MetricAggregate{
+			"connector-count": {Average: &v, Maximum: &v, Minimum: &v},
+		},
+		QueryInfo: []MetricQueryInfo{
+			{MetricName: "connector-count", SourceType: MetricBackendPrometheus},
+		},
+	}
+}
+
+// TestConnectClusterMetrics_JSONShape asserts the envelope and metadata serialize
+// with exactly the Connect-meaningful keys — no broker fields, no region/cluster_arn.
+func TestConnectClusterMetrics_JSONShape(t *testing.T) {
+	b, err := json.Marshal(sampleConnectClusterMetrics())
+	require.NoError(t, err)
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &envelope))
+
+	// Envelope keys exactly.
+	envelopeKeys := keysOf(envelope)
+	assert.ElementsMatch(t, []string{"metadata", "results", "aggregates", "query_info"}, envelopeKeys,
+		"envelope must carry only metadata/results/aggregates/query_info, got %v", envelopeKeys)
+
+	// Top-level broker-envelope noise must be gone.
+	assert.NotContains(t, envelopeKeys, "region")
+	assert.NotContains(t, envelopeKeys, "cluster_arn")
+
+	var meta map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(envelope["metadata"], &meta))
+	metaKeys := keysOf(meta)
+	assert.ElementsMatch(t, []string{"start_date", "end_date", "period", "metrics_source"}, metaKeys,
+		"metadata must carry only start_date/end_date/period/metrics_source, got %v", metaKeys)
+
+	// None of the broker metadata fields may appear.
+	for _, brokerField := range []string{
+		"cluster_type", "number_of_broker_nodes", "kafka_version", "broker_az_distribution",
+		"enhanced_monitoring", "follower_fetching", "instance_type", "tiered_storage", "broker_type",
+	} {
+		assert.NotContains(t, metaKeys, brokerField, "broker field %q must not serialize for Connect", brokerField)
+	}
+}
+
+// TestConnectClusterMetrics_RoundTrip confirms marshal->unmarshal preserves the data.
+func TestConnectClusterMetrics_RoundTrip(t *testing.T) {
+	original := sampleConnectClusterMetrics()
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got ConnectClusterMetrics
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.True(t, original.Metadata.StartDate.Equal(got.Metadata.StartDate))
+	assert.True(t, original.Metadata.EndDate.Equal(got.Metadata.EndDate))
+	assert.Equal(t, int32(60), got.Metadata.Period)
+	assert.Equal(t, "prometheus", got.Metadata.MetricsSource)
+	require.Len(t, got.Metrics, 1)
+	assert.Equal(t, "connector-count", got.Metrics[0].Label)
+	require.NotNil(t, got.Metrics[0].Value)
+	assert.Equal(t, 4.0, *got.Metrics[0].Value)
+}
+
+// TestConnectMetricMetadata_MetricsSourceAlwaysPresent locks the gate decision:
+// metrics_source has no omitempty, so an unset source still serializes the key.
+func TestConnectMetricMetadata_MetricsSourceAlwaysPresent(t *testing.T) {
+	b, err := json.Marshal(ConnectMetricMetadata{})
+	require.NoError(t, err)
+
+	var meta map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &meta))
+	assert.Contains(t, keysOf(meta), "metrics_source",
+		"metrics_source must always serialize (no omitempty)")
+	assert.JSONEq(t, `""`, string(meta["metrics_source"]))
+}
+
+// TestConnectClusterMetrics_BackwardCompatUnmarshal is the abuse/edge case (R4):
+// a legacy state file whose Connect metrics carry the old broker-shaped fields must
+// load without error. Unknown broker fields are ignored; start/end/period/results
+// populate; metrics_source defaults to empty.
+func TestConnectClusterMetrics_BackwardCompatUnmarshal(t *testing.T) {
+	legacy := `{
+		"region": "us-east-1",
+		"cluster_arn": "arn:aws:kafka:us-east-1:123:cluster/foo/abc",
+		"metadata": {
+			"cluster_type": "PROVISIONED",
+			"number_of_broker_nodes": 3,
+			"kafka_version": "3.5.1",
+			"broker_az_distribution": "DEFAULT",
+			"enhanced_monitoring": "PER_BROKER",
+			"start_date": "2026-06-16T14:54:03Z",
+			"end_date": "2026-06-23T14:54:03Z",
+			"period": 300,
+			"follower_fetching": false,
+			"instance_type": "kafka.m5.large",
+			"tiered_storage": false,
+			"broker_type": "standard"
+		},
+		"results": [
+			{"start": "2026-06-16T14:54:03Z", "end": "2026-06-16T14:55:03Z", "label": "connector-count", "value": 4}
+		],
+		"aggregates": {"connector-count": {"avg": 4, "max": 4, "min": 4}},
+		"query_info": []
+	}`
+
+	var got ConnectClusterMetrics
+	err := json.Unmarshal([]byte(legacy), &got)
+	require.NoError(t, err, "legacy broker-shaped Connect metrics must unmarshal without error")
+
+	// Meaningful fields survive.
+	assert.Equal(t, time.Date(2026, 6, 16, 14, 54, 3, 0, time.UTC), got.Metadata.StartDate.UTC())
+	assert.Equal(t, time.Date(2026, 6, 23, 14, 54, 3, 0, time.UTC), got.Metadata.EndDate.UTC())
+	assert.Equal(t, int32(300), got.Metadata.Period)
+	// metrics_source absent from legacy data -> empty.
+	assert.Equal(t, "", got.Metadata.MetricsSource)
+	// Metric series preserved.
+	require.Len(t, got.Metrics, 1)
+	assert.Equal(t, "connector-count", got.Metrics[0].Label)
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/types/connect_metrics_test.go
+++ b/internal/types/connect_metrics_test.go
@@ -19,7 +19,7 @@ func sampleConnectClusterMetrics() ConnectClusterMetrics {
 			StartDate:     start,
 			EndDate:       end,
 			Period:        60,
-			MetricsSource: "prometheus",
+			MetricsSource: MetricBackendPrometheus,
 		},
 		Metrics: []ProcessedMetric{
 			{Start: start.Format(time.RFC3339), End: end.Format(time.RFC3339), Label: "connector-count", Value: &v},
@@ -78,7 +78,7 @@ func TestConnectClusterMetrics_RoundTrip(t *testing.T) {
 	assert.True(t, original.Metadata.StartDate.Equal(got.Metadata.StartDate))
 	assert.True(t, original.Metadata.EndDate.Equal(got.Metadata.EndDate))
 	assert.Equal(t, int32(60), got.Metadata.Period)
-	assert.Equal(t, "prometheus", got.Metadata.MetricsSource)
+	assert.Equal(t, MetricBackendPrometheus, got.Metadata.MetricsSource)
 	require.Len(t, got.Metrics, 1)
 	assert.Equal(t, "connector-count", got.Metrics[0].Label)
 	require.NotNil(t, got.Metrics[0].Value)
@@ -136,7 +136,7 @@ func TestConnectClusterMetrics_BackwardCompatUnmarshal(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 6, 23, 14, 54, 3, 0, time.UTC), got.Metadata.EndDate.UTC())
 	assert.Equal(t, int32(300), got.Metadata.Period)
 	// metrics_source absent from legacy data -> empty.
-	assert.Equal(t, "", got.Metadata.MetricsSource)
+	assert.Empty(t, got.Metadata.MetricsSource)
 	// Metric series preserved.
 	require.Len(t, got.Metrics, 1)
 	assert.Equal(t, "connector-count", got.Metrics[0].Label)

--- a/internal/types/discovery_common.go
+++ b/internal/types/discovery_common.go
@@ -53,7 +53,7 @@ func (c *KafkaAdminClientInformation) SetTopics(topicDetails []TopicDetails) {
 
 func (c *KafkaAdminClientInformation) SetSelfManagedConnectors(connectors []SelfManagedConnector) {
 	// Preserve existing metrics when updating connectors
-	var existingMetrics *ProcessedClusterMetrics
+	var existingMetrics *ConnectClusterMetrics
 	if c.SelfManagedConnectors != nil {
 		existingMetrics = c.SelfManagedConnectors.Metrics
 	}
@@ -168,7 +168,7 @@ func mergeSelfManagedConnectors(newConnectors, oldConnectors *SelfManagedConnect
 // preferConnectorMetrics returns the metrics to keep when merging two
 // SelfManagedConnectors: the new run's metrics if present, otherwise the old
 // run's, otherwise nil.
-func preferConnectorMetrics(newConnectors, oldConnectors *SelfManagedConnectors) *ProcessedClusterMetrics {
+func preferConnectorMetrics(newConnectors, oldConnectors *SelfManagedConnectors) *ConnectClusterMetrics {
 	if newConnectors != nil && newConnectors.Metrics != nil {
 		return newConnectors.Metrics
 	}

--- a/internal/types/discovery_common_test.go
+++ b/internal/types/discovery_common_test.go
@@ -79,7 +79,7 @@ func TestMergeSelfManagedConnectors_NewZeroConnectorsWithMetrics_PrefersNew(t *t
 // Preservation is split across this path and mergeSelfManagedConnectors — guarding
 // both prevents a silent regression through the type change.
 func TestSetSelfManagedConnectors_PreservesExistingMetrics(t *testing.T) {
-	existing := &ConnectClusterMetrics{Metadata: ConnectMetricMetadata{MetricsSource: "jolokia"}}
+	existing := &ConnectClusterMetrics{Metadata: ConnectMetricMetadata{MetricsSource: MetricBackendJolokia}}
 	info := &KafkaAdminClientInformation{
 		SelfManagedConnectors: &SelfManagedConnectors{
 			Connectors: []SelfManagedConnector{{Name: "old"}},

--- a/internal/types/discovery_common_test.go
+++ b/internal/types/discovery_common_test.go
@@ -8,7 +8,7 @@ import (
 
 // smc builds a SelfManagedConnectors with the named connectors and the given
 // metrics pointer (which may be nil).
-func smc(names []string, metrics *ProcessedClusterMetrics) *SelfManagedConnectors {
+func smc(names []string, metrics *ConnectClusterMetrics) *SelfManagedConnectors {
 	conns := make([]SelfManagedConnector, 0, len(names))
 	for _, n := range names {
 		conns = append(conns, SelfManagedConnector{Name: n})
@@ -19,15 +19,15 @@ func smc(names []string, metrics *ProcessedClusterMetrics) *SelfManagedConnector
 // R9: re-running a scan without --metrics must not wipe previously-collected
 // metrics. New connectors take precedence; metrics prefer-new-fall-back-to-old.
 func TestMergeSelfManagedConnectors_NewNilMetrics_KeepsOld(t *testing.T) {
-	oldM := &ProcessedClusterMetrics{}
+	oldM := &ConnectClusterMetrics{}
 	merged := mergeSelfManagedConnectors(smc([]string{"a"}, nil), smc([]string{"a"}, oldM))
 	require.NotNil(t, merged.Metrics)
 	require.Same(t, oldM, merged.Metrics, "old metrics preserved when new run carries none")
 }
 
 func TestMergeSelfManagedConnectors_NewMetrics_Wins(t *testing.T) {
-	oldM := &ProcessedClusterMetrics{}
-	newM := &ProcessedClusterMetrics{}
+	oldM := &ConnectClusterMetrics{}
+	newM := &ConnectClusterMetrics{}
 	merged := mergeSelfManagedConnectors(smc([]string{"a"}, newM), smc([]string{"a"}, oldM))
 	require.Same(t, newM, merged.Metrics, "freshly-collected metrics take precedence")
 }
@@ -36,7 +36,7 @@ func TestMergeSelfManagedConnectors_NewMetrics_Wins(t *testing.T) {
 // but carries metrics — those metrics must not be dropped. RED against the
 // current early-return at discovery_common.go.
 func TestMergeSelfManagedConnectors_OldZeroConnectorsButMetrics_Preserved(t *testing.T) {
-	oldM := &ProcessedClusterMetrics{}
+	oldM := &ConnectClusterMetrics{}
 	old := smc(nil, oldM) // zero connectors, but has metrics
 	new := smc([]string{"a"}, nil)
 
@@ -50,7 +50,7 @@ func TestMergeSelfManagedConnectors_OldZeroConnectorsButMetrics_Preserved(t *tes
 // Edge case (R9): the new run discovered zero connectors — old connectors and
 // old metrics must both survive.
 func TestMergeSelfManagedConnectors_NewZeroConnectors_KeepsOld(t *testing.T) {
-	oldM := &ProcessedClusterMetrics{}
+	oldM := &ConnectClusterMetrics{}
 	old := smc([]string{"a"}, oldM)
 	new := smc(nil, nil)
 
@@ -63,8 +63,8 @@ func TestMergeSelfManagedConnectors_NewZeroConnectors_KeepsOld(t *testing.T) {
 // Edge case (R9): new run has zero connectors but freshly-collected metrics —
 // the new metrics win, old connectors survive.
 func TestMergeSelfManagedConnectors_NewZeroConnectorsWithMetrics_PrefersNew(t *testing.T) {
-	oldM := &ProcessedClusterMetrics{}
-	newM := &ProcessedClusterMetrics{}
+	oldM := &ConnectClusterMetrics{}
+	newM := &ConnectClusterMetrics{}
 	old := smc([]string{"a"}, oldM)
 	new := smc(nil, newM)
 
@@ -72,4 +72,25 @@ func TestMergeSelfManagedConnectors_NewZeroConnectorsWithMetrics_PrefersNew(t *t
 
 	require.Len(t, merged.Connectors, 1, "old connectors retained")
 	require.Same(t, newM, merged.Metrics, "freshly-collected metrics take precedence even with zero new connectors")
+}
+
+// R6 (Set path): SetSelfManagedConnectors rebuilds the connectors object when a
+// scan updates connectors; it must carry forward any previously-collected metrics.
+// Preservation is split across this path and mergeSelfManagedConnectors — guarding
+// both prevents a silent regression through the type change.
+func TestSetSelfManagedConnectors_PreservesExistingMetrics(t *testing.T) {
+	existing := &ConnectClusterMetrics{Metadata: ConnectMetricMetadata{MetricsSource: "jolokia"}}
+	info := &KafkaAdminClientInformation{
+		SelfManagedConnectors: &SelfManagedConnectors{
+			Connectors: []SelfManagedConnector{{Name: "old"}},
+			Metrics:    existing,
+		},
+	}
+
+	info.SetSelfManagedConnectors([]SelfManagedConnector{{Name: "new"}})
+
+	require.NotNil(t, info.SelfManagedConnectors.Metrics, "existing metrics must survive a connector update")
+	require.Same(t, existing, info.SelfManagedConnectors.Metrics)
+	require.Len(t, info.SelfManagedConnectors.Connectors, 1)
+	require.Equal(t, "new", info.SelfManagedConnectors.Connectors[0].Name)
 }

--- a/internal/types/self_managed_connect.go
+++ b/internal/types/self_managed_connect.go
@@ -8,6 +8,6 @@ type SelfManagedConnector struct {
 }
 
 type SelfManagedConnectors struct {
-	Connectors []SelfManagedConnector   `json:"connectors"`
-	Metrics    *ProcessedClusterMetrics `json:"metrics,omitempty"`
+	Connectors []SelfManagedConnector `json:"connectors"`
+	Metrics    *ConnectClusterMetrics `json:"metrics,omitempty"`
 }


### PR DESCRIPTION
## What

Self-managed Kafka Connect metrics (`SelfManagedConnectors.Metrics`) reused the broker-shaped `ProcessedClusterMetrics` / `MetricMetadata`. For a Connect cluster that meant the serialized `"metrics"` block carried ~9 empty broker fields plus an empty `region` / `cluster_arn` — pure noise, an artifact of type reuse rather than data we ever collect.

This replaces that with a purpose-built `ConnectClusterMetrics` / `ConnectMetricMetadata` carrying only the fields meaningful in the Connect scope: `start_date`, `end_date`, `period`, and `metrics_source`.

**Before**

```json
"metrics": {
  "region": "",
  "cluster_arn": "",
  "metadata": {
    "cluster_type": "", "number_of_broker_nodes": 0, "kafka_version": "",
    "broker_az_distribution": "", "enhanced_monitoring": "",
    "start_date": "...", "end_date": "...", "period": 300,
    "follower_fetching": false, "instance_type": "",
    "tiered_storage": false, "broker_type": ""
  }
}
```

**After**

```json
"metrics": {
  "metadata": {
    "start_date": "...",
    "end_date": "...",
    "period": 60,
    "metrics_source": "prometheus"
  },
  "results": [ ... ],
  "aggregates": { ... },
  "query_info": [ ... ]
}
```

## Testing

- Full Go suite green: **51 packages OK, 0 failed**. Frontend `tsc -b && vite build` clean.
- New tests (test-first): exact JSON-shape assertion (no broker fields), round-trip, per-backend `metrics_source` injection end-to-end, and metrics preservation across **both** the Set and merge paths.
- A type-level test confirms `ConnectClusterMetrics` *tolerates* legacy broker-shaped JSON (unknown broker fields ignored, `metrics_source` defaults empty). This is **not** a live state-file migration path, and shouldn't be read as one: the production loader (`NewStateFromBytes`) uses `DisallowUnknownFields` and would in fact reject a broker-shaped block. That's moot in practice — no released version (≤ v0.8.5) ever populated `SelfManagedConnectors.Metrics` (the `scan self-managed-connectors` command did not exist before this stack), so no state file in the wild carries broker-shaped Connect metrics and there is nothing real to migrate.


> Stacked on `feat/connector-metrics-restore` (PR base is that branch, not `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

