### PR TITLE
fix(ui): rename Compact Topics card to Compact Non-Internal Topics

### DIFF
--- a/cmd/ui/frontend/package.json
+++ b/cmd/ui/frontend/package.json
@@ -51,7 +51,7 @@
   "resolutions": {
     "lodash": "^4.18.0",
     "lodash-es": "^4.18.0",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.4"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import { Tabs } from '@/components/common/Tabs'
 import { formatRetentionTime, parseCleanupPolicies } from '@/lib/utils'
 import type { KafkaAdminInfo, Topic } from '@/types'
 
@@ -5,7 +7,16 @@ interface ClusterTopicsProps {
   kafkaAdminInfo?: KafkaAdminInfo
 }
 
+type TopicScope = 'non-internal' | 'internal'
+
+const TOPIC_SCOPE_TABS = [
+  { id: 'non-internal', label: 'Non-Internal' },
+  { id: 'internal', label: 'Internal' },
+]
+
 export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
+  const [topicScope, setTopicScope] = useState<TopicScope>('non-internal')
+
   if (!kafkaAdminInfo?.topics?.details) {
     return (
       <div className="bg-card rounded-lg border border-border p-6 transition-colors">
@@ -19,39 +30,52 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
     )
   }
 
+  const summary = kafkaAdminInfo.topics.summary
+
+  // topics/total_partitions/compact_topics/compact_partitions only ever count
+  // non-internal (not "__"-prefixed) topics, despite the plain names — the
+  // internal counterparts are separate fields (internal_topics/
+  // total_internal_partitions/etc). Scoped here by tab so only one set of 4
+  // stats shows at a time, each labeled unambiguously either way.
+  const scopedStats =
+    topicScope === 'non-internal'
+      ? [
+          { value: summary.topics, label: 'Total Non-Internal Topics' },
+          { value: summary.compact_topics, label: 'Compact Non-Internal Topics' },
+          { value: summary.total_partitions, label: 'Total Non-Internal Partitions' },
+          { value: summary.compact_partitions, label: 'Compact Non-Internal Partitions' },
+        ]
+      : [
+          { value: summary.internal_topics, label: 'Internal Topics' },
+          { value: summary.compact_internal_topics, label: 'Compact Internal Topics' },
+          { value: summary.total_internal_partitions, label: 'Internal Partitions' },
+          { value: summary.compact_internal_partitions, label: 'Compact Internal Partitions' },
+        ]
+
   return (
     <div className="space-y-6">
       {/* Topic Summary */}
-      <div className="bg-card rounded-lg border border-border p-6 transition-colors">
-        <h3 className="text-xl font-semibold text-foreground mb-4">
+      <div className="bg-card rounded-lg border border-border transition-colors overflow-hidden">
+        <h3 className="text-xl font-semibold text-foreground px-6 pt-6">
           Topics Overview
         </h3>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <div className="bg-secondary rounded-lg p-4 transition-colors">
-            <div className="text-2xl font-bold text-foreground">
-              {kafkaAdminInfo.topics.summary.topics}
+        <Tabs
+          tabs={TOPIC_SCOPE_TABS}
+          activeId={topicScope}
+          onChange={(id) => setTopicScope(id as TopicScope)}
+        />
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-6">
+          {scopedStats.map((stat) => (
+            <div
+              key={stat.label}
+              className="bg-secondary rounded-lg p-4 transition-colors"
+            >
+              <div className="text-2xl font-bold text-foreground">{stat.value}</div>
+              <div className="text-sm text-muted-foreground">{stat.label}</div>
             </div>
-            <div className="text-sm text-muted-foreground">Total Non-Internal Topics</div>
-          </div>
-          <div className="bg-secondary rounded-lg p-4 transition-colors">
-            <div className="text-2xl font-bold text-foreground">
-              {kafkaAdminInfo.topics.summary.total_partitions}
-            </div>
-            <div className="text-sm text-muted-foreground">Total Non-Internal Partitions</div>
-          </div>
-          <div className="bg-secondary rounded-lg p-4 transition-colors">
-            <div className="text-2xl font-bold text-foreground">
-              {kafkaAdminInfo.topics.summary.internal_topics}
-            </div>
-            <div className="text-sm text-muted-foreground">Internal Topics</div>
-          </div>
-          <div className="bg-secondary rounded-lg p-4 transition-colors">
-            <div className="text-2xl font-bold text-foreground">
-              {kafkaAdminInfo.topics.summary.compact_topics}
-            </div>
-            <div className="text-sm text-muted-foreground">Compact Non-Internal Topics</div>
-          </div>
+          ))}
         </div>
       </div>
 

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
@@ -50,7 +50,7 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
             <div className="text-2xl font-bold text-foreground">
               {kafkaAdminInfo.topics.summary.compact_topics}
             </div>
-            <div className="text-sm text-muted-foreground">Compact Topics</div>
+            <div className="text-sm text-muted-foreground">Compact Non-Internal Topics</div>
           </div>
         </div>
       </div>

--- a/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
+++ b/cmd/ui/frontend/src/components/explore/clusters/ClusterTopics.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react'
+import { Filter } from 'lucide-react'
 import { Tabs } from '@/components/common/Tabs'
+import { Button } from '@/components/common/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/common/ui/popover'
 import { formatRetentionTime, parseCleanupPolicies } from '@/lib/utils'
 import type { KafkaAdminInfo, Topic } from '@/types'
 
@@ -16,6 +19,12 @@ const TOPIC_SCOPE_TABS = [
 
 export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
   const [topicScope, setTopicScope] = useState<TopicScope>('non-internal')
+  // All Topics table filter — independent of the summary tabs above, and
+  // additive (both checked shows everything, both unchecked shows nothing).
+  const [showNonInternal, setShowNonInternal] = useState(true)
+  const [showInternal, setShowInternal] = useState(true)
+  const [showCompact, setShowCompact] = useState(true)
+  const [showDelete, setShowDelete] = useState(true)
 
   if (!kafkaAdminInfo?.topics?.details) {
     return (
@@ -40,9 +49,9 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
   const scopedStats =
     topicScope === 'non-internal'
       ? [
-          { value: summary.topics, label: 'Total Non-Internal Topics' },
+          { value: summary.topics, label: 'Non-Internal Topics' },
           { value: summary.compact_topics, label: 'Compact Non-Internal Topics' },
-          { value: summary.total_partitions, label: 'Total Non-Internal Partitions' },
+          { value: summary.total_partitions, label: 'Non-Internal Partitions' },
           { value: summary.compact_partitions, label: 'Compact Non-Internal Partitions' },
         ]
       : [
@@ -51,6 +60,17 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
           { value: summary.total_internal_partitions, label: 'Internal Partitions' },
           { value: summary.compact_internal_partitions, label: 'Compact Internal Partitions' },
         ]
+
+  const filteredTopics = kafkaAdminInfo.topics.details.filter((topic) => {
+    const scopeMatches = topic.name.startsWith('__') ? showInternal : showNonInternal
+    // A topic can carry both policies at once (e.g. "compact,delete" — see
+    // parseCleanupPolicies) — it matches if it has ANY checked policy, not
+    // only if it has exactly the checked set.
+    const policies = parseCleanupPolicies(topic.configurations['cleanup.policy'])
+    const cleanupMatches =
+      (showCompact && policies.includes('compact')) || (showDelete && policies.includes('delete'))
+    return scopeMatches && cleanupMatches
+  })
 
   return (
     <div className="space-y-6">
@@ -81,7 +101,77 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
 
       {/* Topics Table */}
       <div className="bg-card rounded-lg border border-border p-6 transition-colors overflow-visible">
-        <h3 className="text-xl font-semibold text-foreground mb-4">All Topics</h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xl font-semibold text-foreground">All Topics</h3>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Filter topics"
+              >
+                <Filter className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-52 p-3"
+            >
+              <div className="space-y-3">
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground mb-1.5">Type</div>
+                  <div className="space-y-2">
+                    <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showNonInternal}
+                        onChange={(e) => setShowNonInternal(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-accent"
+                      />
+                      Non-Internal
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showInternal}
+                        onChange={(e) => setShowInternal(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-accent"
+                      />
+                      Internal
+                    </label>
+                  </div>
+                </div>
+
+                <div className="border-t border-border pt-3">
+                  <div className="text-xs font-medium text-muted-foreground mb-1.5">
+                    Cleanup Policy
+                  </div>
+                  <div className="space-y-2">
+                    <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showCompact}
+                        onChange={(e) => setShowCompact(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-accent"
+                      />
+                      Compact
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showDelete}
+                        onChange={(e) => setShowDelete(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-accent"
+                      />
+                      Delete
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
 
         <div className="overflow-x-auto overflow-y-visible">
           <table className="w-full text-sm overflow-visible">
@@ -89,6 +179,9 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
               <tr className="border-b border-border overflow-visible">
                 <th className="text-left py-3 font-medium text-foreground">
                   Topic Name
+                </th>
+                <th className="text-center py-3 font-medium text-foreground">
+                  Type
                 </th>
                 <th className="text-center py-3 font-medium text-foreground">
                   Partitions
@@ -105,17 +198,21 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-600 overflow-visible">
-              {kafkaAdminInfo.topics.details.map((topic: Topic, index: number) => (
+              {filteredTopics.map((topic: Topic, index: number) => (
                 <tr key={index}>
                   <td className="py-3 text-foreground">
-                    <div className="flex items-center">
-                      <span className="font-mono text-sm">{topic.name}</span>
-                      {topic.name.startsWith('__') && (
-                        <span className="ml-2 px-2 py-1 text-xs bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
-                          Internal
-                        </span>
-                      )}
-                    </div>
+                    <span className="font-mono text-sm">{topic.name}</span>
+                  </td>
+                  <td className="py-3 text-center">
+                    {topic.name.startsWith('__') ? (
+                      <span className="px-2 py-1 text-xs bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
+                        Internal
+                      </span>
+                    ) : (
+                      <span className="px-2 py-1 text-xs bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 rounded">
+                        Non-Internal
+                      </span>
+                    )}
                   </td>
                   <td className="py-3 text-center text-foreground">
                     {topic.partitions}
@@ -188,7 +285,9 @@ export const ClusterTopics = ({ kafkaAdminInfo }: ClusterTopicsProps) => {
         </div>
 
         <div className="mt-4 text-sm text-muted-foreground text-center">
-          Showing all {kafkaAdminInfo.topics.details.length} topics
+          {filteredTopics.length === kafkaAdminInfo.topics.details.length
+            ? `Showing all ${kafkaAdminInfo.topics.details.length} topics`
+            : `Showing ${filteredTopics.length} of ${kafkaAdminInfo.topics.details.length} topics`}
         </div>
       </div>
     </div>

--- a/cmd/ui/frontend/src/types/aws/msk.ts
+++ b/cmd/ui/frontend/src/types/aws/msk.ts
@@ -284,9 +284,14 @@ export interface KafkaACL {
  */
 export interface TopicSummary {
   topics: number
-  total_partitions: number
   internal_topics: number
+  total_partitions: number
+  total_internal_partitions: number
   compact_topics: number
+  compact_internal_topics: number
+  compact_partitions: number
+  compact_internal_partitions: number
+  remote_storage_topics: number
 }
 
 /**

--- a/cmd/ui/frontend/yarn.lock
+++ b/cmd/ui/frontend/yarn.lock
@@ -2853,10 +2853,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1, fast-uri@^3.0.6, fast-uri@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@^3.0.1, fast-uri@^3.0.6, fast-uri@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.19.1"


### PR DESCRIPTION
kafkaAdminInfo.topics.summary.compact_topics only counts non-internal compacted topics (verified against CalculateTopicSummaryFromDetails in internal/types/kafka.go and against a real customer state file: 315 non-internal + 35 internal = 350 true total, but the field/card only ever reflected the 315). Same scope issue the prior PR (#390) fixed for Total Topics/Total Partitions, applied here for consistency.

## Description

Topics Overview card: 
  - Split into Non-Internal / Internal tabs instead of a flat row of cards — each tab shows 4 stats (Topics,
  Compact Topics, Partitions, Compact Partitions) scoped to that type, so all 8 real summary fields are now
  visible without a wall of near-duplicate labels.
  - Dropped the redundant "Total" prefix on the Non-Internal labels for consistency with the Internal ones.
  
  All Topics table:
  - Moved the "Internal" badge out of the Topic Name cell into its own Type column (matching the existing
  Cleanup Policy column), and added a "Non-Internal" badge that didn't exist before — previously non-internal
  topics got no badge at all.
  - Added a filter icon next to "All Topics" with two checkbox groups — Type (Non-Internal/Internal) and
  Cleanup Policy (Compact/Delete) — all four independently toggleable and additive (both checked in a group
  shows everything; a topic matches on cleanup policy if it has any checked policy, since a topic can carry
  both compact and delete at once).


---

## Changes Made

- [x] Feature/bug fix/improvement description
- [ ] Any breaking changes
- [ ] Documentation updates

---

## Testing

- [ ] New tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass

**Test Instructions:**

<!-- How should reviewers test this? -->

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)

---

## Screenshots/Demo/Output

<!-- If applicable, add screenshots or demo links -->
