### PR TITLE
fix(scan): clearer schema-registry URL errors + Apicurio guidance

### DIFF
--- a/cmd/scan/schema_registry/cmd_scan_schema_registry.go
+++ b/cmd/scan/schema_registry/cmd_scan_schema_registry.go
@@ -72,7 +72,7 @@ func NewScanSchemaRegistryCmd() *cobra.Command {
 	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
 	requiredFlags.SortFlags = false
 	requiredFlags.StringVar(&stateFile, "state-file", "", "The path to the kcp state file.")
-	requiredFlags.StringVar(&srType, "sr-type", "", "Schema registry type: 'confluent' or 'glue'")
+	requiredFlags.StringVar(&srType, "sr-type", "", "Schema registry type: 'confluent' or 'glue'. Use 'confluent' for any registry exposing a Confluent-compatible REST API, e.g. Apicurio via its /apis/ccompat/v7 endpoint.")
 	schemaRegistryCmd.Flags().AddFlagSet(requiredFlags)
 
 	confluentFlags := pflag.NewFlagSet("confluent", pflag.ExitOnError)

--- a/cmd/scan/schema_registry/cmd_scan_schema_registry.go
+++ b/cmd/scan/schema_registry/cmd_scan_schema_registry.go
@@ -179,6 +179,14 @@ func runScanConfluentSchemaRegistry() error {
 		return fmt.Errorf("failed to get auth option: %v", err)
 	}
 
+	// Pre-flight the endpoint before handing off to the confluent-kafka-go client,
+	// which would otherwise surface a non-JSON (HTML) response as the opaque
+	// "invalid character '<'". The validator's error is already actionable, so it
+	// is returned as-is rather than re-wrapped.
+	if err := client.ValidateConfluentSchemaRegistryURL(opts.Url, authOption); err != nil {
+		return err
+	}
+
 	schemaRegistryClient, err := client.NewSchemaRegistryClient(opts.Url, authOption)
 	if err != nil {
 		return fmt.Errorf("failed to create schema registry client: %v", err)

--- a/cmd/scan/schema_registry/cmd_scan_schema_registry_test.go
+++ b/cmd/scan/schema_registry/cmd_scan_schema_registry_test.go
@@ -1,0 +1,55 @@
+package schema_registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMinimalStateFile writes an empty-but-valid kcp state file and returns its path.
+func writeMinimalStateFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0o600))
+	return path
+}
+
+// setConfluentFlags sets the package-level flag vars the confluent scan reads and
+// restores them after the test to avoid cross-test bleed.
+func setConfluentFlags(t *testing.T, serverURL, statePath string) {
+	t.Helper()
+	origURL, origUnauth, origBasic, origUser, origPass, origState := url, useUnauthenticated, useBasicAuth, username, password, stateFile
+	t.Cleanup(func() {
+		url, useUnauthenticated, useBasicAuth, username, password, stateFile = origURL, origUnauth, origBasic, origUser, origPass, origState
+	})
+
+	url = serverURL
+	useUnauthenticated = true
+	useBasicAuth = false
+	username = ""
+	password = ""
+	stateFile = statePath
+}
+
+func TestRunScanConfluentSchemaRegistry_PreflightBlocksHtmlEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!DOCTYPE html><html><body>not a registry</body></html>"))
+	}))
+	defer server.Close()
+
+	setConfluentFlags(t, server.URL, writeMinimalStateFile(t))
+
+	err := runScanConfluentSchemaRegistry()
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid character",
+		"the pre-flight must replace the opaque library decode error")
+	assert.Contains(t, err.Error(), "does not look like a Schema Registry",
+		"the actionable pre-flight message should reach the user")
+}

--- a/internal/client/schema_registry.go
+++ b/internal/client/schema_registry.go
@@ -38,8 +38,10 @@ func configureBasicAuth(srConfig *schemaregistry.Config, username, password stri
 	srConfig.BasicAuthUserInfo = fmt.Sprintf("%s:%s", username, password)
 }
 
-// NewSchemaRegistryClient creates a new Schema Registry client for the given URL
-func NewSchemaRegistryClient(url string, opts ...SchemaRegistryOption) (schemaregistry.Client, error) {
+// resolveSchemaRegistryConfig applies the given options onto a default
+// (unauthenticated) config. Shared by NewSchemaRegistryClient and the pre-flight
+// validator so both honor the same auth resolution.
+func resolveSchemaRegistryConfig(opts ...SchemaRegistryOption) SchemaRegistryConfig {
 	config := SchemaRegistryConfig{
 		authType: types.SchemaRegistryAuthTypeUnauthenticated,
 	}
@@ -47,6 +49,13 @@ func NewSchemaRegistryClient(url string, opts ...SchemaRegistryOption) (schemare
 	for _, opt := range opts {
 		opt(&config)
 	}
+
+	return config
+}
+
+// NewSchemaRegistryClient creates a new Schema Registry client for the given URL
+func NewSchemaRegistryClient(url string, opts ...SchemaRegistryOption) (schemaregistry.Client, error) {
+	config := resolveSchemaRegistryConfig(opts...)
 
 	srConfig := schemaregistry.NewConfig(url)
 

--- a/internal/client/schema_registry_preflight.go
+++ b/internal/client/schema_registry_preflight.go
@@ -1,0 +1,166 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/confluentinc/kcp/internal/types"
+)
+
+const (
+	// maxSnippetRunes bounds how much of an attacker-influenceable response body
+	// is embedded in an error message.
+	maxSnippetRunes = 200
+	// maxProbeBodyBytes caps how many bytes of the probe response are read into
+	// memory, so a hostile or huge response cannot exhaust it.
+	maxProbeBodyBytes = 4096
+	// probeTimeout bounds the whole pre-flight request.
+	probeTimeout = 30 * time.Second
+)
+
+// ValidateConfluentSchemaRegistryURL performs a pre-flight GET against the
+// Schema Registry's /config endpoint (the same endpoint the scan's first call
+// hits) and returns a clear, class-distinct error when the endpoint is not a
+// usable Schema Registry. It honors the same auth options as the scan and
+// returns nil only when the endpoint responds 2xx with a JSON body.
+//
+// It exists because confluent-kafka-go decodes any 2xx body as JSON without
+// checking Content-Type; pointing --url at an HTML endpoint otherwise surfaces
+// the opaque "invalid character '<' looking for beginning of value".
+func ValidateConfluentSchemaRegistryURL(rawURL string, opts ...SchemaRegistryOption) error {
+	cfg := resolveSchemaRegistryConfig(opts...)
+
+	probeURL, err := buildConfigProbeURL(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid schema registry url %q: %w", rawURL, err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, probeURL, nil)
+	if err != nil {
+		return fmt.Errorf("invalid schema registry url %q: %w", rawURL, err)
+	}
+	if cfg.authType == types.SchemaRegistryAuthTypeBasicAuth {
+		req.SetBasicAuth(cfg.username, cfg.password)
+	}
+
+	httpClient := &http.Client{
+		Timeout: probeTimeout,
+		// Refuse redirects: a real Schema Registry /config responds directly, so a
+		// 3xx is surfaced as a class-distinct error rather than followed. This
+		// blocks SSRF to internal/metadata addresses and stops the basic-auth
+		// header from following a cross-scheme/host redirect.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not reach schema registry at %s: %w", displayURL(rawURL), err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes))
+
+	switch {
+	case resp.StatusCode >= 300 && resp.StatusCode < 400:
+		return fmt.Errorf("schema registry at %s returned an unexpected redirect (HTTP %d to %s); a Schema Registry REST API responds directly, so this URL is being refused — verify --url",
+			displayURL(rawURL), resp.StatusCode, sanitizeBodySnippet([]byte(resp.Header.Get("Location"))))
+
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("schema registry at %s rejected the request with an authentication error (HTTP %d); check --use-basic-auth / --username / --password",
+			displayURL(rawURL), resp.StatusCode)
+
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		// A real Schema Registry reports errors as a JSON body
+		// ({"error_code":..,"message":".."}) — that message is the useful part, so
+		// surface it. A non-JSON body (an HTML error page from a proxy/web server)
+		// is noise, so report only the status and point at the URL.
+		if isJSONBody(body) {
+			return fmt.Errorf("schema registry at %s returned HTTP %d: %s",
+				displayURL(rawURL), resp.StatusCode, sanitizeBodySnippet(body))
+		}
+		return notSchemaRegistryError(rawURL, fmt.Sprintf("it returned HTTP %d with a non-JSON (%s) body",
+			resp.StatusCode, contentTypeOrUnknown(resp.Header.Get("Content-Type"))))
+
+	default:
+		if !isJSONBody(body) {
+			return notSchemaRegistryError(rawURL, fmt.Sprintf("it returned a non-JSON response (Content-Type: %s)",
+				contentTypeOrUnknown(resp.Header.Get("Content-Type"))))
+		}
+		return nil
+	}
+}
+
+// isJSONBody reports whether body parses as JSON. confluent-kafka-go decodes any
+// body as JSON without this check, which is the root cause this pre-flight guards.
+func isJSONBody(body []byte) bool {
+	var raw json.RawMessage
+	return json.Unmarshal(body, &raw) == nil
+}
+
+// notSchemaRegistryError builds the message shown when an endpoint responds but
+// is not a Schema Registry REST API. It deliberately omits the response body —
+// an HTML error/login page is noise — and gives the operator a next step.
+func notSchemaRegistryError(rawURL, detail string) error {
+	return fmt.Errorf("%s does not look like a Schema Registry REST API: %s; verify --url points to the Schema Registry endpoint",
+		displayURL(rawURL), detail)
+}
+
+// buildConfigProbeURL appends the Schema Registry global config path to the
+// user-supplied base URL, tolerating a trailing slash.
+func buildConfigProbeURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/config"
+	return u.String(), nil
+}
+
+// displayURL renders a scheme://host form of the URL for error messages, which
+// avoids echoing any userinfo, path, or query the caller may have supplied.
+func displayURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func contentTypeOrUnknown(ct string) string {
+	if ct == "" {
+		return "unknown"
+	}
+	return ct
+}
+
+// sanitizeBodySnippet makes a response-body fragment safe to embed in an error
+// message and log line: control characters (including newlines and tabs) are
+// replaced with spaces, runs of whitespace are collapsed, the result is trimmed,
+// and it is truncated to a bounded length with an ellipsis. This guards against
+// log injection and oversized error output from a hostile or wrong endpoint.
+func sanitizeBodySnippet(body []byte) string {
+	var b strings.Builder
+	for _, r := range string(body) {
+		if unicode.IsControl(r) {
+			b.WriteRune(' ')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+
+	collapsed := strings.Join(strings.Fields(b.String()), " ")
+
+	runes := []rune(collapsed)
+	if len(runes) > maxSnippetRunes {
+		return string(runes[:maxSnippetRunes]) + "…"
+	}
+	return collapsed
+}

--- a/internal/client/schema_registry_preflight_test.go
+++ b/internal/client/schema_registry_preflight_test.go
@@ -1,0 +1,245 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeBodySnippet(t *testing.T) {
+	t.Run("strips control characters and collapses whitespace to single line", func(t *testing.T) {
+		got := sanitizeBodySnippet([]byte("line1\nline2\ttab\r\n\x00end"))
+
+		assert.Equal(t, "line1 line2 tab end", got)
+		assert.NotContains(t, got, "\n")
+		assert.NotContains(t, got, "\t")
+		assert.NotContains(t, got, "\r")
+		assert.NotContains(t, got, "\x00")
+	})
+
+	t.Run("truncates an over-long body with an ellipsis and stays bounded", func(t *testing.T) {
+		got := sanitizeBodySnippet([]byte(strings.Repeat("a", 500)))
+
+		assert.True(t, strings.HasSuffix(got, "…"), "expected ellipsis suffix, got %q", got)
+		assert.LessOrEqual(t, utf8.RuneCountInString(got), 201, "snippet should be bounded")
+	})
+
+	t.Run("leaves a short clean body unchanged", func(t *testing.T) {
+		assert.Equal(t, "hello world", sanitizeBodySnippet([]byte("hello world")))
+	})
+
+	t.Run("returns empty string for empty body", func(t *testing.T) {
+		assert.Equal(t, "", sanitizeBodySnippet([]byte{}))
+	})
+}
+
+const validConfigJSON = `{"compatibilityLevel":"BACKWARD"}`
+
+func TestValidateConfluentSchemaRegistryURL(t *testing.T) {
+	t.Run("passes for a real schema registry (unauthenticated, JSON /config)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/config", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, validConfigJSON)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		assert.NoError(t, err)
+	})
+
+	t.Run("passes and sends basic auth when configured", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			u, p, ok := r.BasicAuth()
+			assert.True(t, ok, "expected basic auth header")
+			assert.Equal(t, "admin", u)
+			assert.Equal(t, "s3cr3t", p)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, validConfigJSON)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithBasicAuth("admin", "s3cr3t"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects HTML on a 2xx without leaking the json decode error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprint(w, "<!DOCTYPE html><html><body>not a registry</body></html>")
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "invalid character", "must not surface the raw json decode error")
+		assert.NotContains(t, err.Error(), "<", "must not dump the HTML body")
+		assert.Contains(t, err.Error(), "text/html", "should name the observed content-type")
+		assert.Contains(t, err.Error(), "does not look like a Schema Registry")
+	})
+
+	t.Run("rejects HTML body even when Content-Type lies that it is JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, "<!DOCTYPE html><html></html>")
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "invalid character")
+	})
+
+	t.Run("reports authentication failure on 401 without leaking credentials", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithBasicAuth("secret-user", "secret-pass"))
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "auth")
+		assert.NotContains(t, err.Error(), "secret-user")
+		assert.NotContains(t, err.Error(), "secret-pass")
+	})
+
+	t.Run("reports authentication failure on 403", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "auth")
+	})
+
+	t.Run("surfaces the schema registry's JSON error body on a non-2xx", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `{"error_code":50001,"message":"backend exploded"}`)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "backend exploded", "a JSON error body is the meaningful part — surface it")
+	})
+
+	t.Run("does not dump an HTML body on a non-2xx, gives url guidance instead", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, "<!DOCTYPE html><html><body>Example Domain</body></html>")
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404", "the status code is the useful signal")
+		assert.Contains(t, err.Error(), "does not look like a Schema Registry")
+		assert.NotContains(t, err.Error(), "<", "must not dump the HTML body")
+		assert.NotContains(t, err.Error(), "Example Domain")
+	})
+
+	t.Run("reports an unreachable host naming the url", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := server.URL
+		server.Close() // free the port so the connection is refused
+
+		err := ValidateConfluentSchemaRegistryURL(url, WithUnauthenticated())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "127.0.0.1", "should name the url host")
+	})
+
+	t.Run("does not leak credentials on a transport error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := server.URL
+		server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(url, WithBasicAuth("secret-user", "secret-pass"))
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "secret-user")
+		assert.NotContains(t, err.Error(), "secret-pass")
+	})
+
+	t.Run("bounds the snippet for an oversized body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, strings.Repeat("x", 5_000_000))
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err)
+		assert.Less(t, utf8.RuneCountInString(err.Error()), 1000, "error must stay bounded regardless of body size")
+	})
+
+	t.Run("rejects an untrusted TLS certificate rather than passing", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, validConfigJSON)
+		}))
+		defer server.Close()
+
+		// Default client (the validator's) does not trust the self-signed cert.
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err, "an untrusted TLS cert must not be silently accepted")
+	})
+
+	t.Run("refuses to follow a redirect (no SSRF / credential-follow)", func(t *testing.T) {
+		redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("redirect target must not be requested: %s", r.URL.Path)
+		}))
+		defer redirectTarget.Close()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirectTarget.URL+"/config", http.StatusFound)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		require.Error(t, err, "a redirect must surface as an error, not be followed")
+		assert.Contains(t, err.Error(), "redirect", "should classify the failure as a redirect, not a generic non-2xx")
+	})
+
+	t.Run("does not send an Authorization header when unauthenticated", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _, ok := r.BasicAuth()
+			assert.False(t, ok, "no basic auth header expected when unauthenticated")
+			assert.Empty(t, r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, validConfigJSON)
+		}))
+		defer server.Close()
+
+		err := ValidateConfluentSchemaRegistryURL(server.URL, WithUnauthenticated())
+		assert.NoError(t, err)
+	})
+
+	t.Run("redacts credentials embedded in the url from the error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprint(w, "<!DOCTYPE html><html></html>")
+		}))
+		defer server.Close()
+
+		u, err := url.Parse(server.URL)
+		require.NoError(t, err)
+		u.User = url.UserPassword("url-user", "url-secret")
+
+		err = ValidateConfluentSchemaRegistryURL(u.String(), WithUnauthenticated())
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "url-secret")
+		assert.NotContains(t, err.Error(), "url-user")
+	})
+}


### PR DESCRIPTION
## What & why

Improves the experience of running `kcp scan schema-registry --sr-type confluent` against Confluent-compatible registries (notably **Apicurio**).

Previously, pointing `--url` at the wrong place — an Apicurio host root, an ingress/route, a UI, or a login proxy — failed with an opaque JSON-decode error:

```
ERROR failed to scan schema registry: failed to get default compatibility:
      invalid character '<' looking for beginning of value
```

The `<` is the first byte of an HTML page: the confluent-kafka-go client decodes any 2xx body as JSON without checking `Content-Type`, so an HTML response surfaces as a cryptic parse failure rather than "you pointed at the wrong endpoint."

## Changes

1. **Pre-flight URL validation** (`internal/client/schema_registry_preflight.go`)
   Before scanning, `GET <url>/config` (the same endpoint the scan's first call hits) and return a clear, class-distinct error when the endpoint is not a usable Schema Registry:
   - non-JSON / HTML body → "does not look like a Schema Registry REST API" (status + content-type, **no** body dump)
   - `3xx` redirect → refused (a real SR responds directly), reports the `Location`
   - `401/403` → authentication error, points at `--use-basic-auth` / `--username` / `--password`
   - non-2xx with a JSON error body → surfaces the registry's own `{"error_code","message"}`
   - Redirects are refused (SSRF guard); response snippets are sanitized and length-bounded; credentials are never echoed.

2. **`--sr-type` help text** (`cmd/scan/schema_registry/cmd_scan_schema_registry.go`)
   Notes that `confluent` works against any registry exposing a Confluent-compatible REST API — e.g. Apicurio via its `/apis/ccompat/v7` endpoint — the most common gotcha when the target isn't Confluent Schema Registry.

## Testing

- Unit tests (`schema_registry_preflight_test.go`, `cmd_scan_schema_registry_test.go`) cover: HTML on 2xx, a lying `Content-Type: application/json` with an HTML body, `401`/`403`, a JSON error body on non-2xx, HTML on non-2xx, redirects, and an unreachable host. All assert the raw `invalid character '<'` decode error never leaks and no response body / credentials are dumped.
- `go test ./cmd/scan/schema_registry/ ./internal/client/` passes.
- Validated end-to-end against a live `apicurio-registry-mem:2.6.5.Final`: scanning the bare host now returns a clear error, and scanning the `/apis/ccompat/v7` endpoint discovers all subjects/versions cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
