### PR TITLE
perf(migration): run e2e scenarios in parallel

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -138,7 +138,11 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-amd64-2
+          # amd64-3 (c6a.4xlarge, 16 vCPU / 32 GB) so the 9 scenarios can run
+          # in parallel (t.Parallel) with headroom; the extra RAM is the real
+          # lever (the suite is wait-bound). ~cost-neutral per run vs -2 given
+          # the wall-clock roughly halves.
+          type: s1-prod-ubuntu24-04-amd64-3
       prologue:
         commands:
           # Minikube is not pre-installed on Semaphore agents

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 BINARY_NAME := kcp
 MAIN_PATH := .
 GOTEST_FLAGS ?= -v
+# Extra flags for the migration e2e run. -parallel caps concurrent scenarios;
+# lower it (e.g. -parallel 3) as the bounded-parallelism toggle if the node saturates.
+MIGRATION_GOTEST_FLAGS ?= -parallel 9
 
 COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -106,7 +109,7 @@ test-migration: test-migration-setup ## Run full migration E2E lifecycle (setup,
 	go test -v -tags=e2e -timeout 40m ./integration-tests/migration/...
 
 test-migration-run: ## Run migration E2E tests against already-provisioned infra (no setup/teardown; CI pairs this with test-migration-setup)
-	go test -v -tags=e2e -timeout 40m ./integration-tests/migration/...
+	go test -v -tags=e2e -timeout 40m $(MIGRATION_GOTEST_FLAGS) ./integration-tests/migration/...
 
 test-migration-setup: ## Set up Minikube + CFK infrastructure for migration E2E
 	@bash integration-tests/migration/testdata/setup.sh

--- a/integration-tests/migration/migration_e2e_test.go
+++ b/integration-tests/migration/migration_e2e_test.go
@@ -147,11 +147,20 @@ func runKCP(t *testing.T, cfg envConfig, args ...string) (string, string, error)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
+	// Run kcp from a per-scenario working directory so its cwd-relative
+	// kcp.log lands in scenarioWorkdir(cfg.Scenario) instead of a shared
+	// /workspace/kcp.log — required for parallel scenarios not to contaminate
+	// each other's logs. The literal "kcp" token after the script supplies $0
+	// so the real kcp args map to "$@" ($1..$n); `mkdir -p` creates the dir on
+	// the emptyDir /workspace volume. cfg.Scenario is a controlled constant.
+	workdir := scenarioWorkdir(cfg.Scenario)
 	kubectlArgs := []string{
 		"--context", cfg.KubeContext,
 		"-n", cfg.Namespace,
 		"exec", cfg.KCPPod, "--",
-		"/workspace/kcp",
+		"sh", "-c",
+		fmt.Sprintf("mkdir -p %s && cd %s && exec /workspace/kcp \"$@\"", workdir, workdir),
+		"kcp",
 	}
 	kubectlArgs = append(kubectlArgs, args...)
 
@@ -516,7 +525,6 @@ func readPodFileLinesFrom(t *testing.T, cfg envConfig, podPath string, startLine
 // the scenario-resolved cfg.TopicName.
 const (
 	e2eProducerLog    = "producer"
-	e2eConsumerGroup  = "kcp-e2e-consumer-group"
 	e2eProducerBinary = "/workspace/producer"
 	e2eConsumerBinary = "/workspace/consumer"
 )
@@ -530,7 +538,7 @@ func startConsumerOnSource(t *testing.T, cfg envConfig, maxMessages int) {
 		e2eConsumerBinary,
 		"--bootstrap", cfg.SourceBootstrap,
 		"--topic", cfg.TopicName,
-		"--group", e2eConsumerGroup,
+		"--group", consumerGroupID(cfg.Scenario),
 		"--max-messages", fmt.Sprintf("%d", maxMessages),
 		"--timeout", "90s",
 	)
@@ -548,15 +556,19 @@ func startProducerOnSource(t *testing.T, cfg envConfig, duration time.Duration) 
 		"--topic", cfg.TopicName,
 		"--duration", duration.String(),
 		"--rate", "10",
+		"--client-id", producerClientID(cfg.Scenario),
 	)
 }
 
 func stopProducer(t *testing.T, cfg envConfig) {
 	t.Helper()
-	killInPod(t, cfg, e2eProducerBinary)
+	// Scope the kill to THIS scenario's producer (matched via its unique
+	// --client-id in the argv), so a parallel scenario's stop can't kill it.
+	killInPod(t, cfg, producerKillPattern(cfg.Scenario))
 }
 
 func TestMigrationE2E(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioBaseline)
 
 	// Set up K8s clients for assertions (runs on host, uses host kubeconfig)
@@ -764,12 +776,15 @@ func TestMigrationE2E(t *testing.T) {
 //
 // Runs against the dedicated "batch" scenario provisioned by setup.sh.
 func TestMigrationE2E_PromoteBatchSize(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioBatch)
 	require.GreaterOrEqual(t, len(cfg.TopicNames), 2,
 		"batch scenario must provision multiple topics (got %v)", cfg.TopicNames)
 
 	stateFile := "/workspace/migration-state-batch.json"
-	const logPath = "/workspace/kcp.log"
+	// Scenario-scoped kcp.log (matches runKCP's per-scenario workdir) so
+	// concurrent scenarios' kcp runs don't inflate the line counts asserted below.
+	logPath := scenarioWorkdir(cfg.Scenario) + "/kcp.log"
 
 	// --- Step 1: init ---
 	t.Run("init", func(t *testing.T) {
@@ -890,6 +905,7 @@ func TestMigrationE2E_PromoteBatchSize(t *testing.T) {
 // topic, cluster link, and gateway CR provisioned by setup.sh — so it is
 // independent of TestMigrationE2E.
 func TestMigrationE2E_PauseOffsetSync_HappyPath(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncHappy)
 
 	stateFile := "/workspace/migration-state-pause-sync-happy.json"
@@ -1074,6 +1090,7 @@ func TestMigrationE2E_PauseOffsetSync_HappyPath(t *testing.T) {
 // Runs against the dedicated "pause-sync-drain" scenario provisioned by
 // setup.sh, so it is independent of the other pause-sync tests.
 func TestMigrationE2E_PauseOffsetSync_Drain(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncDrain)
 
 	stateFile := "/workspace/migration-state-pause-sync-drain.json"
@@ -1198,6 +1215,7 @@ func TestMigrationE2E_PauseOffsetSync_Drain(t *testing.T) {
 // its own cluster link so flipping offset-sync to "false" does not leak
 // into other tests.
 func TestMigrationE2E_PauseOffsetSync_InitRefuses(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncRefuses)
 
 	setClusterLinkConfig(t, cfg, "consumer.offset.sync.enable", "false")
@@ -1259,6 +1277,7 @@ func TestMigrationE2E_PauseOffsetSync_InitRefuses(t *testing.T) {
 // dedicated source topic, cluster link, and gateway CR provisioned by
 // setup.sh — so it is independent of the other migration tests.
 func TestMigrationE2E_PauseOffsetSync_RestoresFilters(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncRestoresFilters)
 
 	stateFile := "/workspace/migration-state-pause-sync-restores-filters.json"
@@ -1370,6 +1389,7 @@ func TestMigrationE2E_PauseOffsetSync_RestoresFilters(t *testing.T) {
 // Phase B: with the rogue producer stopped, re-running execute re-verifies
 // the fence (source offsets stable) and completes the migration to switched.
 func TestMigrationE2E_RogueProducerDetection(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioRogueProducer)
 
 	kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -1601,6 +1621,7 @@ func TestMigrationE2E_RogueProducerDetection(t *testing.T) {
 // Runs against the "pause-sync-rogue" scenario — its own dedicated source
 // topic, cluster link, and gateway CR provisioned by setup.sh.
 func TestMigrationE2E_PauseOffsetSync_RogueProducerRollback(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncRogue)
 
 	kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -1788,6 +1809,7 @@ func TestMigrationE2E_PauseOffsetSync_RogueProducerRollback(t *testing.T) {
 // topic, cluster link, and gateway CR provisioned by setup.sh — so flipping
 // offset-sync to "false" does not leak into other tests.
 func TestMigrationE2E_PauseOffsetSync_DriftRollsBackFence(t *testing.T) {
+	t.Parallel()
 	cfg := loadEnvConfig(t, scenarioPauseSyncDrift)
 
 	kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/integration-tests/migration/scenario_ids_test.go
+++ b/integration-tests/migration/scenario_ids_test.go
@@ -1,0 +1,104 @@
+package migration_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// producerClientID is the scenario-scoped Kafka client.id passed to the source
+// producer (`--client-id`). Built solely from the controlled scenario constant.
+func producerClientID(scenario string) string { return "kcp-e2e-producer-" + scenario }
+
+// producerKillPattern is the `pkill -f` pattern that terminates ONLY this
+// scenario's producer. It is exactly the scenario-scoped client.id, which
+// appears in the producer's argv, so it cannot match a sibling scenario.
+func producerKillPattern(scenario string) string { return producerClientID(scenario) }
+
+// consumerGroupID is the scenario-scoped consumer group.id. Distinct groups keep
+// concurrent scenarios' consumers off a shared coordinator, avoiding rebalance
+// churn under t.Parallel().
+func consumerGroupID(scenario string) string { return "kcp-e2e-consumer-group-" + scenario }
+
+// scenarioWorkdir is the per-scenario in-pod working directory kcp runs from, so
+// its cwd-relative kcp.log becomes /workspace/<scenario>/kcp.log — isolated from
+// other scenarios' kcp runs under t.Parallel().
+func scenarioWorkdir(scenario string) string { return "/workspace/" + scenario }
+
+// allScenarios mirrors setup.sh's SCENARIOS array and the scenario constants in
+// migration_e2e_test.go. Kept in sync by hand; drift would make the abuse test
+// below cover the wrong set.
+var allScenarios = []string{
+	"baseline", "pause-sync-happy", "pause-sync-refuses",
+	"pause-sync-restores-filters", "pause-sync-rogue", "pause-sync-drift",
+	"pause-sync-drain", "batch", "rogue-producer",
+}
+
+// producerArgv reproduces the argv that startProducerOnSource launches, so the
+// kill pattern is matched against a realistic command line.
+func producerArgv(scenario string) string {
+	return "/workspace/producer --bootstrap src:9071 --topic e2e-test-topic-" + scenario +
+		" --duration 5m0s --rate 10 --client-id " + producerClientID(scenario)
+}
+
+// pkillMatches models `pkill -f <pattern>`: the pattern is matched against the
+// full argv. Our patterns contain no ERE metacharacters, so substring is exact.
+func pkillMatches(pattern, argv string) bool { return strings.Contains(argv, pattern) }
+
+func TestProducerClientIDIsScenarioScoped(t *testing.T) {
+	if got := producerClientID("baseline"); got != "kcp-e2e-producer-baseline" {
+		t.Fatalf("producerClientID(baseline) = %q, want kcp-e2e-producer-baseline", got)
+	}
+}
+
+func TestConsumerGroupIDIsScenarioScoped(t *testing.T) {
+	if got := consumerGroupID("batch"); got != "kcp-e2e-consumer-group-batch" {
+		t.Fatalf("consumerGroupID(batch) = %q, want kcp-e2e-consumer-group-batch", got)
+	}
+}
+
+// Abuse case: a scenario's producer kill pattern must match ONLY its own
+// producer and never a sibling's. A sibling match means one parallel scenario's
+// stopProducer would kill another scenario's producer.
+func TestProducerKillPatternMatchesOnlyOwnScenario(t *testing.T) {
+	for _, a := range allScenarios {
+		pattern := producerKillPattern(a)
+		if !pkillMatches(pattern, producerArgv(a)) {
+			t.Errorf("kill pattern %q does not match its own producer (%s)", pattern, a)
+		}
+		for _, b := range allScenarios {
+			if a == b {
+				continue
+			}
+			if pkillMatches(pattern, producerArgv(b)) {
+				t.Errorf("kill pattern for %q ALSO matches sibling %q — would kill the wrong producer", a, b)
+			}
+		}
+	}
+}
+
+// Abuse case: the kill pattern is derived solely from the controlled scenario
+// constant, never interpolated external input.
+func TestProducerKillPatternDerivedFromScenarioConstant(t *testing.T) {
+	for _, s := range allScenarios {
+		if producerKillPattern(s) != producerClientID(s) {
+			t.Errorf("kill pattern for %q must equal its scenario-derived client-id", s)
+		}
+	}
+}
+
+// scenarioWorkdir gives each scenario its own kcp working directory so kcp's
+// cwd-relative kcp.log lands per-scenario — otherwise the batch test's exact
+// log-line counts are contaminated by concurrent scenarios' kcp runs.
+func TestScenarioWorkdirIsScenarioScoped(t *testing.T) {
+	if got := scenarioWorkdir("batch"); got != "/workspace/batch" {
+		t.Fatalf("scenarioWorkdir(batch) = %q, want /workspace/batch", got)
+	}
+	seen := map[string]bool{}
+	for _, s := range allScenarios {
+		d := scenarioWorkdir(s)
+		if seen[d] {
+			t.Errorf("scenarioWorkdir collision at %q", d)
+		}
+		seen[d] = true
+	}
+}

--- a/integration-tests/migration/testdata/setup.sh
+++ b/integration-tests/migration/testdata/setup.sh
@@ -64,8 +64,8 @@ else
   minikube start \
     --profile "${PROFILE}" \
     --driver=docker \
-    --cpus=4 \
-    --memory=8192 \
+    --cpus="${MINIKUBE_CPUS:-12}" \
+    --memory="${MINIKUBE_MEMORY:-24576}" \
     --disk-size=20g \
     --kubernetes-version=v1.30.0
 fi


### PR DESCRIPTION
Runs the 9 migration e2e scenarios **in parallel** instead of serially — that serial `go test` was ~65% of the ~23.5 min CI critical path. Scenarios are already resource-isolated; serialization was a harness limitation. **No test assertions or FSM expectations change** — only isolation mechanics, `t.Parallel()`, and runtime sizing.

**Stacked on #387** (`perf/migration-e2e-ci-time`) — merge that first.

## Changes

- **Scoped process identity** — per-scenario producer `--client-id`, `stopProducer`'s `pkill` scoped to it (was pod-wide, would kill a sibling's producer), scenario-scoped consumer `group.id`. New untagged `scenario_ids_test.go` with the pure builders + abuse tests (incl. kill-pattern can't match a sibling).
- **Per-scenario kcp workdir** — `runKCP` runs from `/workspace/<scenario>` so each `kcp.log` is isolated; the batch test's exact log-count assertions stay correct under concurrency.
- **`t.Parallel()`** on the 9 scenario tests (benchmark stays serial — shares `baseline`).
- **Runtime** — Minikube `4/8192`→`12/24576` (env-overridable), Semaphore agent `amd64-2`→`amd64-3` (16 vCPU / 32 GB), `-parallel 9` toggle (`MIGRATION_GOTEST_FLAGS`).

## Verification

Run locally, both suites green: full `go test ./...` exit 0; **15/15 e2e PASS** at `-parallel 3` (8 CPU / 14 GB Minikube) in **~5.9 min vs ~14.75 min serial (~2.5×)**; isolation held under concurrency (no sibling kills, batch log-counts intact, no rebalance churn). Security review: 0 findings. Full 9-way at 24 GB is validated by the branch CI run.

Forge run — code review deferred to a `mega-review` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
