### PR TITLE
feat(log): mirror terminal output to kcp.log via an os.Stdout tee (capture-by-default)

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -48,7 +48,10 @@ var RootCmd = &cobra.Command{
 			},
 		})
 
-		// Console handler: Warn+ by default, Debug+ with --verbose
+		// Console handler: Warn+ by default, Debug+ with --verbose.
+		// Bind it to the real os.Stdout *before* installCapture swaps the stream
+		// below, so slog console records go straight to the terminal and are
+		// never re-captured into kcp.log (the file handler already logs them).
 		consoleLevel := slog.LevelWarn
 		if verbose {
 			consoleLevel = slog.LevelDebug
@@ -65,6 +68,22 @@ var RootCmd = &cobra.Command{
 
 		// --- End logging setup ---
 
+		// Verify we can write to the cwd before redirecting the streams: if we
+		// can't, there is no kcp.log to mirror into and the error must reach the
+		// real stderr. Keep this ahead of installCapture so its os.Exit doesn't
+		// abandon an undrained mirror.
+		if err := checkWritePermissions(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", color.RedString("Error: %v", err))
+			os.Exit(1)
+		}
+
+		// From here on every byte written to the terminal is mirrored into
+		// kcp.log by default (see log_capture.go). Usage/help text is emitted
+		// before this point — cobra runs it without the root PersistentPreRun —
+		// so it is excluded automatically. FlushCapture (deferred in main)
+		// drains the mirror on exit.
+		installCapture(lumberjackLogger)
+
 		if build_info.IsDev() {
 			fmt.Printf("\n%s\n%s\n%s\n%s\n%s\n\n",
 				color.RedString("┌─────────────────────────────────────────────────────────────────────────────────────────────┐"),
@@ -79,11 +98,6 @@ var RootCmd = &cobra.Command{
 			color.GreenString("version=%s", build_info.Version),
 			color.YellowString("commit=%s", build_info.Commit),
 			color.BlueString("date=%s", build_info.Date))
-
-		if err := checkWritePermissions(); err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", color.RedString("Error: %v", err))
-			os.Exit(1)
-		}
 	},
 }
 

--- a/cmd/log_capture.go
+++ b/cmd/log_capture.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"sync"
+)
+
+// terminalCapture tees everything written to os.Stdout/os.Stderr once
+// installCapture has run: bytes are forwarded verbatim to the original streams
+// (colour intact) and, line by line, an ANSI/control-stripped copy is written
+// to kcp.log. This makes the user-facing narrative land in the shared support
+// log by default — with no per-call-site wrapper — while usage/help text
+// (emitted before PersistentPreRun installs the capture) is naturally excluded.
+//
+// This is the "capture by default" alternative to an opt-in output.* package:
+// commands keep using plain fmt.Print*/color and their output is mirrored for
+// them. slog stays independent for diagnostics.
+type terminalCapture struct {
+	realOut, realErr *os.File
+	outW, errW       *os.File
+	wg               sync.WaitGroup
+	closeOnce        sync.Once
+}
+
+// activeCapture holds the installed capture so FlushCapture (deferred in main)
+// can tear it down on any exit path. It is nil when no capture is active — for
+// example the --help path, where cobra prints usage without ever running the
+// root PersistentPreRun.
+var activeCapture *terminalCapture
+
+var (
+	// captureANSIRE matches SGR colour codes (e.g. \x1b[36m, \x1b[0m) that
+	// fatih/color emits on a TTY. Stripping them keeps the kcp.log copy plain.
+	captureANSIRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+	// captureCtrlRE matches C0 control characters except tab (\x09) and newline
+	// (\x0a, handled by line splitting) plus DEL. Stripping them keeps the log
+	// free of non-printable bytes and stops mirrored content forging log lines.
+	captureCtrlRE = regexp.MustCompile(`[\x00-\x08\x0b-\x1f\x7f]`)
+)
+
+// installCapture redirects os.Stdout and os.Stderr through pipes, forwarding
+// bytes to the original streams and mirroring a clean, line-based copy into
+// logW.
+//
+// It must be called *after* slog's console handler has been bound to the
+// original os.Stdout; otherwise slog console records would loop back through
+// the mirror and be double-written to kcp.log (the file handler already logs
+// them). It must also run *after* the cwd write check, since a mirror target
+// in an unwritable directory is pointless.
+func installCapture(logW io.Writer) {
+	c := &terminalCapture{realOut: os.Stdout, realErr: os.Stderr}
+
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		return // leave the streams untouched; narrative simply isn't mirrored
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		_ = outR.Close()
+		_ = outW.Close()
+		return
+	}
+
+	c.outW, c.errW = outW, errW
+	os.Stdout = outW
+	os.Stderr = errW
+
+	c.wg.Add(2)
+	go c.pump(outR, c.realOut, logW)
+	go c.pump(errR, c.realErr, logW)
+
+	activeCapture = c
+}
+
+// FlushCapture restores the original streams, closes the pipe writers, and
+// waits for the pump goroutines to drain any buffered output into kcp.log. It
+// is safe to call when no capture is active. Defer it from main so it runs on
+// success, error, and panic-unwind — before the process exits — because the
+// mirror is drained asynchronously and os.Exit would otherwise abandon it.
+func FlushCapture() {
+	c := activeCapture
+	if c == nil {
+		return
+	}
+	c.closeOnce.Do(func() {
+		os.Stdout = c.realOut
+		os.Stderr = c.realErr
+		_ = c.outW.Close()
+		_ = c.errW.Close()
+		c.wg.Wait()
+	})
+}
+
+// pump forwards raw bytes from r to term as they arrive — so half-line
+// interactive prompts appear on the terminal immediately — while accumulating
+// a line buffer. Each completed line is sanitised and written to logW; any
+// trailing partial line (e.g. a prompt with no newline) is flushed when the
+// pipe closes.
+func (c *terminalCapture) pump(r io.ReadCloser, term io.Writer, logW io.Writer) {
+	defer c.wg.Done()
+	defer func() { _ = r.Close() }()
+
+	buf := make([]byte, 4096)
+	var line []byte
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			_, _ = term.Write(chunk) // verbatim, immediate: colour + prompts intact
+
+			line = append(line, chunk...)
+			for {
+				i := bytes.IndexByte(line, '\n')
+				if i < 0 {
+					break
+				}
+				mirrorLine(logW, line[:i])
+				line = line[i+1:]
+			}
+		}
+		if err != nil {
+			mirrorLine(logW, line) // flush any trailing partial line
+			return
+		}
+	}
+}
+
+// mirrorLine strips colour and control bytes from a single terminal line and
+// writes the clean result (with a trailing newline) to logW. Blank or
+// whitespace-only lines produce no record, so kcp.log isn't padded with empties.
+func mirrorLine(logW io.Writer, raw []byte) {
+	clean := captureANSIRE.ReplaceAll(raw, nil)
+	clean = captureCtrlRE.ReplaceAll(clean, nil)
+	if len(bytes.TrimSpace(clean)) == 0 {
+		return
+	}
+	_, _ = logW.Write(append(clean, '\n'))
+}

--- a/cmd/log_capture_test.go
+++ b/cmd/log_capture_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// runPump feeds write into a pipe, runs pump to completion, and returns what
+// reached the terminal leg (verbatim) and the log leg (sanitised).
+func runPump(t *testing.T, write func(w *os.File)) (term, logged string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	var termBuf, logBuf bytes.Buffer
+	c := &terminalCapture{}
+	c.wg.Add(1)
+	go c.pump(r, &termBuf, &logBuf)
+
+	write(w)
+	_ = w.Close()
+	c.wg.Wait() // happens-before: safe to read the buffers after this
+
+	return termBuf.String(), logBuf.String()
+}
+
+func TestPumpForwardsRawAndStripsForLog(t *testing.T) {
+	term, logged := runPump(t, func(w *os.File) {
+		// cyan "hello" + reset, then a plain line
+		_, _ = fmt.Fprint(w, "\x1b[36mhello\x1b[0m\nworld\n")
+	})
+
+	if !strings.Contains(term, "\x1b[36mhello\x1b[0m") {
+		t.Errorf("terminal leg lost colour: %q", term)
+	}
+	if term != "\x1b[36mhello\x1b[0m\nworld\n" {
+		t.Errorf("terminal leg not verbatim: %q", term)
+	}
+	if logged != "hello\nworld\n" {
+		t.Errorf("log leg not stripped/line-preserved: %q", logged)
+	}
+}
+
+func TestPumpFlushesTrailingPartialLine(t *testing.T) {
+	// An interactive prompt has no trailing newline; it must still reach the
+	// log when the stream closes, and reach the terminal verbatim beforehand.
+	term, logged := runPump(t, func(w *os.File) {
+		_, _ = fmt.Fprint(w, "Continue? (y/N): ")
+	})
+
+	if term != "Continue? (y/N): " {
+		t.Errorf("terminal leg not verbatim: %q", term)
+	}
+	if logged != "Continue? (y/N): \n" {
+		t.Errorf("trailing partial not flushed: %q", logged)
+	}
+}
+
+func TestPumpSkipsBlankLines(t *testing.T) {
+	_, logged := runPump(t, func(w *os.File) {
+		_, _ = fmt.Fprint(w, "\n\n   \nreal line\n\x1b[0m\n")
+	})
+
+	if logged != "real line\n" {
+		t.Errorf("blank/whitespace/colour-only lines not skipped: %q", logged)
+	}
+}
+
+func TestPumpStripsControlBytesKeepsTabs(t *testing.T) {
+	_, logged := runPump(t, func(w *os.File) {
+		_, _ = fmt.Fprint(w, "col1\tcol2\x07\x00\r\n")
+	})
+
+	// Tab preserved (table alignment); bell/nul/CR removed.
+	if logged != "col1\tcol2\n" {
+		t.Errorf("control-byte handling wrong: %q", logged)
+	}
+}
+
+func TestFlushCaptureNoopWhenInactive(t *testing.T) {
+	prev := activeCapture
+	activeCapture = nil
+	defer func() { activeCapture = prev }()
+
+	FlushCapture() // must not panic when no capture is installed
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,11 @@ func main() {
 }
 
 func run() error {
+	// Drain the terminal->kcp.log mirror on every exit path (success, error,
+	// panic-unwind) before main calls os.Exit. The mirror is filled by pump
+	// goroutines, so this must run to guarantee the last lines reach the log.
+	defer cmd.FlushCapture()
+
 	if err := cmd.RootCmd.Execute(); err != nil {
 		slog.Error(err.Error())
 		return err


### PR DESCRIPTION
## What

Mirror user-facing terminal output into `kcp.log` **by default**, without wrapping any call site.

The root `PersistentPreRun` installs a tee: it swaps `os.Stdout`/`os.Stderr` for pipes, forwards bytes verbatim to the original streams (colour intact), and writes an ANSI/control-stripped, line-based copy into `kcp.log`. Commands keep using plain `fmt.Print*`/`color.*` — their narrative is mirrored for them. `slog` stays independent for diagnostics.

## Why

We want the shared support log to contain what a command actually did (scans, files written, switchover steps). The opt-in alternative (a `output.*` package used in place of every `fmt.Print*`) works but touches ~50 files and has to be remembered at every new call site. This flips the model: **capture by default, exclude the exceptions.**

This is the counterpart to the `feat/log-capture-terminal-output` branch (the opt-in `output.*` approach). Both branch off `main`; this PR exists so we can compare the two in practice and pick one.

## How it behaves

- **Capture by default** — any `fmt.Print*`/`color` written during a command's `Run` lands in `kcp.log`, no wrapper needed.
- **Usage/help excluded for free** — cobra prints usage and handles `--help` / flag-parse errors *before* the root `PersistentPreRun`, so the tee isn't installed yet and nothing is mirrored (verified: `kcp --help` and bad-flag invocations create no log).
- **Colours preserved on the terminal**, stripped in the log (`fatih/color` freezes its TTY decision at init, before the swap).
- **Interactive prompts still render immediately** — bytes are forwarded to the terminal as they arrive; the log copy is line-buffered and any trailing partial line is flushed on close.
- **`slog` unaffected** — the console handler is bound to the real `os.Stdout` *before* the swap, so diagnostics reach the terminal directly and are not re-captured (no double-logging; the file handler already records them).

## Trade-offs (reviewers, weigh these)

1. **Async drain.** Output flows through pump goroutines, so flush-on-exit is deliberate: `FlushCapture` is deferred from `main`, and the cwd write-check is kept ahead of the tee so its `os.Exit` never abandons an undrained mirror.
2. **Subprocess inheritance.** Anything kcp spawns that inherits `os.Stdout` would also be mirrored (feature or noise, depending).
3. **Usage after a *runtime* `RunE` error** (post-`PersistentPreRun`) would be mirrored; set `SilenceUsage: true` if undesired.
4. **No per-line timestamp** on mirrored narrative (the `output.*` approach routed through `slog`, adding a `time INFO` prefix). Raw lines keep tables/markdown readable in the log.

## Size

4 files, +259/−6 — versus ~53 files for the `output.*` approach.

## Testing

- `cmd/log_capture_test.go` — 5 unit tests: verbatim-terminal vs stripped-log, trailing-partial-prompt flush, blank-line skip, tab preservation with control-byte stripping, nil no-op. All pass.
- `gofmt` / `go vet ./...` / `go build ./...` clean; `go test ./cmd/` passes.
- Manual: `kcp version` in a scratch dir — banners + the command's own `fmt` output appear in `kcp.log` (ANSI-stripped); `kcp --help` creates no log.

## Follow-up (only if this approach wins)

Delete the `output.*` machinery (package, mirror marker, `FanOutHandler`, `DropMirrored`) and revert those call sites to plain `fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
