### PR TITLE
perf(ci): reduce migration e2e pipeline wall-clock time

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -132,7 +132,9 @@ blocks:
             - make test-schema-registry
 
   - name: 'integration: migration e2e'
-    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
+    # Only needs the Go module cache — the e2e suite drives `kcp migration`, not
+    # the UI, so it uses a stub frontend dist instead of the yarn build.
+    dependencies: ['resolve go dependencies']
     task:
       agent:
         machine:
@@ -150,12 +152,30 @@ blocks:
       jobs:
         - name: 'migration e2e'
           commands:
-            - cache restore frontend-dependencies
+            - export IMAGE_CACHE_DIR="$HOME/.cache/confluent-images"
             - cache restore go-mod-cache
             - cache restore go-build-cache
-            - cd cmd/ui/frontend && yarn install && yarn build && cd -
+            # Stub dist — the e2e suite exercises `kcp migration` (never the UI),
+            # so a single index.html satisfies the frontend go:embed and skips the
+            # full yarn install + vite build. Same trick as the 'docs build' block.
+            - mkdir -p cmd/ui/frontend/dist && echo '<!doctype html>' > cmd/ui/frontend/dist/index.html
+            # Warm the Confluent container-image cache; setup.sh loads it into the
+            # Minikube node right after `minikube start`.
+            - cache restore confluent-images
             - make test-migration-setup
-            - make test-migration
+            # Tests only. Using `make test-migration` here would re-run setup (its
+            # Make prereq) and teardown (its EXIT trap) on top of the explicit
+            # setup above and the epilogue teardown below — doubling both.
+            - make test-migration-run
+            # Persist the node's Confluent images for the next run (main only;
+            # best-effort so a cache-store failure never fails the pipeline).
+            - >-
+              if [ "$SEMAPHORE_GIT_WORKING_BRANCH" = "main" ] && [ -s "$IMAGE_CACHE_DIR/images.list" ]; then
+                eval "$(minikube docker-env --profile kcp-e2e)";
+                docker save $(cat "$IMAGE_CACHE_DIR/images.list") -o "$IMAGE_CACHE_DIR/confluent-images.tar" || true;
+                cache delete confluent-images || true;
+                cache store confluent-images "$IMAGE_CACHE_DIR" || true;
+              fi
       epilogue:
         always:
           commands:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pre-commit-install: ## Install git pre-commit hooks
 # Tests
 # ==============================================================================
 
-.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry
+.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-run test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry
 
 test-go: build-frontend ## Run Go unit tests (excludes Terraform validation; see test-tf-validation)
 	go test $(GOTEST_FLAGS) ./...
@@ -103,6 +103,9 @@ test-go-coverage-ui: build-frontend ## Run Go tests with coverage and open HTML 
 test-migration: test-migration-setup ## Run full migration E2E lifecycle (setup, test, teardown)
 	@trap 'echo ""; echo "Tearing down migration E2E infrastructure..."; bash integration-tests/migration/testdata/teardown.sh' EXIT; \
 	echo "Running migration E2E tests..."; \
+	go test -v -tags=e2e -timeout 40m ./integration-tests/migration/...
+
+test-migration-run: ## Run migration E2E tests against already-provisioned infra (no setup/teardown; CI pairs this with test-migration-setup)
 	go test -v -tags=e2e -timeout 40m ./integration-tests/migration/...
 
 test-migration-setup: ## Set up Minikube + CFK infrastructure for migration E2E

--- a/integration-tests/migration/testdata/setup.sh
+++ b/integration-tests/migration/testdata/setup.sh
@@ -13,6 +13,17 @@ INIT_CONTAINER_TAG="${INIT_CONTAINER_TAG:-3.2.1}"
 GATEWAY_TAG="${GATEWAY_TAG:-1.2.0-1-ubi9}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-900s}"
 
+# Confluent images pulled by kubelet inside the Minikube node. Single source of
+# truth for the background pre-pull and the optional CI image cache (see
+# IMAGE_CACHE_DIR below).
+CONFLUENT_IMAGES=(
+  "docker.io/confluentinc/confluent-operator:${CFK_CHART_VERSION}"
+  "docker.io/confluentinc/cp-server:${CP_SERVER_TAG}"
+  "docker.io/confluentinc/confluent-init-container:${INIT_CONTAINER_TAG}"
+  "docker.io/confluentinc/confluent-gateway-for-cloud:${GATEWAY_TAG}"
+  "docker.io/alpine:3.20"
+)
+
 # wait_for_pods waits until at least one pod matching the label exists, then
 # waits for all matching pods to be Ready, printing status every 15s.
 wait_for_pods() {
@@ -66,6 +77,22 @@ KUBECONFIG_PATH="${HOME}/.kube/config"
 
 echo "Minikube is running."
 
+# --- CI image cache (optional; no-op locally) ---
+# When IMAGE_CACHE_DIR is set (CI), record the image list so the CI save step can
+# re-tarball exactly these images without duplicating tags, and load any
+# previously cached tarball into the node's Docker daemon. kubelet then finds the
+# images locally (IfNotPresent) and the background pre-pull below only refreshes
+# manifests instead of re-downloading layers. Every step is best-effort — a cache
+# miss or corrupt tarball just falls back to a normal registry pull.
+if [ -n "${IMAGE_CACHE_DIR:-}" ]; then
+  mkdir -p "${IMAGE_CACHE_DIR}"
+  printf '%s\n' "${CONFLUENT_IMAGES[@]}" > "${IMAGE_CACHE_DIR}/images.list"
+  if [ -f "${IMAGE_CACHE_DIR}/confluent-images.tar" ]; then
+    echo "Loading cached Confluent images into the node..."
+    docker load -i "${IMAGE_CACHE_DIR}/confluent-images.tar" || true
+  fi
+fi
+
 # --- Docker Hub auth (avoids rate limiting for pre-pulls and kubelet pulls) ---
 if [ -n "${DOCKERHUB_USER:-}" ] && [ -n "${DOCKERHUB_APIKEY:-}" ]; then
   echo "Authenticating Docker Hub in minikube..."
@@ -74,11 +101,9 @@ fi
 
 # --- Pre-pull images in background (speeds up later helm install / kubectl apply) ---
 echo "Pre-pulling container images in background..."
-docker pull "docker.io/confluentinc/confluent-operator:${CFK_CHART_VERSION}" &>/dev/null &
-docker pull "docker.io/confluentinc/cp-server:${CP_SERVER_TAG}" &>/dev/null &
-docker pull "docker.io/confluentinc/confluent-init-container:${INIT_CONTAINER_TAG}" &>/dev/null &
-docker pull "docker.io/confluentinc/confluent-gateway-for-cloud:${GATEWAY_TAG}" &>/dev/null &
-docker pull "docker.io/alpine:3.20" &>/dev/null &
+for image in "${CONFLUENT_IMAGES[@]}"; do
+  docker pull "${image}" &>/dev/null &
+done
 echo "  (images pulling in background)"
 
 # --- Namespace ---


### PR DESCRIPTION
## What & why

The `integration: migration e2e` block is the CI pipeline's critical path — every other block finishes well before it, so its internal runtime is the ~25+ min the suite has crept up to. These three changes cut its wall-clock **without touching any test** (no `*_test.go` files are modified).

## Changes

### A — stop double-running setup/teardown
CI ran `make test-migration-setup` and then `make test-migration`, but `test-migration` re-runs setup via its Make prerequisite and teardown via its `EXIT` trap. So setup ran twice (the second pass still rebuilds the 4 Go binaries, re-applies every CR, and re-polls block-reconcile) and teardown ran redundantly.
- New `test-migration-run` Make target: tests only, no setup/teardown.
- CI now pairs explicit `test-migration-setup` with `test-migration-run`; teardown runs once in the epilogue.
- **Local `make test-migration` is unchanged** (still setup + test + teardown).

### B — stub the frontend dist instead of building it
The e2e suite exercises `kcp migration` via `kubectl exec`; it never serves the UI. A single `dist/index.html` satisfies the `go:embed` so the binary compiles — the exact trick the `docs build` block already relies on. Replaces `yarn install && yarn build`, and the block now depends only on `resolve go dependencies`, so it no longer waits on the frontend-dependencies block to start.

### D — cache the Confluent container images across runs (experimental)
Today only the K8s preload tarballs (`~/.minikube/cache/`) are cached; the large Confluent images (`cp-server`, operator, gateway, init-container) are re-pulled from Docker Hub on every cold start. `setup.sh` now single-sources the image list and, when `IMAGE_CACHE_DIR` is set, `docker load`s a cached tarball into the Minikube node so kubelet finds them locally. CI saves them after a green `main` run. Every step is best-effort (`|| true`) — a cache miss or corrupt tarball degrades to a normal registry pull. No-op for local runs.

> D's payoff is only observable in CI; if the branch run shows no wall-clock win, it's trivially revertible.

## Verification
- `make -n test-migration-run` → `go test` only (no setup prereq); `make -n test-migration` unchanged.
- `bash -n setup.sh` / `teardown.sh`; `semaphore.yml` parses; all 9 blocks intact.
- D shell guard exercised across unset / set-no-tarball / set-with-tarball; save step expands to the 5 images.
- B: covered by the currently-green `docs build` stub precedent (a local Go compile was blocked by an unrelated broken goenv install, not by this change).

## Note
This was a **strike run** — no in-pipeline code review. The PR review is the first review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
