### PR TITLE
refactor(migration): model unrouted-producer detection as verify_fence FSM step

### DIFF
--- a/cmd/migration/list/migration_lister.go
+++ b/cmd/migration/list/migration_lister.go
@@ -170,6 +170,8 @@ func (ml *MigrationLister) getStatusColor(state string) *color.Color {
 		return color.New(color.FgCyan)
 	case "fenced":
 		return color.New(color.FgYellow)
+	case "fence_verified":
+		return color.New(color.FgYellow)
 	case "promoted":
 		return color.New(color.FgGreen)
 	case "switched":

--- a/integration-tests/migration/migration_e2e_test.go
+++ b/integration-tests/migration/migration_e2e_test.go
@@ -28,9 +28,9 @@ import (
 // (source topic, cluster link, gateway CR) provisioned by setup.sh so that
 // tests are fully isolated and do not depend on execution order.
 const (
-	scenarioBaseline                 = "baseline"                   // TestMigrationE2E
-	scenarioPauseSyncHappy           = "pause-sync-happy"           // TestMigrationE2E_PauseOffsetSync_HappyPath
-	scenarioPauseSyncRefuses         = "pause-sync-refuses"         // TestMigrationE2E_PauseOffsetSync_InitRefuses
+	scenarioBaseline                 = "baseline"                    // TestMigrationE2E
+	scenarioPauseSyncHappy           = "pause-sync-happy"            // TestMigrationE2E_PauseOffsetSync_HappyPath
+	scenarioPauseSyncRefuses         = "pause-sync-refuses"          // TestMigrationE2E_PauseOffsetSync_InitRefuses
 	scenarioPauseSyncRestoresFilters = "pause-sync-restores-filters" // TestMigrationE2E_PauseOffsetSync_RestoresFilters
 )
 

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -120,15 +120,13 @@ func NewMigrationOrchestrator(
 		Src:  []string{StateFenced},
 		Dst:  StateInitialized,
 	})
-
-	// fence_verified is a point-in-time attestation and never survives a
-	// restart: a rogue producer may have appeared since the run that verified
-	// the fence, and there is no downstream re-verification (PromoteTopics'
-	// zero-lag check samples instants and misses intermittent producers).
-	// Demote to fenced so a resume re-runs the verify_fence detection window.
-	if config.CurrentState == StateFenceVerified {
-		config.CurrentState = StateFenced
-	}
+	// Backward transition: fence verification expires across restarts (fired
+	// at bootstrap below, never during a run)
+	events = append(events, fsm.EventDesc{
+		Name: EventExpireVerification,
+		Src:  []string{StateFenceVerified},
+		Dst:  StateFenced,
+	})
 
 	// Bootstrap FSM from persisted state to enable resumability (e.g. "initialized" skips init, resumes at lag check).
 	//
@@ -153,6 +151,19 @@ func NewMigrationOrchestrator(
 			"before_" + EventSwitch:      orchestrator.onSwitch,
 		},
 	)
+
+	// fence_verified is a point-in-time attestation and never survives a
+	// restart: a rogue producer may have appeared since the run that verified
+	// the fence, and there is no downstream re-verification (PromoteTopics'
+	// zero-lag check samples instants and misses intermittent producers).
+	// Expire it so a resume re-runs the verify_fence detection window. The
+	// transition has no action callback and its source state matches, so it
+	// cannot fail; the guard keeps the FSM honest if that ever changes.
+	if orchestrator.fsm.Is(StateFenceVerified) {
+		if err := orchestrator.fsm.Event(context.Background(), EventExpireVerification); err != nil {
+			slog.Error("❌ failed to expire fence verification at bootstrap", "error", err)
+		}
+	}
 
 	return orchestrator
 }

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -39,7 +39,8 @@ var canonicalWorkflow = []WorkflowStep{
 	{EventInitialize, "initializing migration", StateUninitialized, StateInitialized},
 	{EventWaitForLags, "checking replication lags", StateInitialized, StateLagsOk},
 	{EventFence, "fencing gateway", StateLagsOk, StateFenced},
-	{EventPromote, "promoting topics", StateFenced, StatePromoted},
+	{EventVerifyFence, "verifying gateway fence", StateFenced, StateFenceVerified},
+	{EventPromote, "promoting topics", StateFenceVerified, StatePromoted},
 	{EventSwitch, "switching gateway config", StatePromoted, StateSwitched},
 }
 
@@ -52,6 +53,7 @@ var stepHeaders = map[string]string{
 	EventInitialize:  "🔍 Initializing migration...",
 	EventWaitForLags: "⏳ Checking replication lags...",
 	EventFence:       "🚧 Fencing gateway...",
+	EventVerifyFence: "🔍 Checking for unrouted producers...",
 	EventPromote:     "🚀 Promoting topics...",
 	EventSwitch:      "🔄 Switching gateway to Confluent Cloud...",
 }
@@ -123,7 +125,7 @@ func NewMigrationOrchestrator(
 	//
 	// Action callbacks are registered per-event (before_<EVENT>), not per-state
 	// (leave_<STATE>), so each is single-purpose. This matters for the fenced
-	// state, which two events leave — promote (forward) and abort_fence
+	// state, which two events leave — verify_fence (forward) and abort_fence
 	// (rollback) — each with its own callback and no event-sniffing guard.
 	orchestrator.fsm = fsm.NewFSM(
 		config.CurrentState,
@@ -136,6 +138,7 @@ func NewMigrationOrchestrator(
 			"before_" + EventInitialize:  orchestrator.onInitialize,
 			"before_" + EventWaitForLags: orchestrator.onWaitForLags,
 			"before_" + EventFence:       orchestrator.onFence,
+			"before_" + EventVerifyFence: orchestrator.onVerifyFence,
 			"before_" + EventPromote:     orchestrator.onPromote,
 			"before_" + EventAbortFence:  orchestrator.onAbortFence,
 			"before_" + EventSwitch:      orchestrator.onSwitch,
@@ -188,10 +191,10 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 
 // handleStepFailure is the single place that maps a failed workflow step to its
 // compensating rollback (if any) and returns the wrapped error. The migration
-// defines exactly one compensation: when promotion is aborted because unrouted
-// producers were detected (ErrUnroutedProducers, signalled up from the workflow
-// layer), roll the fence back to initialized via abort_fence — which unfences
-// the gateway (see onAbortFence) — so a re-run rechecks lags and re-fences.
+// defines exactly one compensation: when fence verification detects unrouted
+// producers (ErrUnroutedProducers, signalled up from the workflow layer), roll
+// the fence back to initialized via abort_fence — which unfences the gateway
+// (see onAbortFence) — so a re-run rechecks lags and re-fences.
 //
 // Rollback failures are logged, not returned: the originating step error is
 // always what surfaces to the caller, and a cancelled abort_fence (e.g. the
@@ -263,9 +266,18 @@ func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
 	}
 }
 
+// onVerifyFence runs the verify_fence transition: delegates to VerifyFence.
+// Registered on before_verify_fence (not leave_fenced), so it fires only for
+// the verify_fence event — never for the abort_fence rollback that also
+// leaves fenced. On ErrUnroutedProducers the transition is cancelled, leaving
+// the FSM at fenced, and handleStepFailure fires the abort_fence rollback.
+func (o *MigrationOrchestrator) onVerifyFence(ctx context.Context, e *fsm.Event) {
+	if err := o.actions.VerifyFence(ctx, o.config); err != nil {
+		e.Cancel(err)
+	}
+}
+
 // onPromote runs the forward promote transition: delegates to PromoteTopics.
-// Registered on before_promote (not leave_fenced), so it fires only for the
-// promote event — never for the abort_fence rollback that also leaves fenced.
 func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
 	p := execParamsFromEvent(e)
 	if err := o.actions.PromoteTopics(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret); err != nil {

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -121,6 +121,15 @@ func NewMigrationOrchestrator(
 		Dst:  StateInitialized,
 	})
 
+	// fence_verified is a point-in-time attestation and never survives a
+	// restart: a rogue producer may have appeared since the run that verified
+	// the fence, and there is no downstream re-verification (PromoteTopics'
+	// zero-lag check samples instants and misses intermittent producers).
+	// Demote to fenced so a resume re-runs the verify_fence detection window.
+	if config.CurrentState == StateFenceVerified {
+		config.CurrentState = StateFenced
+	}
+
 	// Bootstrap FSM from persisted state to enable resumability (e.g. "initialized" skips init, resumes at lag check).
 	//
 	// Action callbacks are registered per-event (before_<EVENT>), not per-state

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -428,8 +428,10 @@ func TestOrchestrator_Execute_UnroutedProducers_UnfenceReadinessFails_StaysAtFen
 
 func TestOrchestrator_Execute_VerifyFencePersistedBeforePromote(t *testing.T) {
 	// A successful unrouted-producer check is its own FSM transition
-	// (fenced → fence_verified) and must be persisted before promotion starts,
-	// so a later promote failure resumes without repeating the detection window.
+	// (fenced → fence_verified), persisted before promotion starts like every
+	// other step. The persisted value is informational — bootstrap demotes it
+	// back to fenced on the next run (see TestOrchestrator_Bootstrap_DemotesFenceVerified)
+	// — but it must still record the FSM's true mid-run position, never promoted.
 	overrides := orchestratorOverrides{
 		promoteMirrorTopicsFn: func(ctx context.Context, cfg clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
 			return nil, fmt.Errorf("confluent cloud API unavailable")
@@ -450,21 +452,47 @@ func TestOrchestrator_Execute_VerifyFencePersistedBeforePromote(t *testing.T) {
 		"successful fence verification should be persisted even when promotion later fails")
 }
 
-func TestOrchestrator_Execute_ResumeFromFenceVerified_SkipsDetection(t *testing.T) {
-	// Resuming from fence_verified must not repeat the detection window. If it
-	// did, the 30s window would trip the 3s context deadline below.
-	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenceVerified, nil)
-	config.DetectUnroutedProducersDuration = 30 * time.Second
+func TestOrchestrator_Bootstrap_DemotesFenceVerified(t *testing.T) {
+	// fence_verified is a point-in-time attestation and never survives a
+	// restart: construction must demote it to fenced so detection re-runs.
+	_, config, _ := newHappyPathOrchestrator(t, StateFenceVerified, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	assert.Equal(t, StateFenced, config.CurrentState,
+		"bootstrap should demote a persisted fence_verified to fenced")
+}
+
+func TestOrchestrator_Execute_ResumeFromFenceVerified_RerunsDetection(t *testing.T) {
+	// A rogue producer may appear between the run that verified the fence and
+	// a later resume (e.g. promote failed, operator re-runs hours later).
+	// fence_verified must not survive the restart: detection re-runs, catches
+	// the rogue producer, and the abort_fence rollback fires.
+	var sourceCallCount int64
+
+	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenceVerified, nil)
+	config.DetectUnroutedProducersDuration = time.Millisecond
+	config.InitialCrYAML = []byte("apiVersion: platform.confluent.io/v1beta1\nkind: Gateway\nmetadata:\n  name: my-gateway\n  namespace: confluent\n")
+
+	// Rogue producer: source offsets keep increasing on every call
+	orch.actions.sourceOffset = &mockOffsetProvider{
+		getFn: func(topic string) (map[int32]int64, error) {
+			n := atomic.AddInt64(&sourceCallCount, 1)
+			return map[int32]int64{0: 100 + n*10}, nil
+		},
+	}
+
+	// Deadline bounds the failure mode where detection is skipped and promote
+	// polls forever on never-zero lag; the happy path finishes in milliseconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	err := orch.Execute(ctx, 0, "api-key", "api-secret")
-	require.NoError(t, err)
+	require.Error(t, err,
+		"resume from fence_verified must re-run detection and catch the rogue producer")
+	assert.ErrorIs(t, err, ErrUnroutedProducers)
 
-	assert.Equal(t, StateSwitched, config.CurrentState)
 	persisted := loadPersistedMigration(t, stateFilePath, config.MigrationId)
-	assert.Equal(t, StateSwitched, persisted.CurrentState)
+	assert.Equal(t, StateInitialized, persisted.CurrentState,
+		"detection on resume should roll back to initialized via abort_fence")
 }
 
 func TestOrchestrator_Execute_PromoteError(t *testing.T) {

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/confluentinc/kcp/internal/services/clusterlink"
 	"github.com/confluentinc/kcp/internal/services/gateway"
+	"github.com/looplab/fsm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -459,6 +460,18 @@ func TestOrchestrator_Bootstrap_DemotesFenceVerified(t *testing.T) {
 
 	assert.Equal(t, StateFenced, config.CurrentState,
 		"bootstrap should demote a persisted fence_verified to fenced")
+}
+
+func TestOrchestrator_ExpireVerificationIsAnFSMEdge(t *testing.T) {
+	// The bootstrap demotion must be modelled as an FSM transition
+	// (expire_verification: fence_verified → fenced), not a config mutation
+	// the machine never sees — so it fires through the FSM callbacks and
+	// appears in fsm.Visualize output alongside abort_fence.
+	orch, _, _ := newHappyPathOrchestrator(t, StateUninitialized, nil)
+
+	assert.Contains(t, fsm.Visualize(orch.fsm),
+		`"fence_verified" -> "fenced" [ label = "expire_verification" ];`,
+		"expire_verification should be a visible edge in the state machine")
 }
 
 func TestOrchestrator_Execute_ResumeFromFenceVerified_RerunsDetection(t *testing.T) {

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -194,7 +194,7 @@ func TestOrchestrator_Execute_FullWorkflow(t *testing.T) {
 }
 
 func TestOrchestrator_Execute_ResumesFromState(t *testing.T) {
-	for _, startState := range []string{StateInitialized, StateLagsOk, StateFenced, StatePromoted} {
+	for _, startState := range []string{StateInitialized, StateLagsOk, StateFenced, StateFenceVerified, StatePromoted} {
 		t.Run("from_"+startState, func(t *testing.T) {
 			var getYAMLCalls int32
 			overrides := orchestratorOverrides{
@@ -426,6 +426,47 @@ func TestOrchestrator_Execute_UnroutedProducers_UnfenceReadinessFails_StaysAtFen
 		"state should remain at fenced when the unfence rollout never becomes ready")
 }
 
+func TestOrchestrator_Execute_VerifyFencePersistedBeforePromote(t *testing.T) {
+	// A successful unrouted-producer check is its own FSM transition
+	// (fenced → fence_verified) and must be persisted before promotion starts,
+	// so a later promote failure resumes without repeating the detection window.
+	overrides := orchestratorOverrides{
+		promoteMirrorTopicsFn: func(ctx context.Context, cfg clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
+			return nil, fmt.Errorf("confluent cloud API unavailable")
+		},
+	}
+
+	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenced, nil, overrides)
+	config.DetectUnroutedProducersDuration = time.Millisecond
+
+	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	require.Error(t, err)
+
+	// The verify step succeeded (stable offsets) and was persisted; the promote
+	// transition was cancelled, so fence_verified is the last good state.
+	assert.Equal(t, StateFenceVerified, config.CurrentState)
+	persisted := loadPersistedMigration(t, stateFilePath, config.MigrationId)
+	assert.Equal(t, StateFenceVerified, persisted.CurrentState,
+		"successful fence verification should be persisted even when promotion later fails")
+}
+
+func TestOrchestrator_Execute_ResumeFromFenceVerified_SkipsDetection(t *testing.T) {
+	// Resuming from fence_verified must not repeat the detection window. If it
+	// did, the 30s window would trip the 3s context deadline below.
+	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenceVerified, nil)
+	config.DetectUnroutedProducersDuration = 30 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := orch.Execute(ctx, 0, "api-key", "api-secret")
+	require.NoError(t, err)
+
+	assert.Equal(t, StateSwitched, config.CurrentState)
+	persisted := loadPersistedMigration(t, stateFilePath, config.MigrationId)
+	assert.Equal(t, StateSwitched, persisted.CurrentState)
+}
+
 func TestOrchestrator_Execute_PromoteError(t *testing.T) {
 	overrides := orchestratorOverrides{
 		promoteMirrorTopicsFn: func(ctx context.Context, cfg clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
@@ -438,20 +479,12 @@ func TestOrchestrator_Execute_PromoteError(t *testing.T) {
 	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
 	require.Error(t, err)
 
-	// State should remain at fenced — the promote transition was cancelled
-	assert.Equal(t, StateFenced, config.CurrentState)
+	// The verify_fence transition succeeded first (detection disabled → no-op),
+	// then the promote transition was cancelled, so the FSM rests at
+	// fence_verified — never promoted.
+	assert.Equal(t, StateFenceVerified, config.CurrentState)
 
-	// No state file should have been written for this run since no transition succeeded.
-	// (We started at fenced and the first attempted transition fenced->promoted failed.)
-	_, loadErr := NewMigrationStateFromFile(stateFilePath)
-	if loadErr == nil {
-		state, _ := NewMigrationStateFromFile(stateFilePath)
-		if state != nil {
-			m, getErr := state.GetMigrationById(config.MigrationId)
-			if getErr == nil {
-				assert.NotEqual(t, StatePromoted, m.CurrentState,
-					"state file should NOT contain migration at promoted state after promote failure")
-			}
-		}
-	}
+	persisted := loadPersistedMigration(t, stateFilePath, config.MigrationId)
+	assert.Equal(t, StateFenceVerified, persisted.CurrentState,
+		"state file should rest at fence_verified after promote failure, never promoted")
 }

--- a/internal/services/migration/state.go
+++ b/internal/services/migration/state.go
@@ -36,6 +36,11 @@ const (
 	// verify_fence step detects unrouted producers; the transition itself
 	// unfences the gateway (see onAbortFence in orchestrator.go).
 	EventAbortFence = "abort_fence"
+	// EventExpireVerification demotes fence_verified to fenced at FSM
+	// bootstrap: the verification is a point-in-time attestation and never
+	// survives a restart, so a resume re-runs the verify_fence detection
+	// window. Fired only by NewMigrationOrchestrator; it has no action.
+	EventExpireVerification = "expire_verification"
 )
 
 // ----- migration configuration -----

--- a/internal/services/migration/state.go
+++ b/internal/services/migration/state.go
@@ -19,6 +19,7 @@ const (
 	StateInitialized   = "initialized"
 	StateLagsOk        = "lags_ok"
 	StateFenced        = "fenced"
+	StateFenceVerified = "fence_verified"
 	StatePromoted      = "promoted"
 	StateSwitched      = "switched"
 )
@@ -28,11 +29,12 @@ const (
 	EventInitialize  = "initialize"
 	EventWaitForLags = "wait_for_lags"
 	EventFence       = "fence"
+	EventVerifyFence = "verify_fence"
 	EventPromote     = "promote"
 	EventSwitch      = "switch"
-	// EventAbortFence rolls back from fenced to initialized when unrouted
-	// producers are detected; the transition itself unfences the gateway
-	// (see leaveFencedCallback in orchestrator.go).
+	// EventAbortFence rolls back from fenced to initialized when the
+	// verify_fence step detects unrouted producers; the transition itself
+	// unfences the gateway (see onAbortFence in orchestrator.go).
 	EventAbortFence = "abort_fence"
 )
 

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -396,30 +396,40 @@ func (s *MigrationActions) detectUnroutedProducers(ctx context.Context, topics [
 	return nil
 }
 
+// VerifyFence verifies the fence held: source offsets must be stable, because
+// an increasing offset after fencing indicates a producer bypassing the
+// gateway. When detection is disabled (DetectUnroutedProducersDuration == 0)
+// the step succeeds immediately so the FSM still records fence_verified.
+//
+// detectUnroutedProducers wraps ErrUnroutedProducers only for a real
+// detection; a network/fetch error propagates as-is. Either way we just
+// return it — restoring traffic (unfencing the gateway) is the state
+// machine's job on the abort_fence rollback transition, which the
+// orchestrator triggers only for ErrUnroutedProducers.
+func (s *MigrationActions) VerifyFence(ctx context.Context, config *MigrationConfig) error {
+	if config.DetectUnroutedProducersDuration <= 0 {
+		slog.Debug("⏭️ unrouted producer detection disabled, skipping")
+		s.reporter.detail("Detection disabled (--detect-unrouted-producers-duration=0) — skipping check")
+		return nil
+	}
+
+	if s.sourceOffset == nil {
+		return fmt.Errorf("source offset service is required for unrouted producer detection")
+	}
+
+	if err := s.detectUnroutedProducers(ctx, config.Topics, config.DetectUnroutedProducersDuration); err != nil {
+		return err
+	}
+	s.reporter.success("Source offsets stable — no unrouted producers detected")
+	return nil
+}
+
 // PromoteTopics polls offsets and promotes mirror topics that reach zero lag
 func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationConfig, clusterApiKey, clusterApiSecret string) error {
 	if s.sourceOffset == nil || s.destinationOffset == nil {
 		return fmt.Errorf("source and destination offset services are required")
 	}
 
-	// If enabled, verify source offsets are stable before promoting.
-	// An increasing offset after fencing indicates a producer bypassing the gateway.
-	if config.DetectUnroutedProducersDuration > 0 {
-		s.reporter.section("🔍 Checking for unrouted producers...")
-		if err := s.detectUnroutedProducers(ctx, config.Topics, config.DetectUnroutedProducersDuration); err != nil {
-			// detectUnroutedProducers wraps ErrUnroutedProducers only for a real
-			// detection; a network/fetch error propagates as-is. Either way we
-			// just return it — restoring traffic (unfencing the gateway) is the
-			// state machine's job on the abort_fence rollback transition, which
-			// the orchestrator triggers only for ErrUnroutedProducers.
-			return err
-		}
-		s.reporter.success("Source offsets stable — no unrouted producers detected")
-		s.reporter.stepDone()
-	}
-
-	// The step banner is printed by the orchestrator (stepHeaders[EventPromote]);
-	// PromoteTopics emits only progress lines, like the other workflow actions.
 	slog.Debug("topic promotion process started")
 
 	const maxPromoteRetries = 3

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -792,30 +792,12 @@ func TestWorkflow_SwitchGateway_WaitErrorIsWrapped(t *testing.T) {
 }
 
 // ===========================================================================
-// DetectUnroutedProducers tests
+// VerifyFence / DetectUnroutedProducers tests
 // ===========================================================================
 
-func TestWorkflow_PromoteTopics_DetectUnroutedProducers_StableOffsets(t *testing.T) {
+func TestWorkflow_VerifyFence_StableOffsets(t *testing.T) {
 	gw := &mockGatewayService{}
-
-	promoted := make(map[string]bool)
-	cl := &mockClusterLinkService{
-		promoteMirrorTopicsFn: func(_ context.Context, _ clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
-			resp := &clusterlink.PromoteMirrorTopicsResponse{}
-			for _, name := range topicNames {
-				promoted[name] = true
-				resp.Data = append(resp.Data, struct {
-					MirrorTopicName string `json:"mirror_topic_name"`
-					ErrorMessage    string `json:"error_message,omitempty"`
-					ErrorCode       int    `json:"error_code,omitempty"`
-				}{
-					MirrorTopicName: name,
-					ErrorCode:       0,
-				})
-			}
-			return resp, nil
-		},
-	}
+	cl := &mockClusterLinkService{}
 
 	// Source offsets are stable (same value on every call)
 	offsetProvider := &mockOffsetProvider{
@@ -825,23 +807,17 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_StableOffsets(t *testing
 	}
 
 	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
-	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1", "topic-2"},
-		ClusterRestEndpoint:             "https://cluster",
-		ClusterId:                       "lkc-123",
-		ClusterLinkName:                 "link-1",
 		DetectUnroutedProducersDuration: time.Millisecond,
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.VerifyFence(context.Background(), config)
 	require.NoError(t, err)
-	assert.True(t, promoted["topic-1"], "topic-1 should have been promoted")
-	assert.True(t, promoted["topic-2"], "topic-2 should have been promoted")
 }
 
-func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_ReturnsError(t *testing.T) {
-	// PromoteTopics only detects — it must NOT unfence the gateway itself.
+func TestWorkflow_VerifyFence_IncreasingOffsets_ReturnsError(t *testing.T) {
+	// VerifyFence only detects — it must NOT unfence the gateway itself.
 	// Restoring traffic is the orchestrator's job on the abort_fence rollback
 	// (see TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack).
 	var applyCalled bool
@@ -872,26 +848,65 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_IncreasingOffsets_Return
 	}
 
 	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, destOffset)
-	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1"},
-		ClusterRestEndpoint:             "https://cluster",
-		ClusterId:                       "lkc-123",
-		ClusterLinkName:                 "link-1",
 		DetectUnroutedProducersDuration: time.Millisecond,
 		InitialCrYAML:                   []byte("apiVersion: platform.confluent.io/v1beta1\nkind: Gateway\nmetadata:\n  name: my-gw\n  namespace: ns\n  managedFields: []\n  resourceVersion: \"123\"\n"),
 		InitialCrName:                   "my-gw",
 		K8sNamespace:                    "ns",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.VerifyFence(context.Background(), config)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnroutedProducers)
 	assert.Contains(t, err.Error(), "topic-1 partition 0")
-	assert.False(t, applyCalled, "PromoteTopics must not unfence the gateway; that is the orchestrator's responsibility")
+	assert.False(t, applyCalled, "VerifyFence must not unfence the gateway; that is the orchestrator's responsibility")
 }
 
-func TestWorkflow_PromoteTopics_DetectUnroutedProducers_FlagDisabled(t *testing.T) {
+func TestWorkflow_VerifyFence_Disabled_SkipsOffsetChecks(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	// Detection is disabled, so the offset providers must never be consulted.
+	var getCalls int64
+	offsetProvider := &mockOffsetProvider{
+		getFn: func(topic string) (map[int32]int64, error) {
+			atomic.AddInt64(&getCalls, 1)
+			return map[int32]int64{0: 100}, nil
+		},
+	}
+
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
+	config := &MigrationConfig{
+		Topics:                          []string{"topic-1"},
+		DetectUnroutedProducersDuration: 0, // check disabled
+	}
+
+	err := wf.VerifyFence(context.Background(), config)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), atomic.LoadInt64(&getCalls),
+		"offset providers should not be consulted when detection is disabled")
+}
+
+func TestWorkflow_VerifyFence_NilOffsetServices(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	wf := NewMigrationActions(gw, cl) // no offset providers
+	config := &MigrationConfig{
+		Topics:                          []string{"topic-1"},
+		DetectUnroutedProducersDuration: time.Millisecond,
+	}
+
+	err := wf.VerifyFence(context.Background(), config)
+	require.Error(t, err)
+	assert.Equal(t, "source offset service is required for unrouted producer detection", err.Error())
+}
+
+func TestWorkflow_PromoteTopics_IgnoresDetectionConfig(t *testing.T) {
+	// Unrouted-producer detection belongs to the verify_fence step; PromoteTopics
+	// must not re-run it. If it did, this test would block on the 30s detection
+	// window and trip the 2s context deadline.
 	gw := &mockGatewayService{}
 
 	promoted := make(map[string]bool)
@@ -913,27 +928,28 @@ func TestWorkflow_PromoteTopics_DetectUnroutedProducers_FlagDisabled(t *testing.
 		},
 	}
 
-	// Source offsets increase — but flag is off, so it shouldn't matter
-	var callCount int64
-	sourceOffset := &mockOffsetProvider{
+	// Zero lag so promotion completes immediately
+	offsetProvider := &mockOffsetProvider{
 		getFn: func(topic string) (map[int32]int64, error) {
-			n := atomic.AddInt64(&callCount, 1)
-			return map[int32]int64{0: 100 + n*10}, nil
+			return map[int32]int64{0: 500}, nil
 		},
 	}
 
-	wf := NewMigrationActionsWithOffsets(gw, cl, sourceOffset, sourceOffset)
+	wf := NewMigrationActionsWithOffsets(gw, cl, offsetProvider, offsetProvider)
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{
 		Topics:                          []string{"topic-1"},
 		ClusterRestEndpoint:             "https://cluster",
 		ClusterId:                       "lkc-123",
 		ClusterLinkName:                 "link-1",
-		DetectUnroutedProducersDuration: 0, // check disabled
+		DetectUnroutedProducersDuration: 30 * time.Second,
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
-	require.NoError(t, err, "with flag disabled, increasing offsets should not block promotion")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := wf.PromoteTopics(ctx, config, "key", "secret")
+	require.NoError(t, err, "PromoteTopics should not run unrouted-producer detection")
 	assert.True(t, promoted["topic-1"])
 }
 


### PR DESCRIPTION
> [!NOTE]
> **Visualization-only draft** stacked on #367 (`feat/rogue-producer-detection`) so the refactor's diff can be reviewed in isolation. Not intended to merge as-is — fold into #367 or rebase to `main` after #367 lands.

## What

Extracts the post-fence unrouted-producer check out of `PromoteTopics` into its own workflow action (`VerifyFence`) and FSM transition (`verify_fence: fenced → fence_verified`):

```mermaid
stateDiagram-v2
    [*] --> uninitialized
    uninitialized --> initialized: initialize
    initialized --> lags_ok: wait_for_lags
    lags_ok --> fenced: fence
    fenced --> fence_verified: verify_fence
    fenced --> initialized: abort_fence
    fence_verified --> fenced: expire_verification
    fence_verified --> promoted: promote
    promoted --> switched: switch
```

<sub>Generated from the live FSM via [`fsm.VisualizeWithType(…, fsm.MERMAID)`](https://pkg.go.dev/github.com/looplab/fsm#VisualizeWithType).</sub>

## Why

The check verifies the *fence* held, not anything about promotion. Inside `PromoteTopics` it printed its own section banner (contradicting the orchestrator-owns-banners convention), had its own config gate, and leaked `ErrUnroutedProducers` through the promote step so `handleStepFailure` could map it to `abort_fence`. As a step, the compensation attaches to the transition that owns it.

## Behavioral changes (intentional)

- **A promote failure now rests at `fence_verified`, not `fenced`** — the FSM's true mid-run position.
- **`fence_verified` never survives a restart.** It is a point-in-time attestation: FSM bootstrap fires an explicit `expire_verification` transition (`fence_verified → fenced`, visible in the diagram above), so a resume re-runs the detection window. (Per review: a rogue producer appearing between a promote failure and a re-run hours later would otherwise go uncaught — `PromoteTopics`' zero-lag check samples instants and misses intermittent producers, and nothing downstream re-verifies the fence. This also preserves #367's semantics, where detection ran on every entry from `fenced`.)
- Old state files at `"fenced"` resume into verification, which is correct — they were never verified.

`abort_fence` keeps `fenced` as its source; all four existing abort/unfence orchestrator tests pass unchanged. When detection is disabled, the step prints an explicit "Detection disabled — skipping check" line under its banner (same honest-skip pattern as 7fa8a48).

## Testing

- New: `TestWorkflow_VerifyFence_*` (4), `TestOrchestrator_Execute_VerifyFencePersistedBeforePromote`, `TestOrchestrator_Bootstrap_DemotesFenceVerified`, `TestOrchestrator_Execute_ResumeFromFenceVerified_RerunsDetection` (rogue producer caught on resume, abort_fence fires), `TestWorkflow_PromoteTopics_IgnoresDetectionConfig`
- Updated: `TestOrchestrator_Execute_PromoteError` (rests at `fence_verified`), resume matrix includes `fence_verified`
- Full `make test-go`: 50 packages ok, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
