### PR TITLE
[DO NOT MERGE] refactor(migration): FSM architecture cleanup (visualization only)

### DIFF
--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -85,24 +85,23 @@ func (m *MigrationExecutor) Run() error {
 	workflow := migration.NewMigrationWorkflowWithOffsets(gatewayService, clusterLinkService, sourceOffset, destinationOffset)
 	workflow.SetRolloutTimeout(m.opts.RolloutTimeout)
 
-	clusterLinkConfig := migration.BuildClusterLinkConfig(&config, m.opts.ClusterApiKey, m.opts.ClusterApiSecret)
-	persist := func() error {
-		m.opts.MigrationState.UpsertMigration(config)
-		return m.opts.MigrationState.WriteToFile(m.opts.MigrationStateFile)
-	}
-
-	// Pre-execute bookend: disable consumer.offset.sync.enable if the
-	// operator opted in at init time. Idempotent and safe on resume.
-	if err := migration.DisableOffsetSync(ctx, clusterLinkService, clusterLinkConfig, &config, persist); err != nil {
-		return err
-	}
-
+	// The orchestrator is the single writer for migration state. Build it up
+	// front so its PersistState can back the offset-sync bookends too, rather
+	// than a parallel write closure.
 	orchestrator := migration.NewMigrationOrchestrator(
 		&config,
 		workflow,
 		&m.opts.MigrationState,
 		m.opts.MigrationStateFile,
 	)
+
+	clusterLinkConfig := migration.BuildClusterLinkConfig(&config, m.opts.ClusterApiKey, m.opts.ClusterApiSecret)
+
+	// Pre-execute bookend: disable consumer.offset.sync.enable if the
+	// operator opted in at init time. Idempotent and safe on resume.
+	if err := migration.DisableOffsetSync(ctx, clusterLinkService, clusterLinkConfig, &config, orchestrator.PersistState); err != nil {
+		return err
+	}
 
 	if err := orchestrator.Execute(ctx, m.opts.LagThreshold, m.opts.ClusterApiKey, m.opts.ClusterApiSecret); err != nil {
 		migration.WarnIfPausedOnExecuteFailure(&config, err)
@@ -111,7 +110,7 @@ func (m *MigrationExecutor) Run() error {
 
 	// Post-execute bookend: restore consumer.offset.sync.enable. Soft-fail
 	// so a restore error does not roll back a successful switchover.
-	migration.RestoreOffsetSync(ctx, clusterLinkService, clusterLinkConfig, &config, persist)
+	migration.RestoreOffsetSync(ctx, clusterLinkService, clusterLinkConfig, &config, orchestrator.PersistState)
 
 	fmt.Printf("✅ Migration completed: %s\n", config.MigrationId)
 	return nil

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -82,15 +82,15 @@ func (m *MigrationExecutor) Run() error {
 
 	gatewayService := gateway.NewK8sService(config.KubeConfigPath)
 	clusterLinkService := clusterlink.NewConfluentCloudService(httpClient)
-	workflow := migration.NewMigrationWorkflowWithOffsets(gatewayService, clusterLinkService, sourceOffset, destinationOffset)
-	workflow.SetRolloutTimeout(m.opts.RolloutTimeout)
+	actions := migration.NewMigrationActionsWithOffsets(gatewayService, clusterLinkService, sourceOffset, destinationOffset)
+	actions.SetRolloutTimeout(m.opts.RolloutTimeout)
 
 	// The orchestrator is the single writer for migration state. Build it up
 	// front so its PersistState can back the offset-sync bookends too, rather
 	// than a parallel write closure.
 	orchestrator := migration.NewMigrationOrchestrator(
 		&config,
-		workflow,
+		actions,
 		&m.opts.MigrationState,
 		m.opts.MigrationStateFile,
 	)

--- a/cmd/migration/init/migration_initializer.go
+++ b/cmd/migration/init/migration_initializer.go
@@ -44,11 +44,11 @@ func (m *MigrationInitializer) Run() error {
 
 	gatewayService := gateway.NewK8sService(config.KubeConfigPath)
 	clusterLinkService := clusterlink.NewConfluentCloudService(httpClient)
-	workflow := migration.NewMigrationWorkflow(gatewayService, clusterLinkService)
+	actions := migration.NewMigrationActions(gatewayService, clusterLinkService)
 
 	orchestrator := migration.NewMigrationOrchestrator(
 		&config,
-		workflow,
+		actions,
 		&m.opts.MigrationState,
 		m.opts.MigrationStateFile,
 	)

--- a/internal/services/migration/offset_sync_bookend.go
+++ b/internal/services/migration/offset_sync_bookend.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/clusterlink"
-	"github.com/fatih/color"
 )
 
 const (
@@ -56,7 +54,8 @@ func DisableOffsetSync(
 		return nil
 	}
 
-	fmt.Printf("\n%s\n", color.CyanString("⏸  Pausing consumer.offset.sync on cluster link..."))
+	r := newReporter()
+	r.section("⏸  Pausing consumer.offset.sync on cluster link...")
 
 	// Per-call deadlines derived from the parent ctx so signal cancellation
 	// still propagates, but a hung REST endpoint cannot block indefinitely.
@@ -88,7 +87,7 @@ func DisableOffsetSync(
 		return fmt.Errorf("disabled %s on cluster link %q but failed to persist marker: %w (recovery: re-enable on the cluster link or correct the migration state file before re-running)", offsetSyncEnableKey, config.ClusterLinkName, err)
 	}
 
-	fmt.Printf("   %s %s set to false on cluster link %s\n", color.GreenString("✔"), offsetSyncEnableKey, config.ClusterLinkName)
+	r.success("%s set to false on cluster link %s", offsetSyncEnableKey, config.ClusterLinkName)
 	return nil
 }
 
@@ -125,7 +124,8 @@ func RestoreOffsetSync(
 		return
 	}
 
-	fmt.Printf("\n%s\n", color.CyanString("▶️  Restoring consumer.offset.sync on cluster link..."))
+	r := newReporter()
+	r.section("▶️  Restoring consumer.offset.sync on cluster link...")
 
 	var alterations []clusterlink.ConfigAlteration
 
@@ -140,9 +140,8 @@ func RestoreOffsetSync(
 		currentConfigs, err := cl.ListConfigs(listCtx, clCfg)
 		listCancel()
 		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"%s Migration completed but failed to read current configs on cluster link %q for restore (%v).\n   The cluster link may still be in the paused state — re-apply %s=true and any %s* configs manually before resuming normal operation.\n",
-				color.YellowString("⚠️"),
+			r.remediation(
+				"Migration completed but failed to read current configs on cluster link %q for restore (%v).\n   The cluster link may still be in the paused state — re-apply %s=true and any %s* configs manually before resuming normal operation.",
 				config.ClusterLinkName,
 				err,
 				offsetSyncEnableKey,
@@ -206,7 +205,7 @@ func RestoreOffsetSync(
 		if err := persist(); err != nil {
 			slog.Warn("cleared restore marker but failed to persist state file", "err", err)
 		}
-		fmt.Printf("   %s %s* configs already match init snapshot on cluster link %s\n", color.GreenString("✔"), consumerOffsetPrefix, config.ClusterLinkName)
+		r.success("%s* configs already match init snapshot on cluster link %s", consumerOffsetPrefix, config.ClusterLinkName)
 		return
 	}
 
@@ -231,9 +230,8 @@ func RestoreOffsetSync(
 			if len(applied) > 0 {
 				appliedStr = strings.Join(applied, ", ")
 			}
-			fmt.Fprintf(os.Stderr,
-				"%s Migration completed but failed to restore %s* configs on cluster link %q (%v).\n   Applied: %s.\n   Still owed: %s — re-apply manually before resuming normal operation.\n",
-				color.YellowString("⚠️"),
+			r.remediation(
+				"Migration completed but failed to restore %s* configs on cluster link %q (%v).\n   Applied: %s.\n   Still owed: %s — re-apply manually before resuming normal operation.",
 				consumerOffsetPrefix,
 				config.ClusterLinkName,
 				err,
@@ -252,7 +250,7 @@ func RestoreOffsetSync(
 	for i, a := range alterations {
 		names[i] = a.Name
 	}
-	fmt.Printf("   %s restored %s* configs on cluster link %s: %s\n", color.GreenString("✔"), consumerOffsetPrefix, config.ClusterLinkName, strings.Join(names, ", "))
+	r.success("restored %s* configs on cluster link %s: %s", consumerOffsetPrefix, config.ClusterLinkName, strings.Join(names, ", "))
 }
 
 // WarnIfPausedOnExecuteFailure prints a stderr remediation message when
@@ -267,9 +265,8 @@ func WarnIfPausedOnExecuteFailure(config *MigrationConfig, execErr error) {
 	if !config.PauseConsumerOffsetSyncFlipped {
 		return
 	}
-	fmt.Fprintf(os.Stderr,
-		"%s Migration execute failed (%v) while cluster link %q has %s=false.\n   Re-run `kcp migration execute` to resume — the bookend is idempotent and the restore will run after a successful switchover — or manually re-enable %s=true on the cluster link.\n",
-		color.YellowString("⚠️"),
+	newReporter().remediation(
+		"Migration execute failed (%v) while cluster link %q has %s=false.\n   Re-run `kcp migration execute` to resume — the bookend is idempotent and the restore will run after a successful switchover — or manually re-enable %s=true on the cluster link.",
 		execErr,
 		config.ClusterLinkName,
 		offsetSyncEnableKey,

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -137,13 +137,7 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 		}
 		slog.Debug("executing migration step", "step", step.Description)
 		if err := o.fsm.Event(ctx, step.Event); err != nil {
-			// If unrouted producers were detected during promotion, roll the FSM
-			// back to initialized so re-running rechecks lags and re-fences. The
-			// abort_fence transition unfences the gateway (see onAbortFence).
-			if errors.Is(err, ErrUnroutedProducers) {
-				o.rollbackFence(ctx)
-			}
-			return fmt.Errorf("failed during %s: %w", step.Description, err)
+			return o.handleStepFailure(ctx, step, err)
 		}
 		if err := o.PersistState(); err != nil {
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
@@ -155,19 +149,25 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 	return nil
 }
 
-// rollbackFence transitions the FSM back to initialized via abort_fence after
-// unrouted producers are detected during promotion. The abort_fence transition
-// unfences the gateway (see onAbortFence). Failures are logged rather
-// than returned — Execute already surfaces the originating detection error, and
-// a cancelled abort_fence (e.g. unfence failed) correctly leaves the FSM fenced.
-func (o *MigrationOrchestrator) rollbackFence(ctx context.Context) {
-	if err := o.fsm.Event(ctx, EventAbortFence); err != nil {
-		slog.Error("❌ failed to roll back to initialized after unrouted producer detection", "error", err)
-		return
+// handleStepFailure is the single place that maps a failed workflow step to its
+// compensating rollback (if any) and returns the wrapped error. The migration
+// defines exactly one compensation: when promotion is aborted because unrouted
+// producers were detected (ErrUnroutedProducers, signalled up from the workflow
+// layer), roll the fence back to initialized via abort_fence — which unfences
+// the gateway (see onAbortFence) — so a re-run rechecks lags and re-fences.
+//
+// Rollback failures are logged, not returned: the originating step error is
+// always what surfaces to the caller, and a cancelled abort_fence (e.g. the
+// unfence itself failed) correctly leaves the FSM at fenced.
+func (o *MigrationOrchestrator) handleStepFailure(ctx context.Context, step WorkflowStep, stepErr error) error {
+	if errors.Is(stepErr, ErrUnroutedProducers) {
+		if err := o.fsm.Event(ctx, EventAbortFence); err != nil {
+			slog.Error("❌ failed to roll back to initialized after unrouted producer detection", "error", err)
+		} else if err := o.PersistState(); err != nil {
+			slog.Error("❌ failed to persist state after abort_fence transition", "error", err)
+		}
 	}
-	if err := o.PersistState(); err != nil {
-		slog.Error("❌ failed to persist state after abort_fence transition", "error", err)
-	}
+	return fmt.Errorf("failed during %s: %w", step.Description, stepErr)
 }
 
 // beforeEventCallback is called before any event transition

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -24,7 +24,17 @@ type WorkflowStep struct {
 	ToState     string
 }
 
-// canonicalWorkflow is the single source of truth for the migration workflow sequence
+// canonicalWorkflow is the single source of truth for the migration workflow
+// sequence — the ordered forward transitions the FSM walks on execute.
+//
+// Two deliberate modelling choices are intentionally NOT represented here:
+//   - The offset-sync pause/restore bookends run OUTSIDE the FSM, wrapped around
+//     the whole execute by the command layer (see offset_sync_bookend.go),
+//     because the restore must run even when the run aborts or ctx is cancelled.
+//   - There is no terminal/failed state. A step failure cancels its transition
+//     (e.Cancel) and leaves the FSM at the last good state; re-running execute
+//     resumes from there. The sole backward edge, abort_fence (fenced →
+//     initialized on unrouted-producer detection), is the only rollback.
 var canonicalWorkflow = []WorkflowStep{
 	{EventInitialize, "initializing migration", StateUninitialized, StateInitialized},
 	{EventWaitForLags, "checking replication lags", StateInitialized, StateLagsOk},
@@ -45,11 +55,26 @@ var stepHeaders = map[string]string{
 	EventSwitch:      "🔄 Switching gateway to Confluent Cloud...",
 }
 
-// ExecutionParams holds runtime parameters needed during migration execution
+// ExecutionParams holds the per-run runtime parameters a transition may need.
+// It is passed to fsm.Event as the sole argument and read back by callbacks via
+// execParamsFromEvent, rather than stashed on the orchestrator, so the values
+// flow with the event instead of living as mutable orchestrator state.
 type ExecutionParams struct {
 	LagThreshold     int64
 	ClusterApiKey    string
 	ClusterApiSecret string
+}
+
+// execParamsFromEvent returns the ExecutionParams passed to fsm.Event. Forward
+// transitions are fired with them; the abort_fence rollback is fired without
+// (onAbortFence needs no runtime params) and this returns the zero value.
+func execParamsFromEvent(e *fsm.Event) ExecutionParams {
+	if len(e.Args) > 0 {
+		if p, ok := e.Args[0].(ExecutionParams); ok {
+			return p
+		}
+	}
+	return ExecutionParams{}
 }
 
 // MigrationOrchestrator manages the FSM lifecycle and coordinates workflow execution
@@ -59,8 +84,7 @@ type MigrationOrchestrator struct {
 	actions        *MigrationActions
 	migrationState *MigrationState
 	stateFilePath  string
-	execParams     ExecutionParams // Runtime execution parameters
-	reporter       *reporter       // user-facing terminal output
+	reporter       *reporter // user-facing terminal output
 }
 
 // NewMigrationOrchestrator creates a new migration orchestrator with injected dependencies
@@ -122,11 +146,8 @@ func NewMigrationOrchestrator(
 
 // Initialize triggers the initialization event
 func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, clusterApiSecret string) error {
-	// Store API credentials for use by callback
-	o.execParams.ClusterApiKey = clusterApiKey
-	o.execParams.ClusterApiSecret = clusterApiSecret
-
-	if err := o.fsm.Event(ctx, EventInitialize); err != nil {
+	params := ExecutionParams{ClusterApiKey: clusterApiKey, ClusterApiSecret: clusterApiSecret}
+	if err := o.fsm.Event(ctx, EventInitialize, params); err != nil {
 		return err
 	}
 	return o.PersistState()
@@ -134,10 +155,11 @@ func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, c
 
 // Execute runs the full migration workflow from the current state
 func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64, clusterApiKey, clusterApiSecret string) error {
-	// Store runtime parameters once for use by all callbacks
-	o.execParams.LagThreshold = lagThreshold
-	o.execParams.ClusterApiKey = clusterApiKey
-	o.execParams.ClusterApiSecret = clusterApiSecret
+	params := ExecutionParams{
+		LagThreshold:     lagThreshold,
+		ClusterApiKey:    clusterApiKey,
+		ClusterApiSecret: clusterApiSecret,
+	}
 
 	// Drive execution from canonical workflow - single source of truth
 	for _, step := range canonicalWorkflow {
@@ -150,7 +172,7 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 			o.reporter.section(header)
 		}
 		slog.Debug("executing migration step", "step", step.Description)
-		if err := o.fsm.Event(ctx, step.Event); err != nil {
+		if err := o.fsm.Event(ctx, step.Event, params); err != nil {
 			return o.handleStepFailure(ctx, step, err)
 		}
 		if err := o.PersistState(); err != nil {
@@ -219,14 +241,16 @@ func (o *MigrationOrchestrator) leaveStateCallback(ctx context.Context, e *fsm.E
 
 // onInitialize runs the initialize transition: delegates to workflow Initialize.
 func (o *MigrationOrchestrator) onInitialize(ctx context.Context, e *fsm.Event) {
-	if err := o.actions.Initialize(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	p := execParamsFromEvent(e)
+	if err := o.actions.Initialize(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }
 
 // onWaitForLags runs the wait_for_lags transition: delegates to workflow CheckLags.
 func (o *MigrationOrchestrator) onWaitForLags(ctx context.Context, e *fsm.Event) {
-	if err := o.actions.CheckLags(ctx, o.config, o.execParams.LagThreshold, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	p := execParamsFromEvent(e)
+	if err := o.actions.CheckLags(ctx, o.config, p.LagThreshold, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -242,7 +266,8 @@ func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
 // Registered on before_promote (not leave_fenced), so it fires only for the
 // promote event — never for the abort_fence rollback that also leaves fenced.
 func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
-	if err := o.actions.PromoteTopics(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	p := execParamsFromEvent(e)
+	if err := o.actions.PromoteTopics(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -56,7 +56,7 @@ type ExecutionParams struct {
 type MigrationOrchestrator struct {
 	config         *MigrationConfig
 	fsm            *fsm.FSM
-	workflow       *MigrationWorkflow
+	actions        *MigrationActions
 	migrationState *MigrationState
 	stateFilePath  string
 	execParams     ExecutionParams // Runtime execution parameters
@@ -66,13 +66,13 @@ type MigrationOrchestrator struct {
 // NewMigrationOrchestrator creates a new migration orchestrator with injected dependencies
 func NewMigrationOrchestrator(
 	config *MigrationConfig,
-	workflow *MigrationWorkflow,
+	actions *MigrationActions,
 	migrationState *MigrationState,
 	stateFilePath string,
 ) *MigrationOrchestrator {
 	orchestrator := &MigrationOrchestrator{
 		config:         config,
-		workflow:       workflow,
+		actions:        actions,
 		migrationState: migrationState,
 		stateFilePath:  stateFilePath,
 		reporter:       newReporter(),
@@ -219,21 +219,21 @@ func (o *MigrationOrchestrator) leaveStateCallback(ctx context.Context, e *fsm.E
 
 // onInitialize runs the initialize transition: delegates to workflow Initialize.
 func (o *MigrationOrchestrator) onInitialize(ctx context.Context, e *fsm.Event) {
-	if err := o.workflow.Initialize(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	if err := o.actions.Initialize(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }
 
 // onWaitForLags runs the wait_for_lags transition: delegates to workflow CheckLags.
 func (o *MigrationOrchestrator) onWaitForLags(ctx context.Context, e *fsm.Event) {
-	if err := o.workflow.CheckLags(ctx, o.config, o.execParams.LagThreshold, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	if err := o.actions.CheckLags(ctx, o.config, o.execParams.LagThreshold, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }
 
 // onFence runs the fence transition: delegates to workflow FenceGateway.
 func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
-	if err := o.workflow.FenceGateway(ctx, o.config); err != nil {
+	if err := o.actions.FenceGateway(ctx, o.config); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -242,7 +242,7 @@ func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
 // Registered on before_promote (not leave_fenced), so it fires only for the
 // promote event — never for the abort_fence rollback that also leaves fenced.
 func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
-	if err := o.workflow.PromoteTopics(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
+	if err := o.actions.PromoteTopics(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -254,7 +254,7 @@ func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
 // execute will retry the unfence.
 func (o *MigrationOrchestrator) onAbortFence(ctx context.Context, e *fsm.Event) {
 	o.reporter.warn("Unrouted producers detected — removing fence to restore traffic")
-	if err := o.workflow.unfenceGateway(ctx, o.config); err != nil {
+	if err := o.actions.unfenceGateway(ctx, o.config); err != nil {
 		slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", err)
 		e.Cancel(fmt.Errorf("failed to unfence gateway: %w", err))
 		return
@@ -264,7 +264,7 @@ func (o *MigrationOrchestrator) onAbortFence(ctx context.Context, e *fsm.Event) 
 
 // onSwitch runs the switch transition: delegates to workflow SwitchGateway.
 func (o *MigrationOrchestrator) onSwitch(ctx context.Context, e *fsm.Event) {
-	if err := o.workflow.SwitchGateway(ctx, o.config); err != nil {
+	if err := o.actions.SwitchGateway(ctx, o.config); err != nil {
 		e.Cancel(err)
 	}
 }

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -43,14 +43,15 @@ var canonicalWorkflow = []WorkflowStep{
 	{EventSwitch, "switching gateway config", StatePromoted, StateSwitched},
 }
 
-// stepHeaders maps a workflow event to the banner shown to the user when the
-// step starts. Kept separate from canonicalWorkflow so the FSM edge definitions
-// carry no presentation.
+// stepHeaders maps a forward workflow event to the banner the Execute loop
+// prints as it walks canonicalWorkflow. Kept separate from canonicalWorkflow so
+// the FSM edge definitions carry no presentation. abort_fence is deliberately
+// absent: it is a compensation fired from handleStepFailure, not a forward loop
+// step, and its messaging is owned by onAbortFence.
 var stepHeaders = map[string]string{
 	EventInitialize:  "🔍 Initializing migration...",
 	EventWaitForLags: "⏳ Checking replication lags...",
 	EventFence:       "🚧 Fencing gateway...",
-	EventAbortFence:  "⚠️ Unrouted producers detected — removing fence to restore traffic...",
 	EventPromote:     "🚀 Promoting topics...",
 	EventSwitch:      "🔄 Switching gateway to Confluent Cloud...",
 }

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -80,20 +80,26 @@ func NewMigrationOrchestrator(
 		Dst:  StateInitialized,
 	})
 
-	// Bootstrap FSM from persisted state to enable resumability (e.g. "initialized" skips init, resumes at lag check)
+	// Bootstrap FSM from persisted state to enable resumability (e.g. "initialized" skips init, resumes at lag check).
+	//
+	// Action callbacks are registered per-event (before_<EVENT>), not per-state
+	// (leave_<STATE>), so each is single-purpose. This matters for the fenced
+	// state, which two events leave — promote (forward) and abort_fence
+	// (rollback) — each with its own callback and no event-sniffing guard.
 	orchestrator.fsm = fsm.NewFSM(
 		config.CurrentState,
 		events,
 		fsm.Callbacks{
-			"before_event":                orchestrator.beforeEventCallback,
-			"after_event":                 orchestrator.afterEventCallback,
-			"enter_state":                 orchestrator.enterStateCallback,
-			"leave_state":                 orchestrator.leaveStateCallback,
-			"leave_" + StateUninitialized: orchestrator.leaveUninitializedCallback,
-			"leave_" + StateInitialized:   orchestrator.leaveInitializedCallback,
-			"leave_" + StateLagsOk:        orchestrator.leaveLagsOkCallback,
-			"leave_" + StateFenced:        orchestrator.leaveFencedCallback,
-			"leave_" + StatePromoted:      orchestrator.leavePromotedCallback,
+			"before_event":               orchestrator.beforeEventCallback,
+			"after_event":                orchestrator.afterEventCallback,
+			"enter_state":                orchestrator.enterStateCallback,
+			"leave_state":                orchestrator.leaveStateCallback,
+			"before_" + EventInitialize:  orchestrator.onInitialize,
+			"before_" + EventWaitForLags: orchestrator.onWaitForLags,
+			"before_" + EventFence:       orchestrator.onFence,
+			"before_" + EventPromote:     orchestrator.onPromote,
+			"before_" + EventAbortFence:  orchestrator.onAbortFence,
+			"before_" + EventSwitch:      orchestrator.onSwitch,
 		},
 	)
 
@@ -109,7 +115,7 @@ func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, c
 	if err := o.fsm.Event(ctx, EventInitialize); err != nil {
 		return err
 	}
-	return o.persistState()
+	return o.PersistState()
 }
 
 // Execute runs the full migration workflow from the current state
@@ -133,13 +139,13 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 		if err := o.fsm.Event(ctx, step.Event); err != nil {
 			// If unrouted producers were detected during promotion, roll the FSM
 			// back to initialized so re-running rechecks lags and re-fences. The
-			// abort_fence transition unfences the gateway (see leaveFencedCallback).
+			// abort_fence transition unfences the gateway (see onAbortFence).
 			if errors.Is(err, ErrUnroutedProducers) {
 				o.rollbackFence(ctx)
 			}
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
 		}
-		if err := o.persistState(); err != nil {
+		if err := o.PersistState(); err != nil {
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
 		}
 		fmt.Printf("%s\n", color.GreenString("✅ Done"))
@@ -151,7 +157,7 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 
 // rollbackFence transitions the FSM back to initialized via abort_fence after
 // unrouted producers are detected during promotion. The abort_fence transition
-// unfences the gateway (see leaveFencedCallback). Failures are logged rather
+// unfences the gateway (see onAbortFence). Failures are logged rather
 // than returned — Execute already surfaces the originating detection error, and
 // a cancelled abort_fence (e.g. unfence failed) correctly leaves the FSM fenced.
 func (o *MigrationOrchestrator) rollbackFence(ctx context.Context) {
@@ -159,7 +165,7 @@ func (o *MigrationOrchestrator) rollbackFence(ctx context.Context) {
 		slog.Error("❌ failed to roll back to initialized after unrouted producer detection", "error", err)
 		return
 	}
-	if err := o.persistState(); err != nil {
+	if err := o.PersistState(); err != nil {
 		slog.Error("❌ failed to persist state after abort_fence transition", "error", err)
 	}
 }
@@ -175,8 +181,12 @@ func (o *MigrationOrchestrator) afterEventCallback(ctx context.Context, e *fsm.E
 	o.config.CurrentState = e.Dst
 }
 
-// persistState saves the current migration state to disk. Called after each successful FSM transition.
-func (o *MigrationOrchestrator) persistState() error {
+// PersistState saves the current migration config to the state file. It is the
+// single writer for migration state: the orchestrator calls it after each
+// successful FSM transition, and the offset-sync bookends (which run outside the
+// FSM) are handed this method so they persist through the same path rather than
+// duplicating the write.
+func (o *MigrationOrchestrator) PersistState() error {
 	if err := o.saveState(); err != nil {
 		return fmt.Errorf("failed to persist state after transition to %s: %w", o.config.CurrentState, err)
 	}
@@ -193,62 +203,57 @@ func (o *MigrationOrchestrator) leaveStateCallback(ctx context.Context, e *fsm.E
 	slog.Debug("FSM: leaving state", "state", e.Src)
 }
 
-// leaveUninitializedCallback delegates to workflow service Initialize
-func (o *MigrationOrchestrator) leaveUninitializedCallback(ctx context.Context, e *fsm.Event) {
+// onInitialize runs the initialize transition: delegates to workflow Initialize.
+func (o *MigrationOrchestrator) onInitialize(ctx context.Context, e *fsm.Event) {
 	if err := o.workflow.Initialize(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
-		return
 	}
 }
 
-// leaveInitializedCallback delegates to workflow service CheckLags
-func (o *MigrationOrchestrator) leaveInitializedCallback(ctx context.Context, e *fsm.Event) {
+// onWaitForLags runs the wait_for_lags transition: delegates to workflow CheckLags.
+func (o *MigrationOrchestrator) onWaitForLags(ctx context.Context, e *fsm.Event) {
 	if err := o.workflow.CheckLags(ctx, o.config, o.execParams.LagThreshold, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
-		return
 	}
 }
 
-// leaveLagsOkCallback delegates to workflow service FenceGateway
-func (o *MigrationOrchestrator) leaveLagsOkCallback(ctx context.Context, e *fsm.Event) {
+// onFence runs the fence transition: delegates to workflow FenceGateway.
+func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
 	if err := o.workflow.FenceGateway(ctx, o.config); err != nil {
 		e.Cancel(err)
-		return
 	}
 }
 
-// leaveFencedCallback handles transitions out of the fenced state. The forward
-// promote transition delegates to PromoteTopics. The abort_fence rollback
-// (triggered after unrouted producers are detected) unfences the gateway to
-// restore traffic to its pre-migration state — the compensating action for
-// fencing lives on the transition that reverses it.
-func (o *MigrationOrchestrator) leaveFencedCallback(ctx context.Context, e *fsm.Event) {
-	if e.Event == EventAbortFence {
-		fmt.Printf("   %s Unrouted producers detected — removing fence to restore traffic\n",
-			color.YellowString("⚠️"))
-		if err := o.workflow.unfenceGateway(ctx, o.config); err != nil {
-			// The gateway is still fenced, so refuse the rollback: cancelling
-			// keeps the FSM in fenced, which honestly reflects reality.
-			// Re-running execute will retry the unfence.
-			slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", err)
-			e.Cancel(fmt.Errorf("failed to unfence gateway: %w", err))
-			return
-		}
-		fmt.Printf("   %s Gateway unfenced — traffic restored to pre-migration state\n",
-			color.GreenString("✔"))
-		return
-	}
+// onPromote runs the forward promote transition: delegates to PromoteTopics.
+// Registered on before_promote (not leave_fenced), so it fires only for the
+// promote event — never for the abort_fence rollback that also leaves fenced.
+func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
 	if err := o.workflow.PromoteTopics(ctx, o.config, o.execParams.ClusterApiKey, o.execParams.ClusterApiSecret); err != nil {
 		e.Cancel(err)
-		return
 	}
 }
 
-// leavePromotedCallback delegates to workflow service SwitchGateway
-func (o *MigrationOrchestrator) leavePromotedCallback(ctx context.Context, e *fsm.Event) {
+// onAbortFence runs the abort_fence rollback: unfences the gateway to restore
+// traffic to its pre-migration state — the compensating action for fencing
+// lives on the transition that reverses it. If unfencing fails, cancel the
+// rollback so the FSM stays fenced, which honestly reflects reality; re-running
+// execute will retry the unfence.
+func (o *MigrationOrchestrator) onAbortFence(ctx context.Context, e *fsm.Event) {
+	fmt.Printf("   %s Unrouted producers detected — removing fence to restore traffic\n",
+		color.YellowString("⚠️"))
+	if err := o.workflow.unfenceGateway(ctx, o.config); err != nil {
+		slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", err)
+		e.Cancel(fmt.Errorf("failed to unfence gateway: %w", err))
+		return
+	}
+	fmt.Printf("   %s Gateway unfenced — traffic restored to pre-migration state\n",
+		color.GreenString("✔"))
+}
+
+// onSwitch runs the switch transition: delegates to workflow SwitchGateway.
+func (o *MigrationOrchestrator) onSwitch(ctx context.Context, e *fsm.Event) {
 	if err := o.workflow.SwitchGateway(ctx, o.config); err != nil {
 		e.Cancel(err)
-		return
 	}
 }
 

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/fatih/color"
 	"github.com/looplab/fsm"
 )
 
@@ -15,22 +14,35 @@ import (
 // EventAbortFence transition back to initialized state.
 var ErrUnroutedProducers = errors.New("unrouted producers detected")
 
-// WorkflowStep defines a single step in the migration workflow
+// WorkflowStep defines a single step in the migration workflow. It is pure FSM
+// topology plus an ops-facing Description; user-facing presentation lives in
+// stepHeaders, keyed by event, so the edge definitions stay presentation-free.
 type WorkflowStep struct {
 	Event       string
 	Description string
 	FromState   string
 	ToState     string
-	UserMessage string // Emoji-prefixed message shown to the user
 }
 
 // canonicalWorkflow is the single source of truth for the migration workflow sequence
 var canonicalWorkflow = []WorkflowStep{
-	{EventInitialize, "initializing migration", StateUninitialized, StateInitialized, "🔍 Initializing migration..."},
-	{EventWaitForLags, "checking replication lags", StateInitialized, StateLagsOk, "⏳ Checking replication lags..."},
-	{EventFence, "fencing gateway", StateLagsOk, StateFenced, "🚧 Fencing gateway..."},
-	{EventPromote, "promoting topics", StateFenced, StatePromoted, ""},
-	{EventSwitch, "switching gateway config", StatePromoted, StateSwitched, "🔄 Switching gateway to Confluent Cloud..."},
+	{EventInitialize, "initializing migration", StateUninitialized, StateInitialized},
+	{EventWaitForLags, "checking replication lags", StateInitialized, StateLagsOk},
+	{EventFence, "fencing gateway", StateLagsOk, StateFenced},
+	{EventPromote, "promoting topics", StateFenced, StatePromoted},
+	{EventSwitch, "switching gateway config", StatePromoted, StateSwitched},
+}
+
+// stepHeaders maps a workflow event to the banner shown to the user when the
+// step starts. Kept separate from canonicalWorkflow so the FSM edge definitions
+// carry no presentation.
+var stepHeaders = map[string]string{
+	EventInitialize:  "🔍 Initializing migration...",
+	EventWaitForLags: "⏳ Checking replication lags...",
+	EventFence:       "🚧 Fencing gateway...",
+	EventAbortFence:  "⚠️ Unrouted producers detected — removing fence to restore traffic...",
+	EventPromote:     "🚀 Promoting topics...",
+	EventSwitch:      "🔄 Switching gateway to Confluent Cloud...",
 }
 
 // ExecutionParams holds runtime parameters needed during migration execution
@@ -48,6 +60,7 @@ type MigrationOrchestrator struct {
 	migrationState *MigrationState
 	stateFilePath  string
 	execParams     ExecutionParams // Runtime execution parameters
+	reporter       *reporter       // user-facing terminal output
 }
 
 // NewMigrationOrchestrator creates a new migration orchestrator with injected dependencies
@@ -62,6 +75,7 @@ func NewMigrationOrchestrator(
 		workflow:       workflow,
 		migrationState: migrationState,
 		stateFilePath:  stateFilePath,
+		reporter:       newReporter(),
 	}
 
 	// Build FSM events from canonical workflow
@@ -132,8 +146,8 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 			continue // Skip already-completed steps (enables resumability)
 		}
 
-		if step.UserMessage != "" {
-			fmt.Printf("\n%s\n", color.CyanString(step.UserMessage))
+		if header, ok := stepHeaders[step.Event]; ok {
+			o.reporter.section(header)
 		}
 		slog.Debug("executing migration step", "step", step.Description)
 		if err := o.fsm.Event(ctx, step.Event); err != nil {
@@ -142,10 +156,10 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 		if err := o.PersistState(); err != nil {
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
 		}
-		fmt.Printf("%s\n", color.GreenString("✅ Done"))
+		o.reporter.stepDone()
 	}
 
-	fmt.Printf("\n%s\n", color.GreenString("✅ Migration complete!"))
+	o.reporter.complete("✅ Migration complete!")
 	return nil
 }
 
@@ -239,15 +253,13 @@ func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
 // rollback so the FSM stays fenced, which honestly reflects reality; re-running
 // execute will retry the unfence.
 func (o *MigrationOrchestrator) onAbortFence(ctx context.Context, e *fsm.Event) {
-	fmt.Printf("   %s Unrouted producers detected — removing fence to restore traffic\n",
-		color.YellowString("⚠️"))
+	o.reporter.warn("Unrouted producers detected — removing fence to restore traffic")
 	if err := o.workflow.unfenceGateway(ctx, o.config); err != nil {
 		slog.Error("❌ failed to unfence gateway after detecting unrouted producers", "error", err)
 		e.Cancel(fmt.Errorf("failed to unfence gateway: %w", err))
 		return
 	}
-	fmt.Printf("   %s Gateway unfenced — traffic restored to pre-migration state\n",
-		color.GreenString("✔"))
+	o.reporter.success("Gateway unfenced — traffic restored to pre-migration state")
 }
 
 // onSwitch runs the switch transition: delegates to workflow SwitchGateway.

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -233,7 +233,7 @@ func TestOrchestrator_Initialize_WorkflowError(t *testing.T) {
 	// Config state should NOT have advanced
 	assert.Equal(t, StateUninitialized, config.CurrentState)
 
-	// State file should not have been written (persistState is called after fsm.Event,
+	// State file should not have been written (PersistState is called after fsm.Event,
 	// and fsm.Event returns error when the callback cancels)
 	_, loadErr := NewMigrationStateFromFile(stateFilePath)
 	if loadErr == nil {

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -135,16 +135,16 @@ func newHappyPathOrchestrator(t *testing.T, initialState string, topics []string
 		},
 	}
 
-	workflow := NewMigrationWorkflowWithOffsets(gw, cl, srcOffset, dstOffset)
-	workflow.lagPollInterval = time.Millisecond
-	workflow.promotePollInterval = time.Millisecond
+	actions := NewMigrationActionsWithOffsets(gw, cl, srcOffset, dstOffset)
+	actions.lagPollInterval = time.Millisecond
+	actions.promotePollInterval = time.Millisecond
 
 	stateDir := t.TempDir()
 	stateFilePath := filepath.Join(stateDir, "migration-state.json")
 
 	migrationState := NewMigrationState()
 
-	orch := NewMigrationOrchestrator(config, workflow, migrationState, stateFilePath)
+	orch := NewMigrationOrchestrator(config, actions, migrationState, stateFilePath)
 
 	return orch, config, stateFilePath
 }
@@ -292,7 +292,7 @@ func TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack(t *testi
 	config.InitialCrYAML = []byte("apiVersion: platform.confluent.io/v1beta1\nkind: Gateway\nmetadata:\n  name: my-gateway\n  namespace: confluent\n")
 
 	// Override source offset provider to return increasing offsets (simulating rogue)
-	orch.workflow.sourceOffset = &mockOffsetProvider{
+	orch.actions.sourceOffset = &mockOffsetProvider{
 		getFn: func(topic string) (map[int32]int64, error) {
 			n := atomic.AddInt64(&sourceCallCount, 1)
 			return map[int32]int64{0: 100 + n*10}, nil
@@ -300,8 +300,8 @@ func TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack(t *testi
 	}
 
 	// Track promote calls to verify it only runs once (not twice from duplicate callback)
-	originalPromote := orch.workflow.clusterLinkService
-	orch.workflow.clusterLinkService = &mockClusterLinkService{
+	originalPromote := orch.actions.clusterLinkService
+	orch.actions.clusterLinkService = &mockClusterLinkService{
 		promoteMirrorTopicsFn: func(ctx context.Context, cfg clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
 			atomic.AddInt64(&promoteCallCount, 1)
 			return originalPromote.PromoteMirrorTopics(ctx, cfg, topicNames)
@@ -351,7 +351,7 @@ func TestOrchestrator_Execute_UnroutedProducers_UnfenceFails_StaysAtFenced(t *te
 	config.InitialCrYAML = []byte("apiVersion: platform.confluent.io/v1beta1\nkind: Gateway\nmetadata:\n  name: my-gateway\n  namespace: confluent\n")
 
 	// Override source offset provider to return increasing offsets
-	orch.workflow.sourceOffset = &mockOffsetProvider{
+	orch.actions.sourceOffset = &mockOffsetProvider{
 		getFn: func(topic string) (map[int32]int64, error) {
 			n := atomic.AddInt64(&applyCallCount, 1)
 			return map[int32]int64{0: 100 + n*10}, nil

--- a/internal/services/migration/reporter.go
+++ b/internal/services/migration/reporter.go
@@ -1,0 +1,89 @@
+package migration
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/fatih/color"
+)
+
+// reporter owns all user-facing terminal output for the migration flow so the
+// orchestrator, workflow and offset-sync bookends don't scatter raw
+// fmt.Printf/Fprintf/color calls. It centralises the emoji, indentation and
+// colour conventions and the destination streams (stdout for progress, stderr
+// for soft-fail remediation notes), giving migration output a single owner and
+// a single point to redirect or silence.
+type reporter struct {
+	out io.Writer
+	err io.Writer
+}
+
+// newReporter returns a reporter that writes progress to stdout and remediation
+// notes to stderr.
+func newReporter() *reporter {
+	return &reporter{out: os.Stdout, err: os.Stderr}
+}
+
+// printf writes to the progress stream. Write errors to a terminal are not
+// actionable, so they are intentionally discarded here (once) rather than at
+// every call site.
+func (r *reporter) printf(format string, a ...any) {
+	_, _ = fmt.Fprintf(r.out, format, a...)
+}
+
+// errf writes to the remediation stream, discarding the unactionable error.
+func (r *reporter) errf(format string, a ...any) {
+	_, _ = fmt.Fprintf(r.err, format, a...)
+}
+
+// section prints a blank line then a cyan banner announcing a major step. The
+// caller includes the leading emoji in msg (e.g. "🔍 Initializing migration...").
+func (r *reporter) section(msg string) {
+	r.printf("\n%s\n", color.CyanString(msg))
+}
+
+// success prints an indented green-✔ line. The text may embed its own colour.
+func (r *reporter) success(format string, a ...any) {
+	r.printf("   %s %s\n", color.GreenString("✔"), fmt.Sprintf(format, a...))
+}
+
+// detail prints an indented ↳ progress line.
+func (r *reporter) detail(format string, a ...any) {
+	r.printf("   ↳ %s\n", fmt.Sprintf(format, a...))
+}
+
+// warn prints an indented yellow-⚠️ line to stdout (in-flow caution).
+func (r *reporter) warn(format string, a ...any) {
+	r.printf("   %s %s\n", color.YellowString("⚠️"), fmt.Sprintf(format, a...))
+}
+
+// remediation prints a yellow-⚠️ soft-fail note to stderr. The body may contain
+// newlines for indented continuation lines; it is not indented on the first
+// line. Used by the offset-sync bookends, whose failures are surfaced as
+// operator guidance without aborting a successful migration.
+func (r *reporter) remediation(format string, a ...any) {
+	r.errf("%s %s\n", color.YellowString("⚠️"), fmt.Sprintf(format, a...))
+}
+
+// stepDone prints the per-step completion marker.
+func (r *reporter) stepDone() {
+	r.printf("%s\n", color.GreenString("✅ Done"))
+}
+
+// complete prints the final green migration-complete banner (blank line first).
+func (r *reporter) complete(msg string) {
+	r.printf("\n%s\n", color.GreenString(msg))
+}
+
+// blank writes a single blank line.
+func (r *reporter) blank() {
+	r.printf("\n")
+}
+
+// line writes a pre-composed line (plus newline) through the reporter's stdout.
+// Used by the few rich multi-colour rows (lag / promotion tables) that don't fit
+// a semantic helper but should still route through the single output owner.
+func (r *reporter) line(s string) {
+	r.printf("%s\n", s)
+}

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -26,6 +26,7 @@ type MigrationWorkflow struct {
 	// FenceGateway and SwitchGateway. A value of 0 means no deadline — the
 	// wait runs until the operator reports ready or the user cancels.
 	rolloutTimeout time.Duration
+	reporter       *reporter // user-facing terminal output
 }
 
 func NewMigrationWorkflow(
@@ -37,6 +38,7 @@ func NewMigrationWorkflow(
 		clusterLinkService:  clusterLinkService,
 		lagPollInterval:     2 * time.Second,
 		promotePollInterval: 5 * time.Second,
+		reporter:            newReporter(),
 	}
 }
 
@@ -53,6 +55,7 @@ func NewMigrationWorkflowWithOffsets(
 		destinationOffset:   destinationOffset,
 		lagPollInterval:     2 * time.Second,
 		promotePollInterval: 5 * time.Second,
+		reporter:            newReporter(),
 	}
 }
 
@@ -81,7 +84,7 @@ func (s *MigrationWorkflow) Initialize(
 		return fmt.Errorf("gateway CR validation failed: %w", err)
 	}
 	slog.Debug("gateway CRs validated")
-	fmt.Printf("   %s Gateway CRs validated\n", color.GreenString("✔"))
+	s.reporter.success("Gateway CRs validated")
 
 	// Validate cluster link and topics
 	clusterLinkConfig := clusterlink.Config{
@@ -115,7 +118,7 @@ func (s *MigrationWorkflow) Initialize(
 		config.Topics = clusterLinkTopics
 	}
 	slog.Debug("cluster link validated", "activeTopicCount", len(clusterLinkTopics))
-	fmt.Printf("   %s Cluster link validated (%d mirror topics active)\n", color.GreenString("✔"), len(clusterLinkTopics))
+	s.reporter.success("Cluster link validated (%d mirror topics active)", len(clusterLinkTopics))
 
 	// Get cluster link configs
 	configs, err := s.clusterLinkService.ListConfigs(ctx, clusterLinkConfig)
@@ -141,7 +144,7 @@ func (s *MigrationWorkflow) Initialize(
 		case observed != "true":
 			return fmt.Errorf("--pause-consumer-offset-sync refused: cluster link %q has %s=%q (expected %q)", config.ClusterLinkName, offsetSyncEnableKey, observed, "true")
 		}
-		fmt.Printf("   %s Cluster link %s=true (pause-on-execute intent recorded)\n", color.GreenString("✔"), offsetSyncEnableKey)
+		s.reporter.success("Cluster link %s=true (pause-on-execute intent recorded)", offsetSyncEnableKey)
 	}
 
 	// Update config with discovered data
@@ -174,13 +177,15 @@ func (s *MigrationWorkflow) CheckLags(
 		return fmt.Errorf("source and destination offset services are required")
 	}
 
-	fmt.Printf("\n%s Checking replication lag across %s (threshold: %s)\n\n",
+	s.reporter.blank()
+	s.reporter.line(fmt.Sprintf("%s Checking replication lag across %s (threshold: %s)",
 		color.CyanString("⏳"),
 		color.CyanString("%d topics", len(config.Topics)),
-		color.YellowString("%d", lagThreshold))
+		color.YellowString("%d", lagThreshold)))
+	s.reporter.blank()
 
 	if len(config.Topics) == 0 {
-		fmt.Printf("%s No topics to check\n", color.GreenString("✔"))
+		s.reporter.line(fmt.Sprintf("%s No topics to check", color.GreenString("✔")))
 		return nil
 	}
 
@@ -217,9 +222,10 @@ func (s *MigrationWorkflow) CheckLags(
 		}
 
 		if allBelowThreshold {
-			fmt.Printf("\n%s All topic lags below threshold (%d)\n",
+			s.reporter.blank()
+			s.reporter.line(fmt.Sprintf("%s All topic lags below threshold (%d)",
 				color.GreenString("✔"),
-				lagThreshold)
+				lagThreshold))
 			return nil
 		}
 
@@ -231,19 +237,19 @@ func (s *MigrationWorkflow) CheckLags(
 
 		elapsed := time.Since(startTime)
 
-		fmt.Printf("   %s Waiting for lag to clear  %s  %s\n",
+		s.reporter.line(fmt.Sprintf("   %s Waiting for lag to clear  %s  %s",
 			color.YellowString("↳"),
 			color.YellowString("%d/%d topics behind", len(topicTotalLags), len(config.Topics)),
-			color.CyanString("elapsed %s", elapsed.Round(time.Second)))
+			color.CyanString("elapsed %s", elapsed.Round(time.Second))))
 
 		for _, topic := range lagTopics {
-			fmt.Printf("   %s %s  %s %s\n",
+			s.reporter.line(fmt.Sprintf("   %s %s  %s %s",
 				color.YellowString("↳"),
 				color.WhiteString(topic),
 				color.CyanString("lag:"),
-				color.YellowString(formatLag64(topicTotalLags[topic])))
+				color.YellowString(formatLag64(topicTotalLags[topic]))))
 		}
-		fmt.Printf("\n")
+		s.reporter.blank()
 
 		select {
 		case <-ctx.Done():
@@ -281,17 +287,17 @@ func (s *MigrationWorkflow) FenceGateway(ctx context.Context, config *MigrationC
 		return fmt.Errorf("failed to apply fenced gateway CR: %w", err)
 	}
 	slog.Debug("fenced gateway CR applied")
-	fmt.Printf("   %s Fenced gateway CR applied\n", color.GreenString("✔"))
+	s.reporter.success("Fenced gateway CR applied")
 
-	fmt.Printf("   ↳ Waiting for gateway readiness...\n")
+	s.reporter.detail("Waiting for gateway readiness...")
 	slog.Debug("waiting for gateway readiness", "rolloutTimeout", s.rolloutTimeout)
 
-	if err := s.gatewayService.WaitForGatewayReady(ctx, config.K8sNamespace, config.InitialCrName, 5*time.Second, s.rolloutTimeout, printGatewayReadinessProgress); err != nil {
+	if err := s.gatewayService.WaitForGatewayReady(ctx, config.K8sNamespace, config.InitialCrName, 5*time.Second, s.rolloutTimeout, s.printGatewayReadinessProgress); err != nil {
 		return fmt.Errorf("failed waiting for gateway readiness: %w", err)
 	}
 
 	slog.Debug("gateway fenced and ready")
-	fmt.Printf("   %s Gateway fenced and ready\n", color.GreenString("✔"))
+	s.reporter.success("Gateway fenced and ready")
 	return nil
 }
 
@@ -341,7 +347,7 @@ func (s *MigrationWorkflow) detectUnroutedProducers(ctx context.Context, topics 
 	}
 
 	// Wait, then snapshot 2
-	fmt.Printf("   ↳ Monitoring source offsets for %s...\n", duration)
+	s.reporter.detail("Monitoring source offsets for %s...", duration)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -384,7 +390,7 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 	// If enabled, verify source offsets are stable before promoting.
 	// An increasing offset after fencing indicates a producer bypassing the gateway.
 	if config.DetectUnroutedProducersDuration > 0 {
-		fmt.Printf("\n%s\n", color.CyanString("🔍 Checking for unrouted producers..."))
+		s.reporter.section("🔍 Checking for unrouted producers...")
 		if err := s.detectUnroutedProducers(ctx, config.Topics, config.DetectUnroutedProducersDuration); err != nil {
 			// detectUnroutedProducers wraps ErrUnroutedProducers only for a real
 			// detection; a network/fetch error propagates as-is. Either way we
@@ -393,12 +399,11 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 			// the orchestrator triggers only for ErrUnroutedProducers.
 			return err
 		}
-		fmt.Printf("   %s Source offsets stable — no unrouted producers detected\n",
-			color.GreenString("✔"))
-		fmt.Printf("%s\n", color.GreenString("✅ Done"))
+		s.reporter.success("Source offsets stable — no unrouted producers detected")
+		s.reporter.stepDone()
 	}
 
-	fmt.Printf("\n%s\n", color.CyanString("📤 Promoting mirror topics..."))
+	s.reporter.section("📤 Promoting mirror topics...")
 	slog.Debug("topic promotion process started")
 
 	const maxPromoteRetries = 3
@@ -451,8 +456,7 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 		sort.Strings(topicsToPromote)
 
 		if len(topicsToPromote) == 0 {
-			fmt.Printf("   ↳ Waiting for lag to reach zero (%d topics remaining)...\n",
-				len(remaining))
+			s.reporter.detail("Waiting for lag to reach zero (%d topics remaining)...", len(remaining))
 			slog.Debug("no topics at zero lag yet, waiting",
 				"remaining", len(remaining), "pollInterval", s.promotePollInterval)
 			select {
@@ -464,17 +468,16 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 		}
 
 		// Promote topics confirmed at zero lag
-		fmt.Printf("   %s %s confirmed at zero lag\n",
-			color.GreenString("✔"),
+		s.reporter.success("%s confirmed at zero lag",
 			color.WhiteString("%d/%d topics", len(topicsToPromote), len(remaining)))
 		for _, topic := range topicsToPromote {
-			fmt.Printf("   %s %s  %s %s\n",
+			s.reporter.line(fmt.Sprintf("   %s %s  %s %s",
 				color.GreenString("↳"),
 				color.WhiteString(topic),
 				color.CyanString("lag:"),
-				color.GreenString("0"))
+				color.GreenString("0")))
 		}
-		fmt.Printf("   ↳ Promoting %d mirror topics...\n", len(topicsToPromote))
+		s.reporter.detail("Promoting %d mirror topics...", len(topicsToPromote))
 		slog.Debug("promoting mirror topics", "topicCount", len(topicsToPromote), "topics", topicsToPromote)
 
 		promoteResponse, err := s.clusterLinkService.PromoteMirrorTopics(ctx, clusterLinkConfig, topicsToPromote)
@@ -485,8 +488,8 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 		for _, topic := range promoteResponse.Data {
 			if topic.ErrorCode != 0 {
 				retryCount[topic.MirrorTopicName]++
-				fmt.Printf("   %s Topic %s promotion error (attempt %d/%d): %s\n",
-					color.RedString("✗"), topic.MirrorTopicName, retryCount[topic.MirrorTopicName], maxPromoteRetries, topic.ErrorMessage)
+				s.reporter.line(fmt.Sprintf("   %s Topic %s promotion error (attempt %d/%d): %s",
+					color.RedString("✗"), topic.MirrorTopicName, retryCount[topic.MirrorTopicName], maxPromoteRetries, topic.ErrorMessage))
 				slog.Warn("topic promotion error",
 					"topic", topic.MirrorTopicName,
 					"errorCode", topic.ErrorCode,
@@ -497,7 +500,7 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 						topic.MirrorTopicName, maxPromoteRetries, topic.ErrorMessage)
 				}
 			} else {
-				fmt.Printf("   %s %s promoted\n", color.GreenString("✔"), topic.MirrorTopicName)
+				s.reporter.success("%s promoted", topic.MirrorTopicName)
 				slog.Debug("topic promotion initiated", "topic", topic.MirrorTopicName)
 				delete(remaining, topic.MirrorTopicName)
 			}
@@ -522,17 +525,17 @@ func (s *MigrationWorkflow) SwitchGateway(ctx context.Context, config *Migration
 		return fmt.Errorf("failed to apply switchover gateway CR: %w", err)
 	}
 	slog.Debug("switchover gateway CR applied")
-	fmt.Printf("   %s Switchover gateway CR applied\n", color.GreenString("✔"))
+	s.reporter.success("Switchover gateway CR applied")
 
-	fmt.Printf("   ↳ Waiting for gateway readiness...\n")
+	s.reporter.detail("Waiting for gateway readiness...")
 	slog.Debug("waiting for gateway readiness", "rolloutTimeout", s.rolloutTimeout)
 
-	if err := s.gatewayService.WaitForGatewayReady(ctx, config.K8sNamespace, config.InitialCrName, 5*time.Second, s.rolloutTimeout, printGatewayReadinessProgress); err != nil {
+	if err := s.gatewayService.WaitForGatewayReady(ctx, config.K8sNamespace, config.InitialCrName, 5*time.Second, s.rolloutTimeout, s.printGatewayReadinessProgress); err != nil {
 		return fmt.Errorf("failed waiting for gateway readiness: %w", err)
 	}
 
 	slog.Debug("gateway switchover complete")
-	fmt.Printf("   %s Gateway switchover complete\n", color.GreenString("✔"))
+	s.reporter.success("Gateway switchover complete")
 	return nil
 }
 
@@ -541,16 +544,15 @@ func (s *MigrationWorkflow) SwitchGateway(ctx context.Context, config *Migration
 // A no-op signal (RolloutDetected=false) is preserved from the previous
 // implementation so users see "no pod restart required" when an apply did not
 // trigger a rollout.
-func printGatewayReadinessProgress(p gateway.GatewayReadinessProgress) {
+func (s *MigrationWorkflow) printGatewayReadinessProgress(p gateway.GatewayReadinessProgress) {
 	if !p.RolloutDetected {
-		fmt.Printf("   %s No pod restart required\n", color.GreenString("✔"))
+		s.reporter.success("No pod restart required")
 		return
 	}
 	if p.InitialPodCount > 0 {
-		fmt.Printf("   ↳ %d/%d pods ready (elapsed %s)\n",
-			p.PodsReady, p.InitialPodCount, formatElapsed(p.Elapsed))
+		s.reporter.detail("%d/%d pods ready (elapsed %s)", p.PodsReady, p.InitialPodCount, formatElapsed(p.Elapsed))
 	} else {
-		fmt.Printf("   ↳ gateway reconciling (elapsed %s)\n", formatElapsed(p.Elapsed))
+		s.reporter.detail("gateway reconciling (elapsed %s)", formatElapsed(p.Elapsed))
 	}
 }
 

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -403,7 +403,8 @@ func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationC
 		s.reporter.stepDone()
 	}
 
-	s.reporter.section("📤 Promoting mirror topics...")
+	// The step banner is printed by the orchestrator (stepHeaders[EventPromote]);
+	// PromoteTopics emits only progress lines, like the other workflow actions.
 	slog.Debug("topic promotion process started")
 
 	const maxPromoteRetries = 3

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -15,7 +15,7 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-type MigrationWorkflow struct {
+type MigrationActions struct {
 	gatewayService      gateway.Service
 	clusterLinkService  clusterlink.Service
 	sourceOffset        offset.Provider
@@ -29,11 +29,11 @@ type MigrationWorkflow struct {
 	reporter       *reporter // user-facing terminal output
 }
 
-func NewMigrationWorkflow(
+func NewMigrationActions(
 	gatewayService gateway.Service,
 	clusterLinkService clusterlink.Service,
-) *MigrationWorkflow {
-	return &MigrationWorkflow{
+) *MigrationActions {
+	return &MigrationActions{
 		gatewayService:      gatewayService,
 		clusterLinkService:  clusterLinkService,
 		lagPollInterval:     2 * time.Second,
@@ -42,13 +42,13 @@ func NewMigrationWorkflow(
 	}
 }
 
-func NewMigrationWorkflowWithOffsets(
+func NewMigrationActionsWithOffsets(
 	gatewayService gateway.Service,
 	clusterLinkService clusterlink.Service,
 	sourceOffset offset.Provider,
 	destinationOffset offset.Provider,
-) *MigrationWorkflow {
-	return &MigrationWorkflow{
+) *MigrationActions {
+	return &MigrationActions{
 		gatewayService:      gatewayService,
 		clusterLinkService:  clusterLinkService,
 		sourceOffset:        sourceOffset,
@@ -61,11 +61,11 @@ func NewMigrationWorkflowWithOffsets(
 
 // SetRolloutTimeout sets the deadline applied to gateway-readiness waits.
 // A value of 0 means no deadline.
-func (s *MigrationWorkflow) SetRolloutTimeout(d time.Duration) {
+func (s *MigrationActions) SetRolloutTimeout(d time.Duration) {
 	s.rolloutTimeout = d
 }
 
-func (s *MigrationWorkflow) Initialize(
+func (s *MigrationActions) Initialize(
 	ctx context.Context,
 	config *MigrationConfig,
 	clusterApiKey, clusterApiSecret string,
@@ -167,7 +167,7 @@ func (s *MigrationWorkflow) Initialize(
 }
 
 // CheckLags polls source and destination offsets until lag is below threshold
-func (s *MigrationWorkflow) CheckLags(
+func (s *MigrationActions) CheckLags(
 	ctx context.Context,
 	config *MigrationConfig,
 	lagThreshold int64,
@@ -280,7 +280,7 @@ func formatLag64(n int64) string {
 // generation. The wait runs without a deadline by default — the operator
 // drives convergence and the user can Ctrl-C if a rollout wedges. An optional
 // per-workflow rolloutTimeout caps the wait when set (via SetRolloutTimeout).
-func (s *MigrationWorkflow) FenceGateway(ctx context.Context, config *MigrationConfig) error {
+func (s *MigrationActions) FenceGateway(ctx context.Context, config *MigrationConfig) error {
 	slog.Debug("fencing gateway", "gateway", config.InitialCrName, "namespace", config.K8sNamespace)
 
 	if err := s.gatewayService.ApplyGatewayYAML(ctx, config.K8sNamespace, config.InitialCrName, config.FencedCrYAML); err != nil {
@@ -305,7 +305,7 @@ func (s *MigrationWorkflow) FenceGateway(ctx context.Context, config *MigrationC
 // The initial CR YAML fetched from k8s contains server-managed metadata
 // (managedFields, resourceVersion, status) that breaks server-side apply,
 // so we strip it before applying.
-func (s *MigrationWorkflow) unfenceGateway(ctx context.Context, config *MigrationConfig) error {
+func (s *MigrationActions) unfenceGateway(ctx context.Context, config *MigrationConfig) error {
 	// Parse the initial CR, strip server metadata, re-marshal
 	var obj map[string]interface{}
 	if err := yaml.Unmarshal(config.InitialCrYAML, &obj); err != nil {
@@ -334,7 +334,7 @@ func (s *MigrationWorkflow) unfenceGateway(ctx context.Context, config *Migratio
 // given duration. If any partition's offset increases between snapshots, it
 // means a producer is writing directly to the source cluster (bypassing the
 // fenced gateway) and the migration should not proceed.
-func (s *MigrationWorkflow) detectUnroutedProducers(ctx context.Context, topics []string, duration time.Duration) error {
+func (s *MigrationActions) detectUnroutedProducers(ctx context.Context, topics []string, duration time.Duration) error {
 	// Snapshot 1
 	slog.Debug("taking first source offset snapshot", "topicCount", len(topics))
 	snapshot1 := make(map[string]map[int32]int64, len(topics))
@@ -382,7 +382,7 @@ func (s *MigrationWorkflow) detectUnroutedProducers(ctx context.Context, topics 
 }
 
 // PromoteTopics polls offsets and promotes mirror topics that reach zero lag
-func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *MigrationConfig, clusterApiKey, clusterApiSecret string) error {
+func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationConfig, clusterApiKey, clusterApiSecret string) error {
 	if s.sourceOffset == nil || s.destinationOffset == nil {
 		return fmt.Errorf("source and destination offset services are required")
 	}
@@ -518,7 +518,7 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 // SwitchGateway applies the switchover gateway CR YAML to point to Confluent
 // Cloud and waits for the operator to report the gateway as Ready. The wait
 // uses the same no-deadline-by-default behavior as FenceGateway.
-func (s *MigrationWorkflow) SwitchGateway(ctx context.Context, config *MigrationConfig) error {
+func (s *MigrationActions) SwitchGateway(ctx context.Context, config *MigrationConfig) error {
 	slog.Debug("switching gateway", "gateway", config.InitialCrName, "namespace", config.K8sNamespace)
 
 	if err := s.gatewayService.ApplyGatewayYAML(ctx, config.K8sNamespace, config.InitialCrName, config.SwitchoverCrYAML); err != nil {
@@ -544,7 +544,7 @@ func (s *MigrationWorkflow) SwitchGateway(ctx context.Context, config *Migration
 // A no-op signal (RolloutDetected=false) is preserved from the previous
 // implementation so users see "no pod restart required" when an apply did not
 // trigger a rollout.
-func (s *MigrationWorkflow) printGatewayReadinessProgress(p gateway.GatewayReadinessProgress) {
+func (s *MigrationActions) printGatewayReadinessProgress(p gateway.GatewayReadinessProgress) {
 	if !p.RolloutDetected {
 		s.reporter.success("No pod restart required")
 		return

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -42,7 +42,7 @@ func TestWorkflow_Initialize_Success(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		MigrationId:         "test-1",
 		K8sNamespace:        "ns",
@@ -70,7 +70,7 @@ func TestWorkflow_Initialize_GatewayFetchError(t *testing.T) {
 	}
 	cl := &mockClusterLinkService{}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		K8sNamespace:  "ns",
 		InitialCrName: "my-gw",
@@ -97,7 +97,7 @@ func TestWorkflow_Initialize_InactiveMirrorTopics(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		K8sNamespace:        "ns",
 		InitialCrName:       "my-gw",
@@ -131,7 +131,7 @@ func TestWorkflow_Initialize_TopicValidationError(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		K8sNamespace:        "ns",
 		InitialCrName:       "my-gw",
@@ -168,7 +168,7 @@ func TestWorkflow_Initialize_NoTopicsDiscoverAll(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		K8sNamespace:        "ns",
 		InitialCrName:       "my-gw",
@@ -197,7 +197,7 @@ func TestWorkflow_Initialize_NoTopicsDiscoverAll(t *testing.T) {
 
 // makeOffsetSyncWorkflow builds a workflow with mocks that satisfy Initialize
 // up to the cluster-link config check. listConfigsFn is the seam under test.
-func makeOffsetSyncWorkflow(t *testing.T, listConfigsFn func(_ context.Context, _ clusterlink.Config) (map[string]string, error)) *MigrationWorkflow {
+func makeOffsetSyncWorkflow(t *testing.T, listConfigsFn func(_ context.Context, _ clusterlink.Config) (map[string]string, error)) *MigrationActions {
 	t.Helper()
 	gw := &mockGatewayService{
 		getGatewayYAMLFn: func(_ context.Context, _, _ string) ([]byte, error) {
@@ -210,7 +210,7 @@ func makeOffsetSyncWorkflow(t *testing.T, listConfigsFn func(_ context.Context, 
 		},
 		listConfigsFn: listConfigsFn,
 	}
-	return NewMigrationWorkflow(gw, cl)
+	return NewMigrationActions(gw, cl)
 }
 
 func TestWorkflow_Initialize_PauseOffsetSync_Pass(t *testing.T) {
@@ -351,7 +351,7 @@ func TestWorkflow_CheckLags_ImmediatelyBelowThreshold(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 	config := &MigrationConfig{
 		Topics: []string{"topic-1", "topic-2"},
 	}
@@ -375,7 +375,7 @@ func TestWorkflow_CheckLags_NoTopics(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 	config := &MigrationConfig{
 		Topics: []string{},
 	}
@@ -388,7 +388,7 @@ func TestWorkflow_CheckLags_NilOffsetServices(t *testing.T) {
 	gw := &mockGatewayService{}
 	cl := &mockClusterLinkService{}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		Topics: []string{"topic-1"},
 	}
@@ -414,7 +414,7 @@ func TestWorkflow_CheckLags_ContextCancelled(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 	config := &MigrationConfig{
 		Topics: []string{"topic-1"},
 	}
@@ -442,7 +442,7 @@ func TestWorkflow_CheckLags_DestinationAhead(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 	config := &MigrationConfig{
 		Topics: []string{"topic-1"},
 	}
@@ -484,7 +484,7 @@ func TestWorkflow_PromoteTopics_AllAtZeroLag(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, offsetProvider, offsetProvider)
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:              []string{"topic-1", "topic-2"},
@@ -533,7 +533,7 @@ func TestWorkflow_PromoteTopics_PartialPromotionError(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, offsetProvider, offsetProvider)
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:              []string{"topic-1", "topic-2"},
@@ -576,7 +576,7 @@ func TestWorkflow_PromoteTopics_MaxRetriesExceeded(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, offsetProvider, offsetProvider)
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:              []string{"topic-1"},
@@ -594,7 +594,7 @@ func TestWorkflow_PromoteTopics_NilOffsetServices(t *testing.T) {
 	gw := &mockGatewayService{}
 	cl := &mockClusterLinkService{}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		Topics: []string{"topic-1"},
 	}
@@ -624,7 +624,7 @@ func TestWorkflow_FenceGateway_HappyPath(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
 	err := wf.FenceGateway(context.Background(), config)
@@ -649,7 +649,7 @@ func TestWorkflow_FenceGateway_DoesNotCallUIDDiffingMethods(t *testing.T) {
 		// waitForGatewayReadyFn defaults to nil → returns nil success
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
 	err := wf.FenceGateway(context.Background(), config)
@@ -664,7 +664,7 @@ func TestWorkflow_FenceGateway_ApplyFailsReturnsWrappedError(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
 	err := wf.FenceGateway(context.Background(), config)
@@ -683,7 +683,7 @@ func TestWorkflow_FenceGateway_WaitTimeoutPropagatesDeadlineExceeded(t *testing.
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	wf.SetRolloutTimeout(100 * time.Millisecond)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
@@ -703,7 +703,7 @@ func TestWorkflow_FenceGateway_WaitContextCancelledPropagates(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -726,7 +726,7 @@ func TestWorkflow_FenceGateway_PassesRolloutTimeoutToService(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	wf.SetRolloutTimeout(15 * time.Minute)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
@@ -745,7 +745,7 @@ func TestWorkflow_FenceGateway_DefaultRolloutTimeoutIsZero(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", FencedCrYAML: []byte("fenced")}
 
 	err := wf.FenceGateway(context.Background(), config)
@@ -766,7 +766,7 @@ func TestWorkflow_SwitchGateway_HappyPath(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", SwitchoverCrYAML: []byte("switchover")}
 
 	err := wf.SwitchGateway(context.Background(), config)
@@ -782,7 +782,7 @@ func TestWorkflow_SwitchGateway_WaitErrorIsWrapped(t *testing.T) {
 		},
 	}
 	cl := &mockClusterLinkService{}
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{K8sNamespace: "ns", InitialCrName: "gw-1", SwitchoverCrYAML: []byte("switchover")}
 
 	err := wf.SwitchGateway(context.Background(), config)
@@ -824,7 +824,7 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_StableOffsets(t *testing
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, offsetProvider, offsetProvider)
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1", "topic-2"},
@@ -871,7 +871,7 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_Return
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1"},
@@ -922,7 +922,7 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_FlagDisabled(t *testing.
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, sourceOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, sourceOffset)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1"},
@@ -947,7 +947,7 @@ func TestWorkflow_UnfenceGateway_StripsServerMetadata(t *testing.T) {
 	}
 	cl := &mockClusterLinkService{}
 
-	wf := NewMigrationWorkflow(gw, cl)
+	wf := NewMigrationActions(gw, cl)
 	config := &MigrationConfig{
 		InitialCrName: "my-gw",
 		K8sNamespace:  "confluent",
@@ -1001,7 +1001,7 @@ func TestWorkflow_DetectUnroutedProducers_ContextCancelled(t *testing.T) {
 		},
 	}
 
-	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE — diff visualization only.**
> This draft PR exists solely to visualize a migration-FSM architecture cleanup against the #367 branch. It is not intended to merge as-is; close without merging once reviewed.

## Summary

Implements the recommendations from an architecture review of the migration FSM (`internal/services/migration`), focused on separation of concerns between `state.go` / `orchestrator.go` / `workflow.go` and on the FSM state/transition modelling. All changes are behaviour-preserving; migration, execute, and init tests pass throughout.

## Commits (each a self-contained cleanup)

1. **event-scoped callbacks + single state writer** — register action callbacks per-event (`before_<EVENT>`) instead of per-state (`leave_<STATE>`), so each is single-purpose and the fenced state's promote/abort_fence transitions no longer share a guarded callback. Make the orchestrator the single writer for migration state (`PersistState`), used by the offset-sync bookends instead of a parallel closure.
2. **consolidate rollback decision** — fold the "unrouted producers → roll back the fence" policy into one documented `handleStepFailure` method; the `Execute` loop is now fully generic.
3. **reporter seam** — route all user-facing output (orchestrator, workflow, and offset-sync bookends) through a single `reporter` that owns the emoji/indent/colour conventions and the stdout/stderr streams. Drop `UserMessage` from the `WorkflowStep` FSM-edge struct into a separate `stepHeaders` map.
4. **rename `MigrationWorkflow` → `MigrationActions`** — the type owns the action methods, not the workflow sequence (that lives in `canonicalWorkflow`).
5. **thread run params via `e.Args`** — remove the mutable `execParams` orchestrator field; params flow with the event. Document the two deliberate modelling choices near `canonicalWorkflow` (bookends run outside the FSM; no terminal/failed state).
6. **banner cleanup** — fix a promote double-header and drop a dead `stepHeaders[EventAbortFence]` entry.

## Test plan

- [x] `go build` / `go vet` clean
- [x] `go test ./internal/services/migration/ ./cmd/migration/execute/ ./cmd/migration/init/` pass at every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)