### PR TITLE
feat(log): clean Warn+ console + full kcp.log diagnostic narrative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ The `internal/client/kafka_admin.go` package handles all auth types. SASL/SCRAM 
 Logs go through a custom `slog` pretty handler that fans out to two legs:
 
 - **`kcp.log`** (lumberjack, rotating) — **everything at Debug+**, rendered structured (`time LEVEL message key=val`) for support.
-- **Console** — **Warn+** by default (`--verbose` → Debug+). WARN/ERROR colour the level; INFO/DEBUG stay off the default console (they surface only under `--verbose`) and render as clean narrative (no time/level prefix) when shown.
+- **Console** — **Warn+** by default (`--verbose` → Debug+). WARN/ERROR colour the level; INFO renders as clean narrative (no time/level prefix); DEBUG (only under `--verbose`) keeps an uncoloured `DEBUG` prefix so diagnostics stay distinct from narrative. INFO/DEBUG stay off the default console (they surface only under `--verbose`); nothing on the console carries a timestamp.
 
 ### Output routing — pick by audience
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,23 @@ The `internal/client/kafka_admin.go` package handles all auth types. SASL/SCRAM 
 
 ## Logging
 
-Logs go to `kcp.log` via lumberjack (rotating) and stdout via a custom `slog` pretty handler. Default level is DEBUG.
+Logs go through a custom `slog` pretty handler that fans out to two legs:
+
+- **`kcp.log`** (lumberjack, rotating) — **everything at Debug+**, rendered structured (`time LEVEL message key=val`) for support.
+- **Console** — **Info+** by default (`--verbose` → Debug+). INFO renders as clean narrative (no time/level prefix); WARN/ERROR colour the level.
+
+### Output routing — pick by audience, not just severity
+
+The console is Info+, so `slog` level doubles as the console audience dial. Choose the mechanism by where the line should land:
+
+| I want it…                                                                 | Use                    | Console?              | `kcp.log`? |
+| -------------------------------------------------------------------------- | ---------------------- | --------------------- | ---------- |
+| Terminal only (banners, end-of-run summaries, tables, interactive prompts) | `fmt.Printf` / `color` | yes                   | **no**     |
+| Terminal **and** log, as narrative                                         | `slog.Info`            | yes (clean)           | yes        |
+| Log only (diagnostic detail — ARNs, address lists, raw timestamps, maps)   | `slog.Debug`           | only with `--verbose` | yes        |
+| Log **and** terminal, as a problem                                         | `slog.Warn` / `slog.Error` | yes (coloured level) | yes    |
+
+Because the console is Info+, **every `slog.Info` is user-facing** — keep noisy attrs (full ARNs, address lists, raw `time.Time`, maps like `tags=map[]`) on a paired `slog.Debug`, never on an INFO line.
 
 ### Emoji standard (PR [#234](https://github.com/confluentinc/kcp/pull/234))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,20 +121,21 @@ The `internal/client/kafka_admin.go` package handles all auth types. SASL/SCRAM 
 Logs go through a custom `slog` pretty handler that fans out to two legs:
 
 - **`kcp.log`** (lumberjack, rotating) — **everything at Debug+**, rendered structured (`time LEVEL message key=val`) for support.
-- **Console** — **Info+** by default (`--verbose` → Debug+). INFO renders as clean narrative (no time/level prefix); WARN/ERROR colour the level.
+- **Console** — **Warn+** by default (`--verbose` → Debug+). WARN/ERROR colour the level; INFO/DEBUG stay off the default console (they surface only under `--verbose`) and render as clean narrative (no time/level prefix) when shown.
 
-### Output routing — pick by audience, not just severity
+### Output routing — pick by audience
 
-The console is Info+, so `slog` level doubles as the console audience dial. Choose the mechanism by where the line should land:
+Commands own their **terminal** narrative with `fmt`/`color` (the indented `discover`/`scan` trees, migration reporter, banners, prompts); `slog` carries the **log** narrative. Because the default console is Warn+, `slog.Info` and `slog.Debug` are equally hidden from the terminal — level is a *log* severity dial, not a console-visibility one. Choose the mechanism by where the line must land:
 
-| I want it…                                                                 | Use                    | Console?              | `kcp.log`? |
-| -------------------------------------------------------------------------- | ---------------------- | --------------------- | ---------- |
-| Terminal only (banners, end-of-run summaries, tables, interactive prompts) | `fmt.Printf` / `color` | yes                   | **no**     |
-| Terminal **and** log, as narrative                                         | `slog.Info`            | yes (clean)           | yes        |
-| Log only (diagnostic detail — ARNs, address lists, raw timestamps, maps)   | `slog.Debug`           | only with `--verbose` | yes        |
-| Log **and** terminal, as a problem                                         | `slog.Warn` / `slog.Error` | yes (coloured level) | yes    |
+| I want it…                                                                  | Use                                                                      | Console?              | `kcp.log`? |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------- | ---------- |
+| Terminal only (banners, end-of-run summaries, tables, interactive prompts)  | `fmt.Printf` / `color`                                                   | yes                   | **no**     |
+| Terminal narrative that must **also** be in the log                         | `fmt`/`color` **and** mirror via `logging.File()` (see migration reporter) | yes                 | yes        |
+| Log narrative (progress the log should record)                              | `slog.Info`                                                              | only with `--verbose` | yes        |
+| Log only (diagnostic detail — ARNs, address lists, raw timestamps, maps)    | `slog.Debug`                                                             | only with `--verbose` | yes        |
+| Terminal **and** log, as a problem                                          | `slog.Warn` / `slog.Error`                                               | yes (coloured level)  | yes        |
 
-Because the console is Info+, **every `slog.Info` is user-facing** — keep noisy attrs (full ARNs, address lists, raw `time.Time`, maps like `tags=map[]`) on a paired `slog.Debug`, never on an INFO line.
+**A command's `fmt` terminal narrative is not in `kcp.log`** unless you mirror it — that gap (the migration offset-sync trace was `fmt`-only) is why the file-only sink (`internal/logging`) and the reporter mirror exist. Even under `--verbose`, keep INFO messages clean: put noisy attrs (full ARNs, address lists, raw `time.Time`, maps like `tags=map[]`) on a paired `slog.Debug`.
 
 ### Emoji standard (PR [#234](https://github.com/confluentinc/kcp/pull/234))
 

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -105,6 +105,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		slog.Debug("build provenance",
+			"cmd", cmd.CommandPath(),
 			"version", build_info.Version,
 			"commit", build_info.Commit,
 			"date", build_info.Date,

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/confluentinc/kcp/cmd/create_asset"
@@ -50,8 +51,9 @@ var RootCmd = &cobra.Command{
 			},
 		})
 
-		// Console handler: Info+ by default (user-facing narrative), Debug+ with --verbose
-		consoleLevel := slog.LevelInfo
+		// Console handler: Warn+ by default (commands own their terminal narrative
+		// via fmt/color; slog carries log narrative), Debug+ with --verbose.
+		consoleLevel := slog.LevelWarn
 		if verbose {
 			consoleLevel = slog.LevelDebug
 		}
@@ -87,14 +89,27 @@ var RootCmd = &cobra.Command{
 			color.YellowString("commit=%s", build_info.Commit),
 			color.BlueString("date=%s", build_info.Date))
 
-		// Detailed, structured build provenance for support diagnostics.
-		// Logged at Debug so it lands in kcp.log (file handler is Debug+)
-		// without doubling the coloured banner above on the console (Info+).
+		// Detailed, structured build provenance for support diagnostics. Logged at
+		// Debug so it lands in kcp.log (file handler is Debug+) without doubling the
+		// coloured banner above on the console (Debug is below the console default).
+		// vcs_modified is "true" when the binary was built from a dirty working tree;
+		// empty when built without VCS stamping (e.g. from a tarball, not a git checkout).
+		var vcsModified string
+		if bi, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range bi.Settings {
+				if s.Key == "vcs.modified" {
+					vcsModified = s.Value
+					break
+				}
+			}
+		}
+
 		slog.Debug("build provenance",
 			"version", build_info.Version,
 			"commit", build_info.Commit,
 			"date", build_info.Date,
 			"dev_build", build_info.IsDev(),
+			"vcs_modified", vcsModified,
 			"go", runtime.Version(),
 			"os", runtime.GOOS,
 			"arch", runtime.GOARCH,

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/confluentinc/kcp/cmd/create_asset"
@@ -21,6 +22,7 @@ import (
 	"github.com/confluentinc/kcp/cmd/update"
 	"github.com/confluentinc/kcp/cmd/version"
 	"github.com/confluentinc/kcp/internal/build_info"
+	"github.com/confluentinc/kcp/internal/logging"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -48,8 +50,8 @@ var RootCmd = &cobra.Command{
 			},
 		})
 
-		// Console handler: Warn+ by default, Debug+ with --verbose
-		consoleLevel := slog.LevelWarn
+		// Console handler: Info+ by default (user-facing narrative), Debug+ with --verbose
+		consoleLevel := slog.LevelInfo
 		if verbose {
 			consoleLevel = slog.LevelDebug
 		}
@@ -57,11 +59,16 @@ var RootCmd = &cobra.Command{
 			SlogOpts: slog.HandlerOptions{
 				Level: consoleLevel,
 			},
+			Console: true,
 		})
 
 		// Fan out to both handlers
 		logger := slog.New(NewFanOutHandler(fileHandler, consoleHandler))
 		slog.SetDefault(logger)
+
+		// File-only mirror sink for components that own rich terminal output
+		// (e.g. the migration reporter) and must still be captured in kcp.log.
+		logging.SetFile(slog.New(fileHandler))
 
 		// --- End logging setup ---
 
@@ -79,6 +86,19 @@ var RootCmd = &cobra.Command{
 			color.GreenString("version=%s", build_info.Version),
 			color.YellowString("commit=%s", build_info.Commit),
 			color.BlueString("date=%s", build_info.Date))
+
+		// Detailed, structured build provenance for support diagnostics.
+		// Logged at Debug so it lands in kcp.log (file handler is Debug+)
+		// without doubling the coloured banner above on the console (Info+).
+		slog.Debug("build provenance",
+			"version", build_info.Version,
+			"commit", build_info.Commit,
+			"date", build_info.Date,
+			"dev_build", build_info.IsDev(),
+			"go", runtime.Version(),
+			"os", runtime.GOOS,
+			"arch", runtime.GOARCH,
+		)
 
 		if err := checkWritePermissions(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", color.RedString("Error: %v", err))
@@ -109,27 +129,60 @@ func init() {
 
 type PrettyHandlerOptions struct {
 	SlogOpts slog.HandlerOptions
+
+	// Console renders INFO records as clean, human-facing narrative (no
+	// time/level prefix) and colours the level on WARN/ERROR. The file
+	// handler leaves this false so kcp.log keeps the full structured form.
+	Console bool
 }
 
 type PrettyHandler struct {
 	slog.Handler
-	l *log.Logger
+	l       *log.Logger
+	console bool
 }
 
 func (h *PrettyHandler) Handle(ctx context.Context, r slog.Record) error {
-	time := r.Time.Format("2006/01/02 15:04:05")
-	level := r.Level.String()
-	message := r.Message
-
 	values := []string{}
 	r.Attrs(func(a slog.Attr) bool {
 		values = append(values, fmt.Sprintf("%s=%v", a.Key, a.Value.Any()))
 		return true
 	})
 
-	h.l.Printf("%s %s %s %s", time, level, message, strings.Join(values, " "))
+	var parts []string
+	switch {
+	case h.console && r.Level == slog.LevelInfo:
+		// User-facing narrative: message + attrs only.
+		parts = append(parts, r.Message)
+	case h.console:
+		// Console WARN/ERROR (and DEBUG under --verbose): coloured level +
+		// message, no timestamp, so problems pop inline with the narrative.
+		parts = append(parts, colorizeLevel(r.Level), r.Message)
+	default:
+		// File: full structured line for support.
+		parts = append(parts,
+			r.Time.Format("2006/01/02 15:04:05"),
+			r.Level.String(),
+			r.Message,
+		)
+	}
+	parts = append(parts, values...)
+
+	h.l.Printf("%s", strings.Join(parts, " "))
 
 	return nil
+}
+
+func colorizeLevel(level slog.Level) string {
+	s := level.String()
+	switch {
+	case level >= slog.LevelError:
+		return color.RedString(s)
+	case level >= slog.LevelWarn:
+		return color.YellowString(s)
+	default:
+		return s
+	}
 }
 
 func NewPrettyHandler(
@@ -139,6 +192,7 @@ func NewPrettyHandler(
 	h := &PrettyHandler{
 		Handler: slog.NewTextHandler(out, &opts.SlogOpts),
 		l:       log.New(out, "", 0),
+		console: opts.Console,
 	}
 
 	return h

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -92,8 +92,13 @@ var RootCmd = &cobra.Command{
 		// Detailed, structured build provenance for support diagnostics. Logged at
 		// Debug so it lands in kcp.log (file handler is Debug+) without doubling the
 		// coloured banner above on the console (Debug is below the console default).
-		// vcs_modified is "true" when the binary was built from a dirty working tree;
-		// empty when built without VCS stamping (e.g. from a tarball, not a git checkout).
+		//
+		// vcs_modified is Go's `vcs.modified` build stamp — did the working tree have
+		// uncommitted changes when the binary was built? It matters for support because
+		// the commit hash alone doesn't fully describe a dirty build:
+		//   "true"  — built from a dirty tree; commit + local edits, not reproducible.
+		//   "false" — built from a clean checkout; commit hash fully describes the binary.
+		//   ""      — no VCS stamp (built outside a git checkout, e.g. from a tarball).
 		var vcsModified string
 		if bi, ok := debug.ReadBuildInfo(); ok {
 			for _, s := range bi.Settings {

--- a/cmd/create_asset/migration_infra/cmd_create_asset_migration_infra.go
+++ b/cmd/create_asset/migration_infra/cmd_create_asset_migration_infra.go
@@ -390,7 +390,7 @@ func parseMSKMigrationInfraOpts() (*MigrationInfraOpts, error) {
 		MigrationType: targetType,
 	}
 
-	slog.Info("using MSK default SASL/SCRAM mechanism", "mechanism", opts.MigrationWizardRequest.SourceSaslScramMechanism)
+	slog.Debug("using MSK default SASL/SCRAM mechanism", "mechanism", opts.MigrationWizardRequest.SourceSaslScramMechanism)
 
 	bootstrapBrokers, err := getBootstrapBrokers(cluster, targetType)
 	if err != nil {
@@ -578,9 +578,9 @@ func parseOSKMigrationInfraOpts() (*MigrationInfraOpts, error) {
 			return nil, fmt.Errorf("invalid --source-sasl-scram-mechanism value %q: must be SCRAM-SHA-256, SCRAM-SHA-512, SHA256, or SHA512", sourceSaslScramMechanism)
 		}
 		opts.MigrationWizardRequest.SourceSaslScramMechanism = normalized
-		slog.Info("using SASL/SCRAM mechanism from --source-sasl-scram-mechanism flag", "mechanism", normalized)
+		slog.Debug("using SASL/SCRAM mechanism from --source-sasl-scram-mechanism flag", "mechanism", normalized)
 	case opts.MigrationWizardRequest.SourceSaslScramMechanism != "":
-		slog.Info("using SASL/SCRAM mechanism from state file", "mechanism", opts.MigrationWizardRequest.SourceSaslScramMechanism)
+		slog.Debug("using SASL/SCRAM mechanism from state file", "mechanism", opts.MigrationWizardRequest.SourceSaslScramMechanism)
 	case targetType.RequiresSaslScram():
 		return nil, fmt.Errorf("SASL/SCRAM mechanism is required for migration type %d but was not found in the state file. "+
 			"Provide it with --source-sasl-scram-mechanism (SCRAM-SHA-256 or SCRAM-SHA-512)", int(targetType))

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -102,6 +102,15 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 	}
 	awsClientInfo.MskClusterConfig = *cluster.ClusterInfo
 
+	// MSK Serverless does not support several AWS-API metadata scans (VPC
+	// connections, nodes, SCRAM secrets, compatible versions, networking) or the
+	// AWS topic APIs. Announce it once per cluster; the individual per-scan skips
+	// stay in kcp.log at Debug.
+	isServerless := cluster.ClusterInfo.ClusterType == kafkatypes.ClusterTypeServerless
+	if isServerless {
+		slog.Warn("⚠️ MSK Serverless cluster; skipping unsupported scans (VPC connections, nodes, SCRAM secrets, compatible versions, networking, topics)")
+	}
+
 	brokers, err := cd.getBootstrapBrokers(ctx, clusterArn)
 	if err != nil {
 		return nil, nil, err
@@ -144,8 +153,8 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 	}
 	awsClientInfo.CompatibleVersions = *versions
 
-	if cluster.ClusterInfo.ClusterType == kafkatypes.ClusterTypeServerless {
-		slog.Warn("⚠️ Cluster networking not supported for MSK Serverless clusters, skipping networking scan")
+	if isServerless {
+		slog.Debug("⏭️ skipping networking scan for MSK Serverless cluster")
 	} else {
 		networking, err := cd.scanNetworkingInfo(ctx, cluster, nodes)
 		if err != nil {
@@ -154,14 +163,19 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 		awsClientInfo.ClusterNetworking = networking
 	}
 
-	if !skipTopics {
+	switch {
+	case skipTopics:
+		fmt.Printf("  ⏭️  Skipping topic discovery\n")
+	case isServerless:
+		// The AWS topic APIs are unsupported on serverless; the serverless notice
+		// above already covers this.
+		slog.Debug("⏭️ skipping topic discovery for MSK Serverless cluster", "clusterArn", clusterArn)
+	default:
 		topics, err := cd.discoverTopics(ctx, clusterArn)
 		if err != nil {
 			return nil, nil, err
 		}
 		kafkaClientInfo.SetTopics(topics)
-	} else {
-		fmt.Printf("  ⏭️  Skipping topic discovery\n")
 	}
 
 	connectors, err := cd.discoverMatchingConnectors(ctx, &awsClientInfo)
@@ -567,7 +581,9 @@ func (cd *ClusterDiscoverer) discoverTopics(ctx context.Context, clusterArn stri
 
 	topics, err := cd.mskService.GetTopicsWithConfigs(ctx, clusterArn)
 	if err != nil {
-		slog.Error("❌ failed to list topics", "clusterArn", clusterArn, "error", err)
+		// Non-fatal: continue without topic details. Serverless is handled by the
+		// caller, so reaching here means a genuine provisioned-cluster failure.
+		slog.Warn("⚠️ failed to list topics; continuing without topic details", "error", err)
 	}
 
 	var topicDetails []types.TopicDetails

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -167,8 +167,10 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 	case skipTopics:
 		fmt.Printf("  ⏭️  Skipping topic discovery\n")
 	case isServerless:
-		// The AWS topic APIs are unsupported on serverless; the serverless notice
-		// above already covers this.
+		// The AWS topic APIs are unsupported on serverless, so we skip discovery
+		// entirely (the serverless notice above already covers this). Unlike the
+		// default path we never call SetTopics here, so Topics stays nil and
+		// serializes as "topics": null; all consumers nil-guard it.
 		slog.Debug("⏭️ skipping topic discovery for MSK Serverless cluster", "clusterArn", clusterArn)
 	default:
 		topics, err := cd.discoverTopics(ctx, clusterArn)

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -586,6 +586,7 @@ func (cd *ClusterDiscoverer) discoverTopics(ctx context.Context, clusterArn stri
 		// Non-fatal: continue without topic details. Serverless is handled by the
 		// caller, so reaching here means a genuine provisioned-cluster failure.
 		slog.Warn("⚠️ failed to list topics; continuing without topic details", "error", err)
+		slog.Debug("failed to list topics", "clusterArn", clusterArn, "error", err)
 	}
 
 	var topicDetails []types.TopicDetails

--- a/cmd/discover/cluster_discoverer_test.go
+++ b/cmd/discover/cluster_discoverer_test.go
@@ -1,8 +1,11 @@
 package discover
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -169,4 +172,38 @@ func TestClusterDiscoverer_NilClusterInfoInDiscoverMetrics(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil ClusterInfo")
+}
+
+// TestDiscoverTopics_LogsClusterArnOnFailure proves the non-fatal topic-listing
+// failure keeps cluster attribution in kcp.log: the surviving WARN stays clean,
+// but a paired DEBUG line records which clusterArn failed, so a support engineer
+// reading a multi-cluster run can still tell which cluster the failure belongs to.
+func TestDiscoverTopics_LogsClusterArnOnFailure(t *testing.T) {
+	const testArn = "arn:aws:kafka:us-east-1:123456789012:cluster/prod/xyz-9"
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	msk, ec2svc, metrics := defaultStubs()
+	msk.getTopicsWithConfigsFn = func(ctx context.Context, clusterArn string) ([]types.TopicDetails, error) {
+		return nil, errors.New("broker unreachable")
+	}
+	cd := newTestClusterDiscoverer(msk, ec2svc, metrics)
+
+	// discoverTopics is non-fatal: it logs and returns a nil error.
+	_, err := cd.discoverTopics(context.Background(), testArn)
+	require.NoError(t, err)
+
+	out := logBuf.String()
+	found := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "level=DEBUG") && strings.Contains(line, "clusterArn="+testArn) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"discoverTopics must record clusterArn on a DEBUG line when topic listing fails; got:\n%s", out)
 }

--- a/cmd/discover/cmd_discover.go
+++ b/cmd/discover/cmd_discover.go
@@ -232,7 +232,7 @@ func parseDiscoverOpts() (*DiscovererOpts, error) {
 		return nil, fmt.Errorf("failed to check state file: %v", err)
 	} else {
 		// State file exists - load it
-		slog.Info("Found existing state file, attempting to load it", "file", stateFileName)
+		slog.Debug("Found existing state file, attempting to load it", "file", stateFileName)
 		state, err = types.NewStateFromFile(stateFileName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load existing state file: %v", err)

--- a/cmd/healthcheck/runner.go
+++ b/cmd/healthcheck/runner.go
@@ -40,7 +40,7 @@ func runHealthcheck(cmd *cobra.Command, args []string) error {
 	clusters := source.GetClusters()
 	slog.Info("clusters to healthcheck", "count", len(clusters), "source", sourceType)
 	for _, cluster := range clusters {
-		slog.Info("cluster", "name", cluster.Name, "id", cluster.UniqueID)
+		slog.Debug("cluster", "name", cluster.Name, "id", cluster.UniqueID)
 	}
 
 	// Reject --output with multiple clusters — there is no sensible way
@@ -144,7 +144,7 @@ func loadStateFile(path string) (*types.State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load state file %q: %w", path, err)
 	}
-	slog.Info("loaded existing state file", "file", path)
+	slog.Debug("loaded existing state file", "file", path)
 	return state, nil
 }
 

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -162,7 +162,12 @@ func (m *MigrationExecutor) createSourceOffset(_ context.Context) (*offset.Servi
 		opts = append(opts, client.WithInsecureSkipVerify())
 	}
 
-	slog.Debug("connecting to source cluster")
+	slog.Debug("connecting to source cluster",
+		"brokers", len(brokerAddresses),
+		"auth_type", authType,
+		"region", region,
+		"insecure_skip_tls_verify", m.opts.InsecureSkipTLSVerify,
+	)
 	sourceClient, err := client.NewKafkaClient(brokerAddresses, region, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to source cluster: %w", err)
@@ -173,8 +178,11 @@ func (m *MigrationExecutor) createSourceOffset(_ context.Context) (*offset.Servi
 }
 
 func (m *MigrationExecutor) createDestinationOffset() (*offset.Service, error) {
-	slog.Debug("connecting to destination cluster (Confluent Cloud)")
 	ccBrokers := strings.Split(m.opts.ClusterBootstrap, ",")
+	slog.Debug("connecting to destination cluster (Confluent Cloud)",
+		"brokers", len(ccBrokers),
+		"insecure_skip_tls_verify", m.opts.InsecureSkipTLSVerify,
+	)
 	destOpts := []client.AdminOption{client.WithSASLPlainAuth(m.opts.ClusterApiKey, m.opts.ClusterApiSecret)}
 	if m.opts.InsecureSkipTLSVerify {
 		destOpts = append(destOpts, client.WithInsecureSkipVerify())

--- a/cmd/pretty_handler_test.go
+++ b/cmd/pretty_handler_test.go
@@ -68,3 +68,58 @@ func TestPrettyHandlerConsoleRender(t *testing.T) {
 		t.Errorf("file leg should stay fully structured:\n%s", file)
 	}
 }
+
+// TestPrettyHandlerConsoleDebugRender locks in how the console leg renders DEBUG
+// under --verbose. Unlike INFO (clean, prefix-free narrative), DEBUG keeps a
+// "DEBUG" level prefix so diagnostics stay distinct from narrative — but the
+// prefix is uncoloured (only WARN/ERROR colour the level) and, like every console
+// record, it carries no timestamp.
+func TestPrettyHandlerConsoleDebugRender(t *testing.T) {
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+
+	buf := &bytes.Buffer{}
+	log := slog.New(NewPrettyHandler(buf, PrettyHandlerOptions{
+		SlogOpts: slog.HandlerOptions{Level: slog.LevelDebug},
+		Console:  true,
+	}))
+	log.Debug("🔍 confluent cloud request", "method", "POST", "ms", 210)
+	out := buf.String()
+	t.Logf("console debug leg:\n%s", out)
+
+	tsRE := regexp.MustCompile(`\d{4}/\d{2}/\d{2}`)
+	if tsRE.MatchString(out) {
+		t.Errorf("console leg should carry no timestamps:\n%s", out)
+	}
+	// Exact prefix+message+attrs: the DEBUG token sits immediately before the
+	// message with no ANSI escape between them, proving it is uncoloured.
+	if !strings.Contains(out, "DEBUG 🔍 confluent cloud request method=POST ms=210") {
+		t.Errorf("console DEBUG should keep an uncoloured level prefix + message + attrs:\n%s", out)
+	}
+	if strings.Contains(out, color.YellowString("DEBUG")) || strings.Contains(out, color.RedString("DEBUG")) {
+		t.Errorf("console DEBUG level should not be coloured (only WARN/ERROR are):\n%s", out)
+	}
+}
+
+// TestColorizeLevel pins the level-colouring policy: WARN/ERROR are coloured
+// (carry ANSI escapes), INFO/DEBUG are returned verbatim so they read as plain
+// narrative/diagnostics.
+func TestColorizeLevel(t *testing.T) {
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+
+	if got := colorizeLevel(slog.LevelDebug); got != "DEBUG" {
+		t.Errorf("DEBUG should be uncoloured, got %q", got)
+	}
+	if got := colorizeLevel(slog.LevelInfo); got != "INFO" {
+		t.Errorf("INFO should be uncoloured, got %q", got)
+	}
+	if got := colorizeLevel(slog.LevelWarn); !strings.Contains(got, "\x1b[") {
+		t.Errorf("WARN should be coloured, got %q", got)
+	}
+	if got := colorizeLevel(slog.LevelError); !strings.Contains(got, "\x1b[") {
+		t.Errorf("ERROR should be coloured, got %q", got)
+	}
+}

--- a/cmd/pretty_handler_test.go
+++ b/cmd/pretty_handler_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bytes"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+// TestPrettyHandlerConsoleRender demonstrates the two rendering legs:
+//   - console: INFO is clean narrative (no time/level prefix); WARN/ERROR
+//     colour the level; nothing carries a timestamp.
+//   - file: every record stays fully structured (time LEVEL message attrs).
+func TestPrettyHandlerConsoleRender(t *testing.T) {
+	// Force colour on so the WARN/ERROR level styling is exercised even though
+	// `go test` writes to a pipe (fatih/color auto-disables otherwise).
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+
+	render := func(console bool, emit func(*slog.Logger)) string {
+		buf := &bytes.Buffer{}
+		log := slog.New(NewPrettyHandler(buf, PrettyHandlerOptions{
+			SlogOpts: slog.HandlerOptions{Level: slog.LevelDebug},
+			Console:  console,
+		}))
+		emit(log)
+		return buf.String()
+	}
+
+	tsRE := regexp.MustCompile(`\d{4}/\d{2}/\d{2}`)
+
+	// --- console leg ---
+	console := render(true, func(l *slog.Logger) {
+		l.Info("🚀 Starting discover")
+		l.Info("✅ found clusters", "count", 3)
+		l.Warn("could not fetch costs", "region", "us-east-1")
+		l.Error("describe cluster failed", "arn", "arn:aws:kafka:us-east-1:...")
+	})
+	t.Logf("console leg:\n%s", console)
+
+	if tsRE.MatchString(console) {
+		t.Errorf("console leg should carry no timestamps:\n%s", console)
+	}
+	if !strings.Contains(console, "✅ found clusters count=3") {
+		t.Errorf("console INFO should be clean narrative with attrs:\n%s", console)
+	}
+	if !strings.Contains(console, color.YellowString("WARN")) {
+		t.Errorf("console WARN level should be yellow:\n%s", console)
+	}
+	if !strings.Contains(console, color.RedString("ERROR")) {
+		t.Errorf("console ERROR level should be red:\n%s", console)
+	}
+
+	// --- file leg ---
+	file := render(false, func(l *slog.Logger) {
+		l.Info("✅ found clusters", "count", 3)
+	})
+	t.Logf("file leg:\n%s", file)
+
+	if !tsRE.MatchString(file) {
+		t.Errorf("file leg should carry a timestamp:\n%s", file)
+	}
+	if !strings.Contains(file, "INFO ✅ found clusters count=3") {
+		t.Errorf("file leg should stay fully structured:\n%s", file)
+	}
+}

--- a/cmd/scan/client_inventory/client_inventory_scanner.go
+++ b/cmd/scan/client_inventory/client_inventory_scanner.go
@@ -59,6 +59,7 @@ func NewClientInventoryScanner(s3Service S3Service, state types.State, opts Clie
 
 func (cis *ClientInventoryScanner) Run() error {
 	fmt.Printf("🚀 Starting client inventory scan for %s\n", cis.opts.S3Uri)
+	slog.Info("🔍 scanning client inventory", "s3_uri", cis.opts.S3Uri, "region", cis.opts.Region, "cluster", cis.opts.ClusterName)
 
 	ctx := context.Background()
 
@@ -71,9 +72,11 @@ func (cis *ClientInventoryScanner) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to list log files: %w", err)
 	}
+	slog.Info("🔍 found log files", "count", len(logFiles))
 
 	if len(logFiles) == 0 {
 		fmt.Printf("  ⏭️  No log files found to process\n")
+		slog.Info("⏭️ no log files found; skipping")
 		return nil
 	}
 
@@ -87,6 +90,7 @@ func (cis *ClientInventoryScanner) Run() error {
 		return fmt.Errorf("failed to persist state file: %w", err)
 	}
 
+	slog.Info("✅ client inventory scan complete", "region", cis.opts.Region, "cluster", cis.opts.ClusterName, "discovered_clients", len(discoveredClients))
 	return nil
 }
 
@@ -101,6 +105,7 @@ func (cis *ClientInventoryScanner) handleLogFiles(ctx context.Context, bucket st
 		}
 
 		fmt.Printf("  🔍 Parsed log file %s: found %d matching log lines\n", file, len(requestsMetadata))
+		slog.Debug("🔍 parsed log file", "file", file, "matching_lines", len(requestsMetadata))
 
 		for _, metadata := range requestsMetadata {
 			// we cannot guarantee that the client id is unique as it may not be set on clients

--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -220,7 +220,7 @@ func runScanClusters(cmd *cobra.Command, args []string) error {
 	clusters := source.GetClusters()
 	slog.Info("clusters to scan", "count", len(clusters), "source", sourceType)
 	for _, cluster := range clusters {
-		slog.Info("cluster", "name", cluster.Name, "id", cluster.UniqueID)
+		slog.Debug("cluster", "name", cluster.Name, "id", cluster.UniqueID)
 	}
 
 	// Apache Kafka-specific docs pointer — link to the version of the docs that
@@ -275,7 +275,7 @@ func runScanClusters(cmd *cobra.Command, args []string) error {
 // avoid silently discarding an existing state file.
 func loadOrCreateState(stateFilePath string) (*types.State, error) {
 	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
-		slog.Info("creating new state file", "file", stateFilePath)
+		slog.Debug("creating new state file", "file", stateFilePath)
 		state := types.NewStateFrom(nil)
 		state.SchemaRegistries = &types.SchemaRegistriesState{}
 		return state, nil
@@ -285,7 +285,7 @@ func loadOrCreateState(stateFilePath string) (*types.State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load state file: %w", err)
 	}
-	slog.Info("loaded existing state file", "file", stateFilePath)
+	slog.Debug("loaded existing state file", "file", stateFilePath)
 	return state, nil
 }
 
@@ -329,7 +329,7 @@ func mergeMSKResults(state *types.State, result *sources.ScanResult) error {
 		}
 	}
 
-	slog.Info("merged MSK scan results", "clusters_scanned", len(result.Clusters))
+	slog.Debug("merged MSK scan results", "clusters_scanned", len(result.Clusters))
 	return nil
 }
 
@@ -388,7 +388,7 @@ func mergeOSKResults(state *types.State, result *sources.ScanResult) error {
 	// Append new clusters after all in-place updates are done
 	state.OSKSources.Clusters = append(state.OSKSources.Clusters, newClusters...)
 
-	slog.Info("merged Apache Kafka scan results", "clusters", len(result.Clusters))
+	slog.Debug("merged Apache Kafka scan results", "clusters", len(result.Clusters))
 	return nil
 }
 

--- a/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
+++ b/cmd/scan/self_managed_connectors/self_managed_connectors_scanner.go
@@ -134,6 +134,7 @@ func (s *SelfManagedConnectorsScanner) Run() error {
 
 	clusterName := utils.GetClusterDisplayName(s.SourceType, s.ClusterArn, s.ClusterID)
 	fmt.Printf("🚀 Starting self-managed connector scan for cluster %s\n", clusterName)
+	slog.Info("🔍 scanning self-managed connectors", "cluster", clusterName)
 
 	connectorNames, err := s.client.ListConnectors()
 	if err != nil {
@@ -141,9 +142,11 @@ func (s *SelfManagedConnectorsScanner) Run() error {
 	}
 
 	fmt.Printf("  🔍 Found %d connectors\n", len(connectorNames))
+	slog.Info("🔍 found connectors", "count", len(connectorNames))
 
 	if len(connectorNames) == 0 {
 		fmt.Printf("  ⏭️  No connectors found for cluster %s, skipping\n", clusterName)
+		slog.Info("⏭️ no connectors found; skipping", "cluster", clusterName)
 		return nil
 	}
 
@@ -191,6 +194,7 @@ func (s *SelfManagedConnectorsScanner) Run() error {
 	}
 
 	fmt.Printf("✅ Self-managed connector scan complete for cluster %s\n", clusterName)
+	slog.Info("✅ self-managed connector scan complete", "cluster", clusterName, "connectors", len(connectors))
 	return nil
 }
 
@@ -200,6 +204,7 @@ func (s *SelfManagedConnectorsScanner) Run() error {
 // present) is captured as ConnectHost for per-host grouping in the UI. Returns
 // the connector, the number of redacted fields, and any error.
 func (s *SelfManagedConnectorsScanner) getConnectorDetails(name string) (types.SelfManagedConnector, int, error) {
+	slog.Debug("🔍 fetching connector details", "connector", name)
 	connector := types.SelfManagedConnector{
 		Name: name,
 	}

--- a/cmd/state/upgrade/cmd_state_upgrade.go
+++ b/cmd/state/upgrade/cmd_state_upgrade.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ func NewStateUpgradeCmd() *cobra.Command {
 		SilenceUsage:  true, // a load/runtime error is not a usage error — don't dump the flags
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			slog.Info("🚀 upgrading state file to current schema", "path", stateFile)
 			state, err := types.NewStateFromFile(stateFile)
 			if err != nil {
 				return err
@@ -27,6 +29,7 @@ func NewStateUpgradeCmd() *cobra.Command {
 			if err := state.WriteToFile(stateFile); err != nil {
 				return err
 			}
+			slog.Info("✅ upgraded state file", "path", stateFile)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s (schema_version stamped)\n", stateFile)
 			return nil
 		},

--- a/cmd/state/version/cmd_state_version.go
+++ b/cmd/state/version/cmd_state_version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -114,6 +115,12 @@ func NewStateVersionCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("%s: %w", stateFile, err)
 			}
+			slog.Debug("🔍 inspected state file metadata",
+				"path", stateFile,
+				"has_kcp_markers", meta.hasKCPMarkers(),
+				"schema_version", meta.SchemaVersion,
+				"kcp_build_version", meta.KcpBuildInfo.Version,
+			)
 			renderStateMetadata(cmd.OutOrStdout(), stateFile, meta)
 			return nil
 		},

--- a/internal/client/kafka_admin.go
+++ b/internal/client/kafka_admin.go
@@ -143,7 +143,7 @@ func AdminOptionForAuth(authType types.AuthType, clusterAuth types.ClusterAuth) 
 }
 
 func configureSASLTypeOAuthAuthentication(config *sarama.Config, region string, insecureSkipVerify bool) {
-	slog.Info("🔍 configuring SASL/OAuth (IAM) authentication")
+	slog.Debug("🔍 configuring SASL/OAuth (IAM) authentication")
 	config.Net.TLS.Enable = true
 	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // user-controlled flag
 	config.Net.SASL.Enable = true
@@ -152,7 +152,7 @@ func configureSASLTypeOAuthAuthentication(config *sarama.Config, region string, 
 }
 
 func configureSASLTypeSCRAMAuthentication(config *sarama.Config, username string, password string, mechanism string, insecureSkipTLSVerify bool) error {
-	slog.Info("configuring SASL/SCRAM authentication", "mechanism", mechanism, "insecure_skip_tls_verify", insecureSkipTLSVerify)
+	slog.Debug("configuring SASL/SCRAM authentication", "mechanism", mechanism, "insecure_skip_tls_verify", insecureSkipTLSVerify)
 	if insecureSkipTLSVerify {
 		slog.Warn("TLS certificate verification is disabled - this should only be used in test environments with self-signed certificates")
 	}
@@ -185,7 +185,7 @@ func configureSASLTypeSCRAMAuthentication(config *sarama.Config, username string
 }
 
 func configureSASLTypePlainAuthentication(config *sarama.Config, username string, password string, withTLSEncryption bool, insecureSkipVerify bool) {
-	slog.Info("configuring SASL/PLAIN authentication", "enableTlsEncryption", withTLSEncryption)
+	slog.Debug("configuring SASL/PLAIN authentication", "enableTlsEncryption", withTLSEncryption)
 	if !withTLSEncryption {
 		slog.Warn("SASL/PLAIN without TLS: credentials will be transmitted in cleartext over the network")
 	}
@@ -200,7 +200,7 @@ func configureSASLTypePlainAuthentication(config *sarama.Config, username string
 }
 
 func configureUnauthenticatedAuthentication(config *sarama.Config, withTLSEncryption bool, insecureSkipVerify bool) {
-	slog.Info("🔍 enabling TLS encryption", "enableTlsEncryption", withTLSEncryption)
+	slog.Debug("🔍 enabling TLS encryption", "enableTlsEncryption", withTLSEncryption)
 	config.Net.TLS.Enable = withTLSEncryption
 	config.Net.TLS.Config = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // user-controlled flag
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,22 @@
+// Package logging provides a file-only slog sink for components that own rich,
+// pre-formatted terminal output (e.g. the migration reporter) and need to
+// mirror a clean, structured copy into kcp.log — without echoing to the
+// console, where they already print their own formatted version.
+//
+// This is a deliberately narrow escape hatch. The default path for emitting a
+// line is the standard slog levels (see the output-routing table in CLAUDE.md);
+// reach for the file-only sink only when a component prints rich terminal
+// output that cannot go through the clean slog.Info console render.
+package logging
+
+import "log/slog"
+
+// file writes ONLY to kcp.log (no console leg). It defaults to a discard sink
+// so mirror calls made before SetFile — and in unit tests — are safe no-ops.
+var file = slog.New(slog.DiscardHandler)
+
+// SetFile installs the file-only logger. Called once during logging setup.
+func SetFile(l *slog.Logger) { file = l }
+
+// File returns the file-only logger.
+func File() *slog.Logger { return file }

--- a/internal/services/clusterlink/clusterlink.go
+++ b/internal/services/clusterlink/clusterlink.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"time"
 )
 
 // httpStatusError is returned by doRequest/doPostRequest when the server
@@ -314,11 +315,14 @@ func (s *ConfluentCloudService) doRequest(ctx context.Context, config Config, pa
 	}
 	req.Header.Set("Authorization", basicAuthHeader(config))
 
+	start := time.Now()
 	res, err := s.httpClient.Do(req)
 	if err != nil {
+		slog.Debug("🔍 confluent cloud request failed", "method", http.MethodGet, "path", path, "ms", time.Since(start).Milliseconds(), "error", err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer func() { _ = res.Body.Close() }()
+	slog.Debug("🔍 confluent cloud request", "method", http.MethodGet, "path", path, "status", res.StatusCode, "ms", time.Since(start).Milliseconds())
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
@@ -351,11 +355,14 @@ func (s *ConfluentCloudService) doPostRequest(ctx context.Context, config Config
 	req.Header.Set("Authorization", basicAuthHeader(config))
 	req.Header.Set("Content-Type", "application/json")
 
+	start := time.Now()
 	res, err := s.httpClient.Do(req)
 	if err != nil {
+		slog.Debug("🔍 confluent cloud request failed", "method", http.MethodPost, "path", path, "ms", time.Since(start).Milliseconds(), "error", err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer func() { _ = res.Body.Close() }()
+	slog.Debug("🔍 confluent cloud request", "method", http.MethodPost, "path", path, "status", res.StatusCode, "ms", time.Since(start).Milliseconds())
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(res.Body)
@@ -392,14 +399,17 @@ func (s *ConfluentCloudService) doPutRequest(ctx context.Context, config Config,
 	req.Header.Set("Authorization", basicAuthHeader(config))
 	req.Header.Set("Content-Type", "application/json")
 
+	start := time.Now()
 	res, err := s.httpClient.Do(req)
 	if err != nil {
+		slog.Debug("🔍 confluent cloud request failed", "method", http.MethodPut, "path", path, "ms", time.Since(start).Milliseconds(), "error", err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, res.Body)
 		_ = res.Body.Close()
 	}()
+	slog.Debug("🔍 confluent cloud request", "method", http.MethodPut, "path", path, "status", res.StatusCode, "ms", time.Since(start).Milliseconds())
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(res.Body)
@@ -417,14 +427,17 @@ func (s *ConfluentCloudService) doDeleteRequest(ctx context.Context, config Conf
 	}
 	req.Header.Set("Authorization", basicAuthHeader(config))
 
+	start := time.Now()
 	res, err := s.httpClient.Do(req)
 	if err != nil {
+		slog.Debug("🔍 confluent cloud request failed", "method", http.MethodDelete, "path", path, "ms", time.Since(start).Milliseconds(), "error", err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, res.Body)
 		_ = res.Body.Close()
 	}()
+	slog.Debug("🔍 confluent cloud request", "method", http.MethodDelete, "path", path, "status", res.StatusCode, "ms", time.Since(start).Milliseconds())
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(res.Body)

--- a/internal/services/cost/cost_service.go
+++ b/internal/services/cost/cost_service.go
@@ -25,7 +25,8 @@ func NewCostService(client *costexplorer.Client) *CostService {
 }
 
 func (cs *CostService) GetCostsForTimeRange(ctx context.Context, region string, startDate time.Time, endDate time.Time, granularity costexplorertypes.Granularity, tags map[string][]string) (types.CostInformation, error) {
-	slog.Info("🔍 getting AWS costs", "region", region, "start", startDate, "end", endDate, "granularity", granularity, "tags", tags)
+	slog.Info("🔍 getting AWS costs", "region", region, "granularity", granularity)
+	slog.Debug("getting AWS costs", "region", region, "start", startDate, "end", endDate, "granularity", granularity, "tags", tags)
 
 	startStr := aws.String(startDate.Format("2006-01-02"))
 	endStr := aws.String(endDate.Format("2006-01-02"))

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -104,13 +104,14 @@ func (s *K8sService) GetGatewayYAML(ctx context.Context, namespace, gatewayName 
 		return nil, fmt.Errorf("failed to marshal to YAML: %w", err)
 	}
 
+	slog.Debug("fetched gateway CR", "namespace", namespace, "gateway", gatewayName, "bytes", len(yamlBytes))
 	return yamlBytes, nil
 }
 
 // ValidateGatewayCRs validates that the initial, fenced, and switchover gateway CRs are consistent
 func (s *K8sService) ValidateGatewayCRs(initialYAML, fencedYAML, switchoverYAML []byte) error {
 	// TODO: implement cross-CR validation
-	slog.Warn("gateway CR validation not yet implemented, skipping")
+	slog.Warn("⚠️ gateway CR validation not yet implemented, skipping")
 	return nil
 }
 
@@ -178,6 +179,8 @@ func (s *K8sService) ApplyGatewayYAML(ctx context.Context, namespace, gatewayNam
 	obj.SetName(gatewayName)
 	obj.SetNamespace(namespace)
 
+	slog.Debug("🔍 applying gateway CR (server-side apply)", "namespace", namespace, "gateway", gatewayName, "bytes", len(yamlData))
+	start := time.Now()
 	_, err = dynamicClient.Resource(gatewayGVR).Namespace(namespace).
 		Apply(ctx, gatewayName, &obj, metav1.ApplyOptions{
 			FieldManager: "kcp-migration",
@@ -187,6 +190,7 @@ func (s *K8sService) ApplyGatewayYAML(ctx context.Context, namespace, gatewayNam
 		return fmt.Errorf("failed to apply gateway YAML: %w", err)
 	}
 
+	slog.Debug("applied gateway CR", "namespace", namespace, "gateway", gatewayName, "ms", time.Since(start).Milliseconds())
 	return nil
 }
 

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -101,6 +101,13 @@ type JMXService struct {
 	clients    []*client.JolokiaClient
 	metrics    MetricDefinitions
 	entityName string // "broker" or "worker" — used in query info descriptions
+
+	// warnedControllerMissing dedupes the "controller MBean not available" caveat
+	// (keyed by MBean) to once per scan. collectRawSample runs on every poll for the
+	// whole scan duration and a missing controller MBean is a persistent config state,
+	// so warning per-poll would flood the console (this caveat is Warn+). Safe without
+	// a mutex: collectRawSample is called sequentially from CollectOverDuration.
+	warnedControllerMissing map[string]bool
 }
 
 // NewJMXService creates a new JMX service with Jolokia clients for each endpoint.
@@ -110,7 +117,12 @@ func NewJMXService(endpoints []string, defs MetricDefinitions, entityName string
 	for i, endpoint := range endpoints {
 		clients[i] = client.NewJolokiaClient(endpoint, opts...)
 	}
-	return &JMXService{clients: clients, metrics: defs, entityName: entityName}
+	return &JMXService{
+		clients:                 clients,
+		metrics:                 defs,
+		entityName:              entityName,
+		warnedControllerMissing: make(map[string]bool),
+	}
 }
 
 // collectRawSample reads raw counter and gauge values from all brokers.
@@ -168,9 +180,10 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 				}
 			}
 		}
-		if !found {
+		if !found && !s.warnedControllerMissing[mb.MBean] {
 			slog.Warn("Controller MBean not available from any broker — metric will be omitted. Ensure your JMX exporter scrapes kafka.controller MBeans.",
 				"mbean", mb.MBean, "metric", mb.Name)
+			s.warnedControllerMissing[mb.MBean] = true
 		}
 	}
 

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -169,7 +169,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 			}
 		}
 		if !found {
-			slog.Info("Controller MBean not available from any broker — metric will be omitted. Ensure your JMX exporter scrapes kafka.controller MBeans.",
+			slog.Warn("Controller MBean not available from any broker — metric will be omitted. Ensure your JMX exporter scrapes kafka.controller MBeans.",
 				"mbean", mb.MBean, "metric", mb.Name)
 		}
 	}
@@ -237,7 +237,7 @@ func (s *JMXService) CollectOverDuration(ctx context.Context, duration, interval
 	if err != nil {
 		return nil, err
 	}
-	slog.Info("JMX baseline sample collected", "elapsed", "0s")
+	slog.Debug("JMX baseline sample collected", "elapsed", "0s")
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -272,7 +272,7 @@ func (s *JMXService) CollectOverDuration(ctx context.Context, duration, interval
 			snapshots = append(snapshots, *snapshot)
 			prevSample = currSample
 
-			slog.Info("JMX snapshot collected",
+			slog.Debug("JMX snapshot collected",
 				"count", len(snapshots),
 				"elapsed", time.Since(startTime).Round(time.Second))
 		}

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -1,8 +1,10 @@
 package jmx
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -296,6 +298,13 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 	}))
 	defer server.Close()
 
+	// Capture slog output to assert the controller-missing caveat is logged once
+	// per scan, not once per poll (collectRawSample runs on every tick).
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
 	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(), "broker")
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
@@ -310,6 +319,11 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 	// GlobalPartitionCount should NOT be in the aggregates (controller MBean unavailable)
 	_, hasGlobal := result.Aggregates["GlobalPartitionCount"]
 	assert.False(t, hasGlobal, "GlobalPartitionCount should be omitted when controller MBean is not available")
+
+	// The caveat must be deduped to a single line even though the controller
+	// MBean is polled on every sample across the scan.
+	warnCount := strings.Count(logBuf.String(), "Controller MBean not available")
+	assert.Equal(t, 1, warnCount, "controller-missing caveat should be logged once per scan, not per poll")
 
 	// But query info should still include it (shows what was attempted)
 	queryNames := make(map[string]bool)

--- a/internal/services/kafka/kafka_service.go
+++ b/internal/services/kafka/kafka_service.go
@@ -62,7 +62,7 @@ func (ks *KafkaService) ScanKafkaResources(clusterType kafkatypes.ClusterType) (
 
 	// Serverless clusters do not support Kafka Admin API and instead returns an EOF error - this should be handled gracefully
 	if clusterType == kafkatypes.ClusterTypeServerless {
-		slog.Warn("⚠️ Serverless clusters do not support querying Kafka ACLs, skipping ACLs scan")
+		slog.Warn("⚠️ MSK Serverless cluster; skipping ACLs scan (Kafka Admin API unsupported on serverless)")
 		return kafkaAdminClientInformation, nil
 	}
 

--- a/internal/services/kafka/kafka_service.go
+++ b/internal/services/kafka/kafka_service.go
@@ -79,7 +79,8 @@ func (ks *KafkaService) ScanKafkaResources(clusterType kafkatypes.ClusterType) (
 
 // scanClusterTopics scans for topics in the Kafka cluster
 func (ks *KafkaService) scanClusterTopics() ([]types.TopicDetails, error) {
-	slog.Info("🔍 scanning for cluster topics", "clusterArn", ks.clusterArn)
+	slog.Info("🔍 scanning for cluster topics")
+	slog.Debug("🔍 scanning for cluster topics", "clusterArn", ks.clusterArn)
 
 	topics, err := ks.client.ListTopicsWithConfigs()
 	if err != nil {
@@ -111,6 +112,7 @@ func (ks *KafkaService) scanClusterTopics() ([]types.TopicDetails, error) {
 // describeKafkaCluster gets cluster metadata and returns the cluster ID along with logging information
 func (ks *KafkaService) describeKafkaCluster() (*client.ClusterKafkaMetadata, error) {
 	slog.Info("🔍 describing kafka cluster")
+	slog.Debug("🔍 describing kafka cluster", "clusterArn", ks.clusterArn)
 
 	clusterMetadata, err := ks.client.GetClusterKafkaMetadata()
 	if err != nil {
@@ -122,6 +124,7 @@ func (ks *KafkaService) describeKafkaCluster() (*client.ClusterKafkaMetadata, er
 // scanKafkaAcls scans for Kafka ACLs in the cluster
 func (ks *KafkaService) scanKafkaAcls() ([]types.Acls, error) {
 	slog.Info("🔍 scanning for kafka acls")
+	slog.Debug("🔍 scanning for kafka acls", "clusterArn", ks.clusterArn)
 
 	acls, err := ks.client.ListAcls()
 	if err != nil {

--- a/internal/services/kafka/kafka_service.go
+++ b/internal/services/kafka/kafka_service.go
@@ -110,7 +110,7 @@ func (ks *KafkaService) scanClusterTopics() ([]types.TopicDetails, error) {
 
 // describeKafkaCluster gets cluster metadata and returns the cluster ID along with logging information
 func (ks *KafkaService) describeKafkaCluster() (*client.ClusterKafkaMetadata, error) {
-	slog.Info("🔍 describing kafka cluster", "clusterArn", ks.clusterArn)
+	slog.Info("🔍 describing kafka cluster")
 
 	clusterMetadata, err := ks.client.GetClusterKafkaMetadata()
 	if err != nil {
@@ -121,7 +121,7 @@ func (ks *KafkaService) describeKafkaCluster() (*client.ClusterKafkaMetadata, er
 
 // scanKafkaAcls scans for Kafka ACLs in the cluster
 func (ks *KafkaService) scanKafkaAcls() ([]types.Acls, error) {
-	slog.Info("🔍 scanning for kafka acls", "clusterArn", ks.clusterArn)
+	slog.Info("🔍 scanning for kafka acls")
 
 	acls, err := ks.client.ListAcls()
 	if err != nil {

--- a/internal/services/kafka/kafka_service_test.go
+++ b/internal/services/kafka/kafka_service_test.go
@@ -1,7 +1,10 @@
 package kafka
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/IBM/sarama"
@@ -451,4 +454,74 @@ func TestKafkaService_scanKafkaAcls(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestKafkaService_LogsClusterArnAtDebug proves the level audit keeps cluster
+// attribution in kcp.log: each scan-start log must carry clusterArn on a paired
+// DEBUG line (not inline on the clean INFO line), so a support engineer reading
+// kcp.log for a multi-cluster run can still tell which cluster each line is about.
+func TestKafkaService_LogsClusterArnAtDebug(t *testing.T) {
+	const testArn = "arn:aws:kafka:us-east-1:123456789012:cluster/test/abc-123"
+
+	tests := []struct {
+		name string
+		mock *mocks.MockKafkaAdmin
+		run  func(ks *KafkaService)
+	}{
+		{
+			name: "scanClusterTopics",
+			mock: &mocks.MockKafkaAdmin{
+				ListTopicsWithConfigsFunc: func() (map[string]sarama.TopicDetail, error) {
+					return map[string]sarama.TopicDetail{}, nil
+				},
+			},
+			run: func(ks *KafkaService) { _, _ = ks.scanClusterTopics() },
+		},
+		{
+			name: "describeKafkaCluster",
+			mock: &mocks.MockKafkaAdmin{
+				GetClusterKafkaMetadataFunc: func() (*client.ClusterKafkaMetadata, error) {
+					return &client.ClusterKafkaMetadata{ClusterID: "c-1"}, nil
+				},
+			},
+			run: func(ks *KafkaService) { _, _ = ks.describeKafkaCluster() },
+		},
+		{
+			name: "scanKafkaAcls",
+			mock: &mocks.MockKafkaAdmin{
+				ListAclsFunc: func() ([]sarama.ResourceAcls, error) {
+					return []sarama.ResourceAcls{}, nil
+				},
+			},
+			run: func(ks *KafkaService) { _, _ = ks.scanKafkaAcls() },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			defer slog.SetDefault(prev)
+
+			ks := &KafkaService{client: tt.mock, authType: types.AuthTypeIAM, clusterArn: testArn}
+			tt.run(ks)
+
+			out := logBuf.String()
+			assert.True(t, debugLineHasAttr(out, "clusterArn", testArn),
+				"%s must record clusterArn on a DEBUG line for kcp.log attribution; got:\n%s", tt.name, out)
+		})
+	}
+}
+
+// debugLineHasAttr reports whether the captured slog text output contains a
+// DEBUG-level line carrying key=val (slog TextHandler renders unquoted values
+// with no spaces verbatim, e.g. clusterArn=arn:aws:...).
+func debugLineHasAttr(logOutput, key, val string) bool {
+	for _, line := range strings.Split(logOutput, "\n") {
+		if strings.Contains(line, "level=DEBUG") && strings.Contains(line, key+"="+val) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/services/metrics/metric_service.go
+++ b/internal/services/metrics/metric_service.go
@@ -101,7 +101,8 @@ func buildProvisionedMetadata(cluster kafkatypes.Cluster, timeWindow types.Cloud
 // ProcessProvisionedCluster processes metrics for provisioned aggregated across all brokers in a cluster
 func (ms *MetricService) ProcessProvisionedCluster(ctx context.Context, cluster kafkatypes.Cluster, followerFetching bool, timeWindow types.CloudWatchTimeWindow) (*types.ClusterMetrics, error) {
 
-	slog.Info("🔍 processing provisioned cluster", "cluster", aws.ToString(cluster.ClusterName), "startDate", timeWindow.StartTime, "endDate", timeWindow.EndTime, "period", timeWindow.Period)
+	slog.Info("🔍 processing provisioned cluster", "cluster", aws.ToString(cluster.ClusterName))
+	slog.Debug("processing provisioned cluster", "cluster", aws.ToString(cluster.ClusterName), "startDate", timeWindow.StartTime, "endDate", timeWindow.EndTime, "period", timeWindow.Period)
 
 	if cluster.Provisioned == nil {
 		return nil, fmt.Errorf("cluster %s has no provisioned configuration", aws.ToString(cluster.ClusterName))
@@ -210,7 +211,8 @@ func (ms *MetricService) ProcessProvisionedCluster(ctx context.Context, cluster 
 
 // ProcessServerlessCluster processes metrics for serverless aggregated across all topics in a cluster
 func (ms *MetricService) ProcessServerlessCluster(ctx context.Context, cluster kafkatypes.Cluster, timeWindow types.CloudWatchTimeWindow) (*types.ClusterMetrics, error) {
-	slog.Info("🔍 processing serverless cluster with topic aggregation", "cluster", aws.ToString(cluster.ClusterName), "startDate", timeWindow.StartTime, "endDate", timeWindow.EndTime)
+	slog.Info("🔍 processing serverless cluster with topic aggregation", "cluster", aws.ToString(cluster.ClusterName))
+	slog.Debug("processing serverless cluster with topic aggregation", "cluster", aws.ToString(cluster.ClusterName), "startDate", timeWindow.StartTime, "endDate", timeWindow.EndTime)
 
 	if cluster.Serverless == nil {
 		return nil, fmt.Errorf("cluster %s has no serverless configuration", aws.ToString(cluster.ClusterName))

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -279,7 +279,13 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 func (o *MigrationOrchestrator) handleStepFailure(ctx context.Context, step WorkflowStep, stepErr error, params ExecutionParams) error {
 	stepFailure := fmt.Errorf("failed during %s: %w", step.Description, stepErr)
 
-	if step.Event != EventPauseOffsetSync && !errors.Is(stepErr, ErrUnroutedProducers) {
+	// A compensating rollback fires only for a pause_offset_sync failure or a
+	// verify_fence unrouted-producers detection; every other step failure just
+	// leaves the FSM at its last good state. Record which branch was taken — the
+	// propagated error names the failing step, but not the rollback decision.
+	willRollback := step.Event == EventPauseOffsetSync || errors.Is(stepErr, ErrUnroutedProducers)
+	slog.Debug("handling migration step failure", "step", step.Event, "will_rollback", willRollback)
+	if !willRollback {
 		return stepFailure
 	}
 
@@ -309,10 +315,14 @@ func (o *MigrationOrchestrator) beforeEventCallback(ctx context.Context, e *fsm.
 	slog.Debug("FSM: before event", "event", e.Event, "src", e.Src, "dst", e.Dst)
 }
 
-// afterEventCallback is called after any event transition
+// afterEventCallback is called after any event transition. This is the
+// migration's diagnostic backbone: every committed state change — forward step,
+// abort_fence rollback, or bootstrap expire_* demotion — lands here as a single
+// Info line, so kcp.log carries the full state timeline of a run. Deep FSM
+// mechanics stay on the before/enter/leave Debug callbacks.
 func (o *MigrationOrchestrator) afterEventCallback(ctx context.Context, e *fsm.Event) {
-	slog.Debug("FSM: after event", "event", e.Event, "src", e.Src, "dst", e.Dst)
 	o.config.CurrentState = e.Dst
+	slog.Info("migration state advanced", "event", e.Event, "from", e.Src, "to", e.Dst, "migration_id", o.config.MigrationId)
 }
 
 // PersistState saves the current migration config to the state file. It is the
@@ -324,6 +334,7 @@ func (o *MigrationOrchestrator) PersistState() error {
 	if err := o.saveState(); err != nil {
 		return fmt.Errorf("failed to persist state after transition to %s: %w", o.config.CurrentState, err)
 	}
+	slog.Debug("persisted migration state", "migration_id", o.config.MigrationId, "state", o.config.CurrentState, "path", o.stateFilePath)
 	return nil
 }
 

--- a/internal/services/migration/reporter.go
+++ b/internal/services/migration/reporter.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 
+	"github.com/confluentinc/kcp/internal/logging"
 	"github.com/fatih/color"
 )
 
@@ -37,25 +39,47 @@ func (r *reporter) errf(format string, a ...any) {
 	_, _ = fmt.Fprintf(r.err, format, a...)
 }
 
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// mirror copies the plain (ANSI-stripped) narrative into kcp.log via the
+// file-only sink. It never reaches the console, so it cannot double the fmt
+// write it accompanies. Terminal formatting stays with the fmt/color call;
+// the log gets a clean, greppable, timestamped copy.
+func (r *reporter) mirror(msg string) {
+	logging.File().Info(ansiRE.ReplaceAllString(msg, ""))
+}
+
+// mirrorWarn is mirror at Warn level, for the in-flow caution helpers.
+func (r *reporter) mirrorWarn(msg string) {
+	logging.File().Warn(ansiRE.ReplaceAllString(msg, ""))
+}
+
 // section prints a blank line then a cyan banner announcing a major step. The
 // caller includes the leading emoji in msg (e.g. "🔍 Initializing migration...").
 func (r *reporter) section(msg string) {
 	r.printf("\n%s\n", color.CyanString(msg))
+	r.mirror(msg)
 }
 
 // success prints an indented green-✔ line. The text may embed its own colour.
 func (r *reporter) success(format string, a ...any) {
-	r.printf("   %s %s\n", color.GreenString("✔"), fmt.Sprintf(format, a...))
+	msg := fmt.Sprintf(format, a...)
+	r.printf("   %s %s\n", color.GreenString("✔"), msg)
+	r.mirror(msg)
 }
 
 // detail prints an indented ↳ progress line.
 func (r *reporter) detail(format string, a ...any) {
-	r.printf("   ↳ %s\n", fmt.Sprintf(format, a...))
+	msg := fmt.Sprintf(format, a...)
+	r.printf("   ↳ %s\n", msg)
+	r.mirror(msg)
 }
 
 // warn prints an indented yellow-⚠️ line to stdout (in-flow caution).
 func (r *reporter) warn(format string, a ...any) {
-	r.printf("   %s %s\n", color.YellowString("⚠️"), fmt.Sprintf(format, a...))
+	msg := fmt.Sprintf(format, a...)
+	r.printf("   %s %s\n", color.YellowString("⚠️"), msg)
+	r.mirrorWarn(msg)
 }
 
 // remediation prints a yellow-⚠️ soft-fail note to stderr. The body may contain
@@ -63,7 +87,9 @@ func (r *reporter) warn(format string, a ...any) {
 // line. Used by the offset-sync bookends, whose failures are surfaced as
 // operator guidance without aborting a successful migration.
 func (r *reporter) remediation(format string, a ...any) {
-	r.errf("%s %s\n", color.YellowString("⚠️"), fmt.Sprintf(format, a...))
+	msg := fmt.Sprintf(format, a...)
+	r.errf("%s %s\n", color.YellowString("⚠️"), msg)
+	r.mirrorWarn(msg)
 }
 
 // stepDone prints the per-step completion marker.
@@ -74,6 +100,7 @@ func (r *reporter) stepDone() {
 // complete prints the final green migration-complete banner (blank line first).
 func (r *reporter) complete(msg string) {
 	r.printf("\n%s\n", color.GreenString(msg))
+	r.mirror(msg)
 }
 
 // blank writes a single blank line.
@@ -86,4 +113,5 @@ func (r *reporter) blank() {
 // a semantic helper but should still route through the single output owner.
 func (r *reporter) line(s string) {
 	r.printf("%s\n", s)
+	r.mirror(s)
 }

--- a/internal/services/migration/reporter_mirror_test.go
+++ b/internal/services/migration/reporter_mirror_test.go
@@ -1,0 +1,69 @@
+package migration
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/logging"
+	"github.com/fatih/color"
+)
+
+// TestReporterMirrorsToFileOnly proves option A: the reporter's terminal output
+// is unchanged (rich, coloured), and a clean ANSI-stripped copy lands in the
+// file-only sink — never echoed to the reporter's stdout/stderr (no doubling).
+func TestReporterMirrorsToFileOnly(t *testing.T) {
+	// Force colour on so the terminal leg carries ANSI we can assert the mirror strips.
+	prevColor := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prevColor })
+
+	var fileBuf bytes.Buffer
+	logging.SetFile(slog.New(slog.NewTextHandler(&fileBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { logging.SetFile(slog.New(slog.DiscardHandler)) })
+
+	var out, errOut bytes.Buffer
+	r := &reporter{out: &out, err: &errOut}
+
+	r.section("🔍 Initializing migration...")
+	r.success("migrated topic %s", "orders")
+	r.detail("waiting for STOPPED")
+	r.warn("offset lag high")
+	r.remediation("run recover to restore")
+	r.complete("✅ Migration complete")
+	r.line(color.GreenString("promotion table row"))
+
+	term := out.String()
+	// Terminal keeps rich formatting: ANSI colour + the ↳ decoration.
+	if !strings.Contains(term, "\x1b[") {
+		t.Errorf("terminal output should retain ANSI colour:\n%q", term)
+	}
+	if !strings.Contains(term, "↳ waiting for STOPPED") {
+		t.Errorf("terminal detail should keep the ↳ decoration:\n%q", term)
+	}
+
+	file := fileBuf.String()
+	// File mirror: ANSI-stripped, structured, no terminal-only decoration glyphs.
+	if strings.Contains(file, "\x1b[") {
+		t.Errorf("file mirror must strip ANSI:\n%s", file)
+	}
+	if strings.Contains(file, "↳") || strings.Contains(file, "✔") {
+		t.Errorf("terminal-only glyphs (↳/✔) must not leak into the log:\n%s", file)
+	}
+	for _, want := range []string{
+		"🔍 Initializing migration...",
+		"migrated topic orders",
+		"waiting for STOPPED",
+		"Migration complete",
+		"promotion table row",
+	} {
+		if !strings.Contains(file, want) {
+			t.Errorf("file mirror missing %q in:\n%s", want, file)
+		}
+	}
+	// warn/remediation mirror at WARN; narrative at INFO.
+	if !strings.Contains(file, "level=WARN") || !strings.Contains(file, "level=INFO") {
+		t.Errorf("expected both INFO narrative and WARN cautions in mirror:\n%s", file)
+	}
+}

--- a/internal/services/msk/msk_service.go
+++ b/internal/services/msk/msk_service.go
@@ -397,7 +397,10 @@ func (ms *MSKService) GetTopicsWithConfigs(ctx context.Context, clusterArn strin
 	}
 
 	if len(failedTopics) > 0 {
-		slog.Warn("retrying failed topics", "count", len(failedTopics))
+		// Log narrative, not a console warning: the first-pass failures are
+		// typically transient (429 rate-limiting) and usually recover on retry.
+		// A genuine, unrecoverable failure surfaces below at Error.
+		slog.Info("🔍 retrying failed topics", "count", len(failedTopics))
 		for _, name := range failedTopics {
 			topicDesc, err := ms.DescribeTopic(ctx, clusterArn, name)
 			if err != nil {

--- a/internal/services/msk/msk_service.go
+++ b/internal/services/msk/msk_service.go
@@ -289,6 +289,7 @@ func (ms *MSKService) GetConfigurations(ctx context.Context, maxResults int32) (
 
 func (ms *MSKService) ListTopics(ctx context.Context, clusterArn string, maxResults int32) ([]kafkatypes.TopicInfo, error) {
 	slog.Info("🔍 listing topics")
+	slog.Debug("🔍 listing topics", "clusterArn", clusterArn)
 
 	var topics []kafkatypes.TopicInfo
 	var nextToken *string
@@ -330,6 +331,7 @@ func (ms *MSKService) DescribeTopic(ctx context.Context, clusterArn string, topi
 
 func (ms *MSKService) GetTopicsWithConfigs(ctx context.Context, clusterArn string) ([]types.TopicDetails, error) {
 	slog.Info("scanning topics via AWS API")
+	slog.Debug("scanning topics via AWS API", "clusterArn", clusterArn)
 
 	// NOTE: No definitive `maxResults` limit in the docs. However, upping to something like a 1000 doesn't speed up the process of listing topics. Moreover, the MSK console
 	// populates the topics at 100 topic intervals which to me hints at that being the limit.

--- a/internal/services/msk/msk_service.go
+++ b/internal/services/msk/msk_service.go
@@ -288,7 +288,7 @@ func (ms *MSKService) GetConfigurations(ctx context.Context, maxResults int32) (
 }
 
 func (ms *MSKService) ListTopics(ctx context.Context, clusterArn string, maxResults int32) ([]kafkatypes.TopicInfo, error) {
-	slog.Info("🔍 listing topics", "clusterArn", clusterArn)
+	slog.Info("🔍 listing topics")
 
 	var topics []kafkatypes.TopicInfo
 	var nextToken *string
@@ -329,7 +329,7 @@ func (ms *MSKService) DescribeTopic(ctx context.Context, clusterArn string, topi
 }
 
 func (ms *MSKService) GetTopicsWithConfigs(ctx context.Context, clusterArn string) ([]types.TopicDetails, error) {
-	slog.Info("scanning topics via AWS API", "clusterArn", clusterArn)
+	slog.Info("scanning topics via AWS API")
 
 	// NOTE: No definitive `maxResults` limit in the docs. However, upping to something like a 1000 doesn't speed up the process of listing topics. Moreover, the MSK console
 	// populates the topics at 100 topic intervals which to me hints at that being the limit.
@@ -381,7 +381,7 @@ func (ms *MSKService) GetTopicsWithConfigs(ctx context.Context, clusterArn strin
 
 			current := progressCount.Add(1)
 			if current%250 == 0 {
-				slog.Info("🔍 describing topics", "processed", current, "total", len(topicList))
+				slog.Debug("🔍 describing topics", "processed", current, "total", len(topicList))
 			}
 		}(topicName)
 	}
@@ -397,7 +397,7 @@ func (ms *MSKService) GetTopicsWithConfigs(ctx context.Context, clusterArn strin
 	}
 
 	if len(failedTopics) > 0 {
-		slog.Info("retrying failed topics", "count", len(failedTopics))
+		slog.Warn("retrying failed topics", "count", len(failedTopics))
 		for _, name := range failedTopics {
 			topicDesc, err := ms.DescribeTopic(ctx, clusterArn, name)
 			if err != nil {

--- a/internal/services/msk/msk_service.go
+++ b/internal/services/msk/msk_service.go
@@ -84,7 +84,7 @@ func (ms *MSKService) GetCompatibleKafkaVersions(ctx context.Context, clusterArn
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "This operation cannot be performed on serverless clusters.") {
-			slog.Warn("⚠️ Compatible versions not supported for MSK Serverless clusters, skipping compatible versions scan")
+			slog.Debug("⏭️ compatible versions not supported for MSK Serverless clusters, skipping compatible versions scan")
 			return &kafka.GetCompatibleKafkaVersionsOutput{
 				CompatibleKafkaVersions: []kafkatypes.CompatibleKafkaVersion{},
 			}, nil
@@ -131,7 +131,7 @@ func (ms *MSKService) ListClientVpcConnections(ctx context.Context, clusterArn s
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "This Region doesn't currently support VPC connectivity with Amazon MSK Serverless clusters") {
-				slog.Warn("⚠️ VPC connectivity not supported for MSK Serverless clusters in this region, skipping VPC connections scan")
+				slog.Debug("⏭️ VPC connectivity not supported for MSK Serverless clusters in this region, skipping VPC connections scan")
 				return []kafkatypes.ClientVpcConnection{}, nil
 			}
 			return nil, fmt.Errorf("failed listing client vpc connections: %v", err)
@@ -181,7 +181,7 @@ func (ms *MSKService) ListNodes(ctx context.Context, clusterArn string, maxResul
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "This operation cannot be performed on serverless clusters.") {
-				slog.Warn("⚠️ Node listing not supported for MSK Serverless clusters, skipping Nodes scan")
+				slog.Debug("⏭️ Node listing not supported for MSK Serverless clusters, skipping Nodes scan")
 				return []kafkatypes.NodeInfo{}, nil
 			}
 			return nil, fmt.Errorf("failed listing nodes: %v", err)
@@ -208,7 +208,7 @@ func (ms *MSKService) ListScramSecrets(ctx context.Context, clusterArn string, m
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "This operation cannot be performed on serverless clusters.") {
-				slog.Warn("⚠️ Scram secret listing not supported for MSK Serverless clusters, skipping scram secrets scan")
+				slog.Debug("⏭️ Scram secret listing not supported for MSK Serverless clusters, skipping scram secrets scan")
 				return []string{}, nil
 			}
 			return nil, fmt.Errorf("failed listing secrets: %v", err)

--- a/internal/sources/msk/msk_source.go
+++ b/internal/sources/msk/msk_source.go
@@ -35,7 +35,7 @@ func (s *MSKSource) LoadCredentials(credentialsPath string) error {
 		return fmt.Errorf("failed to load MSK credentials: %v", errs)
 	}
 	s.credentials = creds
-	slog.Info("loaded MSK credentials", "regions", len(creds.Regions))
+	slog.Debug("loaded MSK credentials", "regions", len(creds.Regions))
 	return nil
 }
 
@@ -79,7 +79,7 @@ func (s *MSKSource) Scan(ctx context.Context, opts sources.ScanOptions) (*source
 		for _, clusterAuth := range regionAuth.Clusters {
 			clusterResult, err := s.scanCluster(regionAuth.Name, clusterAuth, opts)
 			if err != nil {
-				slog.Info("skipping cluster", "cluster", clusterAuth.Name, "error", err)
+				slog.Warn("skipping cluster", "cluster", clusterAuth.Name, "error", err)
 				continue
 			}
 			result.Clusters = append(result.Clusters, *clusterResult)
@@ -101,7 +101,8 @@ func (s *MSKSource) scanCluster(region string, clusterAuth types.ClusterAuth, op
 		return nil, fmt.Errorf("failed to determine auth type for cluster: %s in region: %s: %v", clusterAuth.Arn, region, err)
 	}
 
-	slog.Info(fmt.Sprintf("starting broker scan for %s using %s authentication", clusterAuth.Arn, authType))
+	slog.Info(fmt.Sprintf("starting broker scan using %s authentication", authType))
+	slog.Debug("starting broker scan", "clusterArn", clusterAuth.Arn, "authType", authType)
 
 	brokerAddresses, err := discoveredCluster.AWSClientInformation.GetBootstrapBrokersForAuthType(authType)
 	if err != nil {
@@ -135,7 +136,8 @@ func (s *MSKSource) scanCluster(region string, clusterAuth types.ClusterAuth, op
 		kafkaAdminInfo.SaslMechanism = types.NormalizeSaslMechanism(clusterAuth.AuthMethod.SASLScram.Mechanism)
 	}
 
-	slog.Info(fmt.Sprintf("broker scan complete for %s", clusterAuth.Arn))
+	slog.Info("broker scan complete")
+	slog.Debug("broker scan complete", "clusterArn", clusterAuth.Arn)
 
 	return &sources.ClusterScanResult{
 		Identifier: sources.ClusterIdentifier{

--- a/internal/sources/osk/osk_source.go
+++ b/internal/sources/osk/osk_source.go
@@ -35,7 +35,7 @@ func (s *OSKSource) LoadCredentials(credentialsPath string) error {
 		return fmt.Errorf("failed to load Apache Kafka credentials: %v", errs)
 	}
 	s.credentials = creds
-	slog.Info("loaded Apache Kafka credentials", "clusters", len(creds.Clusters))
+	slog.Debug("loaded Apache Kafka credentials", "clusters", len(creds.Clusters))
 	return nil
 }
 

--- a/internal/state/migrate/migrate.go
+++ b/internal/state/migrate/migrate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/confluentinc/kcp/internal/build_info"
 )
@@ -33,6 +34,13 @@ func Upgrade(data []byte) (migrated []byte, fromLabel string, err error) {
 		return nil, "", fmt.Errorf("failed to inspect state file: %w", err)
 	}
 
+	slog.Debug("🔍 inspecting state file schema",
+		"detected_schema_version", schemaVersion,
+		"kcp_build_version", buildVersion,
+		"era", era,
+		"current_schema_version", CurrentSchemaVersion,
+	)
+
 	if schemaVersion > CurrentSchemaVersion {
 		// File-driven dev check: a dev-STAMPED file may carry a schema_version for an
 		// unreleased/local shape, so do not advise `kcp update` (spec §6.9). We inspect
@@ -49,6 +57,7 @@ func Upgrade(data []byte) (migrated []byte, fromLabel string, err error) {
 
 	// Current shape: pass through unchanged.
 	if schemaVersion == CurrentSchemaVersion {
+		slog.Debug("⏭️ state file already at current schema, no migration needed", "schema_version", schemaVersion)
 		return data, fmt.Sprintf("schema_version=%d", schemaVersion), nil
 	}
 	// Era C file without an explicit schema_version is the current shape. A pre-v0.4.0
@@ -59,6 +68,7 @@ func Upgrade(data []byte) (migrated []byte, fromLabel string, err error) {
 		if buildVersion != "" {
 			label = "kcp_build_info.version=" + buildVersion
 		}
+		slog.Debug("⏭️ state file has current-era shape without an explicit schema_version, treating as current", "label", label)
 		return data, label, nil
 	}
 
@@ -78,6 +88,7 @@ func Upgrade(data []byte) (migrated []byte, fromLabel string, err error) {
 	applied := false
 	for _, s := range steps {
 		if s.appliesWhen(era, buildVersion) {
+			slog.Debug("🔍 applying state schema migration step", "step", s.name, "era", era)
 			doc, err = s.transform(doc)
 			if err != nil {
 				return nil, "", fmt.Errorf("migration step %q failed: %w", s.name, err)
@@ -96,5 +107,6 @@ func Upgrade(data []byte) (migrated []byte, fromLabel string, err error) {
 	if buildVersion != "" {
 		label = "kcp_build_info.version=" + buildVersion
 	}
+	slog.Info("✅ migrated state file to current schema", "from", label, "to_schema_version", CurrentSchemaVersion)
 	return out, label, nil
 }

--- a/internal/types/discovery_msk.go
+++ b/internal/types/discovery_msk.go
@@ -174,7 +174,8 @@ func (c *AWSClientInformation) GetBootstrapBrokersForAuthType(authType AuthType)
 		return nil, fmt.Errorf("auth type: %v not yet supported", authType)
 	}
 
-	slog.Info("🔍 found broker addresses", "visibility", visibility, "authType", authType, "addresses", brokerList)
+	slog.Info("🔍 found broker addresses", "visibility", visibility, "authType", authType)
+	slog.Debug("found broker addresses", "visibility", visibility, "authType", authType, "addresses", brokerList)
 
 	// Split by comma and trim whitespace from each address, filter out empty strings
 	rawAddresses := strings.Split(brokerList, ",")
@@ -211,7 +212,8 @@ func (c *AWSClientInformation) GetAllBootstrapBrokersForAuthType(authType AuthTy
 		return nil, fmt.Errorf("auth type: %v not yet supported", authType)
 	}
 
-	slog.Info("🔍 found broker addresses", "authType", authType, "addresses", brokerList)
+	slog.Info("🔍 found broker addresses", "authType", authType)
+	slog.Debug("found broker addresses", "authType", authType, "addresses", brokerList)
 
 	rawAddresses := strings.Split(strings.Join(brokerList, ","), ",")
 	addresses := make([]string, 0, len(rawAddresses))

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -96,6 +96,7 @@ func NewStateFromFile(stateFile string) (*State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read state file %s: %v", stateFile, err)
 	}
+	slog.Debug("🔍 loading state file", "path", stateFile, "bytes", len(data))
 	return NewStateFromBytes(data)
 }
 
@@ -135,8 +136,13 @@ func NewStateFromBytes(data []byte) (*State, error) {
 		state.UpgradedFrom = fromLabel
 	}
 	if state.KcpBuildInfo.Version == "" {
-		slog.Warn("state file has no kcp_build_info.version, this may not be a valid KCP state file")
+		slog.Warn("⚠️ state file has no kcp_build_info.version, this may not be a valid KCP state file")
 	}
+	slog.Debug("loaded state file",
+		"schema_version", state.SchemaVersion,
+		"kcp_build_version", state.KcpBuildInfo.Version,
+		"upgraded_from", state.UpgradedFrom,
+	)
 	return &state, nil
 }
 
@@ -204,6 +210,7 @@ func (s *State) WriteToFile(filePath string) error {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 
+	slog.Debug("wrote state file", "path", filePath, "schema_version", s.SchemaVersion, "bytes", len(data))
 	return nil
 }
 
@@ -242,7 +249,11 @@ func backupIfMigrating(filePath string) error {
 	if err := os.WriteFile(bak, existing, 0600); err != nil {
 		return fmt.Errorf("failed to back up state file before migrating write: %w", err)
 	}
-	slog.Debug("backed up state file before migrating write", "backup", bak)
+	slog.Debug("backed up state file before migrating write",
+		"backup", bak,
+		"from_schema_version", probe.SchemaVersion,
+		"to_schema_version", migrate.CurrentSchemaVersion,
+	)
 	return nil
 }
 

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -242,7 +242,7 @@ func backupIfMigrating(filePath string) error {
 	if err := os.WriteFile(bak, existing, 0600); err != nil {
 		return fmt.Errorf("failed to back up state file before migrating write: %w", err)
 	}
-	slog.Info("backed up state file before migrating write", "backup", bak)
+	slog.Debug("backed up state file before migrating write", "backup", bak)
 	return nil
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -46,7 +46,7 @@ func GetKafkaVersion(clusterInfo types.AWSClientInformation) string {
 	case kafkatypes.ClusterTypeProvisioned:
 		return ConvertKafkaVersion(clusterInfo.MskClusterConfig.Provisioned.CurrentBrokerSoftwareInfo.KafkaVersion)
 	case kafkatypes.ClusterTypeServerless:
-		slog.Warn("⚠️ Serverless clusters do not return a Kafka version, defaulting to 4.0.0")
+		slog.Debug("Serverless clusters do not return a Kafka version, defaulting to 4.0.0")
 		return "4.0.0"
 	default:
 		slog.Warn(fmt.Sprintf("⚠️ Unknown cluster type: %v, defaulting to 4.0.0", clusterInfo.MskClusterConfig.ClusterType))


### PR DESCRIPTION
## Summary

Reworks kcp's logging into a clean two-leg model and fills the gaps where in some cases reading `kcp.log` had no evidence of what a run actually did.

- **`kcp.log`** (rotating file) — **everything at Debug+**, rendered structured
  (`time LEVEL message key=val`) for support.
- **Console** — **Warn+** by default (`--verbose` -> Debug+). Commands keep owning their curated `fmt`/`color` terminal narrative; `slog` carries the *log* narrative. WARN/ERROR colour the level; INFO/DEBUG render as clean, prefix-free narrative when shown.

The throughline across the branch: **audience/severity routing** — pick `fmt` vs. `slog`, and the `slog` level, by *where the line must land*, not by how important it feels. A file-only sink (`internal/logging`) lets components that own rich terminal output (the migration reporter) mirror a clean copy into `kcp.log` without doubling on the console. The full model is documented in `CLAUDE.md`.

## What's in the branch

**Foundation — handler + routing model**
- Console handler renders INFO as clean prefix-free narrative and colours WARN/ERROR; the file leg stays structured Debug+. Console default settled at **Warn+** (an interim Info+ default flooded `discover`/`scan`, which already own a curated `fmt` tree).
- `internal/logging`: a file-only `slog` sink; the **migration reporter** mirrors its choke-point narrative through it, ANSI-stripped.
- Build provenance split: the coloured banner stays terminal-only; a structured `slog.Debug("build provenance", …)` goes to `kcp.log`, now with `vcs_modified`  (indicating if a local build was from unstaged commits) and the flag-free command path (`cmd.CommandPath()`).

**Level audit**
- Retriaged `slog.Info` sites for the Warn+ console: noisy attrs moved to paired Debug lines, semi-diagnostic lines demoted to Debug, a few skip/error/retry lines promoted to Warn. Serverless-scan logging consolidated.

**Narrative capture (previously missing from `kcp.log`)**
- **client-inventory** / **self-managed-connector** scans: work-level start / found-count / completion (per-item at Debug) — names and counts only, never config values.
- **state load / migrate / upgrade** (`internal/state/migrate` had *zero* logging): schema detection, per-upcaster-step, and a Debug/Info split so a real N→M migration reads differently from a pass-through — see the `kcp state upgrade` example below.
- **migration flow**: the FSM after-event callback emits the "migration state advanced" backbone (every forward step, `abort_fence` rollback, bootstrap demotion, each with `migration_id`); every Confluent Cloud REST call is traced (method/path/status/latency); gateway CR apply/fetch and source/destination connection logs added — see the examples below.

**Discovery behavior note**
- Serverless MSK clusters now skip topic discovery entirely rather than erroring through the AWS `ListTopics` path (which is unsupported on serverless). Because that path never calls `SetTopics`, `Topics` stays `nil` (serializes as `"topics": null` instead of an empty object); all consumers nil-guard it. Net effect is the same empty result, minus a spurious per-run error log.

## Secret-safety

The REST trace and connection logs record method/path/status/latency and broker counts only — **never request/response bodies, headers, or credentials** (cluster-link config carries SASL secrets). `TestScanner_DoesNotLogRawSecret` guards the connector path; a secret scan of a full captured e2e `kcp.log` (1382 lines) found nothing sensitive.

## Examples

Build provenance:
```shell
2026/07/09 16:34:19 DEBUG build provenance cmd=kcp help version=0.0.0-localdev commit=fe3c416b998a677650bd7ab203bdf43426f506b2 date=2026-07-09T15:31:36Z dev_build=true vcs_modified=true go=go1.26.0 os=darwin arch=arm64
```

`vcs_modified` is Go's `vcs.modified` build stamp — whether the working tree had uncommitted changes at build time. It matters because the commit hash alone doesn't fully describe a dirty build:
- `true` — built from a dirty tree; commit + local edits, **not** reproducible from that hash.
- `false` — built from a clean checkout; the commit hash fully describes the binary.
- *(empty)* — no VCS stamp (built outside a git checkout, e.g. from a release tarball).

Migration flow — one promote step, showing the mirrored reporter narrative (INFO), the FSM backbone, and the CC REST trace woven together in `kcp.log`:
```shell
2026/07/09 17:16:23 INFO 📤 Promoting mirror topics...
2026/07/09 17:16:23 DEBUG executing migration step step=promoting topics
2026/07/09 17:16:23 INFO 1/1 topics confirmed at zero lag
2026/07/09 17:16:23 INFO    ↳ e2e-test-topic-baseline  lag: 0
2026/07/09 17:16:23 INFO Promoting 1 mirror topics...
2026/07/09 17:16:23 DEBUG 🔍 confluent cloud request method=POST path=/kafka/v3/clusters/OGN…/links/e2e-link-baseline/mirrors:promote status=200 ms=210
2026/07/09 17:16:23 INFO    ↳ e2e-test-topic-baseline promotion accepted (awaiting STOPPED)
2026/07/09 17:16:28 INFO e2e-test-topic-baseline stopped
2026/07/09 17:16:28 DEBUG FSM: before event event=promote src=fence_verified dst=promoted
2026/07/09 17:16:28 INFO migration state advanced event=promote from=fence_verified to=promoted migration_id=migration-815dcfa9-…
2026/07/09 17:16:28 DEBUG persisted migration state migration_id=migration-815dcfa9-… state=promoted path=/workspace/migration-state.json
```

Rollback path — the fence-verify step detects unrouted producers, unfences, and the central error sink records the full diagnostic (previously `fmt`-only, invisible to the log):
```shell
2026/07/09 17:21:40 DEBUG handling migration step failure step=verify_fence will_rollback=true
2026/07/09 17:21:40 WARN Unrouted producers detected — removing fence to restore traffic
[… gateway rollout …]
2026/07/09 17:22:25 INFO Gateway unfenced — traffic restored to pre-migration state
2026/07/09 17:22:25 INFO migration state advanced event=abort_fence from=offset_sync_paused to=initialized migration_id=migration-46ce8d1d-…
2026/07/09 17:22:25 ERROR failed to execute migration: failed during verifying gateway fence: transition canceled with error: unrouted producers detected:
  topic e2e-test-topic-rogue-producer partition 0: offset 168 → 204 (+36, ~4 msg/s)
  topic e2e-test-topic-rogue-producer partition 1: offset 151 → 180 (+29, ~3 msg/s)
  topic e2e-test-topic-rogue-producer partition 2: offset 173 → 209 (+36, ~4 msg/s)
```

`kcp state upgrade` logging:
```shell
2026/07/09 18:54:37 DEBUG build provenance cmd=kcp state upgrade version=0.0.0-localdev commit=9217ab94815097e0c82b57141ffdd162f4d57ada date=2026-07-09T17:54:01Z dev_build=true vcs_modified=false go=go1.26.0 os=darwin arch=arm64
2026/07/09 18:54:37 INFO 🚀 upgrading state file to current schema path=kcp-state.json
2026/07/09 18:54:37 DEBUG 🔍 loading state file path=kcp-state.json bytes=3113950
2026/07/09 18:54:37 DEBUG 🔍 inspecting state file schema detected_schema_version=0 kcp_build_version=v0.4.0 era=B current_schema_version=1
2026/07/09 18:54:37 DEBUG 🔍 applying state schema migration step step=B: normalize array-form schema_registries to object era=B
2026/07/09 18:54:37 DEBUG 🔍 applying state schema migration step step=B->C: nest top-level regions under msk_sources era=B
2026/07/09 18:54:37 INFO ✅ migrated state file to current schema from=kcp_build_info.version=v0.4.0 to_schema_version=1
2026/07/09 18:54:37 DEBUG loaded state file schema_version=0 kcp_build_version=v0.4.0 upgraded_from=kcp_build_info.version=v0.4.0
2026/07/09 18:54:37 DEBUG backed up state file before migrating write backup=kcp-state.json.20260709T175437Z.bak from_schema_version=0 to_schema_version=1
2026/07/09 18:54:37 DEBUG wrote state file path=kcp-state.json schema_version=1 bytes=3114692
2026/07/09 18:54:37 INFO ✅ upgraded state file path=kcp-state.json
```

## Verification

- `make test-go` — green (56 packages, 0 failures).
- Full migration e2e suite on Minikube/CFK — **9/9 PASS** (~14 min), with the new lines observed landing in `kcp.log`: FSM transitions, the CC REST trace, gateway applies, and the three rollback-scenario decisions.
- `kcp state upgrade` exercised against a legacy era-B fixture: `kcp.log` shows the full detect -> per-step -> migrated -> backup -> write trail while the console stayed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

