### PR TITLE
perf(offset): batch offset sweeps — one ListOffsets request per broker instead of one per topic

### DIFF
--- a/integration-tests/migration/offset_bench_test.go
+++ b/integration-tests/migration/offset_bench_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package migration_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// offsetBenchResult mirrors the JSON printed by testdata/offsetbench.
+type offsetBenchResult struct {
+	Topics          int     `json:"topics"`
+	PartitionsTotal int     `json:"partitions_total"`
+	LoopMs          int64   `json:"loop_ms"`
+	LoopPerTopicUs  int64   `json:"loop_per_topic_us"`
+	BatchUs         int64   `json:"batch_us"`
+	Speedup         float64 `json:"speedup"`
+	OffsetsMatch    bool    `json:"offsets_match"`
+}
+
+// benchTopicCount returns the benchmark topic count, overridable via
+// KCP_E2E_BENCH_TOPICS for quicker local iterations.
+func benchTopicCount(t *testing.T) int {
+	t.Helper()
+	if v := os.Getenv("KCP_E2E_BENCH_TOPICS"); v != "" {
+		n, err := strconv.Atoi(v)
+		require.NoError(t, err, "KCP_E2E_BENCH_TOPICS must be an integer")
+		return n
+	}
+	return 1000
+}
+
+// buildAndCopyOffsetBench cross-compiles testdata/offsetbench for the runner
+// pod and copies it to /workspace/offsetbench. Mirrors what setup.sh does for
+// the producer/consumer helpers, but done here so the benchmark can be
+// iterated on without re-running the full environment setup.
+func buildAndCopyOffsetBench(t *testing.T, cfg envConfig) {
+	t.Helper()
+
+	binPath := filepath.Join(t.TempDir(), "offsetbench-linux")
+	build := exec.Command("go", "build", "-o", binPath, "./testdata/offsetbench")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+	out, err := build.CombinedOutput()
+	require.NoError(t, err, "failed to build offsetbench: %s", string(out))
+
+	cp := exec.Command("kubectl",
+		"--context", cfg.KubeContext,
+		"-n", cfg.Namespace,
+		"cp", binPath, cfg.KCPPod+":/workspace/offsetbench")
+	out, err = cp.CombinedOutput()
+	require.NoError(t, err, "failed to copy offsetbench into pod: %s", string(out))
+
+	_, err = runInPod(t, cfg, 30*time.Second, "chmod", "+x", "/workspace/offsetbench")
+	require.NoError(t, err, "failed to chmod offsetbench in pod")
+}
+
+// runOffsetBench executes the benchmark inside the runner pod against the
+// source cluster and parses the trailing JSON line from stdout.
+func runOffsetBench(t *testing.T, cfg envConfig, topics int) offsetBenchResult {
+	t.Helper()
+
+	stdout, err := runInPod(t, cfg, 5*time.Minute,
+		"/workspace/offsetbench",
+		"--bootstrap", cfg.SourceBootstrap,
+		"--topics", strconv.Itoa(topics),
+	)
+	require.NoError(t, err, "offsetbench run failed: %s", stdout)
+
+	// The result is the single JSON line on stdout, but kubectl exec merges
+	// remote stdout/stderr by read-arrival order, so a late progress line
+	// can land after it — scan backwards for the last line that parses.
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	var res offsetBenchResult
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "{") && json.Unmarshal([]byte(line), &res) == nil {
+			return res
+		}
+	}
+	t.Fatalf("no JSON result line in offsetbench output: %s", stdout)
+	return res
+}
+
+// TestOffsetFetchBenchmark quantifies the offset-fetch sweep the migration
+// workflow performs before promoting (CheckLags and the PromoteTopics
+// zero-lag scan). Pre-optimization the workflow called offset.Service.Get
+// once per topic per cluster — with ~1000 topics that is ~1000 serial
+// ListOffsets round trips per cluster per sweep, the "~70s of prep"
+// observed against real clusters. The workflow now uses GetMany (one
+// ListOffsets request per leader broker); this test times both sweeps over
+// the same topics in the same run and asserts the batched sweep is
+// dramatically faster and returns identical offsets.
+//
+// The speedup floor is deliberately far below the observed in-cluster
+// ratio: the point is catching a regression to per-topic round trips, not
+// asserting an exact latency profile. Real-world gains are larger still —
+// per-topic cost scales with network RTT (~50ms against AWS vs sub-ms
+// here), while the batched sweep pays O(brokers) RTTs regardless of topic
+// count.
+func TestOffsetFetchBenchmark(t *testing.T) {
+	cfg := loadEnvConfig(t, scenarioBaseline)
+	topics := benchTopicCount(t)
+
+	buildAndCopyOffsetBench(t, cfg)
+
+	res := runOffsetBench(t, cfg, topics)
+	require.Equal(t, topics, res.Topics)
+	require.NotZero(t, res.PartitionsTotal, "sweep returned no partitions")
+	require.True(t, res.OffsetsMatch, "loop and batch sweeps returned different offsets")
+
+	t.Logf("offset fetch sweep over %d topics (%d partitions total):", res.Topics, res.PartitionsTotal)
+	t.Logf("  per-topic loop (pre-optimization workflow): %d ms total, %d µs/topic",
+		res.LoopMs, res.LoopPerTopicUs)
+	t.Logf("  batched GetMany (current workflow):         %d µs total", res.BatchUs)
+	t.Logf("  speedup: %.1fx", res.Speedup)
+
+	// A regression back to per-topic fetching shows up as ~1x; the floor
+	// only needs to sit safely above that. Under a quiet cluster the
+	// observed ratio is ~85x, but when the whole e2e suite has just run,
+	// broker load compresses it to single digits — so keep the floor low
+	// enough to never flake on a busy broker.
+	require.Greater(t, res.Speedup, 3.0,
+		"batched sweep should be at least 3x faster than per-topic sweep at %d topics", topics)
+}

--- a/integration-tests/migration/testdata/offsetbench/main.go
+++ b/integration-tests/migration/testdata/offsetbench/main.go
@@ -1,0 +1,194 @@
+// Offset-fetch benchmark used by the migration e2e tests.
+//
+// Ensures --topics topics exist on the cluster (creating any that are
+// missing in batched CreateTopics requests), then times fetching every
+// topic's log-end offsets two ways through internal/services/offset — the
+// exact code the migration workflow uses for its lag-check and promote
+// sweeps:
+//
+//	loop  — Service.Get per topic, serially: one ListOffsets round trip
+//	        per topic (the pre-optimization workflow behavior)
+//	batch — Service.GetMany over all topics: one ListOffsets request per
+//	        leader broker (the current workflow behavior)
+//
+// Both sweeps must return identical offsets; the result is printed as a
+// single JSON object on stdout. Plaintext unauthenticated — matches the
+// e2e fixture cluster posture.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"maps"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/client"
+	"github.com/confluentinc/kcp/internal/services/offset"
+)
+
+const createChunkSize = 500
+
+type result struct {
+	Topics          int     `json:"topics"`
+	PartitionsTotal int     `json:"partitions_total"`
+	LoopMs          int64   `json:"loop_ms"`
+	LoopPerTopicUs  int64   `json:"loop_per_topic_us"`
+	BatchUs         int64   `json:"batch_us"`
+	Speedup         float64 `json:"speedup"`
+	OffsetsMatch    bool    `json:"offsets_match"`
+}
+
+func main() {
+	var (
+		bootstrap  = flag.String("bootstrap", "", "comma-separated Kafka bootstrap servers (required)")
+		topicCount = flag.Int("topics", 1000, "number of benchmark topics to ensure and sweep (min 1)")
+		partitions = flag.Int("partitions", 1, "partitions per benchmark topic")
+		prefix     = flag.String("prefix", "kcp-offsetbench-", "benchmark topic name prefix")
+	)
+	flag.Parse()
+
+	if *bootstrap == "" {
+		log.Fatal("--bootstrap is required")
+	}
+	if *topicCount < 1 {
+		log.Fatalf("--topics must be at least 1, got %d", *topicCount)
+	}
+
+	// Same client constructor and settings as production offset fetching.
+	kafkaClient, err := client.NewKafkaClient(strings.Split(*bootstrap, ","), "",
+		client.WithUnauthenticatedPlaintextAuth())
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
+	defer kafkaClient.Close()
+
+	ctx := context.Background()
+
+	topics := topicNames(*prefix, *topicCount)
+	if err := ensureTopics(kafkaClient, topics, int32(*partitions)); err != nil {
+		log.Fatalf("failed to ensure benchmark topics: %v", err)
+	}
+
+	svc := offset.NewOffsetService(kafkaClient)
+	if err := awaitTopicsFetchable(ctx, svc, topics); err != nil {
+		log.Fatalf("failed waiting for topics to become fetchable: %v", err)
+	}
+
+	res := result{Topics: *topicCount}
+
+	// The pre-optimization workflow sweep: one Get (one ListOffsets round
+	// trip) per topic, serially, over a warm client.
+	loopStart := time.Now()
+	loopOffsets := make(map[string]map[int32]int64, len(topics))
+	for _, topic := range topics {
+		offsets, err := svc.Get(ctx, topic)
+		if err != nil {
+			log.Fatalf("loop sweep failed for topic %s: %v", topic, err)
+		}
+		loopOffsets[topic] = offsets
+	}
+	loopDur := time.Since(loopStart)
+	res.LoopMs = loopDur.Milliseconds()
+	res.LoopPerTopicUs = loopDur.Microseconds() / int64(len(topics))
+	for _, offsets := range loopOffsets {
+		res.PartitionsTotal += len(offsets)
+	}
+
+	// The batched sweep the workflow now uses.
+	batchStart := time.Now()
+	batchOffsets, err := svc.GetMany(ctx, topics)
+	if err != nil {
+		log.Fatalf("batch sweep failed: %v", err)
+	}
+	batchDur := time.Since(batchStart)
+	res.BatchUs = batchDur.Microseconds()
+
+	// Compute the ratio from the raw durations — millisecond truncation
+	// would zero out a sub-1ms batched sweep and report a bogus speedup.
+	if batchDur > 0 {
+		res.Speedup = float64(loopDur) / float64(batchDur)
+	}
+
+	// A mismatch is reported in the JSON rather than aborting, so the e2e
+	// test's assertion on it can actually fire and print both timings.
+	res.OffsetsMatch = maps.EqualFunc(loopOffsets, batchOffsets, maps.Equal)
+
+	out, err := json.Marshal(res)
+	if err != nil {
+		log.Fatalf("failed to marshal result: %v", err)
+	}
+	fmt.Println(string(out))
+}
+
+func topicNames(prefix string, n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("%s%04d", prefix, i)
+	}
+	return names
+}
+
+// ensureTopics creates any missing benchmark topics in chunked CreateTopics
+// requests against the controller. Already-existing topics are fine —
+// reruns against a warm environment are expected.
+func ensureTopics(kafkaClient sarama.Client, topics []string, partitions int32) error {
+	controller, err := kafkaClient.Controller()
+	if err != nil {
+		return fmt.Errorf("failed to get controller: %w", err)
+	}
+
+	for start := 0; start < len(topics); start += createChunkSize {
+		end := min(start+createChunkSize, len(topics))
+		details := make(map[string]*sarama.TopicDetail, end-start)
+		for _, topic := range topics[start:end] {
+			details[topic] = &sarama.TopicDetail{
+				NumPartitions:     partitions,
+				ReplicationFactor: 1,
+			}
+		}
+
+		resp, err := controller.CreateTopics(&sarama.CreateTopicsRequest{
+			Version:      2,
+			TopicDetails: details,
+			Timeout:      60 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("CreateTopics request failed: %w", err)
+		}
+		for topic, topicErr := range resp.TopicErrors {
+			if topicErr.Err != sarama.ErrNoError && topicErr.Err != sarama.ErrTopicAlreadyExists {
+				return fmt.Errorf("failed to create topic %s: %v", topic, topicErr.Err)
+			}
+		}
+		fmt.Fprintf(os.Stderr, "ensured topics %d-%d\n", start, end-1)
+	}
+	return nil
+}
+
+// awaitTopicsFetchable runs untimed warm-up sweeps until offsets for every
+// benchmark topic can actually be fetched. On a fresh environment the
+// just-created topics may not be in metadata yet, and leader elections for
+// hundreds of new partitions can still be settling — either would fail (or
+// skew) the timed sweeps with propagation noise that has nothing to do with
+// what this benchmark measures. GetMany surfaces both cases as errors, so a
+// clean sweep certifies readiness end to end.
+func awaitTopicsFetchable(ctx context.Context, svc *offset.Service, topics []string) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		_, err := svc.GetMany(ctx, topics)
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("topics still not fetchable at deadline: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "warm-up sweep not yet clean: %v\n", err)
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/internal/services/migration/mock_test.go
+++ b/internal/services/migration/mock_test.go
@@ -122,14 +122,30 @@ func (m *mockClusterLinkService) AlterConfigs(ctx context.Context, config cluste
 	return fmt.Errorf("mockClusterLinkService.AlterConfigs not configured")
 }
 
-// mockOffsetProvider implements offset.Provider using a function field for test control.
+// mockOffsetProvider implements offset.Provider using function fields for
+// test control. Tests may script the whole batch via getManyFn or, more
+// commonly, per topic via getFn — the GetMany fallback assembles the batch
+// result from per-topic calls, failing the whole sweep on the first error
+// (matching the real GetMany's all-or-nothing contract).
 type mockOffsetProvider struct {
-	getFn func(topic string) (map[int32]int64, error)
+	getFn     func(topic string) (map[int32]int64, error)
+	getManyFn func(topics []string) (map[string]map[int32]int64, error)
 }
 
-func (m *mockOffsetProvider) Get(topic string) (map[int32]int64, error) {
-	if m.getFn != nil {
-		return m.getFn(topic)
+func (m *mockOffsetProvider) GetMany(_ context.Context, topics []string) (map[string]map[int32]int64, error) {
+	if m.getManyFn != nil {
+		return m.getManyFn(topics)
 	}
-	return nil, fmt.Errorf("mockOffsetProvider.Get not configured")
+	if m.getFn == nil {
+		return nil, fmt.Errorf("mockOffsetProvider not configured")
+	}
+	out := make(map[string]map[int32]int64, len(topics))
+	for _, topic := range topics {
+		offsets, err := m.getFn(topic)
+		if err != nil {
+			return nil, err
+		}
+		out[topic] = offsets
+	}
+	return out, nil
 }

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -2,10 +2,12 @@ package migration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/clusterlink"
@@ -13,6 +15,15 @@ import (
 	"github.com/confluentinc/kcp/internal/services/offset"
 	"github.com/fatih/color"
 )
+
+// maxConsecutiveSweepFailures is how many offset sweeps in a row may fail
+// before CheckLags/PromoteTopics abort. A failed sweep is tolerated by
+// waiting for the loop's next tick (the tick interval is the backoff — no
+// separate schedule), so transient disruptions like leader elections and
+// rolling broker restarts ride out across ~3 ticks (+ GetMany's internal
+// refresh-and-retry per sweep) while a persistent failure still surfaces
+// within seconds. The counter resets on any successful sweep.
+const maxConsecutiveSweepFailures = 3
 
 type MigrationWorkflow struct {
 	gatewayService      gateway.Service
@@ -200,6 +211,7 @@ func (s *MigrationWorkflow) CheckLags(
 	defer ticker.Stop()
 
 	startTime := time.Now()
+	sweepFailures := 0
 
 	for {
 		select {
@@ -211,17 +223,29 @@ func (s *MigrationWorkflow) CheckLags(
 		allBelowThreshold := true
 		topicTotalLags := make(map[string]int64)
 
-		for _, topic := range config.Topics {
-			sourceOffsets, err := s.sourceOffset.Get(topic)
-			if err != nil {
-				return fmt.Errorf("failed to get source offsets for %s: %w", topic, err)
+		sourceOffsets, destinationOffsets, err := s.fetchSourceAndDestinationOffsets(ctx, config.Topics)
+		if err != nil {
+			sweepFailures++
+			if sweepFailures >= maxConsecutiveSweepFailures {
+				return fmt.Errorf("offset sweep failed %d consecutive times: %w", sweepFailures, err)
 			}
-			destinationOffsets, err := s.destinationOffset.Get(topic)
-			if err != nil {
-				return fmt.Errorf("failed to get destination offsets for %s: %w", topic, err)
+			slog.Warn("⚠️ offset sweep failed, retrying on next tick",
+				"attempt", sweepFailures, "maxAttempts", maxConsecutiveSweepFailures, "error", err)
+			// Deliberately not ticker.C: a slow failing sweep can outlast the
+			// tick interval, leaving a tick buffered in the ticker's channel —
+			// receiving that would retry immediately with zero backoff. A fresh
+			// timer guarantees a full interval's pause between failed sweeps.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(s.lagPollInterval):
 			}
+			continue
+		}
+		sweepFailures = 0
 
-			lag := offset.ComputeTotalLag(sourceOffsets, destinationOffsets)
+		for _, topic := range config.Topics {
+			lag := offset.ComputeTotalLag(sourceOffsets[topic], destinationOffsets[topic])
 			if lag > lagThreshold {
 				allBelowThreshold = false
 				topicTotalLags[topic] = lag
@@ -263,6 +287,39 @@ func (s *MigrationWorkflow) CheckLags(
 		case <-ticker.C:
 		}
 	}
+}
+
+// fetchSourceAndDestinationOffsets sweeps both clusters' offsets for the
+// given topics concurrently — the clusters are independent, so a poll tick
+// pays the slower of the two sweeps rather than their sum.
+func (s *MigrationWorkflow) fetchSourceAndDestinationOffsets(ctx context.Context, topics []string) (map[string]map[int32]int64, map[string]map[int32]int64, error) {
+	var (
+		wg                 sync.WaitGroup
+		source, dest       map[string]map[int32]int64
+		sourceErr, destErr error
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		source, sourceErr = s.sourceOffset.GetMany(ctx, topics)
+	}()
+	go func() {
+		defer wg.Done()
+		dest, destErr = s.destinationOffset.GetMany(ctx, topics)
+	}()
+	wg.Wait()
+
+	var errs []error
+	if sourceErr != nil {
+		errs = append(errs, fmt.Errorf("failed to get source offsets: %w", sourceErr))
+	}
+	if destErr != nil {
+		errs = append(errs, fmt.Errorf("failed to get destination offsets: %w", destErr))
+	}
+	if len(errs) > 0 {
+		return nil, nil, errors.Join(errs...)
+	}
+	return source, dest, nil
 }
 
 // formatLag64 formats an int64 with comma separators (e.g. 21655 -> "21,655")
@@ -337,6 +394,7 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 	for _, topic := range config.Topics {
 		remaining[topic] = true
 	}
+	sweepFailures := 0
 
 	for {
 		select {
@@ -394,26 +452,39 @@ func (s *MigrationWorkflow) PromoteTopics(ctx context.Context, config *Migration
 		// Find topics at zero lag that still need a promote request. Topics
 		// already accepted (awaiting STOPPED confirmation) are skipped so we
 		// don't re-promote them.
-		var topicsToPromote []string
+		candidates := make([]string, 0, len(remaining))
 		for topic := range remaining {
 			if awaitingStop[topic] {
 				continue
 			}
-			sourceOffsets, err := s.sourceOffset.Get(topic)
-			if err != nil {
-				return fmt.Errorf("failed to get source offsets for %s: %w", topic, err)
-			}
-			destinationOffsets, err := s.destinationOffset.Get(topic)
-			if err != nil {
-				return fmt.Errorf("failed to get destination offsets for %s: %w", topic, err)
-			}
+			candidates = append(candidates, topic)
+		}
+		sort.Strings(candidates)
 
-			lag := offset.ComputeTotalLag(sourceOffsets, destinationOffsets)
+		sourceOffsets, destinationOffsets, err := s.fetchSourceAndDestinationOffsets(ctx, candidates)
+		if err != nil {
+			sweepFailures++
+			if sweepFailures >= maxConsecutiveSweepFailures {
+				return fmt.Errorf("offset sweep failed %d consecutive times: %w", sweepFailures, err)
+			}
+			slog.Warn("⚠️ offset sweep failed, retrying on next tick",
+				"attempt", sweepFailures, "maxAttempts", maxConsecutiveSweepFailures, "error", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(s.promotePollInterval):
+			}
+			continue
+		}
+		sweepFailures = 0
+
+		var topicsToPromote []string
+		for _, topic := range candidates {
+			lag := offset.ComputeTotalLag(sourceOffsets[topic], destinationOffsets[topic])
 			if lag == 0 {
 				topicsToPromote = append(topicsToPromote, topic)
 			}
 		}
-		sort.Strings(topicsToPromote)
 
 		// Cap the batch when a promote batch size is configured.
 		if s.promoteBatchSize > 0 && len(topicsToPromote) > s.promoteBatchSize {

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -1027,3 +1027,192 @@ func TestFormatLag64(t *testing.T) {
 		})
 	}
 }
+
+// ===========================================================================
+// Sweep-failure tolerance tests (maxConsecutiveSweepFailures)
+// ===========================================================================
+
+// zeroLagBatch builds a GetMany-shaped result with the same offset for every
+// topic, so source and destination compare at zero lag.
+func zeroLagBatch(topics []string, off int64) map[string]map[int32]int64 {
+	out := make(map[string]map[int32]int64, len(topics))
+	for _, topic := range topics {
+		out[topic] = map[int32]int64{0: off}
+	}
+	return out
+}
+
+func TestWorkflow_CheckLags_ToleratesTransientSweepFailures(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	// The source sweep fails twice (fewer than maxConsecutiveSweepFailures),
+	// then succeeds at zero lag.
+	var calls atomic.Int32
+	sourceOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			if calls.Add(1) <= 2 {
+				return nil, fmt.Errorf("leader election in progress")
+			}
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+	destOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+
+	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf.lagPollInterval = time.Millisecond
+	config := &MigrationConfig{Topics: []string{"topic-1"}}
+
+	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	require.NoError(t, err, "two transient sweep failures must be ridden out")
+	assert.GreaterOrEqual(t, calls.Load(), int32(3), "expected the sweep to be retried on later ticks")
+}
+
+func TestWorkflow_CheckLags_AbortsAfterMaxConsecutiveSweepFailures(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	var calls atomic.Int32
+	sourceOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			calls.Add(1)
+			return nil, fmt.Errorf("broker unreachable")
+		},
+	}
+	destOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+
+	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf.lagPollInterval = time.Millisecond
+	config := &MigrationConfig{Topics: []string{"topic-1"}}
+
+	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d consecutive", maxConsecutiveSweepFailures))
+	assert.Contains(t, err.Error(), "broker unreachable", "the underlying cause must be preserved")
+	assert.Equal(t, int32(maxConsecutiveSweepFailures), calls.Load(),
+		"the sweep must not be attempted again after the abort threshold")
+}
+
+func TestWorkflow_CheckLags_SweepFailureCounterResetsOnSuccess(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	// Scripted sequence: fail, fail, succeed-above-threshold (loop continues),
+	// fail, fail, succeed-at-zero-lag. Four total failures but never three in
+	// a row — only a counter that resets on success lets this pass.
+	var calls atomic.Int32
+	sourceOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			switch calls.Add(1) {
+			case 1, 2, 4, 5:
+				return nil, fmt.Errorf("transient sweep failure")
+			case 3:
+				return zeroLagBatch(topics, 5000), nil // lag 4000 → above threshold
+			default:
+				return zeroLagBatch(topics, 1000), nil // lag 0 → done
+			}
+		},
+	}
+	destOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+
+	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf.lagPollInterval = time.Millisecond
+	config := &MigrationConfig{Topics: []string{"topic-1"}}
+
+	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	require.NoError(t, err, "four non-consecutive failures must not abort")
+	assert.Equal(t, int32(6), calls.Load())
+}
+
+func TestWorkflow_PromoteTopics_ToleratesTransientSweepFailures(t *testing.T) {
+	gw := &mockGatewayService{}
+
+	promoted := make(map[string]bool)
+	cl := &mockClusterLinkService{
+		promoteMirrorTopicsFn: func(_ context.Context, _ clusterlink.Config, topicNames []string) (*clusterlink.PromoteMirrorTopicsResponse, error) {
+			resp := &clusterlink.PromoteMirrorTopicsResponse{}
+			for _, name := range topicNames {
+				promoted[name] = true
+				resp.Data = append(resp.Data, struct {
+					MirrorTopicName string `json:"mirror_topic_name"`
+					ErrorMessage    string `json:"error_message,omitempty"`
+					ErrorCode       int    `json:"error_code,omitempty"`
+				}{
+					MirrorTopicName: name,
+					ErrorCode:       0,
+				})
+			}
+			return resp, nil
+		},
+		listMirrorTopicsFn: func(_ context.Context, _ clusterlink.Config) ([]clusterlink.MirrorTopic, error) {
+			return []clusterlink.MirrorTopic{
+				{MirrorTopicName: "topic-1", MirrorStatus: clusterlink.MirrorStatusStopped},
+			}, nil
+		},
+	}
+
+	// The source sweep fails twice, then reports zero lag so promotion runs.
+	var calls atomic.Int32
+	sourceOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			if calls.Add(1) <= 2 {
+				return nil, fmt.Errorf("leader election in progress")
+			}
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+	destOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+
+	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf.promotePollInterval = time.Millisecond
+	config := &MigrationConfig{Topics: []string{"topic-1"}}
+
+	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	require.NoError(t, err, "two transient sweep failures must be ridden out")
+	assert.True(t, promoted["topic-1"], "topic must still be promoted after tolerated failures")
+}
+
+func TestWorkflow_PromoteTopics_AbortsAfterMaxConsecutiveSweepFailures(t *testing.T) {
+	gw := &mockGatewayService{}
+	cl := &mockClusterLinkService{}
+
+	var calls atomic.Int32
+	sourceOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			calls.Add(1)
+			return nil, fmt.Errorf("broker unreachable")
+		},
+	}
+	destOffset := &mockOffsetProvider{
+		getManyFn: func(topics []string) (map[string]map[int32]int64, error) {
+			return zeroLagBatch(topics, 1000), nil
+		},
+	}
+
+	wf := NewMigrationWorkflowWithOffsets(gw, cl, sourceOffset, destOffset)
+	wf.promotePollInterval = time.Millisecond
+	config := &MigrationConfig{Topics: []string{"topic-1"}}
+
+	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d consecutive", maxConsecutiveSweepFailures))
+	assert.Contains(t, err.Error(), "broker unreachable", "the underlying cause must be preserved")
+	assert.Equal(t, int32(maxConsecutiveSweepFailures), calls.Load(),
+		"the sweep must not be attempted again after the abort threshold")
+}

--- a/internal/services/offset/offset.go
+++ b/internal/services/offset/offset.go
@@ -1,16 +1,27 @@
 package offset
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"slices"
+	"sync"
+	"time"
 
 	"github.com/IBM/sarama"
+	"golang.org/x/sync/errgroup"
 )
+
+// retryBackoff is how long GetMany waits after refreshing metadata before
+// retrying failed partitions. An immediate retry tends to observe the same
+// in-flight leader election that failed the first pass; a short pause gives
+// the cluster time to settle. A var (not const) so tests exercising the
+// retry path can shrink it.
+var retryBackoff = 500 * time.Millisecond
 
 // Provider abstracts offset retrieval for testability.
 type Provider interface {
-	Get(topic string) (map[int32]int64, error)
+	GetMany(ctx context.Context, topics []string) (map[string]map[int32]int64, error)
 }
 
 // Service provides offset operations against a Kafka cluster.
@@ -28,53 +39,208 @@ func (t *Service) Close() error {
 	return t.client.Close()
 }
 
-// Get fetches the log end offset (LEO) for every partition of a topic.
-// Requests are batched by leader broker for efficiency.
-func (t *Service) Get(topic string) (map[int32]int64, error) {
-	partitions, err := t.client.Partitions(topic)
+// Get fetches the log end offset (LEO) for every partition of a topic. It
+// is a single-topic wrapper over GetMany kept for the package tests and the
+// offsetbench loop-vs-batch contrast; production sweeps call GetMany, which
+// costs one request per broker instead of one per topic.
+func (t *Service) Get(ctx context.Context, topic string) (map[int32]int64, error) {
+	results, err := t.GetMany(ctx, []string{topic})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get partitions for topic %q: %w", topic, err)
+		return nil, err
+	}
+	return results[topic], nil
+}
+
+// topicPartition identifies a single partition during a batched fetch.
+type topicPartition struct {
+	topic     string
+	partition int32
+}
+
+// failedPartition pairs a partition with the error that deferred it to the
+// retry pass, so the sweep's final error can name the underlying cause.
+type failedPartition struct {
+	tp    topicPartition
+	cause error
+}
+
+// GetMany fetches the log end offset (LEO) for every partition of every
+// topic in a single sweep. Partitions are grouped by leader broker across
+// all topics and one ListOffsets request is sent per broker (concurrently),
+// so a sweep of N topics costs one round trip instead of N.
+//
+// Partitions that fail because cached metadata went stale mid-sweep (leader
+// moved, replica unavailable, or the cached leader broker unreachable) are
+// retried once against refreshed metadata before the sweep fails.
+func (t *Service) GetMany(ctx context.Context, topics []string) (map[string]map[int32]int64, error) {
+	results := make(map[string]map[int32]int64, len(topics))
+	if len(topics) == 0 {
+		return results, nil
 	}
 
-	slog.Debug("fetching offsets", "topic", topic, "partitions", len(partitions))
+	slog.Debug("fetching offsets for topic batch", "topics", len(topics))
 
-	brokerPartitions := make(map[*sarama.Broker][]int32)
-	for _, p := range partitions {
-		leader, err := t.client.Leader(topic, p)
+	pending := make([]topicPartition, 0, len(topics))
+	for _, topic := range topics {
+		partitions, err := t.client.Partitions(topic)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get leader for %s/%d: %w", topic, p, err)
+			return nil, fmt.Errorf("failed to get partitions for topic %q: %w", topic, err)
 		}
-		brokerPartitions[leader] = append(brokerPartitions[leader], p)
+		results[topic] = make(map[int32]int64, len(partitions))
+		for _, p := range partitions {
+			pending = append(pending, topicPartition{topic: topic, partition: p})
+		}
 	}
 
-	offsets := make(map[int32]int64, len(partitions))
+	retriable, err := t.fetchBatch(pending, results)
+	if err != nil {
+		return nil, err
+	}
+	if len(retriable) > 0 {
+		retry := make([]topicPartition, 0, len(retriable))
+		refresh := make([]string, 0, len(retriable))
+		seen := make(map[string]struct{}, len(retriable))
+		for _, f := range retriable {
+			retry = append(retry, f.tp)
+			if _, dup := seen[f.tp.topic]; !dup {
+				seen[f.tp.topic] = struct{}{}
+				refresh = append(refresh, f.tp.topic)
+			}
+		}
+		slog.Debug("retrying offset fetch after metadata refresh",
+			"partitions", len(retriable), "topics", len(refresh))
+		if err := t.client.RefreshMetadata(refresh...); err != nil {
+			return nil, fmt.Errorf("failed to refresh metadata for retry: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(retryBackoff):
+		}
+
+		stillFailed, err := t.fetchBatch(retry, results)
+		if err != nil {
+			return nil, err
+		}
+		if len(stillFailed) > 0 {
+			return nil, fmt.Errorf("offset fetch failed for %d partition(s) after metadata refresh: %w",
+				len(stillFailed), stillFailed[0].cause)
+		}
+	}
+
+	slog.Debug("fetched offsets for topic batch", "topics", len(topics))
+	return results, nil
+}
+
+// fetchBatch groups partitions by leader broker, issues one ListOffsets
+// request per broker, and writes offsets into results. Partitions whose
+// leader lookup failed, whose offset block carried a stale-metadata error,
+// or whose broker request failed at the transport level are returned (with
+// their cause) for the caller to retry; any other failure aborts the batch.
+func (t *Service) fetchBatch(tps []topicPartition, results map[string]map[int32]int64) ([]failedPartition, error) {
+	var failed []failedPartition
+
+	brokerPartitions := make(map[*sarama.Broker][]topicPartition)
+	for _, tp := range tps {
+		leader, err := t.client.Leader(tp.topic, tp.partition)
+		if err != nil {
+			// Leader lookup fails when cached metadata is stale; defer to
+			// the caller's refresh-and-retry pass.
+			failed = append(failed, failedPartition{
+				tp:    tp,
+				cause: fmt.Errorf("failed to get leader for %s/%d: %w", tp.topic, tp.partition, err),
+			})
+			continue
+		}
+		brokerPartitions[leader] = append(brokerPartitions[leader], tp)
+	}
+
+	// Brokers are independent, so fan the per-broker requests out
+	// concurrently: the sweep costs one round trip, not brokers' worth.
+	var (
+		mu sync.Mutex
+		g  errgroup.Group
+	)
 	for broker, parts := range brokerPartitions {
-		req := &sarama.OffsetRequest{
-			Version: 1,
-		}
-		for _, p := range parts {
-			req.AddBlock(topic, p, sarama.OffsetNewest, 1)
-		}
-
-		resp, err := broker.GetAvailableOffsets(req)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get offsets from broker %s: %w", broker.Addr(), err)
-		}
-
-		for _, p := range parts {
-			block := resp.GetBlock(topic, p)
-			if block == nil {
-				return nil, fmt.Errorf("no offset block returned for %s/%d", topic, p)
+		g.Go(func() error {
+			req := &sarama.OffsetRequest{
+				Version: 1,
 			}
-			if block.Err != sarama.ErrNoError {
-				return nil, fmt.Errorf("offset error for %s/%d: %v", topic, p, block.Err)
+			for _, tp := range parts {
+				req.AddBlock(tp.topic, tp.partition, sarama.OffsetNewest, 1)
 			}
-			offsets[p] = block.Offset
-		}
+
+			resp, err := broker.GetAvailableOffsets(req)
+			if err != nil {
+				// A transport-level failure (connection refused/reset, EOF from
+				// a restarting broker) is the blunt form of stale metadata: the
+				// cached leader is gone. Defer every partition routed to this
+				// broker to the refresh-and-retry pass — after the refresh they
+				// re-route to the current leaders — rather than failing the
+				// sweep on a condition the retry exists to absorb.
+				//
+				// Deliberately unclassified: persistent transport failures
+				// (bad TLS/SASL config, dead cluster) also take this path and
+				// cost one refresh + backoff + retry per sweep before
+				// surfacing. That bounded delay is accepted because reliably
+				// separating "broker restarting" from "misconfigured" out of
+				// the wrapped error is not feasible, and misclassifying a
+				// transient as fatal would abort a live migration.
+				mu.Lock()
+				for _, tp := range parts {
+					failed = append(failed, failedPartition{
+						tp:    tp,
+						cause: fmt.Errorf("offset request to broker %s failed for %s/%d: %w", broker.Addr(), tp.topic, tp.partition, err),
+					})
+				}
+				mu.Unlock()
+				return nil
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			for _, tp := range parts {
+				block := resp.GetBlock(tp.topic, tp.partition)
+				switch {
+				case block == nil:
+					return fmt.Errorf("no offset block returned for %s/%d", tp.topic, tp.partition)
+				case block.Err == sarama.ErrNoError:
+					results[tp.topic][tp.partition] = block.Offset
+				case isStaleMetadataErr(block.Err):
+					failed = append(failed, failedPartition{
+						tp:    tp,
+						cause: fmt.Errorf("offset error for %s/%d: %w", tp.topic, tp.partition, block.Err),
+					})
+				default:
+					return fmt.Errorf("offset error for %s/%d: %v", tp.topic, tp.partition, block.Err)
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
-	slog.Debug("fetched offsets", "topic", topic, "partitions", len(offsets))
-	return offsets, nil
+	return failed, nil
+}
+
+// isStaleMetadataErr reports whether a per-partition error indicates the
+// client's cached metadata is out of date (so a refresh-and-retry can
+// succeed) rather than a persistent failure. UNKNOWN_TOPIC_OR_PARTITION is
+// included because a broker that no longer hosts a partition (leadership
+// moved since the metadata was cached) answers with it; for a genuinely
+// deleted topic the retry fails and the specific error is surfaced via the
+// failedPartition cause.
+func isStaleMetadataErr(err sarama.KError) bool {
+	switch err {
+	case sarama.ErrNotLeaderForPartition,
+		sarama.ErrLeaderNotAvailable,
+		sarama.ErrUnknownTopicOrPartition,
+		sarama.ErrReplicaNotAvailable:
+		return true
+	}
+	return false
 }
 
 // Exists checks whether a topic exists on the cluster by refreshing metadata.

--- a/internal/services/offset/offset_test.go
+++ b/internal/services/offset/offset_test.go
@@ -1,8 +1,137 @@
 package offset
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
 )
+
+// newMockCluster starts a single MockBroker acting as controller and leader
+// for numTopics single-partition topics named <prefix>0..<prefix>N-1, with
+// the log end offset for each set to 100+i. The caller must Close the broker
+// and client.
+func newMockCluster(t *testing.T, numTopics int) (*sarama.MockBroker, sarama.Client, []string) {
+	t.Helper()
+
+	broker := sarama.NewMockBroker(t, 1)
+
+	topics := make([]string, numTopics)
+	metadata := sarama.NewMockMetadataResponse(t).
+		SetBroker(broker.Addr(), broker.BrokerID()).
+		SetController(broker.BrokerID())
+	offsets := sarama.NewMockOffsetResponse(t)
+	for i := range topics {
+		topics[i] = fmt.Sprintf("bench-topic-%03d", i)
+		metadata.SetLeader(topics[i], 0, broker.BrokerID())
+		offsets.SetOffset(topics[i], 0, sarama.OffsetNewest, int64(100+i))
+	}
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest":    metadata,
+		"OffsetRequest":      offsets,
+	})
+
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_8_0_0
+	client, err := sarama.NewClient([]string{broker.Addr()}, cfg)
+	if err != nil {
+		t.Fatalf("failed to create client against mock broker: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+		broker.Close()
+	})
+	return broker, client, topics
+}
+
+// countOffsetRequests counts ListOffsets requests in the mock broker history.
+func countOffsetRequests(broker *sarama.MockBroker) int {
+	count := 0
+	for _, rr := range broker.History() {
+		if _, ok := rr.Request.(*sarama.OffsetRequest); ok {
+			count++
+		}
+	}
+	return count
+}
+
+func TestGetMany_OffsetsMatchPerTopicGet(t *testing.T) {
+	_, client, topics := newMockCluster(t, 25)
+	svc := NewOffsetService(client)
+
+	batched, err := svc.GetMany(t.Context(), topics)
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(batched) != len(topics) {
+		t.Fatalf("GetMany returned %d topics, want %d", len(batched), len(topics))
+	}
+
+	for _, topic := range topics {
+		single, err := svc.Get(t.Context(), topic)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", topic, err)
+		}
+		if len(single) != len(batched[topic]) {
+			t.Fatalf("topic %s: Get returned %d partitions, GetMany %d", topic, len(single), len(batched[topic]))
+		}
+		for p, off := range single {
+			if batched[topic][p] != off {
+				t.Errorf("topic %s partition %d: Get=%d GetMany=%d", topic, p, off, batched[topic][p])
+			}
+		}
+	}
+}
+
+func TestGetMany_OneRequestPerBroker(t *testing.T) {
+	broker, client, topics := newMockCluster(t, 50)
+	svc := NewOffsetService(client)
+
+	if _, err := svc.GetMany(t.Context(), topics); err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if got := countOffsetRequests(broker); got != 1 {
+		t.Errorf("GetMany over 50 topics sent %d ListOffsets requests, want 1", got)
+	}
+
+	// The per-topic sweep the workflow used to do: one request per topic.
+	// Kept as a contrast so a regression back to per-topic fetching in
+	// GetMany is caught by the assertion above, not just slower in e2e.
+	before := countOffsetRequests(broker)
+	for _, topic := range topics {
+		if _, err := svc.Get(t.Context(), topic); err != nil {
+			t.Fatalf("Get(%s): %v", topic, err)
+		}
+	}
+	if got := countOffsetRequests(broker) - before; got != len(topics) {
+		t.Errorf("per-topic sweep sent %d ListOffsets requests, want %d", got, len(topics))
+	}
+}
+
+func TestGetMany_Empty(t *testing.T) {
+	_, client, _ := newMockCluster(t, 1)
+	svc := NewOffsetService(client)
+
+	got, err := svc.GetMany(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("GetMany(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetMany(nil) returned %d topics, want 0", len(got))
+	}
+}
+
+func TestGetMany_UnknownTopic(t *testing.T) {
+	_, client, topics := newMockCluster(t, 3)
+	svc := NewOffsetService(client)
+
+	_, err := svc.GetMany(t.Context(), append(topics, "no-such-topic"))
+	if err == nil {
+		t.Fatal("GetMany with unknown topic: want error, got nil")
+	}
+}
 
 func TestSortedPartitionIDs(t *testing.T) {
 	src := map[int32]int64{0: 100, 2: 200, 4: 400}
@@ -64,5 +193,73 @@ func TestComputeTotalLag_DstAhead(t *testing.T) {
 
 	if got != want {
 		t.Errorf("ComputeTotalLag (dst ahead) = %d, want %d", got, want)
+	}
+}
+
+// TestGetMany_DeadLeaderBrokerRetried simulates the cached leader broker being
+// unreachable (restarting/gone): the first metadata response names a dead
+// broker as leader, so the offset request fails at the transport level. The
+// refresh-and-retry pass must re-route the partition to the live leader and
+// succeed rather than failing the sweep.
+func TestGetMany_DeadLeaderBrokerRetried(t *testing.T) {
+	// Shrink the retry backoff so the test doesn't pay the production 500ms.
+	oldBackoff := retryBackoff
+	retryBackoff = 5 * time.Millisecond
+	t.Cleanup(func() { retryBackoff = oldBackoff })
+
+	live := sarama.NewMockBroker(t, 1)
+
+	// A broker that is registered in metadata but not listening: reserve a
+	// real port with a MockBroker, then close it so connections are refused.
+	dead := sarama.NewMockBroker(t, 2)
+	deadAddr := dead.Addr()
+	deadID := dead.BrokerID()
+	dead.Close()
+
+	const topic = "transport-retry-topic"
+
+	metaDeadLeader := sarama.NewMockMetadataResponse(t).
+		SetBroker(live.Addr(), live.BrokerID()).
+		SetBroker(deadAddr, deadID).
+		SetController(live.BrokerID()).
+		SetLeader(topic, 0, deadID)
+	metaLiveLeader := sarama.NewMockMetadataResponse(t).
+		SetBroker(live.Addr(), live.BrokerID()).
+		SetController(live.BrokerID()).
+		SetLeader(topic, 0, live.BrokerID())
+
+	live.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		// The first metadata response (client bootstrap) points the leader at
+		// the dead broker; every later one (GetMany's RefreshMetadata during
+		// the retry pass) points at the live broker.
+		"MetadataRequest": sarama.NewMockSequence(metaDeadLeader, metaLiveLeader),
+		"OffsetRequest":   sarama.NewMockOffsetResponse(t).SetOffset(topic, 0, sarama.OffsetNewest, 4242),
+	})
+
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_8_0_0
+	client, err := sarama.NewClient([]string{live.Addr()}, cfg)
+	if err != nil {
+		t.Fatalf("failed to create client against mock broker: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+		live.Close()
+	})
+
+	svc := NewOffsetService(client)
+	got, err := svc.GetMany(t.Context(), []string{topic})
+	if err != nil {
+		t.Fatalf("GetMany with dead leader broker: %v", err)
+	}
+	if got[topic][0] != 4242 {
+		t.Fatalf("offset = %d, want 4242", got[topic][0])
+	}
+	// Exactly one ListOffsets must reach the live broker: the post-refresh
+	// retry. The first attempt died on the dead broker's socket, proving the
+	// transport-error path (not a lucky first route) was exercised.
+	if n := countOffsetRequests(live); n != 1 {
+		t.Errorf("live broker received %d ListOffsets requests, want 1 (the post-refresh retry)", n)
 	}
 }


### PR DESCRIPTION

## Summary

The migration workflow's lag-check (`CheckLags`) and promote (`PromoteTopics`) loops fetched offsets with one serial round trip **per topic per cluster** per poll tick. At WAN latency that dominates the tick: 616 topics × 2 clusters × ~50ms ≈ the ~70s of per-tick "prep" observed.

- **`offset.Provider` now exposes `GetMany(ctx, topics)`** — partitions grouped by leader broker across all topics, one ListOffsets request per broker, brokers fanned out concurrently. A sweep costs ~one round trip regardless of topic count. `Get(topic)` remains as a single-topic wrapper for tests and the benchmark contrast.
- **Source and destination sweeps run concurrently** — a poll tick pays the slower of the two clusters, not their sum.
- **Refresh-and-retry for stale routing** — stale-metadata block errors (`NOT_LEADER`, …), leader-lookup failures, and broker **transport** failures (restarting/unreachable cached leader) defer to a single metadata-refresh + retry pass before the sweep fails. Transport errors are deliberately unclassified — the bounded extra latency for a persistent misconfiguration (~one refresh + 500ms per sweep) is documented in code.
- **Poll-loop tolerance** — both loops tolerate up to 3 consecutive failed sweeps (warn, wait one full poll interval on a fresh timer, retry; counter resets on success), so a leader election or rolling broker restart no longer aborts a live migration's FSM step. Previously any fetch error was fatal.

## Performance

Same benchmark binary, same code paths the workflow uses, 1,000 single-partition topics (minikube CFK; WAN latency injected on the client pod via `tc netem`, RTT verified by ping):

| RTT | Per-topic loop (old) | Batched GetMany (new) | Speedup |
|---|---|---|---|
| 0.08 ms (LAN) | 245 ms | 3.3 ms | ~75x |
| 11 ms | 13.6 s | 19.9 ms | ~680x |
| 51 ms | 53.5 s | 62.9 ms | **~850x** |

Loop cost scales as `topics × RTT`; batched cost is ~one round trip, flat in topic count. Both sweeps assert byte-identical offsets in every run. 

## Behavior gates

- Offsets/lag math unchanged: every value still comes from a live ListOffsets response; an errored partition never contributes a value; a sweep returns complete results or an error (no partials).
- All failure paths remain fail-loud — the change is *when* the workflow gives up (3 tick-paced strikes), never *what* it reports. A missing destination partition still counts full source offset as lag; errors can only delay promotion, never fake zero lag.
- Migration remains resumable: an aborted step re-runs from persisted FSM state exactly as before.

## Test plan

- [x] Unit: `go test -race ./internal/services/offset/... ./internal/services/migration/...` — includes new tests for one-request-per-broker batching, dead-leader transport retry (mock broker with real dead socket), sweep-failure tolerance/abort/counter-reset in both loops
- [x] `TestOffsetFetchBenchmark` (e2e): loop-vs-batch over 1,000 topics, identical-offsets assertion, ≥3x regression floor
- [x] Full migration e2e suite (`make test-migration`, fresh Minikube + CFK): all five tests green in two separate runs, including PromoteBatchSize (106s) and all pause-offset-sync tests
- [x] Two full code-review passes; 12 findings resolved or explicitly accepted-and-documented
- [x] `go vet` (incl. `-tags e2e`), gofmt, golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
