### PR TITLE
fix(lint): resolve pre-existing lint violations breaking tagged builds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,3 @@ linters:
 formatters:
   enable:
     - gofmt
-
-issues:
-  new-from-rev: main

--- a/cmd/create_asset/migrate_connectors/connector_utility/cmd_connector_utility.go
+++ b/cmd/create_asset/migrate_connectors/connector_utility/cmd_connector_utility.go
@@ -122,18 +122,16 @@ func parseConnectorUtilityOpts() (*ConnectorUtilityOpts, error) {
 			return nil, fmt.Errorf("no connectors found for cluster %s in %s. The cluster exists but has no MSK Connect or self-managed connectors", cluster.Name, stateFile)
 		}
 		clustersByArn[clusterId] = cluster
-	} else {
-		if state.MSKSources != nil {
-			for _, region := range state.MSKSources.Regions {
-				for i := range region.Clusters {
-					cluster := &region.Clusters[i]
-					// Include cluster if it has any connectors (MSK Connect or self-managed)
-					hasConnectors := len(cluster.AWSClientInformation.Connectors) > 0 ||
-						(cluster.KafkaAdminClientInformation.SelfManagedConnectors != nil &&
-							len(cluster.KafkaAdminClientInformation.SelfManagedConnectors.Connectors) > 0)
-					if hasConnectors {
-						clustersByArn[cluster.Arn] = cluster
-					}
+	} else if state.MSKSources != nil {
+		for _, region := range state.MSKSources.Regions {
+			for i := range region.Clusters {
+				cluster := &region.Clusters[i]
+				// Include cluster if it has any connectors (MSK Connect or self-managed)
+				hasConnectors := len(cluster.AWSClientInformation.Connectors) > 0 ||
+					(cluster.KafkaAdminClientInformation.SelfManagedConnectors != nil &&
+						len(cluster.KafkaAdminClientInformation.SelfManagedConnectors.Connectors) > 0)
+				if hasConnectors {
+					clustersByArn[cluster.Arn] = cluster
 				}
 			}
 		}

--- a/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/msk/msk_connectors_migrator_test.go
@@ -275,7 +275,7 @@ func TestMskConnectorMigrator_Run_CreatesOutputDirectory(t *testing.T) {
 	migrator := NewMskConnectorMigrator(opts)
 
 	// Run will fail at API call, but directory should be created.
-	migrator.Run()
+	_ = migrator.Run()
 
 	// Verify directory was created.
 	info, err := os.Stat(outputPath)

--- a/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
+++ b/cmd/create_asset/migrate_connectors/self_managed/self_managed_connectors_migrator_test.go
@@ -275,7 +275,7 @@ func TestSelfManagedConnectorMigrator_Run_CreatesOutputDirectory(t *testing.T) {
 	migrator := NewSelfManagedConnectorMigrator(opts)
 
 	// Run will fail at API call, but directory should be created.
-	migrator.Run()
+	_ = migrator.Run()
 
 	// Verify directory was created.
 	info, err := os.Stat(outputPath)

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -62,14 +62,14 @@ func (m *MigrationExecutor) Run() error {
 	if err != nil {
 		return err
 	}
-	defer sourceOffset.Close()
+	defer func() { _ = sourceOffset.Close() }()
 
 	// Create destination Kafka client (CC)
 	destinationOffset, err := m.createDestinationOffset()
 	if err != nil {
 		return err
 	}
-	defer destinationOffset.Close()
+	defer func() { _ = destinationOffset.Close() }()
 
 	httpClient := http.DefaultClient
 	if m.opts.InsecureSkipTLSVerify {

--- a/cmd/migration/lagcheck/lagcheck_tui.go
+++ b/cmd/migration/lagcheck/lagcheck_tui.go
@@ -248,10 +248,10 @@ func (m model) View() string {
 	b.WriteString("  ")
 	if m.err != nil {
 		b.WriteString(indicatorError)
-		b.WriteString(fmt.Sprintf(" Refreshing every %ds (error, retrying...)", m.pollSeconds))
+		fmt.Fprintf(&b, " Refreshing every %ds (error, retrying...)", m.pollSeconds)
 	} else {
 		b.WriteString(indicatorRunning)
-		b.WriteString(fmt.Sprintf(" Refreshing every %ds", m.pollSeconds))
+		fmt.Fprintf(&b, " Refreshing every %ds", m.pollSeconds)
 	}
 
 	if !m.lastUpdated.IsZero() {

--- a/internal/services/clusterlink/clusterlink.go
+++ b/internal/services/clusterlink/clusterlink.go
@@ -313,7 +313,7 @@ func (s *ConfluentCloudService) doRequest(ctx context.Context, config Config, pa
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
@@ -350,7 +350,7 @@ func (s *ConfluentCloudService) doPostRequest(ctx context.Context, config Config
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(res.Body)

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -383,14 +383,14 @@ func buildJMXQueryInfo(endpointURLs []string, duration, interval time.Duration, 
 				mb.ValueKey, mb.MBean, entityName)
 		}
 		infos = append(infos, types.MetricQueryInfo{
-			MetricName:    mb.Name,
-			SourceType:    types.MetricBackendJolokia,
-			Statistic:     statistic,
-			Period:        periodSec,
-			QueryDuration: durationStr,
-			MBeanPath:     mb.MBean,
-			JolokiaURL:    exampleURL,
-			CurlCommand:   fmt.Sprintf("curl '%s/read/%s'", exampleURL, mb.MBean),
+			MetricName:      mb.Name,
+			SourceType:      types.MetricBackendJolokia,
+			Statistic:       statistic,
+			Period:          periodSec,
+			QueryDuration:   durationStr,
+			MBeanPath:       mb.MBean,
+			JolokiaURL:      exampleURL,
+			CurlCommand:     fmt.Sprintf("curl '%s/read/%s'", exampleURL, mb.MBean),
 			AggregationNote: note,
 		})
 	}
@@ -417,14 +417,14 @@ func buildJMXQueryInfo(endpointURLs []string, duration, interval time.Duration, 
 			"Wildcard MBean pattern %s; the %s attribute is summed across all matching MBeans on all %d %s(s). Add -u user:pass to the curl command if authentication is configured.",
 			mb.MBean, mb.Attribute, endpointCount, entityName)
 		infos = append(infos, types.MetricQueryInfo{
-			MetricName:    mb.Name,
-			SourceType:    types.MetricBackendJolokia,
-			Statistic:     statistic,
-			Period:        periodSec,
-			QueryDuration: durationStr,
-			MBeanPath:     mb.MBean,
-			JolokiaURL:    exampleURL,
-			CurlCommand:   fmt.Sprintf("curl '%s/read/%s/%s'", exampleURL, mb.MBean, mb.Attribute),
+			MetricName:      mb.Name,
+			SourceType:      types.MetricBackendJolokia,
+			Statistic:       statistic,
+			Period:          periodSec,
+			QueryDuration:   durationStr,
+			MBeanPath:       mb.MBean,
+			JolokiaURL:      exampleURL,
+			CurlCommand:     fmt.Sprintf("curl '%s/read/%s/%s'", exampleURL, mb.MBean, mb.Attribute),
 			AggregationNote: note,
 		})
 	}

--- a/internal/services/markdown/markdown_service_test.go
+++ b/internal/services/markdown/markdown_service_test.go
@@ -21,7 +21,7 @@ func TestPrintMarkdownTable(t *testing.T) {
 	}
 
 	t.Log("Basic table (all values shown):")
-	New().AddTable(headers, data).Print()
+	_ = New().AddTable(headers, data).Print()
 }
 
 func TestPrintMarkdownTableWithMissingData(t *testing.T) {
@@ -34,7 +34,7 @@ func TestPrintMarkdownTableWithMissingData(t *testing.T) {
 		{"Lando Norris", "McLaren", "205", "0"},
 	}
 
-	New().AddTable(headers, data).Print()
+	_ = New().AddTable(headers, data).Print()
 }
 
 func TestPrintMarkdownTableWithSkipRepeat(t *testing.T) {
@@ -55,7 +55,7 @@ func TestPrintMarkdownTableWithSkipRepeat(t *testing.T) {
 
 	// Skip repeating values for Team (column 0) and Nationality (column 2)
 	t.Log("Table with repeated values hidden:")
-	New().AddTable(headers, data, 0, 2).Print()
+	_ = New().AddTable(headers, data, 0, 2).Print()
 }
 
 func TestMarkdownBuilder(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMarkdownBuilder(t *testing.T) {
 	md.AddCodeBlock("fmt.Println(\"F1 Championship 2025\")", "go")
 	md.AddHorizontalRule()
 	md.AddParagraph("Report generated using the markdown builder.")
-	md.Print()
+	_ = md.Print()
 }
 
 func TestMarkdownBuilderWithSkipRepeat(t *testing.T) {
@@ -102,7 +102,7 @@ func TestMarkdownBuilderWithSkipRepeat(t *testing.T) {
 	md.AddParagraph("Showing drivers by team with skip repeat on team column.")
 	md.AddTable(headers, data, 0) // Skip repeat on team column
 	md.AddParagraph("Notice how the team name only shows once per group.")
-	md.Print()
+	_ = md.Print()
 }
 
 func TestPrintOptions(t *testing.T) {

--- a/internal/utils/input_validation.go
+++ b/internal/utils/input_validation.go
@@ -124,7 +124,7 @@ func BindEnvToFlags(cmd *cobra.Command) error {
 		// e.g., "vpc-id" -> "VPC_ID"
 		envVarName := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 
-		v.BindEnv(flagName, envVarName)
+		_ = v.BindEnv(flagName, envVarName)
 
 		// If the flag wasn't explicitly set via command line
 		// AND
@@ -133,7 +133,7 @@ func BindEnvToFlags(cmd *cobra.Command) error {
 		// set the flag value from the environment
 		if !f.Changed && v.IsSet(flagName) {
 			val := v.Get(flagName)
-			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+			_ = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Remove `new-from-rev: main` from `.golangci.yml` — this setting masked 17 pre-existing lint violations by only reporting issues on changed lines. On tagged release builds, `main` doesn't exist in the checkout, causing the diff processor to fail and fall back to full-repo scanning, which exposed all 17 issues and failed the build.
- Fix all 17 pre-existing violations across 9 files: unchecked error returns (`errcheck`), `else { if }` → `else if` (`gocritic`), `WriteString(Sprintf(...))` → `Fprintf` (`staticcheck`), and misaligned struct fields (`gofmt`).

## Test plan
- [x] `golangci-lint run --config .golangci.yml ./...` reports 0 issues
- [x] `make test-go` passes all unit tests
- [ ] Verify next tagged release build passes lint in Semaphore

🤖 Generated with [Claude Code](https://claude.com/claude-code)