### PR TITLE
feat(ui): show Connect metrics for MSK clusters, not just OSK

### DIFF
--- a/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/confluentinc/kcp/internal/redact"
@@ -105,6 +106,53 @@ func TestMskConnectorMigrator_Run_GeneratedTerraformIsLeakFree(t *testing.T) {
 	// (fail-closed) rather than as a working credential.
 	assert.Contains(t, string(tf), fmt.Sprintf("%q = %q", "database.password", redact.Placeholder),
 		"sensitive field must render as the redaction placeholder in the generated Terraform")
+}
+
+// Path traversal: a connector name carrying "../" (attacker-controllable via a
+// hostile state file even though AWS constrains MSK Connect names server-side) must
+// not let the generated .tf escape OutputDir. Mirrors the self-managed migrator test
+// so the security-critical write-containment is asserted on both identical paths.
+func TestMskConnectorMigrator_Run_HostileNameStaysInOutputDir(t *testing.T) {
+	server := echoTranslateServer(t)
+	defer server.Close()
+
+	root := t.TempDir()
+	outDir := filepath.Join(root, "out")
+
+	migrator := NewMskConnectorMigrator(MigrateMskConnectorOpts{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+		Connectors: []types.ConnectorSummary{
+			{
+				ConnectorName: "../escaped",
+				ConnectorConfiguration: map[string]string{
+					"connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+				},
+			},
+		},
+		OutputDir: outDir,
+	})
+	migrator.baseURL = server.URL
+
+	require.NoError(t, migrator.Run())
+
+	// The traversal target the unsanitized name would have produced must not exist.
+	_, err := os.Stat(filepath.Join(root, "escaped-connector.tf"))
+	assert.True(t, os.IsNotExist(err), "connector must not be written outside OutputDir")
+
+	// Every file the run produced must live inside OutputDir.
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	var connectorFiles int
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), string(filepath.Separator))
+		if strings.HasSuffix(e.Name(), "-connector.tf") {
+			connectorFiles++
+		}
+	}
+	assert.Equal(t, 1, connectorFiles, "exactly one connector .tf must be written inside OutputDir")
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator.go
+++ b/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator.go
@@ -208,7 +208,17 @@ func (mc *SelfManagedConnectorMigrator) translateConnectorConfig(connector types
 		return nil, nil, fmt.Errorf("'connector.class' not found in config")
 	}
 
-	pluginName, err := connector_utils.InferPluginName(connectorClass.(string))
+	// connector.Config is map[string]any (JSON-decoded from the Connect REST API
+	// or rehydrated from the state file), so connector.class can deserialize to a
+	// non-string (number/bool/object/null) on a malformed or tampered source. A
+	// bare type assertion would panic and crash the whole migrate-connectors run;
+	// the comma-ok form turns it into a per-connector error the Run loop skips.
+	connectorClassStr, ok := connectorClass.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("'connector.class' is not a string")
+	}
+
+	pluginName, err := connector_utils.InferPluginName(connectorClassStr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to determine plugin name: %w", err)
 	}

--- a/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
@@ -444,6 +444,66 @@ func TestSelfManagedConnectorMigrator_TranslateConnectorConfig_UnsupportedConnec
 	assert.Contains(t, err.Error(), "failed to determine plugin name")
 }
 
+// Regression: connector.Config is map[string]any, so connector.class can arrive as
+// a non-string (a JSON number/bool/object from a malformed Connect response or a
+// tampered state file). The translate path must return an error rather than panic on
+// a bare type assertion, which would crash the whole migrate-connectors run.
+func TestSelfManagedConnectorMigrator_TranslateConnectorConfig_NonStringConnectorClass(t *testing.T) {
+	migrator := &SelfManagedConnectorMigrator{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+	}
+
+	connector := types.SelfManagedConnector{
+		Name: "test-connector",
+		Config: map[string]any{
+			"connector.class": 42, // not a string
+			"topics":          "test-topic",
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		_, _, err := migrator.translateConnectorConfig(connector)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "'connector.class' is not a string")
+	})
+}
+
+// Run() must survive a connector whose connector.class is non-string: the per-connector
+// translate error is logged and skipped, the run completes without panicking, and no
+// .tf is written for the bad connector.
+func TestSelfManagedConnectorMigrator_Run_NonStringConnectorClassIsSkipped(t *testing.T) {
+	server := echoTranslateServer(t)
+	defer server.Close()
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	migrator := NewSelfManagedConnectorMigrator(MigrateSelfManagedConnectorOpts{
+		EnvironmentId: "env-123",
+		ClusterId:     "lkc-123",
+		CcApiKey:      "test-key",
+		CcApiSecret:   "test-secret",
+		Connectors: []types.SelfManagedConnector{
+			{
+				Name: "bad-class",
+				Config: map[string]any{
+					"connector.class": map[string]any{"nested": "object"}, // not a string
+				},
+			},
+		},
+		OutputDir: outDir,
+	})
+	migrator.baseURL = server.URL
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, migrator.Run())
+	})
+
+	_, err := os.Stat(filepath.Join(outDir, "bad-class-connector.tf"))
+	assert.True(t, os.IsNotExist(err), "no .tf should be written for a connector with a non-string connector.class")
+}
+
 func TestSelfManagedConnectorMigrator_Run_WritesProvidersTfAndVariablesTf(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "connectors-output")

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -297,11 +297,20 @@ func connectorAuthType(connector kafkaconnecttypes.ConnectorSummary) (types.Auth
 	}
 }
 
-// bootstrapMatches reports whether any cluster broker address appears in the
-// connector's bootstrap-server string.
+// bootstrapMatches reports whether the connector and the cluster share at least one
+// bootstrap broker. Both sides are comma-separated host:port lists; we compare by exact
+// host:port equality (after splitting and trimming) rather than substring containment,
+// so a broker address can't spuriously match by being a substring of an unrelated
+// connector's bootstrap string (e.g. a host that merely shares a DNS prefix/suffix).
 func bootstrapMatches(connectorBootstrap string, brokerAddresses []string) bool {
+	connectorHosts := make(map[string]struct{})
+	for _, addr := range strings.Split(connectorBootstrap, ",") {
+		if trimmed := strings.TrimSpace(addr); trimmed != "" {
+			connectorHosts[trimmed] = struct{}{}
+		}
+	}
 	for _, brokerAddress := range brokerAddresses {
-		if strings.Contains(connectorBootstrap, brokerAddress) {
+		if _, ok := connectorHosts[strings.TrimSpace(brokerAddress)]; ok {
 			return true
 		}
 	}

--- a/cmd/discover/connector_discoverer_test.go
+++ b/cmd/discover/connector_discoverer_test.go
@@ -255,3 +255,34 @@ func TestDiscoverMatchingConnectors_DoesNotLogRawSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, logBuf.String(), "hunter2", "raw secret must never be logged")
 }
+
+// bootstrapMatches must compare host:port entries by exact equality, not substring
+// containment, so a cluster broker address can't spuriously match an unrelated
+// connector whose bootstrap host merely shares a DNS prefix/suffix.
+func TestBootstrapMatches_ExactHostPortOnly(t *testing.T) {
+	brokers := []string{
+		"b-1.test.kafka.us-east-1.amazonaws.com:9098",
+		"b-2.test.kafka.us-east-1.amazonaws.com:9098",
+	}
+
+	t.Run("substring of a connector host is not a match", func(t *testing.T) {
+		// The broker host:port is a substring of this connector's host but is not an
+		// exact entry — must not match.
+		connector := "b-1.test.kafka.us-east-1.amazonaws.com.attacker.example:9098"
+		assert.False(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("a different cluster does not match", func(t *testing.T) {
+		connector := "b-9.other.kafka.us-east-1.amazonaws.com:9098"
+		assert.False(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("exact host:port matches (including whitespace tolerance)", func(t *testing.T) {
+		connector := "b-1.test.kafka.us-east-1.amazonaws.com:9098, b-2.test.kafka.us-east-1.amazonaws.com:9098"
+		assert.True(t, bootstrapMatches(connector, brokers))
+	})
+
+	t.Run("empty connector bootstrap never matches", func(t *testing.T) {
+		assert.False(t, bootstrapMatches("", brokers))
+	})
+}

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -255,10 +256,26 @@ func (ui *UI) handleGetOSKMetrics(c echo.Context) error {
 	}
 
 	if filteredMetrics.Metrics == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error":   "No metrics available for this cluster",
-			"message": "Run 'kcp scan clusters --source-type apache-kafka --metrics jolokia' or '--metrics prometheus' to collect metrics",
-		})
+		// An empty filtered result is ambiguous: the cluster either never had metrics
+		// collected, or it has metrics but none fall in the selected date range. Only
+		// the former warrants the "run a scan" hint. When a date filter was applied,
+		// re-probe without it (reusing the same lookup) to tell them apart; an
+		// out-of-range window then falls through to a normal empty 200 so the UI shows
+		// an empty chart rather than a misleading error. FilterClusterMetrics is shared
+		// with the `kcp report metrics` CLI, so the distinction is made here in the
+		// handler rather than by changing the filter's contract.
+		neverCollected := true
+		if startTime != nil || endTime != nil {
+			if unfiltered, uErr := ui.reportService.FilterClusterMetrics(processedState, clusterId, "osk", nil, nil); uErr == nil && unfiltered.Metrics != nil {
+				neverCollected = false
+			}
+		}
+		if neverCollected {
+			return c.JSON(http.StatusNotFound, map[string]any{
+				"error":   "No metrics available for this cluster",
+				"message": "Run 'kcp scan clusters --source-type apache-kafka --metrics jolokia' or '--metrics prometheus' to collect metrics",
+			})
+		}
 	}
 
 	return c.JSON(http.StatusOK, filteredMetrics)
@@ -305,16 +322,19 @@ func (ui *UI) handleGetConnectMetrics(c echo.Context) error {
 
 	filteredMetrics, err := ui.reportService.FilterConnectMetrics(processedState, clusterId, sourceType, startTime, endTime)
 	if err != nil {
+		// "Never collected" is the only case that warrants the scan-guidance hint.
+		// A cluster that HAS metrics but whose selected date range excludes them all
+		// is not an error — it falls through to a normal (empty) 200 below, so the
+		// user sees an empty chart rather than a misleading "run a scan" message.
+		if errors.Is(err, report.ErrNoConnectMetricsCollected) {
+			return c.JSON(http.StatusNotFound, map[string]any{
+				"error":   "No Connect metrics available for this cluster",
+				"message": "Run 'kcp scan self-managed-connectors --metrics jolokia' or '--metrics prometheus' to collect Connect metrics",
+			})
+		}
 		return c.JSON(http.StatusNotFound, map[string]any{
 			"error":   "Cluster not found or no Connect metrics available",
 			"message": err.Error(),
-		})
-	}
-
-	if filteredMetrics.Metrics == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error":   "No Connect metrics available for this cluster",
-			"message": "Run 'kcp scan self-managed-connectors --metrics jolokia' or '--metrics prometheus' to collect Connect metrics",
 		})
 	}
 

--- a/cmd/ui/api/api.go
+++ b/cmd/ui/api/api.go
@@ -25,7 +25,7 @@ type ReportService interface {
 	FilterRegionCosts(processedState report.ProcessedState, regionName string, startTime, endTime *time.Time) (*report.ProcessedRegionCosts, error)
 	FilterMetrics(processedState report.ProcessedState, regionName, clusterName string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
 	FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error)
-	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error)
+	FilterConnectMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error)
 }
 
 type UICmdOpts struct {
@@ -118,7 +118,10 @@ func (ui *UI) Run() error {
 
 	e.GET("/metrics/:region/:cluster", ui.handleGetMetrics)
 	e.GET("/metrics/osk/:clusterId", ui.handleGetOSKMetrics)
-	e.GET("/metrics/osk/:clusterId/connect", ui.handleGetOSKConnectMetrics)
+	// Connect is Kafka-distribution agnostic — one route serves both MSK and OSK.
+	// The literal "connect" first segment avoids shadowing by the static "osk" node
+	// and the "/metrics/:region/:cluster" param route.
+	e.GET("/metrics/connect/:sourceType", ui.handleGetConnectMetrics)
 	e.GET("/costs/:region", ui.handleGetCosts)
 
 	e.POST("/upload-state", ui.handleUploadState)
@@ -261,9 +264,11 @@ func (ui *UI) handleGetOSKMetrics(c echo.Context) error {
 	return c.JSON(http.StatusOK, filteredMetrics)
 }
 
-func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
-	clusterId := c.Param("clusterId")
-
+// handleGetConnectMetrics serves self-managed Connect metrics for either an MSK or OSK
+// cluster. sourceType is an explicit path param ({msk, osk}); clusterId is a query param
+// (OSK cluster id, or an MSK ARN URL-encoded by the client). The filter searches only the
+// named source set, so a cluster id never resolves across source types.
+func (ui *UI) handleGetConnectMetrics(c echo.Context) error {
 	state, err := ui.getStateBySession(c)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]any{
@@ -272,9 +277,19 @@ func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
 		})
 	}
 
-	if state.OSKSources == nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error": "No OSK sources in state",
+	sourceType := c.Param("sourceType")
+	if sourceType != "msk" && sourceType != "osk" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "Invalid source type",
+			"message": fmt.Sprintf("source type %q is not supported (must be 'msk' or 'osk')", sourceType),
+		})
+	}
+
+	clusterId := c.QueryParam("clusterId")
+	if clusterId == "" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error":   "Missing cluster identifier",
+			"message": "clusterId query parameter is required",
 		})
 	}
 
@@ -288,7 +303,7 @@ func (ui *UI) handleGetOSKConnectMetrics(c echo.Context) error {
 
 	processedState := ui.reportService.ProcessState(*state)
 
-	filteredMetrics, err := ui.reportService.FilterConnectMetrics(processedState, clusterId, startTime, endTime)
+	filteredMetrics, err := ui.reportService.FilterConnectMetrics(processedState, clusterId, sourceType, startTime, endTime)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]any{
 			"error":   "Cluster not found or no Connect metrics available",

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -25,6 +25,14 @@ type mockReportService struct {
 	connectCalled         bool
 	lastConnectClusterID  string
 	lastConnectSourceType string
+
+	// clusterMetrics drives FilterClusterMetrics. clusterMetricsUnfiltered is returned
+	// for the handler's no-date-filter re-probe (both startTime and endTime nil) so a
+	// test can model "collected, but out of the selected range"; clusterMetrics is
+	// returned when a date filter is present. clusterErr, if set, is returned for all.
+	clusterMetrics           *types.ProcessedClusterMetrics
+	clusterMetricsUnfiltered *types.ProcessedClusterMetrics
+	clusterErr               error
 }
 
 func (m *mockReportService) ProcessState(state types.State) report.ProcessedState {
@@ -40,7 +48,13 @@ func (m *mockReportService) FilterMetrics(processedState report.ProcessedState, 
 }
 
 func (m *mockReportService) FilterClusterMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ProcessedClusterMetrics, error) {
-	return nil, nil
+	if m.clusterErr != nil {
+		return nil, m.clusterErr
+	}
+	if startTime == nil && endTime == nil && m.clusterMetricsUnfiltered != nil {
+		return m.clusterMetricsUnfiltered, nil
+	}
+	return m.clusterMetrics, nil
 }
 
 func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
@@ -434,8 +448,9 @@ func TestHandleGetConnectMetrics_MissingSessionId_Returns400(t *testing.T) {
 }
 
 func TestHandleGetConnectMetrics_NoMetrics_Returns404WithGuidance(t *testing.T) {
-	// Filter found the cluster but it carries no Connect metrics (empty struct, nil Metrics).
-	mock := &mockReportService{connectMetrics: &types.ConnectClusterMetrics{}}
+	// Filter found the cluster but it never had Connect metrics collected, signalled
+	// by the ErrNoConnectMetricsCollected sentinel. Only this case gets scan guidance.
+	mock := &mockReportService{connectErr: report.ErrNoConnectMetricsCollected}
 	ui := connectMetricsTestUI(mock)
 
 	rec := callConnectHandler(ui, "msk", "?clusterId=some-arn&sessionId=s1")
@@ -448,6 +463,23 @@ func TestHandleGetConnectMetrics_NoMetrics_Returns404WithGuidance(t *testing.T) 
 	}
 }
 
+// A cluster that HAS Connect metrics but whose selected date range excludes them all
+// must return 200 with an empty result (not the never-collected 404), so the UI shows
+// an empty chart instead of a misleading "run a scan" error.
+func TestHandleGetConnectMetrics_CollectedButOutOfRange_Returns200(t *testing.T) {
+	mock := &mockReportService{connectMetrics: &types.ConnectClusterMetrics{Metrics: nil}}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for collected-but-out-of-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "scan self-managed-connectors") {
+		t.Errorf("must not show scan-guidance when metrics exist but fall outside the date range: %s", rec.Body.String())
+	}
+}
+
 func TestHandleGetConnectMetrics_FilterError_Returns404(t *testing.T) {
 	mock := &mockReportService{connectErr: fmt.Errorf("cluster 'x' not found in msk sources")}
 	ui := connectMetricsTestUI(mock)
@@ -456,5 +488,83 @@ func TestHandleGetConnectMetrics_FilterError_Returns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 when filter returns not-found error, got %d", rec.Code)
+	}
+}
+
+// oskMetricsTestUI builds a UI whose seeded session "s1" has a non-nil OSKSources so
+// handleGetOSKMetrics passes its "no Apache Kafka sources" guard and reaches the filter.
+func oskMetricsTestUI(mock *mockReportService) *UI {
+	ui := &UI{
+		reportService: mock,
+		states:        make(map[string]*types.State),
+	}
+	ui.states["s1"] = &types.State{OSKSources: &types.OSKSourcesState{}}
+	return ui
+}
+
+func callOSKMetricsHandler(ui *UI, query string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/metrics/osk/osk-kafka"+query, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("clusterId")
+	c.SetParamValues("osk-kafka")
+	_ = ui.handleGetOSKMetrics(c)
+	return rec
+}
+
+// A cluster that never had metrics collected returns 404 with scan guidance.
+func TestHandleGetOSKMetrics_NeverCollected_Returns404WithGuidance(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics:           &types.ProcessedClusterMetrics{Metrics: nil},
+		clusterMetricsUnfiltered: &types.ProcessedClusterMetrics{Metrics: nil},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1&startDate=2030-01-01T00:00:00Z&endDate=2030-01-02T00:00:00Z")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for never-collected metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "scan clusters") {
+		t.Errorf("expected scan-guidance message, got: %s", rec.Body.String())
+	}
+}
+
+// A cluster that HAS metrics but whose selected date range excludes them all returns
+// 200 with an empty result (not the never-collected 404), so the UI shows an empty
+// chart rather than a misleading "run a scan" error.
+func TestHandleGetOSKMetrics_CollectedButOutOfRange_Returns200(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics: &types.ProcessedClusterMetrics{Metrics: nil}, // filtered window: empty
+		clusterMetricsUnfiltered: &types.ProcessedClusterMetrics{ // unfiltered: has data
+			Metrics: []types.ProcessedMetric{{Label: "BytesInPerSec"}},
+		},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1&startDate=2030-01-01T00:00:00Z&endDate=2030-01-02T00:00:00Z")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for collected-but-out-of-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "scan clusters") {
+		t.Errorf("must not show scan-guidance when metrics exist but fall outside the date range: %s", rec.Body.String())
+	}
+}
+
+// Metrics present within the selected range return 200 with data and no re-probe needed.
+func TestHandleGetOSKMetrics_HasData_Returns200(t *testing.T) {
+	mock := &mockReportService{
+		clusterMetrics: &types.ProcessedClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "BytesInPerSec"}},
+		},
+	}
+	ui := oskMetricsTestUI(mock)
+
+	rec := callOSKMetricsHandler(ui, "?sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for in-range metrics, got %d (body: %s)", rec.Code, rec.Body.String())
 	}
 }

--- a/cmd/ui/api/api_test.go
+++ b/cmd/ui/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,8 +16,16 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// mockReportService satisfies the ReportService interface for testing
-type mockReportService struct{}
+// mockReportService satisfies the ReportService interface for testing.
+// The connect* fields configure FilterConnectMetrics and capture the args it was
+// called with, so handler tests can assert source-type/cluster-id passthrough.
+type mockReportService struct {
+	connectMetrics        *types.ConnectClusterMetrics
+	connectErr            error
+	connectCalled         bool
+	lastConnectClusterID  string
+	lastConnectSourceType string
+}
 
 func (m *mockReportService) ProcessState(state types.State) report.ProcessedState {
 	return report.ProcessedState{}
@@ -34,8 +43,11 @@ func (m *mockReportService) FilterClusterMetrics(processedState report.Processed
 	return nil, nil
 }
 
-func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
-	return nil, nil
+func (m *mockReportService) FilterConnectMetrics(processedState report.ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
+	m.connectCalled = true
+	m.lastConnectClusterID = clusterID
+	m.lastConnectSourceType = sourceType
+	return m.connectMetrics, m.connectErr
 }
 
 func newTestUI() *UI {
@@ -298,5 +310,151 @@ func TestGetState_NoStateLoaded_ReturnsNotFound(t *testing.T) {
 	}
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+// connectMetricsTestUI builds a UI with the given mock and a seeded session "s1"
+// so getStateBySession resolves and the connect handler can run.
+func connectMetricsTestUI(mock *mockReportService) *UI {
+	ui := &UI{
+		reportService: mock,
+		states:        make(map[string]*types.State),
+	}
+	ui.states["s1"] = &types.State{}
+	return ui
+}
+
+// callConnectHandler invokes handleGetConnectMetrics with the given path param and
+// query string, returning the recorder for assertions.
+func callConnectHandler(ui *UI, sourceType, query string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/metrics/connect/"+sourceType+query, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("sourceType")
+	c.SetParamValues(sourceType)
+	_ = ui.handleGetConnectMetrics(c)
+	return rec
+}
+
+func TestHandleGetConnectMetrics_OSK_ReturnsMetrics(t *testing.T) {
+	mock := &mockReportService{
+		connectMetrics: &types.ConnectClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "connector-count"}},
+		},
+	}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.lastConnectSourceType != "osk" {
+		t.Errorf("expected sourceType 'osk' passed to filter, got %q", mock.lastConnectSourceType)
+	}
+	if mock.lastConnectClusterID != "osk-kafka" {
+		t.Errorf("expected clusterID 'osk-kafka' passed to filter, got %q", mock.lastConnectClusterID)
+	}
+}
+
+func TestHandleGetConnectMetrics_MSK_ReturnsMetrics(t *testing.T) {
+	mock := &mockReportService{
+		connectMetrics: &types.ConnectClusterMetrics{
+			Metrics: []types.ProcessedMetric{{Label: "connector-count"}},
+		},
+	}
+	ui := connectMetricsTestUI(mock)
+
+	// MSK ARNs contain ':' and '/', so the client URL-encodes them in the query value.
+	arn := "arn%3Aaws%3Akafka%3Aus-east-1%3A123456789012%3Acluster%2Fmsk-kafka%2Fdef-456"
+	rec := callConnectHandler(ui, "msk", "?clusterId="+arn+"&sessionId=s1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.lastConnectSourceType != "msk" {
+		t.Errorf("expected sourceType 'msk' passed to filter, got %q", mock.lastConnectSourceType)
+	}
+	if mock.lastConnectClusterID != "arn:aws:kafka:us-east-1:123456789012:cluster/msk-kafka/def-456" {
+		t.Errorf("expected decoded ARN passed to filter, got %q", mock.lastConnectClusterID)
+	}
+}
+
+// Abuse case: an unknown source type is rejected with 4xx and never reaches the filter.
+func TestHandleGetConnectMetrics_UnknownSourceType_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "foo", "?clusterId=whatever&sessionId=s1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown source type, got %d", rec.Code)
+	}
+	if mock.connectCalled {
+		t.Error("filter must not be called for an unknown source type")
+	}
+}
+
+func TestHandleGetConnectMetrics_MissingClusterId_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?sessionId=s1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing clusterId, got %d", rec.Code)
+	}
+	if mock.connectCalled {
+		t.Error("filter must not be called when clusterId is missing")
+	}
+}
+
+// Abuse case: a malformed date range is rejected with 400 (preserved parseDateRange behavior).
+func TestHandleGetConnectMetrics_MalformedDate_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka&sessionId=s1&startDate=not-a-date")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed date, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetConnectMetrics_MissingSessionId_Returns400(t *testing.T) {
+	mock := &mockReportService{}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "osk", "?clusterId=osk-kafka")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing sessionId, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetConnectMetrics_NoMetrics_Returns404WithGuidance(t *testing.T) {
+	// Filter found the cluster but it carries no Connect metrics (empty struct, nil Metrics).
+	mock := &mockReportService{connectMetrics: &types.ConnectClusterMetrics{}}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "msk", "?clusterId=some-arn&sessionId=s1")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cluster with no Connect metrics, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "scan self-managed-connectors") {
+		t.Errorf("expected scan-guidance message, got: %s", rec.Body.String())
+	}
+}
+
+func TestHandleGetConnectMetrics_FilterError_Returns404(t *testing.T) {
+	mock := &mockReportService{connectErr: fmt.Errorf("cluster 'x' not found in msk sources")}
+	ui := connectMetricsTestUI(mock)
+
+	rec := callConnectHandler(ui, "msk", "?clusterId=x&sessionId=s1")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when filter returns not-found error, got %d", rec.Code)
 	}
 }

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterConnectors.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterConnectors.tsx
@@ -61,6 +61,10 @@ interface ClusterConnectorsProps {
     }
   }
   clusterId?: string
+  // Required: a Connect cluster is distribution-agnostic, so every caller must state
+  // which source set the connect-metrics endpoint should search. Leaving it optional
+  // risks an MSK caller silently falling back to the OSK source and 404-ing.
+  sourceType: 'msk' | 'osk'
 }
 
 export const ClusterConnectors = ({
@@ -68,6 +72,7 @@ export const ClusterConnectors = ({
   selfManagedConnectors = [],
   connectMetrics,
   clusterId,
+  sourceType,
 }: ClusterConnectorsProps) => {
   const [activeTab, setActiveTab] = useState<ConnectorTab>(CONNECTOR_TABS.MSK)
   const [copiedConnector, setCopiedConnector] = useState<string | null>(null)
@@ -290,6 +295,7 @@ export const ClusterConnectors = ({
         {connectMetrics?.metadata && clusterId && (
           <ConnectMetrics
             clusterId={clusterId}
+            sourceType={sourceType}
             connectMetricsMetadata={connectMetrics.metadata}
           />
         )}

--- a/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ConnectMetrics.tsx
@@ -17,6 +17,7 @@ import type { ApiMetadata } from '@/types/api/common'
 
 interface ConnectMetricsProps {
   clusterId: string
+  sourceType: 'msk' | 'osk'
   connectMetricsMetadata?: {
     start_date?: string
     end_date?: string
@@ -27,6 +28,7 @@ interface ConnectMetricsProps {
 
 export const ConnectMetrics = ({
   clusterId,
+  sourceType,
   connectMetricsMetadata,
 }: ConnectMetricsProps) => {
   const [startDate, setStartDate] = useState<Date | undefined>(undefined)
@@ -35,6 +37,7 @@ export const ConnectMetrics = ({
 
   const { metricsResponse, isLoading, error } = useConnectMetricsFetch({
     clusterId,
+    sourceType,
     startDate,
     endDate,
   })

--- a/cmd/ui/frontend/src/components/explore/views/MSKClusterReport.tsx
+++ b/cmd/ui/frontend/src/components/explore/views/MSKClusterReport.tsx
@@ -121,6 +121,11 @@ export const MSKClusterReport = () => {
                 selfManagedConnectors={
                   cluster.kafka_admin_client_information?.self_managed_connectors?.connectors || []
                 }
+                connectMetrics={
+                  cluster.kafka_admin_client_information?.self_managed_connectors?.metrics
+                }
+                clusterId={getClusterArn(cluster) || cluster.arn || undefined}
+                sourceType="msk"
               />
             </div>
           )}

--- a/cmd/ui/frontend/src/components/explore/views/OSKClusterReport.tsx
+++ b/cmd/ui/frontend/src/components/explore/views/OSKClusterReport.tsx
@@ -86,6 +86,7 @@ export const OSKClusterReport = () => {
                 cluster.kafka_admin_client_information?.self_managed_connectors?.metrics
               }
               clusterId={selectedOSKClusterId ?? undefined}
+              sourceType="osk"
             />
           )}
 

--- a/cmd/ui/frontend/src/hooks/useConnectMetricsFetch.ts
+++ b/cmd/ui/frontend/src/hooks/useConnectMetricsFetch.ts
@@ -5,6 +5,7 @@ import { useSessionId } from '@/stores/store'
 
 interface ConnectMetricsFetchConfig {
   clusterId: string
+  sourceType: 'msk' | 'osk'
   startDate: Date | undefined
   endDate: Date | undefined
 }
@@ -21,6 +22,7 @@ interface ConnectMetricsFetchReturn {
  */
 export const useConnectMetricsFetch = ({
   clusterId,
+  sourceType,
   startDate,
   endDate,
 }: ConnectMetricsFetchConfig): ConnectMetricsFetchReturn => {
@@ -40,7 +42,7 @@ export const useConnectMetricsFetch = ({
       setError(null)
 
       try {
-        const data = await apiClient.metrics.getOSKConnectMetrics(clusterId, sessionId, {
+        const data = await apiClient.metrics.getConnectMetrics(sourceType, clusterId, sessionId, {
           startDate,
           endDate,
         })
@@ -53,7 +55,7 @@ export const useConnectMetricsFetch = ({
     }
 
     fetchMetrics()
-  }, [clusterId, startDate, endDate, sessionId])
+  }, [clusterId, sourceType, startDate, endDate, sessionId])
 
   return {
     metricsResponse,

--- a/cmd/ui/frontend/src/services/apiClient.ts
+++ b/cmd/ui/frontend/src/services/apiClient.ts
@@ -187,15 +187,20 @@ const metrics = {
   },
 
   /**
-   * Get Connect metrics for an OSK cluster
+   * Get self-managed Connect metrics for a cluster. Connect is Kafka-distribution
+   * agnostic, so the same endpoint serves both MSK and OSK; sourceType is an explicit
+   * path segment and clusterId is a query param (OSK cluster id, or an MSK ARN — passed
+   * as a query value so its ':' and '/' characters are URL-encoded rather than breaking
+   * path-segment routing).
    */
-  async getOSKConnectMetrics(
+  async getConnectMetrics(
+    sourceType: 'msk' | 'osk',
     clusterId: string,
     sessionId: string,
     params?: MetricsQueryParams,
     config?: RequestConfig
   ): Promise<MetricsApiResponse> {
-    const queryParams: Record<string, string | Date | undefined> = { sessionId }
+    const queryParams: Record<string, string | Date | undefined> = { sessionId, clusterId }
     if (params?.startDate) {
       queryParams.startDate =
         params.startDate instanceof Date ? params.startDate : new Date(params.startDate)
@@ -205,7 +210,7 @@ const metrics = {
         params.endDate instanceof Date ? params.endDate : new Date(params.endDate)
     }
     return get<MetricsApiResponse>(
-      `${API_ENDPOINTS.METRICS}/osk/${encodeURIComponent(clusterId)}/connect`,
+      `${API_ENDPOINTS.METRICS}/connect/${encodeURIComponent(sourceType)}`,
       queryParams,
       config
     )

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -11,6 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/confluentinc/kcp/internal/types"
 )
+
+// ErrNoConnectMetricsCollected reports that a cluster exists but has never had any
+// self-managed Connect metrics collected. It is deliberately distinct from an empty
+// date-filtered result (a cluster that HAS metrics, none of which fall in the queried
+// window): the former warrants a "run a scan" hint, the latter is a valid empty 200.
+// The API layer maps this sentinel to the scan-guidance response via errors.Is.
+var ErrNoConnectMetricsCollected = errors.New("no Connect metrics collected for cluster")
 
 const (
 	// metricTimestampFormat is the timestamp format used for metric data
@@ -356,9 +364,11 @@ func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clu
 
 	smc := adminInfo.SelfManagedConnectors
 	if smc == nil || smc.Metrics == nil {
-		// No Connect metrics collected for this cluster — the handler detects
-		// the nil Metrics slice and returns a "no metrics" response.
-		return &types.ConnectClusterMetrics{}, nil
+		// The cluster exists but no Connect metrics were ever collected. Signal this
+		// distinctly from the empty date-filtered result returned below, so the API
+		// layer shows the "run a scan" hint only when there is genuinely nothing to
+		// collect — not when the user simply picked a window with no data points.
+		return nil, ErrNoConnectMetricsCollected
 	}
 
 	filteredMetrics := rs.filterMetricsByDateRange(smc.Metrics.Metrics, startTime, endTime)

--- a/internal/services/report/report_service.go
+++ b/internal/services/report/report_service.go
@@ -330,29 +330,31 @@ func (rs *ReportService) filterOSKClusterMetrics(processedState ProcessedState, 
 	}, nil
 }
 
-// FilterConnectMetrics filters Connect metrics for an OSK cluster by cluster ID and date range
-func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
-	var targetCluster *ProcessedOSKCluster
+// FilterConnectMetrics filters self-managed Connect metrics for a cluster by cluster ID and
+// date range. Connect is Kafka-distribution agnostic, so the same metrics live on the shared
+// KafkaAdminClientInformation for both MSK and OSK clusters; sourceType selects which source set
+// to search (and which identifier to match: MSK by ARN, OSK by cluster ID). Each branch searches
+// only its own source set, so a cluster identifier never resolves across source types.
+func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clusterID string, sourceType string, startTime, endTime *time.Time) (*types.ConnectClusterMetrics, error) {
+	var adminInfo *types.KafkaAdminClientInformation
 
-	for _, source := range processedState.Sources {
-		if source.Type == types.SourceTypeOSK && source.OSKData != nil {
-			for _, cluster := range source.OSKData.Clusters {
-				if strings.EqualFold(cluster.ID, clusterID) {
-					targetCluster = &cluster
-					break
-				}
-			}
-		}
-		if targetCluster != nil {
-			break
-		}
+	// Dispatch to the matching source set only — this is what structurally prevents
+	// a cluster identifier resolving across source types. Mirrors the dispatcher
+	// shape of FilterClusterMetrics.
+	switch sourceType {
+	case "osk":
+		adminInfo = findOSKConnectAdminInfo(processedState, clusterID)
+	case "msk":
+		adminInfo = findMSKConnectAdminInfo(processedState, clusterID)
+	default:
+		return nil, fmt.Errorf("invalid source type '%s' (must be 'msk' or 'osk')", sourceType)
 	}
 
-	if targetCluster == nil {
-		return nil, fmt.Errorf("cluster '%s' not found in OSK sources", clusterID)
+	if adminInfo == nil {
+		return nil, fmt.Errorf("cluster '%s' not found in %s sources", clusterID, sourceType)
 	}
 
-	smc := targetCluster.KafkaAdminClientInformation.SelfManagedConnectors
+	smc := adminInfo.SelfManagedConnectors
 	if smc == nil || smc.Metrics == nil {
 		// No Connect metrics collected for this cluster — the handler detects
 		// the nil Metrics slice and returns a "no metrics" response.
@@ -371,6 +373,42 @@ func (rs *ReportService) FilterConnectMetrics(processedState ProcessedState, clu
 		Aggregates: aggregates,
 		QueryInfo:  smc.Metrics.QueryInfo,
 	}, nil
+}
+
+// findOSKConnectAdminInfo returns the admin-client info for the OSK cluster matching
+// clusterID (by cluster ID), or nil if no OSK cluster matches.
+func findOSKConnectAdminInfo(processedState ProcessedState, clusterID string) *types.KafkaAdminClientInformation {
+	for _, source := range processedState.Sources {
+		if source.Type != types.SourceTypeOSK || source.OSKData == nil {
+			continue
+		}
+		for _, cluster := range source.OSKData.Clusters {
+			if strings.EqualFold(cluster.ID, clusterID) {
+				info := cluster.KafkaAdminClientInformation
+				return &info
+			}
+		}
+	}
+	return nil
+}
+
+// findMSKConnectAdminInfo returns the admin-client info for the MSK cluster matching
+// clusterID (by ARN), or nil if no MSK cluster matches.
+func findMSKConnectAdminInfo(processedState ProcessedState, clusterID string) *types.KafkaAdminClientInformation {
+	for _, source := range processedState.Sources {
+		if source.Type != types.SourceTypeMSK || source.MSKData == nil {
+			continue
+		}
+		for _, region := range source.MSKData.Regions {
+			for _, cluster := range region.Clusters {
+				if strings.EqualFold(cluster.Arn, clusterID) {
+					info := cluster.KafkaAdminClientInformation
+					return &info
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // filterMetrics filters the processed state by region, cluster, and date range

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -921,7 +921,7 @@ func TestCalculateMetricsAggregates(t *testing.T) {
 func TestFilterConnectMetrics(t *testing.T) {
 	rs := NewReportService()
 
-	connectMetrics := &types.ConnectClusterMetrics{
+	oskConnectMetrics := &types.ConnectClusterMetrics{
 		Metrics: []types.ProcessedMetric{
 			{Start: "2025-01-01T00:00:00Z", End: "2025-01-01T00:01:00Z", Label: "connector-count", Value: ptr(2.0)},
 			{Start: "2025-01-01T00:01:00Z", End: "2025-01-01T00:02:00Z", Label: "connector-count", Value: ptr(2.0)},
@@ -933,6 +933,21 @@ func TestFilterConnectMetrics(t *testing.T) {
 		},
 	}
 
+	mskConnectMetrics := &types.ConnectClusterMetrics{
+		Metrics: []types.ProcessedMetric{
+			{Start: "2025-01-01T00:00:00Z", End: "2025-01-01T00:01:00Z", Label: "connector-count", Value: ptr(5.0)},
+			{Start: "2025-01-02T00:00:00Z", End: "2025-01-02T00:01:00Z", Label: "connector-count", Value: ptr(7.0)},
+		},
+		Metadata: types.ConnectMetricMetadata{Period: 60, MetricsSource: types.MetricBackendPrometheus},
+		QueryInfo: []types.MetricQueryInfo{
+			{MetricName: "connector-count", Statistic: "Point-in-time value (per worker)"},
+		},
+	}
+
+	const mskArn = "arn:aws:kafka:us-east-1:123456789012:cluster/msk-kafka/def-456"
+
+	// State carries BOTH an OSK and an MSK cluster, each with Connect metrics, so the
+	// source-type branches and cross-source isolation can be exercised against one fixture.
 	stateWithConnect := ProcessedState{
 		Sources: []ProcessedSource{
 			{
@@ -946,12 +961,36 @@ func TestFilterConnectMetrics(t *testing.T) {
 									Connectors: []types.SelfManagedConnector{
 										{Name: "test-connector"},
 									},
-									Metrics: connectMetrics,
+									Metrics: oskConnectMetrics,
 								},
 							},
 							Metadata: types.OSKClusterMetadata{
 								Environment: "test",
 								Location:    "local",
+							},
+						},
+					},
+				},
+			},
+			{
+				Type: types.SourceTypeMSK,
+				MSKData: &ProcessedMSKSource{
+					Regions: []ProcessedRegion{
+						{
+							Name: "us-east-1",
+							Clusters: []ProcessedCluster{
+								{
+									Name: "msk-kafka",
+									Arn:  mskArn,
+									KafkaAdminClientInformation: types.KafkaAdminClientInformation{
+										SelfManagedConnectors: &types.SelfManagedConnectors{
+											Connectors: []types.SelfManagedConnector{
+												{Name: "msk-connector"},
+											},
+											Metrics: mskConnectMetrics,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -975,8 +1014,8 @@ func TestFilterConnectMetrics(t *testing.T) {
 		},
 	}
 
-	t.Run("returns Connect metrics for existing cluster", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", nil, nil)
+	t.Run("returns Connect metrics for existing OSK cluster", func(t *testing.T) {
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 3)
@@ -988,32 +1027,101 @@ func TestFilterConnectMetrics(t *testing.T) {
 		assert.Equal(t, "connector-count", result.QueryInfo[0].MetricName)
 	})
 
+	t.Run("returns Connect metrics for existing MSK cluster", func(t *testing.T) {
+		result, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "msk", nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Metrics, 2)
+		assert.Equal(t, types.MetricBackendPrometheus, result.Metadata.MetricsSource, "MSK metrics_source carried through")
+	})
+
 	t.Run("filters by date range", func(t *testing.T) {
 		start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		end := time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC)
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", &start, &end)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", &start, &end)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 2) // only Jan 1 metrics
 	})
 
 	t.Run("cluster not found returns error", func(t *testing.T) {
-		_, err := rs.FilterConnectMetrics(stateWithConnect, "nonexistent", nil, nil)
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "nonexistent", "osk", nil, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("cluster without self-managed connectors returns empty metrics", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", nil, nil)
+		result, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", "osk", nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Nil(t, result.Metrics)
 	})
 
 	t.Run("case-insensitive cluster ID match", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateWithConnect, "OSK-KAFKA", nil, nil)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "OSK-KAFKA", "osk", nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.Metrics, 3)
+	})
+
+	// Abuse case: cross-source-type bleed. A cluster identifier that exists under one
+	// source type must never resolve when queried under the other source type.
+	t.Run("OSK cluster id requested as msk does not bleed", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "msk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("MSK cluster arn requested as osk does not bleed", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "osk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	// Abuse case: an unknown source type is rejected, not silently defaulted to a source.
+	t.Run("unknown source type returns error", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "bogus", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source type")
+	})
+
+	// MSK-branch coverage symmetric to the OSK cases above: not-found, no-connectors,
+	// and date filtering must each be exercised through the MSK lookup path.
+	t.Run("MSK cluster not found returns error", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateWithConnect, "arn:aws:kafka:us-east-1:000000000000:cluster/nope/zzz", "msk", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("MSK cluster without self-managed connectors returns empty metrics", func(t *testing.T) {
+		const arn = "arn:aws:kafka:us-east-1:123456789012:cluster/msk-bare/ghi-789"
+		stateMSKNoConnect := ProcessedState{
+			Sources: []ProcessedSource{
+				{
+					Type: types.SourceTypeMSK,
+					MSKData: &ProcessedMSKSource{
+						Regions: []ProcessedRegion{
+							{
+								Name:     "us-east-1",
+								Clusters: []ProcessedCluster{{Name: "msk-bare", Arn: arn}},
+							},
+						},
+					},
+				},
+			},
+		}
+		result, err := rs.FilterConnectMetrics(stateMSKNoConnect, arn, "msk", nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Nil(t, result.Metrics)
+	})
+
+	t.Run("filters by date range on the MSK path", func(t *testing.T) {
+		start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, mskArn, "msk", &start, &end)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Metrics, 1) // only the Jan 1 MSK metric
 	})
 }

--- a/internal/services/report/report_service_test.go
+++ b/internal/services/report/report_service_test.go
@@ -1050,11 +1050,24 @@ func TestFilterConnectMetrics(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 
-	t.Run("cluster without self-managed connectors returns empty metrics", func(t *testing.T) {
-		result, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", "osk", nil, nil)
+	t.Run("cluster without self-managed connectors signals never-collected", func(t *testing.T) {
+		_, err := rs.FilterConnectMetrics(stateNoConnect, "osk-kafka-no-connect", "osk", nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoConnectMetricsCollected)
+	})
+
+	t.Run("collected metrics outside the date range return empty without error", func(t *testing.T) {
+		// Distinct from "never collected": the cluster HAS Connect metrics, the
+		// selected window just excludes them all. This must NOT surface as the
+		// never-collected sentinel — it is a valid empty result the API serves as a
+		// 200, so the user sees an empty chart rather than a "run a scan" message.
+		start := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2030, 1, 2, 0, 0, 0, 0, time.UTC)
+		result, err := rs.FilterConnectMetrics(stateWithConnect, "osk-kafka", "osk", &start, &end)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		assert.Nil(t, result.Metrics)
+		assert.Empty(t, result.Metrics)
+		assert.NotErrorIs(t, err, ErrNoConnectMetricsCollected)
 	})
 
 	t.Run("case-insensitive cluster ID match", func(t *testing.T) {
@@ -1093,7 +1106,7 @@ func TestFilterConnectMetrics(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 
-	t.Run("MSK cluster without self-managed connectors returns empty metrics", func(t *testing.T) {
+	t.Run("MSK cluster without self-managed connectors signals never-collected", func(t *testing.T) {
 		const arn = "arn:aws:kafka:us-east-1:123456789012:cluster/msk-bare/ghi-789"
 		stateMSKNoConnect := ProcessedState{
 			Sources: []ProcessedSource{
@@ -1110,10 +1123,9 @@ func TestFilterConnectMetrics(t *testing.T) {
 				},
 			},
 		}
-		result, err := rs.FilterConnectMetrics(stateMSKNoConnect, arn, "msk", nil, nil)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		assert.Nil(t, result.Metrics)
+		_, err := rs.FilterConnectMetrics(stateMSKNoConnect, arn, "msk", nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoConnectMetricsCollected)
 	})
 
 	t.Run("filters by date range on the MSK path", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Kafka Connect is distribution-agnostic, but the Connect-metrics display added in #303 was wired OSK-only. MSK clusters already collect self-managed Connect metrics at scan time (onto `KafkaAdminClientInformation.SelfManagedConnectors.Metrics`) — they just weren't displayed. This generalizes the UI/API plumbing so the same charts/table/query view renders for MSK too, and hardens a few connector edges surfaced in review.

Stacked on top of #358 (`feat/connect-metrics-metadata`).

## Show Connect metrics for MSK clusters (`7556133d`)

- `FilterConnectMetrics` now takes a `sourceType` and searches only the matching source set (OSK by cluster ID, MSK by ARN) via per-source finder helpers, mirroring the `FilterClusterMetrics` dispatcher — a cluster id never resolves across source types.
- Replaced `GET /metrics/osk/:clusterId/connect` with a source-type route `GET /metrics/connect/:sourceType?clusterId=...`. The literal `connect` first segment avoids Echo static-node shadowing of `/metrics/:region/:cluster`, and `clusterId` moves to a query param so MSK ARNs (which contain `/`) aren't split across path segments.
- Frontend: `getOSKConnectMetrics` → `getConnectMetrics(sourceType, ...)`; `useConnectMetricsFetch` and `ConnectMetrics`/`ClusterConnectors` thread a required `sourceType`; `MSKClusterReport` passes the ARN + `"msk"`, `OSKClusterReport` passes `"osk"`.

## Hardening (`4e4380e1`)

- **migrate-connectors (self-managed):** guard the `connector.class` type assertion so a non-string value returns a per-connector error instead of panicking the whole run.
- **migrate-connectors (MSK):** added a path-traversal test asserting a hostile `../` connector name stays inside `OutputDir`.
- **ui/api + report:** distinguish "no Connect metrics ever collected" (404 + scan guidance via new `report.ErrNoConnectMetricsCollected` sentinel) from "collected, but none in the selected date range" (empty 200 → empty chart). Same disambiguation applied to the OSK broker-metrics handler.
- **discover:** match connectors to clusters by exact bootstrap `host:port` equality instead of substring containment.

## Testing

- `go test ./...` — all 51 packages pass.
- Tests cover OSK + MSK happy paths, date filtering, and abuse cases: cross-source bleed (both directions), unknown sourceType (4xx), and no-metrics (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
