### PR TITLE
fix: install script rate limit, stronger dev warning, remove stale changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Scan existing Kafka deployments, generate migration plans and cost reports, create infrastructure-as-code assets, and execute end-to-end migrations with real-time monitoring.
 
-> **[Full documentation](https://confluentinc.github.io/kcp/)** · **[Latest release](https://github.com/confluentinc/kcp/releases/latest)** · **[Changelog](CHANGELOG.md)**
+> **[Full documentation](https://confluentinc.github.io/kcp/)** · **[Latest release](https://github.com/confluentinc/kcp/releases/latest)**
 
 ## Installation
 

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -65,11 +65,12 @@ var RootCmd = &cobra.Command{
 		// --- End logging setup ---
 
 		if build_info.IsDev() {
-			fmt.Printf("\n%s\n%s\n%s\n%s\n\n",
-				color.RedString("┌─────────────────────────────────────────────────────────────────────────┐"),
-				color.RedString("│ ⚠️  WARNING: This is a development build                                │"),
-				color.RedString("│ Official releases: https://github.com/confluentinc/kcp/releases         │"),
-				color.RedString("└─────────────────────────────────────────────────────────────────────────┘"))
+			fmt.Printf("\n%s\n%s\n%s\n%s\n%s\n\n",
+				color.RedString("┌─────────────────────────────────────────────────────────────────────────────────────────────┐"),
+				color.RedString("│ ⚠️  WARNING: This is a development build — not a defined release.                           │"),
+				color.RedString("│ This build and any state files it generates should NOT be used for production or live use.  │"),
+				color.RedString("│ Install a released binary: https://github.com/confluentinc/kcp/releases                    │"),
+				color.RedString("└─────────────────────────────────────────────────────────────────────────────────────────────┘"))
 		}
 
 		fmt.Printf("%s %s %s %s\n",

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -67,9 +67,9 @@ var RootCmd = &cobra.Command{
 		if build_info.IsDev() {
 			fmt.Printf("\n%s\n%s\n%s\n%s\n%s\n\n",
 				color.RedString("┌─────────────────────────────────────────────────────────────────────────────────────────────┐"),
-				color.RedString("│ ⚠️  WARNING: This is a development build — not a defined release.                           │"),
+				color.RedString("│ ⚠️  WARNING: This is a development build — not a defined release.                            │"),
 				color.RedString("│ This build and any state files it generates should NOT be used for production or live use.  │"),
-				color.RedString("│ Install a released binary: https://github.com/confluentinc/kcp/releases                    │"),
+				color.RedString("│ Install a released binary: https://github.com/confluentinc/kcp/releases                     │"),
 				color.RedString("└─────────────────────────────────────────────────────────────────────────────────────────────┘"))
 		}
 

--- a/install.sh
+++ b/install.sh
@@ -56,10 +56,15 @@ if [ -n "${KCP_VERSION:-}" ]; then
   TAG="$KCP_VERSION"
 else
   echo "Resolving latest kcp release..."
-  TAG=$($DOWNLOAD "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name":' \
-    | sed -E 's/.*"([^"]+)".*/\1/')
-  [ -n "$TAG" ] || err "could not determine the latest release tag from the GitHub API"
+  # Use the releases/latest redirect instead of the API to avoid
+  # unauthenticated rate limits (60/hr shared per IP).
+  LATEST_URL="https://github.com/${REPO}/releases/latest"
+  if command -v curl >/dev/null 2>&1; then
+    TAG=$(curl -fsSL -o /dev/null -w '%{url_effective}' "$LATEST_URL" | sed 's|.*/tag/||')
+  else
+    TAG=$(wget --spider -S "$LATEST_URL" 2>&1 | grep -i 'Location:' | tail -1 | sed 's|.*/tag/||' | tr -d '[:space:]')
+  fi
+  [ -n "$TAG" ] || err "could not determine the latest release tag"
 fi
 
 BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"


### PR DESCRIPTION
## Summary

- **install.sh**: Switch version resolution from GitHub API to redirect-based approach, avoiding the 60/hr unauthenticated rate limit that affects users on shared IPs (e.g. corporate VPNs)
- **Dev warning**: Strengthen the terminal warning for dev builds to explicitly state that this build and its state files should not be used for production or live use
- **README**: Remove stale Changelog link

## Testing

Dev warning confirmed across multiple commands (`kcp discover`, `kcp scan clusters`):

<img width="858" height="590" alt="image" src="https://github.com/user-attachments/assets/dae2ca07-499d-4bd8-91fe-bde48a84095a" />


> Screenshot shows the updated warning banner appearing consistently on `./kcp discover` and `./kcp scan clusters`, with the stronger wording about production/live use.

Install script redirect tested:
```
$ curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/confluentinc/kcp/releases/latest | sed 's|.*/tag/||'
v0.8.5
```

## Test plan

- [x] `make test-go` — all unit tests pass
- [x] `make build && ./kcp version` — dev warning banner shows updated wording
- [x] Redirect-based version resolution returns correct tag (`v0.8.5`)
- [x] Dev warning displays on `kcp discover` and `kcp scan clusters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)