### PR TITLE
[DO NOT MERGE] refactor(migration): move gateway unfence to abort_fence rollback (diff visualization only)

### DIFF
--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -131,14 +131,11 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 		}
 		slog.Debug("executing migration step", "step", step.Description)
 		if err := o.fsm.Event(ctx, step.Event); err != nil {
-			// If unrouted producers were detected and the gateway was unfenced,
-			// transition back to initialized so re-running rechecks lags and re-fences.
+			// If unrouted producers were detected during promotion, roll the FSM
+			// back to initialized so re-running rechecks lags and re-fences. The
+			// abort_fence transition unfences the gateway (see leaveFencedCallback).
 			if errors.Is(err, ErrUnroutedProducers) {
-				if abortErr := o.fsm.Event(ctx, EventAbortFence); abortErr != nil {
-					slog.Error("❌ failed to transition back to initialized after unrouted producer detection", "error", abortErr)
-				} else if persistErr := o.persistState(); persistErr != nil {
-					slog.Error("❌ failed to persist state after abort_fence transition", "error", persistErr)
-				}
+				o.rollbackFence(ctx)
 			}
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
 		}
@@ -150,6 +147,21 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 
 	fmt.Printf("\n%s\n", color.GreenString("✅ Migration complete!"))
 	return nil
+}
+
+// rollbackFence transitions the FSM back to initialized via abort_fence after
+// unrouted producers are detected during promotion. The abort_fence transition
+// unfences the gateway (see leaveFencedCallback). Failures are logged rather
+// than returned — Execute already surfaces the originating detection error, and
+// a cancelled abort_fence (e.g. unfence failed) correctly leaves the FSM fenced.
+func (o *MigrationOrchestrator) rollbackFence(ctx context.Context) {
+	if err := o.fsm.Event(ctx, EventAbortFence); err != nil {
+		slog.Error("❌ failed to roll back to initialized after unrouted producer detection", "error", err)
+		return
+	}
+	if err := o.persistState(); err != nil {
+		slog.Error("❌ failed to persist state after abort_fence transition", "error", err)
+	}
 }
 
 // beforeEventCallback is called before any event transition
@@ -205,11 +217,25 @@ func (o *MigrationOrchestrator) leaveLagsOkCallback(ctx context.Context, e *fsm.
 	}
 }
 
-// leaveFencedCallback delegates to workflow service PromoteTopics.
-// Skip if the event is abort_fence — that transition is a rollback,
-// not a forward step.
+// leaveFencedCallback handles transitions out of the fenced state. The forward
+// promote transition delegates to PromoteTopics. The abort_fence rollback
+// (triggered after unrouted producers are detected) unfences the gateway to
+// restore traffic to its pre-migration state — the compensating action for
+// fencing lives on the transition that reverses it.
 func (o *MigrationOrchestrator) leaveFencedCallback(ctx context.Context, e *fsm.Event) {
 	if e.Event == EventAbortFence {
+		fmt.Printf("   %s Unrouted producers detected — removing fence to restore traffic\n",
+			color.YellowString("⚠️"))
+		if err := o.workflow.unfenceGateway(ctx, o.config); err != nil {
+			// The gateway is still fenced, so refuse the rollback: cancelling
+			// keeps the FSM in fenced, which honestly reflects reality.
+			// Re-running execute will retry the unfence.
+			slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", err)
+			e.Cancel(fmt.Errorf("failed to unfence gateway: %w", err))
+			return
+		}
+		fmt.Printf("   %s Gateway unfenced — traffic restored to pre-migration state\n",
+			color.GreenString("✔"))
 		return
 	}
 	if err := o.workflow.PromoteTopics(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -386,14 +386,9 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 	if config.DetectUnroutedProducersDuration > 0 {
 		fmt.Printf("\n%s\n", color.CyanString("🔍 Checking for unrouted producers..."))
 		if err := s.detectUnroutedProducers(ctx, config.Topics, config.DetectUnroutedProducersDuration); err != nil {
-			fmt.Printf("   %s Unrouted producers detected — removing fence to restore traffic\n",
-				color.YellowString("⚠️"))
-			if unfenceErr := s.unfenceGateway(ctx, config); unfenceErr != nil {
-				slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", unfenceErr)
-			} else {
-				fmt.Printf("   %s Gateway unfenced — traffic restored to pre-migration state\n",
-					color.GreenString("✔"))
-			}
+			// Signal detection to the orchestrator by wrapping ErrUnroutedProducers.
+			// Restoring traffic (unfencing the gateway) is the state machine's
+			// responsibility, performed on the abort_fence rollback transition.
 			return fmt.Errorf("%w: %w", ErrUnroutedProducers, err)
 		}
 		fmt.Printf("   %s Source offsets stable — no unrouted producers detected\n",

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -840,11 +840,14 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_StableOffsets(t *testing
 	assert.True(t, promoted["topic-2"], "topic-2 should have been promoted")
 }
 
-func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_UnfencesGateway(t *testing.T) {
-	var unfenced bool
+func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_ReturnsError(t *testing.T) {
+	// PromoteTopics only detects — it must NOT unfence the gateway itself.
+	// Restoring traffic is the orchestrator's job on the abort_fence rollback
+	// (see TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack).
+	var applyCalled bool
 	gw := &mockGatewayService{
 		applyGatewayYAMLFn: func(_ context.Context, _, _ string, _ []byte) error {
-			unfenced = true
+			applyCalled = true
 			return nil
 		},
 	}
@@ -883,9 +886,10 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_Unfenc
 
 	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnroutedProducers)
 	assert.Contains(t, err.Error(), "unrouted producer(s) detected")
 	assert.Contains(t, err.Error(), "topic-1 partition 0")
-	assert.True(t, unfenced, "gateway should be unfenced after detecting unrouted producers")
+	assert.False(t, applyCalled, "PromoteTopics must not unfence the gateway; that is the orchestrator's responsibility")
 }
 
 func TestWorkflow_PromoteTopics_DetectUnroutedProducers_FlagDisabled(t *testing.T) {


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE — diff visualization only.**
> This draft PR exists solely to visualize the proposed changes against the #367 branch. The changes are intended to be folded into #367 directly, not merged as a separate PR. Close without merging once reviewed.

## Summary

Addresses review feedback on #367. All three comments converged on one architectural issue: the unfence-gateway side effect lived in the workflow/business layer (`PromoteTopics`) instead of on the state-machine rollback. This restructures it into a compensation pattern.

## Changes

- **`PromoteTopics` (`workflow.go`)** — now only *detects* unrouted producers and returns `ErrUnroutedProducers`. It no longer touches the gateway.
- **`leaveFencedCallback` (`orchestrator.go`)** — the `abort_fence` branch (previously a no-op `return`) now performs the unfence. The compensating action lives on the transition that reverses fencing. If unfence fails it cancels the rollback, so the FSM stays `fenced` rather than falsely reporting `initialized` while the gateway is still fenced — a correctness improvement over the previous log-and-swallow.
- **`Execute` (`orchestrator.go`)** — extracted the nested `ErrUnroutedProducers` handling into a `rollbackFence(ctx)` helper.

## Tests

- Updated `TestWorkflow_..._IncreasingOffsets` → `..._ReturnsError` to assert `PromoteTopics` no longer unfences (now the orchestrator's responsibility).
- `TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack` continues to pass; its output confirms the unfence messaging now originates from the `abort_fence` transition.
- `go test ./internal/services/migration/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)