### PR TITLE
Fix/UI topic cleanup policy badges

### DIFF
--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
@@ -1,4 +1,4 @@
-import { formatRetentionTime } from '@/lib/utils'
+import { formatRetentionTime, parseCleanupPolicies } from '@/lib/utils'
 import type { KafkaAdminInfo, Topic } from '@/types'
 
 interface ClusterTopicsProps {
@@ -100,15 +100,22 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
                     {topic.replication_factor}
                   </td>
                   <td className="py-3 text-center">
-                    <span
-                      className={`px-2 py-1 text-xs rounded ${
-                        topic.configurations['cleanup.policy'] === 'compact'
-                          ? 'bg-blue-100 text-blue-800 dark:bg-accent/20 dark:text-accent'
-                          : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                      }`}
-                    >
-                      {topic.configurations['cleanup.policy'] === 'compact' ? 'Compact' : 'Delete'}
-                    </span>
+                    <div className="flex items-center justify-center gap-1">
+                      {parseCleanupPolicies(topic.configurations['cleanup.policy']).includes(
+                        'compact'
+                      ) && (
+                        <span className="px-2 py-1 text-xs rounded bg-blue-100 text-blue-800 dark:bg-accent/20 dark:text-accent">
+                          Compact
+                        </span>
+                      )}
+                      {parseCleanupPolicies(topic.configurations['cleanup.policy']).includes(
+                        'delete'
+                      ) && (
+                        <span className="px-2 py-1 text-xs rounded bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                          Delete
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="py-3 text-center text-foreground">
                     <div className="relative group">

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
@@ -32,13 +32,13 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
             <div className="text-2xl font-bold text-foreground">
               {kafkaAdminInfo.topics.summary.topics}
             </div>
-            <div className="text-sm text-muted-foreground">Total Topics</div>
+            <div className="text-sm text-muted-foreground">Total Non-Internal Topics</div>
           </div>
           <div className="bg-secondary rounded-lg p-4 transition-colors">
             <div className="text-2xl font-bold text-foreground">
               {kafkaAdminInfo.topics.summary.total_partitions}
             </div>
-            <div className="text-sm text-muted-foreground">Total Partitions</div>
+            <div className="text-sm text-muted-foreground">Total Non-Internal Partitions</div>
           </div>
           <div className="bg-secondary rounded-lg p-4 transition-colors">
             <div className="text-2xl font-bold text-foreground">
@@ -73,7 +73,7 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
                   Replication Factor
                 </th>
                 <th className="text-center py-3 font-medium text-foreground">
-                  Type
+                  Cleanup Policy
                 </th>
                 <th className="text-center py-3 font-medium text-foreground">
                   Retention (ms)

--- a/cmd/ui/frontend/src/lib/utils.ts
+++ b/cmd/ui/frontend/src/lib/utils.ts
@@ -46,6 +46,19 @@ export const formatRetentionTime = (
 }
 
 /**
+ * Splits a Kafka `cleanup.policy` config value into its component policies.
+ * Handles combined values like "compact,delete" or "delete,compact" (order
+ * is not guaranteed by the broker), and defaults to "delete" when the config
+ * key is absent, matching Kafka's own broker default.
+ *
+ * @param {string} [cleanupPolicy] - The raw `cleanup.policy` config value
+ * @returns {string[]} The component policy tokens, e.g. ['compact', 'delete']
+ */
+export const parseCleanupPolicies = (cleanupPolicy?: string): string[] => {
+  return (cleanupPolicy ?? 'delete').split(',').map((policy) => policy.trim())
+}
+
+/**
  * Downloads data as a CSV file
  * @param csvData - The CSV content as a string
  * @param filename - The filename without extension (e.g., 'metrics-cluster-region')

--- a/cmd/ui/frontend/tests/e2e/cluster-topics-cleanup-policy.spec.ts
+++ b/cmd/ui/frontend/tests/e2e/cluster-topics-cleanup-policy.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+import stateFixture from './fixtures/state-topic-cleanup-policy.json' with { type: 'json' }
+
+test.describe('Topic cleanup-policy badges', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.click('button:has-text("Upload KCP State File")')
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'state-topic-cleanup-policy.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(stateFixture)),
+    })
+    await page.waitForTimeout(500)
+    await page.click('text=cleanup-policy-test-cluster')
+    await page.click('nav button:has-text("Topics")')
+  })
+
+  test('shows only the Delete badge for a delete-only topic', async ({ page }) => {
+    const row = page.locator('tbody tr').filter({ hasText: 'orders-events' })
+    await expect(row.getByText('Delete', { exact: true })).toBeVisible()
+    await expect(row.getByText('Compact', { exact: true })).toHaveCount(0)
+  })
+
+  test('shows only the Compact badge for a compact-only topic', async ({ page }) => {
+    const row = page.locator('tbody tr').filter({ hasText: 'ktable-changelog' })
+    await expect(row.getByText('Compact', { exact: true })).toBeVisible()
+    await expect(row.getByText('Delete', { exact: true })).toHaveCount(0)
+  })
+
+  test('shows both badges for a topic with cleanup.policy=compact,delete', async ({ page }) => {
+    const row = page.locator('tbody tr').filter({ hasText: 'audit-log' })
+    await expect(row.getByText('Compact', { exact: true })).toBeVisible()
+    await expect(row.getByText('Delete', { exact: true })).toBeVisible()
+  })
+
+  test('shows both badges regardless of policy order (delete,compact)', async ({ page }) => {
+    const row = page.locator('tbody tr').filter({ hasText: 'reversed-policy-topic' })
+    await expect(row.getByText('Compact', { exact: true })).toBeVisible()
+    await expect(row.getByText('Delete', { exact: true })).toBeVisible()
+  })
+
+  test('internal compacted topic still shows the Internal tag alongside Compact', async ({ page }) => {
+    const row = page.locator('tbody tr').filter({ hasText: '__consumer_offsets' })
+    await expect(row.getByText('Internal', { exact: true })).toBeVisible()
+    await expect(row.getByText('Compact', { exact: true })).toBeVisible()
+    await expect(row.getByText('Delete', { exact: true })).toHaveCount(0)
+  })
+})

--- a/cmd/ui/frontend/tests/e2e/fixtures/state-topic-cleanup-policy.json
+++ b/cmd/ui/frontend/tests/e2e/fixtures/state-topic-cleanup-policy.json
@@ -1,0 +1,110 @@
+{
+  "msk_sources": {
+    "regions": [
+      {
+        "name": "us-east-1",
+        "configurations": [],
+        "costs": null,
+        "clusters": [
+          {
+            "name": "cleanup-policy-test-cluster",
+            "arn": "arn:aws:kafka:us-east-1:123456789012:cluster/cleanup-policy-test-cluster/00000000-0000-0000-0000-000000000099",
+            "region": "us-east-1",
+            "aws_client_information": {
+              "bootstrap_brokers": {},
+              "msk_cluster_config": {
+                "ClusterName": "cleanup-policy-test-cluster",
+                "ClusterArn": "arn:aws:kafka:us-east-1:123456789012:cluster/cleanup-policy-test-cluster/00000000-0000-0000-0000-000000000099",
+                "ClusterType": "PROVISIONED",
+                "CreationTime": "2026-01-01T00:00:00Z",
+                "CurrentVersion": "K1",
+                "Provisioned": {
+                  "NumberOfBrokerNodes": 3,
+                  "CurrentBrokerSoftwareInfo": { "KafkaVersion": "3.8.x" },
+                  "BrokerNodeGroupInfo": {
+                    "InstanceType": "kafka.m5.large",
+                    "StorageInfo": { "EbsStorageInfo": { "VolumeSize": 100 } }
+                  }
+                }
+              },
+              "nodes": [],
+              "cluster_networking": {},
+              "cluster_operations": [],
+              "client_vpc_connections": [],
+              "connectors": [],
+              "ScramSecrets": []
+            },
+            "kafka_admin_client_information": {
+              "topics": {
+                "summary": {
+                  "topics": 4,
+                  "total_partitions": 12,
+                  "internal_topics": 1,
+                  "compact_topics": 3
+                },
+                "details": [
+                  {
+                    "name": "orders-events",
+                    "partitions": 3,
+                    "replication_factor": 3,
+                    "configurations": {
+                      "cleanup.policy": "delete",
+                      "retention.ms": "604800000"
+                    }
+                  },
+                  {
+                    "name": "ktable-changelog",
+                    "partitions": 3,
+                    "replication_factor": 3,
+                    "configurations": {
+                      "cleanup.policy": "compact",
+                      "retention.ms": "604800000"
+                    }
+                  },
+                  {
+                    "name": "audit-log",
+                    "partitions": 3,
+                    "replication_factor": 3,
+                    "configurations": {
+                      "cleanup.policy": "compact,delete",
+                      "retention.ms": "604800000"
+                    }
+                  },
+                  {
+                    "name": "reversed-policy-topic",
+                    "partitions": 3,
+                    "replication_factor": 3,
+                    "configurations": {
+                      "cleanup.policy": "delete,compact",
+                      "retention.ms": "604800000"
+                    }
+                  },
+                  {
+                    "name": "__consumer_offsets",
+                    "partitions": 50,
+                    "replication_factor": 3,
+                    "configurations": {
+                      "cleanup.policy": "compact",
+                      "retention.ms": "604800000"
+                    }
+                  }
+                ]
+              },
+              "acls": []
+            },
+            "metrics": {
+              "metadata": { "instance_type": "kafka.m5.large", "broker_type": "kafka.m5.large", "period": 86400 },
+              "results": [],
+              "query_info": []
+            },
+            "discovered_clients": []
+          }
+        ]
+      }
+    ]
+  },
+  "osk_sources": {},
+  "schema_registries": null,
+  "kcp_build_info": { "version": "test", "commit": "test", "date": "2026-07-20T00:00:00Z" },
+  "timestamp": "2026-07-20T00:00:00Z"
+}

--- a/internal/types/state_schema_test.go
+++ b/internal/types/state_schema_test.go
@@ -15,7 +15,7 @@ var updateSchemaGolden = false // flip to true locally to regenerate, then back
 // walkSchema returns sorted "path:jsontag" lines for every json-tagged field
 // reachable from t, so any add/remove/rename/re-parent shows up as a diff.
 func walkSchema(t reflect.Type, prefix string, seen map[reflect.Type]bool, out *[]string) {
-	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+	for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		t = t.Elem()
 	}
 	if t.Kind() == reflect.Map {


### PR DESCRIPTION
## Description

Fixes a mislabeling bug in the `kcp ui` Topics tab: topics with a combined `cleanup.policy` of `compact,delete` (or `delete,compact`) were shown with only a "Delete" badge, hiding the fact that they're actively compacting. This matters beyond cosmetics — compacted vs. non-compacted partition counts factor directly into Confluent Cloud Enterprise eCKU sizing, so an inaccurate badge risks under-counting compacted partitions during migration sizing conversations. Also clarifies two summary-card labels and a column header that were misleading about what they actually count.

---

## Changes Made

- [x] Fix: per-topic "Type" column now renders **both** Compact and Delete badges independently when a topic's `cleanup.policy` contains both tokens (previously an exact-string-match bug meant `compact,delete` only ever showed "Delete"). Column header renamed from "Type" to "Cleanup Policy" to match.
- [x] Fix: "Total Topics" and "Total Partitions" summary cards renamed to "Total Non-Internal Topics" / "Total Non-Internal Partitions" — verified against the backend (`CalculateTopicSummaryFromDetails` in `internal/types/kafka.go`) that these fields only ever count non-internal (`__`-prefixed excluded) topics/partitions; the old labels implied a grand total that included internal topics, which they don't.
- [x] Fix (unrelated, pre-existing): `internal/types/state_schema_test.go` used the deprecated `reflect.Ptr` alias, which failed the repo's `golangci-lint` pre-commit gate on bare `main` regardless of this change. Fixed with the tool-suggested `reflect.Pointer` equivalent in its own commit so it doesn't block this PR.
- [x] Any breaking changes — none. Purely additive/cosmetic UI changes; no state file schema or API changes.
- [x] Documentation updates — not needed (no user-facing docs describe this UI in that level of detail today).

---

## Testing

- [x] New tests added/updated — new Playwright e2e spec `cmd/ui/frontend/tests/e2e/cluster-topics-cleanup-policy.spec.ts` (5 cases: delete-only, compact-only, `compact,delete`, `delete,compact` reversed-order, and an internal+compacted topic), with a new fixture `state-topic-cleanup-policy.json`.
- [x] Manual testing completed — built the binary and drove the UI directly against the fixture to confirm rendering before relying on the automated spec.
- [x] All tests pass — `yarn type-check` clean; e2e spec 5/5 passing (RED confirmed pre-fix: 2/5 failing on the combined-policy cases, exactly as expected; GREEN post-fix: 5/5).

**Test Instructions:**

1. `cd cmd/ui/frontend && yarn test:e2e tests/e2e/cluster-topics-cleanup-policy.spec.ts`
2. Or manually: `make build && ./kcp ui --state-file cmd/ui/frontend/tests/e2e/fixtures/state-topic-cleanup-policy.json`, open the `cleanup-policy-test-cluster` cluster → Topics tab, and check `audit-log` / `reversed-policy-topic` rows show both Compact and Delete badges.

---

## Checklist

- [x] Code follows project style guidelines (Tailwind inline classes, `@/` aliases, named exports — matches existing `ClusterTopics.tsx` conventions)
- [x] Self-review completed
- [ ] Documentation updated (if needed) — n/a
- [x] No breaking changes (or breaking changes documented) — none

---

## Screenshots/Demo/Output
<img width="1362" height="160" alt="Screenshot 2026-07-21 at 11 50 26" src="https://github.com/user-attachments/assets/e0bf7c5d-58a1-4ea1-be1f-f396e1901616" />
<img width="1488" height="729" alt="Screenshot 2026-07-21 at 11 50 54" src="https://github.com/user-attachments/assets/61baffb0-6bef-4097-870e-0998c76db841" />
