### PR TITLE
fix(migration): actually validate the gateway CRs instead of claiming to

### DIFF
--- a/cmd/migration/init/cmd_migration_init.go
+++ b/cmd/migration/init/cmd_migration_init.go
@@ -60,8 +60,12 @@ func NewMigrationInitCmd() *cobra.Command {
 		Long: `Initialize a new migration by validating infrastructure and persisting migration state.
 
 This command validates the cluster link and mirror topics on the destination cluster,
-fetches the current gateway CR from Kubernetes, validates consistency across the initial,
-fenced, and switchover gateway CRs, and writes the migration configuration to the state file.
+fetches the current gateway CR from Kubernetes, validates the initial, fenced and switchover
+gateway CRs against each other — including that the Kubernetes secrets they reference exist
+in the namespace — and writes the migration configuration to the state file.
+
+Validating up front matters because the alternative is discovering the problem at cutover,
+after client traffic has already been fenced.
 
 The state file can then be used by 'kcp migration execute' to run the migration.
 

--- a/internal/services/gateway/gateway.go
+++ b/internal/services/gateway/gateway.go
@@ -26,12 +26,13 @@ const (
 	GatewayGroup          = "platform.confluent.io"
 	GatewayVersion        = "v1beta1"
 	GatewayResourcePlural = "gateways"
+	GatewayKind           = "Gateway"
 )
 
 // Service defines gateway operations
 type Service interface {
 	GetGatewayYAML(ctx context.Context, namespace, gatewayName string) ([]byte, error)
-	ValidateGatewayCRs(initialYAML, fencedYAML, switchoverYAML []byte) error
+	ValidateGatewayCRs(ctx context.Context, namespace, gatewayName string, initialYAML, fencedYAML, switchoverYAML []byte) (CRValidationResult, error)
 	CheckPermissions(ctx context.Context, verb, resource, group, namespace string) (bool, error)
 	ApplyGatewayYAML(ctx context.Context, namespace, gatewayName string, yamlData []byte) error
 	WaitForGatewayObservedGeneration(ctx context.Context, namespace, gatewayName string, pollInterval, timeout time.Duration) error
@@ -107,13 +108,6 @@ func (s *K8sService) GetGatewayYAML(ctx context.Context, namespace, gatewayName 
 
 	slog.Debug("fetched gateway CR", "namespace", namespace, "gateway", gatewayName, "bytes", len(yamlBytes))
 	return yamlBytes, nil
-}
-
-// ValidateGatewayCRs validates that the initial, fenced, and switchover gateway CRs are consistent
-func (s *K8sService) ValidateGatewayCRs(initialYAML, fencedYAML, switchoverYAML []byte) error {
-	// TODO: implement cross-CR validation
-	slog.Warn("⚠️ gateway CR validation not yet implemented, skipping")
-	return nil
 }
 
 // CheckPermissions checks if the user has the required Kubernetes permissions

--- a/internal/services/gateway/validate.go
+++ b/internal/services/gateway/validate.go
@@ -174,16 +174,19 @@ func checkGatewayShape(cr gatewayCR, f *findings) {
 		f.problem("the %s gateway CR has kind %q, expected %q", cr.role, kind, GatewayKind)
 	}
 
+	// The declared apiVersion is not cosmetic. ApplyGatewayYAML sends the object
+	// body verbatim through the pinned v1beta1 GVR, and server-side apply rejects
+	// a patch whose apiVersion disagrees with the endpoint's ("Incorrect version
+	// specified in apply patch" — apimachinery structuredmerge). A mismatch here
+	// fails the apply mid-migration, which is exactly what this gate exists to
+	// prevent, so both halves are refusals.
 	apiVersion, _ := stringField(cr.obj, "apiVersion")
 	group, version := splitAPIVersion(apiVersion)
 	switch {
 	case group != GatewayGroup:
 		f.problem("the %s gateway CR has apiVersion %q, expected group %q", cr.role, apiVersion, GatewayGroup)
 	case version != GatewayVersion:
-		// kcp applies through the pinned v1beta1 GVR whatever the file declares,
-		// so the declared version is quietly ignored — worth surfacing, but not
-		// worth refusing a migration over.
-		f.warn("the %s gateway CR declares apiVersion %q but kcp applies it as %s/%s", cr.role, apiVersion, GatewayGroup, GatewayVersion)
+		f.problem("the %s gateway CR declares apiVersion %q, but kcp applies gateways as %s/%s and the API server refuses an apply whose version disagrees", cr.role, apiVersion, GatewayGroup, GatewayVersion)
 	}
 
 	if spec, ok := mapField(cr.obj, "spec"); !ok || len(spec) == 0 {
@@ -195,15 +198,29 @@ func checkGatewayShape(cr gatewayCR, f *findings) {
 // ApplyGatewayYAML calls SetName/SetNamespace with the migration's target, so a
 // file for a different gateway is not rejected — it is silently applied over
 // this one.
+//
+// Only a value that is present and *wrong* is a refusal: an absent name or
+// namespace is the one ApplyGatewayYAML fills in, so a CR file that omits it
+// works today and must keep working.
 func checkGatewayIdentity(cr gatewayCR, namespace, gatewayName string, f *findings) {
 	metadata, _ := mapField(cr.obj, "metadata")
 
-	if name, _ := stringField(metadata, "name"); name != gatewayName {
+	if name, ok := stringField(metadata, "name"); ok && name != "" && name != gatewayName {
 		f.problem("the %s gateway CR is named %q but the migration targets gateway %q (kcp would apply this file under the target name)", cr.role, name, gatewayName)
 	}
 
-	if ns, ok := stringField(metadata, "namespace"); ok && ns != namespace {
+	if ns, ok := stringField(metadata, "namespace"); ok && ns != "" && ns != namespace {
 		f.problem("the %s gateway CR declares namespace %q but the migration targets namespace %q", cr.role, ns, namespace)
+	}
+
+	// managedFields is the fingerprint of a file produced by `kubectl get -o
+	// yaml`. Deriving the switchover CR that way is a natural workflow, but
+	// client-go refuses to apply such an object outright ("cannot apply an object
+	// with managed fields already set"), before any request leaves the process —
+	// so the apply would fail after the fence, with clients already blocked.
+	// unfenceGateway strips this same metadata for the same reason.
+	if _, present := metadata["managedFields"]; present {
+		f.problem("the %s gateway CR carries metadata.managedFields, which server-side apply refuses; it looks like `kubectl get -o yaml` output — strip managedFields, resourceVersion, uid, creationTimestamp and status", cr.role)
 	}
 }
 
@@ -219,11 +236,11 @@ func checkGatewayIdentity(cr gatewayCR, namespace, gatewayName string, f *findin
 // while leaving another serving — the SCRAM pre-registration route in
 // docs/assets/gateway-switchover stays available throughout.
 func checkFenceBlocks(fenced, switchover gatewayCR, f *findings) {
-	fencedRoutes, routesPresent := fencedRouteNames(fenced)
+	fencedList, routesPresent := fencedRoutes(fenced)
 	switch {
-	case len(fencedRoutes) > 0:
-		// The fenced CR blocks at least one named route — nothing to report.
-	case treeContainsKey(fenced.obj, "fence"):
+	case len(fencedList) > 0:
+		// The fenced CR blocks at least one route — nothing to report.
+	case treeContainsNonNilKey(fenced.obj, "fence"):
 		// A fence exists somewhere kcp cannot attribute to a route. Don't refuse:
 		// the CRD may grow other placements. Say only what is true — that the
 		// fence could not be confirmed.
@@ -234,18 +251,27 @@ func checkFenceBlocks(fenced, switchover gatewayCR, f *findings) {
 		f.problem("the fenced gateway CR contains no fence block, so applying it would not block client traffic — the migration would promote topics while producers are still writing to the source")
 	}
 
-	fencedSet := make(map[string]struct{}, len(fencedRoutes))
-	for _, route := range fencedRoutes {
-		fencedSet[route] = struct{}{}
+	fencedSet := make(map[string]struct{}, len(fencedList))
+	for _, route := range fencedList {
+		if route.matchable {
+			fencedSet[route.identity] = struct{}{}
+		}
 	}
 
-	switchoverRoutes, _ := fencedRouteNames(switchover)
-	var stillFenced, otherFenced []string
-	for _, route := range switchoverRoutes {
-		if _, migrationRoute := fencedSet[route]; migrationRoute {
-			stillFenced = append(stillFenced, route)
-		} else {
-			otherFenced = append(otherFenced, route)
+	switchoverList, _ := fencedRoutes(switchover)
+	var stillFenced, otherFenced, unmatchable []string
+	for _, route := range switchoverList {
+		switch {
+		case !route.matchable:
+			// Neither a name nor an endpoint: there is nothing to match this
+			// against in the fenced CR, so claiming either outcome would be a
+			// guess. Positional matching is not a substitute — the two files
+			// routinely hold different numbers of routes.
+			unmatchable = append(unmatchable, route.label)
+		case containsKey(fencedSet, route.identity):
+			stillFenced = append(stillFenced, route.label)
+		default:
+			otherFenced = append(otherFenced, route.label)
 		}
 	}
 
@@ -257,6 +283,15 @@ func checkFenceBlocks(fenced, switchover gatewayCR, f *findings) {
 	if len(otherFenced) > 0 {
 		f.warn("the switchover gateway CR fences route(s) the migration does not fence (%s); clients on those routes will be blocked after switchover", strings.Join(otherFenced, ", "))
 	}
+	if len(unmatchable) > 0 {
+		f.warn("the switchover gateway CR fences route(s) with neither a name nor an endpoint (%s), so kcp cannot tell whether they are the route(s) the migration fenced; confirm by hand that switchover lifts the fence", strings.Join(unmatchable, ", "))
+	}
+}
+
+// containsKey is a readability shim for set membership in a switch arm.
+func containsKey[V any](set map[string]V, key string) bool {
+	_, found := set[key]
+	return found
 }
 
 // checkSpecsDiffer catches the wrong-file mistakes that yield a "successful"
@@ -367,9 +402,19 @@ func checkStreamingDomainWiring(cr gatewayCR, f *findings) {
 // CRD keeps growing new ones. A path-based collector would silently stop
 // covering the field that matters.
 var secretRefKeys = map[string]struct{}{
-	"secretRef":       {},
-	"configSecretRef": {},
+	"secretRef":            {},
+	"configSecretRef":      {},
+	"clientCredentialsRef": {},
 }
+
+// unrecognisedRefKeySuffix is the naming convention every Secret-naming field in
+// the Gateway CRD follows. A string field matching it that is not in
+// secretRefKeys is a field this validator does not know about: report it rather
+// than let the gap sit behind a tick claiming the secrets were checked.
+//
+// clientCredentialsRef was found this way — it names a Secret in four of the
+// shipped switchover examples and was silently unchecked.
+const unrecognisedRefKeySuffix = "Ref"
 
 // checkSecretRefsExist confirms every Secret the fenced and switchover CRs
 // reference already exists in the namespace. This is the check that would have
@@ -384,9 +429,18 @@ var secretRefKeys = map[string]struct{}{
 // confirmed NotFound refuses.
 func checkSecretRefsExist(ctx context.Context, clientset kubernetes.Interface, namespace string, crs []gatewayCR, result *CRValidationResult, f *findings) {
 	refs := map[string]struct{}{}
+	unrecognised := map[string]struct{}{}
 	for _, cr := range crs {
-		collectSecretRefs(cr.obj, refs)
+		collectSecretRefs(cr.obj, refs, unrecognised)
 	}
+
+	// A Ref-suffixed field this validator does not know is a hole in the check,
+	// not a detail: say so rather than let the reported count imply completeness.
+	if len(unrecognised) > 0 {
+		f.warn("the fenced/switchover gateway CRs use reference field(s) kcp does not know how to check: %s — any Kubernetes secret they name is not verified",
+			describeSet(unrecognised))
+	}
+
 	if len(refs) == 0 {
 		slog.Debug("no secret references found in gateway CRs", "namespace", namespace)
 		return
@@ -432,31 +486,95 @@ func checkSecretRefsExist(ctx context.Context, clientset kubernetes.Interface, n
 }
 
 // collectSecretRefs walks an arbitrary CR subtree collecting the names of the
-// Secrets it references. A secretRef whose value is not a string is descended
-// into rather than recorded, so a future object-valued form still gets walked.
-func collectSecretRefs(v any, into map[string]struct{}) {
+// Secrets it references, plus any Ref-suffixed field it does not recognise.
+//
+// A known ref key whose value is not a string is descended into rather than
+// recorded, so a future object-valued form still gets walked.
+func collectSecretRefs(v any, into, unrecognised map[string]struct{}) {
+	collectSecretRefsGuarded(v, into, unrecognised, walkGuard{})
+}
+
+func collectSecretRefsGuarded(v any, into, unrecognised map[string]struct{}, guard walkGuard) {
+	if guard.seen(v) {
+		return
+	}
 	switch node := v.(type) {
 	case map[string]any:
 		for key, child := range node {
-			if _, isRef := secretRefKeys[key]; isRef {
-				if name, ok := child.(string); ok && name != "" {
+			name, isString := child.(string)
+			if _, known := secretRefKeys[key]; known {
+				if isString && name != "" {
 					into[name] = struct{}{}
 					continue
 				}
+			} else if isString && strings.HasSuffix(key, unrecognisedRefKeySuffix) {
+				unrecognised[key] = struct{}{}
 			}
-			collectSecretRefs(child, into)
+			collectSecretRefsGuarded(child, into, unrecognised, guard)
 		}
 	case []any:
 		for _, child := range node {
-			collectSecretRefs(child, into)
+			collectSecretRefsGuarded(child, into, unrecognised, guard)
 		}
 	}
 }
 
-// fencedRouteNames returns the names of spec.routes entries carrying a fence
-// block, and whether spec.routes was present at all — "no routes" and "routes
-// but none fenced" are different failures.
-func fencedRouteNames(cr gatewayCR) (fenced []string, routesPresent bool) {
+// walkGuard records the composite nodes a tree walk has already visited.
+//
+// YAML aliases let a sub-kilobyte document describe an astronomically large
+// logical tree (an "anchor bomb"): goccy/go-yaml resolves an alias by *sharing*
+// the anchored node rather than copying it, so parsing stays cheap while a naive
+// recursive walk traverses the fully expanded graph and effectively never
+// returns — a ~700 byte CR file was measured at 12 seconds and a ~850 byte one
+// at hours, on a flat 3 MB heap, with no way to interrupt it. Skipping nodes
+// already visited collapses the walk back to the parsed document's real size: an
+// alias pointing at a node we have already walked cannot contribute anything new.
+type walkGuard map[uintptr]struct{}
+
+// seen reports whether node has been walked before, recording it if not. Only
+// non-empty maps and slices are tracked: scalars carry no identity worth
+// deduplicating, and Go may hand distinct empty composites the same backing
+// pointer (which would wrongly collapse them — harmless here, since an empty
+// node has nothing to walk, but not worth relying on).
+func (g walkGuard) seen(node any) bool {
+	v := reflect.ValueOf(node)
+	switch v.Kind() {
+	case reflect.Map, reflect.Slice:
+		if v.Len() == 0 {
+			return false
+		}
+	default:
+		return false
+	}
+
+	ptr := v.Pointer()
+	if _, visited := g[ptr]; visited {
+		return true
+	}
+	g[ptr] = struct{}{}
+	return false
+}
+
+// routeFence is one fenced route: an identity that can be matched across two
+// separate CR files, and a label to call it in a finding.
+//
+// Position cannot serve as the identity — the fenced and switchover CRs routinely
+// hold different numbers of routes (the switchover examples drop the source
+// domain's route entirely), so routes[0] in one file is not routes[0] in the
+// other. A route name is the identity when present; failing that the endpoint it
+// serves, which is what actually distinguishes routes in the shipped examples
+// (port 9595 for clients, 9599 for SCRAM pre-registration). With neither, the
+// route cannot be matched across files at all and matchable is false.
+type routeFence struct {
+	identity  string
+	label     string
+	matchable bool
+}
+
+// fencedRoutes returns the spec.routes entries carrying a fence block, and
+// whether spec.routes was present at all — "no routes" and "routes but none
+// fenced" are different failures.
+func fencedRoutes(cr gatewayCR) (fenced []routeFence, routesPresent bool) {
 	spec, _ := mapField(cr.obj, "spec")
 	routes, ok := sliceField(spec, "routes")
 	if !ok {
@@ -468,30 +586,54 @@ func fencedRouteNames(cr gatewayCR) (fenced []string, routesPresent bool) {
 		if !ok {
 			continue
 		}
-		if _, hasFence := route["fence"]; !hasFence {
+		// `fence: null` is how a scripted edit (yq, kustomize) removes a fence —
+		// server-side apply deletes a nulled field — so an explicit null is not a
+		// fence. Counting it as one would refuse a switchover CR that works.
+		// An empty `fence: {}` still counts: the CRD's own defaults may apply.
+		if fence, hasFence := route["fence"]; !hasFence || fence == nil {
 			continue
 		}
-		fenced = append(fenced, routeLabel(route, i))
+
+		entry := routeFence{label: routeLabel(route, i)}
+		if name, ok := stringField(route, "name"); ok && name != "" {
+			entry.identity, entry.matchable = "name="+name, true
+		} else if endpoint, ok := stringField(route, "endpoint"); ok && endpoint != "" {
+			entry.identity, entry.matchable = "endpoint="+endpoint, true
+			entry.label = fmt.Sprintf("%s (endpoint %s)", entry.label, endpoint)
+		}
+		fenced = append(fenced, entry)
 	}
-	slices.Sort(fenced)
+
+	slices.SortFunc(fenced, func(a, b routeFence) int { return strings.Compare(a.label, b.label) })
 	return fenced, true
 }
 
-// treeContainsKey reports whether key appears anywhere in the subtree.
-func treeContainsKey(v any, key string) bool {
+// treeContainsNonNilKey reports whether key appears anywhere in the subtree with
+// a value that is not null. Null is excluded for the same reason fencedRoutes
+// ignores `fence: null` — an explicitly nulled field is a field being removed,
+// not a field being set. Guarded against alias amplification for the same reason
+// as collectSecretRefs.
+func treeContainsNonNilKey(v any, key string) bool {
+	return treeContainsNonNilKeyGuarded(v, key, walkGuard{})
+}
+
+func treeContainsNonNilKeyGuarded(v any, key string, guard walkGuard) bool {
+	if guard.seen(v) {
+		return false
+	}
 	switch node := v.(type) {
 	case map[string]any:
-		if _, found := node[key]; found {
+		if value, found := node[key]; found && value != nil {
 			return true
 		}
 		for _, child := range node {
-			if treeContainsKey(child, key) {
+			if treeContainsNonNilKeyGuarded(child, key, guard) {
 				return true
 			}
 		}
 	case []any:
 		for _, child := range node {
-			if treeContainsKey(child, key) {
+			if treeContainsNonNilKeyGuarded(child, key, guard) {
 				return true
 			}
 		}
@@ -529,8 +671,8 @@ func splitAPIVersion(apiVersion string) (group, version string) {
 
 // The CR tree is untyped YAML, so these read one level with a type assertion
 // instead of unstructured.Nested*: those deep-copy the subtree through
-// runtime.DeepCopyJSONValue, which panics on the plain ints goccy/go-yaml
-// produces for fields like nodeIdRanges.start.
+// runtime.DeepCopyJSONValue, which panics on the uint64 goccy/go-yaml produces
+// for a positive integer like nodeIdRanges.start (it tolerates int64 only).
 
 func mapField(m map[string]any, key string) (map[string]any, bool) {
 	v, ok := m[key].(map[string]any)

--- a/internal/services/gateway/validate.go
+++ b/internal/services/gateway/validate.go
@@ -1,0 +1,548 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// The three roles a gateway CR plays in a migration. Used to name the offending
+// file in findings, so an operator knows which flag to go and fix.
+const (
+	roleInitial    = "initial"
+	roleFenced     = "fenced"
+	roleSwitchover = "switchover"
+)
+
+// CRValidationResult records what ValidateGatewayCRs actually verified, so the
+// caller can report the outcome truthfully instead of printing a tick that only
+// means "the function returned".
+type CRValidationResult struct {
+	// SecretRefsChecked is how many distinct secret references were confirmed
+	// present in the namespace. Zero with an empty SecretCheckSkipped means the
+	// CRs reference no secrets.
+	SecretRefsChecked int
+	// SecretCheckSkipped is non-empty when the live secret lookup could not run,
+	// and carries the reason. The static checks still ran.
+	SecretCheckSkipped string
+	// Warnings are non-fatal findings the operator should see. They do not block
+	// the migration.
+	Warnings []string
+}
+
+// findings accumulates validation output. A problem blocks the migration; a
+// warning is surfaced to the operator but lets it proceed. Checks append rather
+// than return early so one run reports every fixable issue instead of making the
+// operator re-run to discover the next one.
+type findings struct {
+	problems []string
+	warnings []string
+}
+
+func (f *findings) problem(format string, a ...any) {
+	f.problems = append(f.problems, fmt.Sprintf(format, a...))
+}
+
+func (f *findings) warn(format string, a ...any) {
+	f.warnings = append(f.warnings, fmt.Sprintf(format, a...))
+}
+
+// gatewayCR is a parsed gateway CR tagged with the role it plays.
+type gatewayCR struct {
+	role string
+	obj  map[string]any
+}
+
+// ValidateGatewayCRs checks the initial, fenced and switchover gateway CRs
+// before a migration starts. It is a pre-flight gate: everything it catches
+// would otherwise surface mid-migration, after client traffic has been fenced,
+// when the only way out is a rollback.
+//
+// Most checks are static, but the one that matters most is not — confirming the
+// secrets the CRs reference actually exist needs a live namespace lookup. That
+// is why this takes a ctx and a namespace: on 2026-07-27 a switchover CR named
+// a Secret that did not exist, the operator refused the spec, and the gateway
+// stayed fenced with every client blocked. Nothing ahead of the apply looked at
+// that secret at all; this does, before any client traffic has been touched.
+func (s *K8sService) ValidateGatewayCRs(ctx context.Context, namespace, gatewayName string, initialYAML, fencedYAML, switchoverYAML []byte) (CRValidationResult, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", s.kubeConfigPath)
+	if err != nil {
+		return CRValidationResult{}, fmt.Errorf("failed to build config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return CRValidationResult{}, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	return validateGatewayCRs(ctx, clientset, namespace, gatewayName, initialYAML, fencedYAML, switchoverYAML)
+}
+
+// validateGatewayCRs is the inner orchestration used by ValidateGatewayCRs.
+// Split from the method so unit tests can inject a fake clientset, matching
+// waitForGatewayPods and waitForGatewayReady.
+func validateGatewayCRs(ctx context.Context, clientset kubernetes.Interface, namespace, gatewayName string, initialYAML, fencedYAML, switchoverYAML []byte) (CRValidationResult, error) {
+	var result CRValidationResult
+
+	// Parsing is terminal rather than one problem among many: every later check
+	// reads the parsed tree, so there is nothing useful left to report.
+	initial, err := parseGatewayCR(roleInitial, initialYAML)
+	if err != nil {
+		return result, err
+	}
+	fenced, err := parseGatewayCR(roleFenced, fencedYAML)
+	if err != nil {
+		return result, err
+	}
+	switchover, err := parseGatewayCR(roleSwitchover, switchoverYAML)
+	if err != nil {
+		return result, err
+	}
+
+	var f findings
+
+	for _, cr := range []gatewayCR{initial, fenced, switchover} {
+		checkGatewayShape(cr, &f)
+	}
+
+	// The initial CR is fetched from the cluster by name, so its identity and
+	// wiring are correct by construction and the operator has already accepted
+	// its spec — checking it again would only add noise.
+	for _, cr := range []gatewayCR{fenced, switchover} {
+		checkGatewayIdentity(cr, namespace, gatewayName, &f)
+		checkStreamingDomainWiring(cr, &f)
+	}
+
+	checkFenceBlocks(fenced, switchover, &f)
+	checkSpecsDiffer(initial, fenced, switchover, &f)
+	checkSecretRefsExist(ctx, clientset, namespace, []gatewayCR{fenced, switchover}, &result, &f)
+
+	// Findings reach the terminal through the caller's reporter (which mirrors
+	// them into kcp.log), and the returned error is logged by main. Logging them
+	// again here would double every line on the console, so these stay at Debug.
+	result.Warnings = f.warnings
+
+	if len(f.problems) > 0 {
+		slog.Debug("gateway CR validation found problems",
+			"namespace", namespace, "gateway", gatewayName,
+			"problems", f.problems, "warnings", f.warnings)
+		return result, fmt.Errorf("%d problem(s) found:\n  - %s", len(f.problems), strings.Join(f.problems, "\n  - "))
+	}
+
+	slog.Debug("gateway CRs validated",
+		"namespace", namespace, "gateway", gatewayName,
+		"secretRefsChecked", result.SecretRefsChecked,
+		"secretCheckSkipped", result.SecretCheckSkipped,
+		"warnings", f.warnings)
+	return result, nil
+}
+
+// parseGatewayCR unmarshals one CR, keeping the role for error messages.
+func parseGatewayCR(role string, data []byte) (gatewayCR, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return gatewayCR{}, fmt.Errorf("the %s gateway CR is empty", role)
+	}
+
+	var obj map[string]any
+	if err := yaml.Unmarshal(data, &obj); err != nil {
+		return gatewayCR{}, fmt.Errorf("failed to parse the %s gateway CR: %w", role, err)
+	}
+	if len(obj) == 0 {
+		return gatewayCR{}, fmt.Errorf("the %s gateway CR contains no fields", role)
+	}
+
+	return gatewayCR{role: role, obj: obj}, nil
+}
+
+// checkGatewayShape confirms the file is a Confluent Gateway CR with a spec.
+// ApplyGatewayYAML pushes whatever it is handed through the pinned Gateway GVR
+// and overwrites name and namespace, so a Deployment or a Kafka CR passed to
+// --fenced-cr-yaml would be applied *as* this gateway.
+func checkGatewayShape(cr gatewayCR, f *findings) {
+	if kind, _ := stringField(cr.obj, "kind"); kind != GatewayKind {
+		f.problem("the %s gateway CR has kind %q, expected %q", cr.role, kind, GatewayKind)
+	}
+
+	apiVersion, _ := stringField(cr.obj, "apiVersion")
+	group, version := splitAPIVersion(apiVersion)
+	switch {
+	case group != GatewayGroup:
+		f.problem("the %s gateway CR has apiVersion %q, expected group %q", cr.role, apiVersion, GatewayGroup)
+	case version != GatewayVersion:
+		// kcp applies through the pinned v1beta1 GVR whatever the file declares,
+		// so the declared version is quietly ignored — worth surfacing, but not
+		// worth refusing a migration over.
+		f.warn("the %s gateway CR declares apiVersion %q but kcp applies it as %s/%s", cr.role, apiVersion, GatewayGroup, GatewayVersion)
+	}
+
+	if spec, ok := mapField(cr.obj, "spec"); !ok || len(spec) == 0 {
+		f.problem("the %s gateway CR has no spec", cr.role)
+	}
+}
+
+// checkGatewayIdentity confirms a CR names the gateway the migration targets.
+// ApplyGatewayYAML calls SetName/SetNamespace with the migration's target, so a
+// file for a different gateway is not rejected — it is silently applied over
+// this one.
+func checkGatewayIdentity(cr gatewayCR, namespace, gatewayName string, f *findings) {
+	metadata, _ := mapField(cr.obj, "metadata")
+
+	if name, _ := stringField(metadata, "name"); name != gatewayName {
+		f.problem("the %s gateway CR is named %q but the migration targets gateway %q (kcp would apply this file under the target name)", cr.role, name, gatewayName)
+	}
+
+	if ns, ok := stringField(metadata, "namespace"); ok && ns != namespace {
+		f.problem("the %s gateway CR declares namespace %q but the migration targets namespace %q", cr.role, ns, namespace)
+	}
+}
+
+// checkFenceBlocks confirms the fenced CR actually fences, and that the
+// switchover CR lifts the fence it applied.
+//
+// Both failures are silent in the same way: the migration runs to completion and
+// reports success. Without a fence, topics are promoted while producers are
+// still writing to the source. With a fence left in the switchover CR, every
+// client stays blocked after kcp declares the migration complete.
+//
+// Fences are tracked per route because a gateway legitimately fences one route
+// while leaving another serving — the SCRAM pre-registration route in
+// docs/assets/gateway-switchover stays available throughout.
+func checkFenceBlocks(fenced, switchover gatewayCR, f *findings) {
+	fencedRoutes, routesPresent := fencedRouteNames(fenced)
+	switch {
+	case len(fencedRoutes) > 0:
+		// The fenced CR blocks at least one named route — nothing to report.
+	case treeContainsKey(fenced.obj, "fence"):
+		// A fence exists somewhere kcp cannot attribute to a route. Don't refuse:
+		// the CRD may grow other placements. Say only what is true — that the
+		// fence could not be confirmed.
+		f.warn("the fenced gateway CR has a fence block that is not on a route, so kcp cannot confirm which routes it blocks")
+	case !routesPresent:
+		f.problem("the fenced gateway CR declares no spec.routes, so it cannot fence client traffic")
+	default:
+		f.problem("the fenced gateway CR contains no fence block, so applying it would not block client traffic — the migration would promote topics while producers are still writing to the source")
+	}
+
+	fencedSet := make(map[string]struct{}, len(fencedRoutes))
+	for _, route := range fencedRoutes {
+		fencedSet[route] = struct{}{}
+	}
+
+	switchoverRoutes, _ := fencedRouteNames(switchover)
+	var stillFenced, otherFenced []string
+	for _, route := range switchoverRoutes {
+		if _, migrationRoute := fencedSet[route]; migrationRoute {
+			stillFenced = append(stillFenced, route)
+		} else {
+			otherFenced = append(otherFenced, route)
+		}
+	}
+
+	if len(stillFenced) > 0 {
+		f.problem("the switchover gateway CR still fences the route(s) the fenced CR blocks (%s), so clients would stay blocked after switchover", strings.Join(stillFenced, ", "))
+	}
+	// kcp cannot know the intent behind fencing a route the migration never
+	// fenced — it may be deliberate — so this warns rather than refuses.
+	if len(otherFenced) > 0 {
+		f.warn("the switchover gateway CR fences route(s) the migration does not fence (%s); clients on those routes will be blocked after switchover", strings.Join(otherFenced, ", "))
+	}
+}
+
+// checkSpecsDiffer catches the wrong-file mistakes that yield a "successful"
+// migration with nothing switched over: the same file passed to both flags, or
+// the live gateway's own spec handed back as the switchover. Either way the
+// apply is a no-op, which does not bump metadata.generation, so even
+// WaitForGatewayAccepted returns immediately and the step reports success.
+//
+// Only exact equality is reported. The live initial CR carries operator defaults
+// the user's file omits, so a *difference* from it proves nothing — this is a
+// cheap identity test, not a diff.
+func checkSpecsDiffer(initial, fenced, switchover gatewayCR, f *findings) {
+	initialSpec, _ := mapField(initial.obj, "spec")
+	fencedSpec, _ := mapField(fenced.obj, "spec")
+	switchoverSpec, _ := mapField(switchover.obj, "spec")
+
+	// A missing spec is already reported by checkGatewayShape; comparing absent
+	// specs here would only produce a second, misleading finding.
+	if len(switchoverSpec) == 0 {
+		return
+	}
+
+	if len(fencedSpec) > 0 && reflect.DeepEqual(fencedSpec, switchoverSpec) {
+		f.problem("the fenced and switchover gateway CRs have identical specs, so the switchover would change nothing (are --fenced-cr-yaml and --switchover-cr-yaml the same file?)")
+	}
+	if len(initialSpec) > 0 && reflect.DeepEqual(initialSpec, switchoverSpec) {
+		f.problem("the switchover gateway CR spec is identical to the live gateway's, so the switchover would not route traffic to Confluent Cloud")
+	}
+}
+
+// checkStreamingDomainWiring confirms each route points at a streaming domain
+// the same CR declares, and at a bootstrap server id that domain defines. The
+// operator rejects a dangling reference — but not until the CR is applied, i.e.
+// mid-migration.
+//
+// Only what the file states is checked: a route with no streamingDomain, or a
+// domain reference with no bootstrapServerId, is left alone rather than assumed
+// mandatory.
+func checkStreamingDomainWiring(cr gatewayCR, f *findings) {
+	spec, _ := mapField(cr.obj, "spec")
+
+	// domain name -> the bootstrap server ids it defines
+	domains := map[string]map[string]struct{}{}
+	rawDomains, _ := sliceField(spec, "streamingDomains")
+	for _, raw := range rawDomains {
+		domain, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := stringField(domain, "name")
+		if !ok {
+			continue
+		}
+		ids := map[string]struct{}{}
+		cluster, _ := mapField(domain, "kafkaCluster")
+		servers, _ := sliceField(cluster, "bootstrapServers")
+		for _, rawServer := range servers {
+			server, ok := rawServer.(map[string]any)
+			if !ok {
+				continue
+			}
+			if id, ok := stringField(server, "id"); ok {
+				ids[id] = struct{}{}
+			}
+		}
+		domains[name] = ids
+	}
+
+	routes, _ := sliceField(spec, "routes")
+	for i, raw := range routes {
+		route, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		ref, ok := mapField(route, "streamingDomain")
+		if !ok {
+			continue
+		}
+		domainName, ok := stringField(ref, "name")
+		if !ok || domainName == "" {
+			continue
+		}
+
+		ids, declared := domains[domainName]
+		if !declared {
+			f.problem("in the %s gateway CR, route %s points at streaming domain %q, which the CR does not declare (declared: %s)",
+				cr.role, routeLabel(route, i), domainName, describeSet(domains))
+			continue
+		}
+
+		id, ok := stringField(ref, "bootstrapServerId")
+		if !ok || id == "" {
+			continue
+		}
+		if _, defined := ids[id]; !defined {
+			f.problem("in the %s gateway CR, route %s points at bootstrapServerId %q, which streaming domain %q does not define (defined: %s)",
+				cr.role, routeLabel(route, i), id, domainName, describeSet(ids))
+		}
+	}
+}
+
+// secretRefKeys are the CRD fields that name a Kubernetes Secret.
+//
+// These are collected by walking the whole CR rather than by fixed paths: across
+// the worked examples in docs/assets/gateway-switchover they appear at six
+// different depths (secret stores, per-bootstrap-server TLS, route client and
+// cluster authentication, SCRAM admin credentials, JAAS pass-through), and the
+// CRD keeps growing new ones. A path-based collector would silently stop
+// covering the field that matters.
+var secretRefKeys = map[string]struct{}{
+	"secretRef":       {},
+	"configSecretRef": {},
+}
+
+// checkSecretRefsExist confirms every Secret the fenced and switchover CRs
+// reference already exists in the namespace. This is the check that would have
+// caught the 2026-07-27 failure.
+//
+// The live initial CR is excluded: it is already running, so its references
+// resolve by construction.
+//
+// Reading Secrets is a privilege plenty of migration operators are not granted,
+// and this validation is new — a denial must not block a migration that would
+// otherwise succeed. So a denial downgrades to a recorded skip, and only a
+// confirmed NotFound refuses.
+func checkSecretRefsExist(ctx context.Context, clientset kubernetes.Interface, namespace string, crs []gatewayCR, result *CRValidationResult, f *findings) {
+	refs := map[string]struct{}{}
+	for _, cr := range crs {
+		collectSecretRefs(cr.obj, refs)
+	}
+	if len(refs) == 0 {
+		slog.Debug("no secret references found in gateway CRs", "namespace", namespace)
+		return
+	}
+
+	names := slices.Sorted(maps.Keys(refs))
+	slog.Debug("🔍 checking gateway CR secret references", "namespace", namespace, "count", len(names), "secrets", names)
+
+	var missing []string
+	for _, name := range names {
+		_, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			result.SecretRefsChecked++
+			slog.Debug("gateway CR secret reference resolved", "namespace", namespace, "secret", name)
+			continue
+		}
+		// Every absent secret is collected rather than returned on: fixing them
+		// one re-run at a time is the loop this check exists to avoid.
+		if apierrors.IsNotFound(err) {
+			missing = append(missing, name)
+			continue
+		}
+		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+			// Report a partial count as no count: "3 of 7 verified" reads as a
+			// pass. Any NotFound already seen is still reported below.
+			result.SecretRefsChecked = 0
+			result.SecretCheckSkipped = fmt.Sprintf("no permission to read secrets in namespace %s", namespace)
+			// The skip itself is reported by the caller; this carries the raw API
+			// error the reported line cannot.
+			slog.Debug("⏭️ cannot verify gateway CR secret references", "namespace", namespace, "secret", name, "error", err)
+			break
+		}
+		// Neither absent nor denied — the API is not answering, so stop instead
+		// of reporting a partial sweep as a complete one.
+		f.problem("failed to check whether secret %q exists in namespace %s: %v", name, namespace, err)
+		break
+	}
+
+	if len(missing) > 0 {
+		f.problem("the fenced/switchover gateway CRs reference %d secret(s) that do not exist in namespace %s: %s — the Confluent operator will refuse the spec and the gateway will stay fenced",
+			len(missing), namespace, strings.Join(missing, ", "))
+	}
+}
+
+// collectSecretRefs walks an arbitrary CR subtree collecting the names of the
+// Secrets it references. A secretRef whose value is not a string is descended
+// into rather than recorded, so a future object-valued form still gets walked.
+func collectSecretRefs(v any, into map[string]struct{}) {
+	switch node := v.(type) {
+	case map[string]any:
+		for key, child := range node {
+			if _, isRef := secretRefKeys[key]; isRef {
+				if name, ok := child.(string); ok && name != "" {
+					into[name] = struct{}{}
+					continue
+				}
+			}
+			collectSecretRefs(child, into)
+		}
+	case []any:
+		for _, child := range node {
+			collectSecretRefs(child, into)
+		}
+	}
+}
+
+// fencedRouteNames returns the names of spec.routes entries carrying a fence
+// block, and whether spec.routes was present at all — "no routes" and "routes
+// but none fenced" are different failures.
+func fencedRouteNames(cr gatewayCR) (fenced []string, routesPresent bool) {
+	spec, _ := mapField(cr.obj, "spec")
+	routes, ok := sliceField(spec, "routes")
+	if !ok {
+		return nil, false
+	}
+
+	for i, raw := range routes {
+		route, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasFence := route["fence"]; !hasFence {
+			continue
+		}
+		fenced = append(fenced, routeLabel(route, i))
+	}
+	slices.Sort(fenced)
+	return fenced, true
+}
+
+// treeContainsKey reports whether key appears anywhere in the subtree.
+func treeContainsKey(v any, key string) bool {
+	switch node := v.(type) {
+	case map[string]any:
+		if _, found := node[key]; found {
+			return true
+		}
+		for _, child := range node {
+			if treeContainsKey(child, key) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range node {
+			if treeContainsKey(child, key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// routeLabel names a route for a finding, falling back to its index when the
+// route has no name.
+func routeLabel(route map[string]any, index int) string {
+	if name, ok := stringField(route, "name"); ok && name != "" {
+		return name
+	}
+	return fmt.Sprintf("routes[%d]", index)
+}
+
+// describeSet renders a set's keys for a finding, so an operator can see what
+// the CR does declare next to what the route asked for.
+func describeSet[V any](set map[string]V) string {
+	names := slices.Sorted(maps.Keys(set))
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
+}
+
+// splitAPIVersion splits "group/version" into its parts. A bare version (no
+// slash) belongs to the core group, which no Gateway CR does.
+func splitAPIVersion(apiVersion string) (group, version string) {
+	if group, version, found := strings.Cut(apiVersion, "/"); found {
+		return group, version
+	}
+	return "", apiVersion
+}
+
+// The CR tree is untyped YAML, so these read one level with a type assertion
+// instead of unstructured.Nested*: those deep-copy the subtree through
+// runtime.DeepCopyJSONValue, which panics on the plain ints goccy/go-yaml
+// produces for fields like nodeIdRanges.start.
+
+func mapField(m map[string]any, key string) (map[string]any, bool) {
+	v, ok := m[key].(map[string]any)
+	return v, ok
+}
+
+func sliceField(m map[string]any, key string) ([]any, bool) {
+	v, ok := m[key].([]any)
+	return v, ok
+}
+
+func stringField(m map[string]any, key string) (string, bool) {
+	v, ok := m[key].(string)
+	return v, ok
+}

--- a/internal/services/gateway/validate_test.go
+++ b/internal/services/gateway/validate_test.go
@@ -1,0 +1,708 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// ===========================================================================
+// Test fixtures
+//
+// A realistic trio modelled on docs/assets/gateway-switchover: the initial CR
+// routes to the source cluster, the fenced CR adds a fence to that route, and
+// the switchover CR drops the source domain and routes to Confluent Cloud.
+//
+// Secret references are spread across three depths on purpose (secret store
+// config, per-bootstrap-server TLS, route cluster authentication) and
+// vault-config is referenced by both CRs so deduplication is exercised.
+// nodeIdRanges carries plain ints, which is what makes the tree unsafe to walk
+// with unstructured.Nested* — see mapField's comment.
+// ===========================================================================
+
+const (
+	testNamespace = "kcp"
+	testGateway   = "migration-gateway"
+)
+
+const initialCR = `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 3
+  secretStores:
+    - name: vault-store
+      provider:
+        type: Vault
+        configSecretRef: vault-config
+  streamingDomains:
+    - name: source-kafka-cluster
+      type: kafka
+      kafkaCluster:
+        bootstrapServers:
+          - id: SCRAM
+            endpoint: SASL_SSL://msk:9096
+            tls:
+              secretRef: msk-tls
+        nodeIdRanges:
+          - name: pool-1
+            start: 1
+            end: 3
+  routes:
+    - name: migration-route
+      endpoint: gateway:9595
+      streamingDomain:
+        name: source-kafka-cluster
+        bootstrapServerId: SCRAM
+      security:
+        auth: passthrough
+`
+
+const fencedCR = `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 3
+  secretStores:
+    - name: vault-store
+      provider:
+        type: Vault
+        configSecretRef: vault-config
+  streamingDomains:
+    - name: source-kafka-cluster
+      type: kafka
+      kafkaCluster:
+        bootstrapServers:
+          - id: SCRAM
+            endpoint: SASL_SSL://msk:9096
+            tls:
+              secretRef: msk-tls
+        nodeIdRanges:
+          - name: pool-1
+            start: 1
+            end: 3
+  routes:
+    - name: migration-route
+      endpoint: gateway:9595
+      fence:
+        scope: ALL
+        errorCode: BROKER_NOT_AVAILABLE
+      streamingDomain:
+        name: source-kafka-cluster
+        bootstrapServerId: SCRAM
+      security:
+        auth: passthrough
+`
+
+const switchoverCR = `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 3
+  secretStores:
+    - name: vault-store
+      provider:
+        type: Vault
+        configSecretRef: vault-config
+  streamingDomains:
+    - name: confluent-cloud
+      type: kafka
+      kafkaCluster:
+        bootstrapServers:
+          - id: SASL_PLAIN
+            endpoint: SASL_SSL://ccloud:9092
+            tls:
+              secretRef: ccloud-tls
+        nodeIdRanges:
+          - name: pool-1
+            start: 0
+            end: 17
+  routes:
+    - name: migration-route
+      endpoint: gateway:9595
+      streamingDomain:
+        name: confluent-cloud
+        bootstrapServerId: SASL_PLAIN
+      security:
+        auth: swap
+        secretStore: vault-store
+        cluster:
+          authentication:
+            type: plain
+            jaasConfigPassThrough:
+              secretRef: plain-jaas
+`
+
+// allTestSecrets are every secret the fenced and switchover fixtures reference.
+var allTestSecrets = []string{"vault-config", "msk-tls", "ccloud-tls", "plain-jaas"}
+
+func newSecret(namespace, name string) runtime.Object {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+// clientsetWithSecrets returns a fake clientset holding the named secrets in the
+// test namespace.
+func clientsetWithSecrets(names ...string) kubernetes.Interface {
+	objects := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		objects = append(objects, newSecret(testNamespace, name))
+	}
+	return newFakeClientset(objects...)
+}
+
+// validate runs the validator against the standard namespace/gateway with all
+// fixture secrets present, so a test only has to vary the CRs it cares about.
+func validate(t *testing.T, initial, fenced, switchover string) (CRValidationResult, error) {
+	t.Helper()
+	return validateGatewayCRs(context.Background(), clientsetWithSecrets(allTestSecrets...),
+		testNamespace, testGateway, []byte(initial), []byte(fenced), []byte(switchover))
+}
+
+// ===========================================================================
+// Happy path
+// ===========================================================================
+
+func TestValidateGatewayCRs_ValidTrio(t *testing.T) {
+	result, err := validate(t, initialCR, fencedCR, switchoverCR)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Warnings)
+	assert.Empty(t, result.SecretCheckSkipped)
+	assert.Equal(t, 4, result.SecretRefsChecked, "vault-config is referenced twice but counted once")
+}
+
+func TestValidateGatewayCRs_ShippedExamplesPass(t *testing.T) {
+	dirs, err := filepath.Glob("../../../docs/assets/gateway-switchover/switchover-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, dirs, "worked examples not found; has docs/assets/gateway-switchover moved?")
+
+	for _, dir := range dirs {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			read := func(name string) []byte {
+				data, err := os.ReadFile(filepath.Join(dir, name))
+				require.NoError(t, err)
+				return data
+			}
+			initial, fenced, switchover := read("gateway_init.yaml"), read("gateway_fenced.yaml"), read("gateway_switchover.yaml")
+
+			// Seed every secret the example references so the live check passes
+			// and the static checks are what this exercises.
+			refs := map[string]struct{}{}
+			for _, data := range [][]byte{fenced, switchover} {
+				cr, err := parseGatewayCR(roleFenced, data)
+				require.NoError(t, err)
+				collectSecretRefs(cr.obj, refs)
+			}
+			objects := make([]runtime.Object, 0, len(refs))
+			for name := range refs {
+				objects = append(objects, newSecret(testNamespace, name))
+			}
+
+			result, err := validateGatewayCRs(context.Background(), newFakeClientset(objects...),
+				testNamespace, testGateway, initial, fenced, switchover)
+
+			require.NoError(t, err, "a shipped example must pass validation")
+			assert.Empty(t, result.Warnings)
+			assert.Positive(t, result.SecretRefsChecked, "every example references at least one secret")
+		})
+	}
+}
+
+// ===========================================================================
+// Parsing — terminal, since every later check reads the parsed tree
+// ===========================================================================
+
+func TestValidateGatewayCRs_EmptyCR(t *testing.T) {
+	_, err := validate(t, initialCR, "   \n", switchoverCR)
+	require.ErrorContains(t, err, "the fenced gateway CR is empty")
+}
+
+func TestValidateGatewayCRs_MalformedYAML(t *testing.T) {
+	_, err := validate(t, initialCR, fencedCR, "kind: Gateway\n  bad: [indent")
+	require.ErrorContains(t, err, "failed to parse the switchover gateway CR")
+}
+
+func TestValidateGatewayCRs_YAMLIsNotAMapping(t *testing.T) {
+	_, err := validate(t, initialCR, "- just\n- a\n- list\n", switchoverCR)
+	require.ErrorContains(t, err, "fenced gateway CR")
+}
+
+// ===========================================================================
+// Shape: kind, apiVersion, spec
+// ===========================================================================
+
+func TestValidateGatewayCRs_WrongKind(t *testing.T) {
+	// The mistake this guards: ApplyGatewayYAML pushes whatever it is handed
+	// through the Gateway GVR, so a Deployment would be applied as the gateway.
+	_, err := validate(t, initialCR, fencedCR, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 1
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `the switchover gateway CR has kind "Deployment", expected "Gateway"`)
+}
+
+func TestValidateGatewayCRs_WrongAPIGroup(t *testing.T) {
+	_, err := validate(t, initialCR, fencedCR, `
+apiVersion: platform.example.com/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  routes:
+    - name: migration-route
+`)
+	require.ErrorContains(t, err, "expected group \"platform.confluent.io\"")
+}
+
+func TestValidateGatewayCRs_UnexpectedAPIVersionWarnsOnly(t *testing.T) {
+	// kcp applies through the pinned v1beta1 GVR whatever the file says, so this
+	// is worth telling the operator about but not worth refusing a migration for.
+	switchover := replaceFirst(t, switchoverCR,
+		"apiVersion: platform.confluent.io/v1beta1",
+		"apiVersion: platform.confluent.io/v1alpha1")
+
+	result, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.NoError(t, err)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "declares apiVersion \"platform.confluent.io/v1alpha1\"")
+}
+
+func TestValidateGatewayCRs_MissingSpec(t *testing.T) {
+	_, err := validate(t, initialCR, fencedCR, `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+`)
+	require.ErrorContains(t, err, "the switchover gateway CR has no spec")
+}
+
+// ===========================================================================
+// Identity: the file must name the gateway the migration targets
+// ===========================================================================
+
+func TestValidateGatewayCRs_NameMismatch(t *testing.T) {
+	fenced := replaceFirst(t, fencedCR, "name: migration-gateway", "name: some-other-gateway")
+
+	_, err := validate(t, initialCR, fenced, switchoverCR)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `the fenced gateway CR is named "some-other-gateway" but the migration targets gateway "migration-gateway"`)
+}
+
+func TestValidateGatewayCRs_NamespaceMismatch(t *testing.T) {
+	fenced := replaceFirst(t, fencedCR, "  name: migration-gateway", "  name: migration-gateway\n  namespace: other-ns")
+
+	_, err := validate(t, initialCR, fenced, switchoverCR)
+
+	require.ErrorContains(t, err, `declares namespace "other-ns" but the migration targets namespace "kcp"`)
+}
+
+func TestValidateGatewayCRs_InitialCRIdentityNotChecked(t *testing.T) {
+	// The initial CR is fetched from the cluster by name, so re-checking its
+	// identity would only add noise.
+	initial := replaceFirst(t, initialCR, "name: migration-gateway", "name: whatever-the-cluster-said")
+
+	_, err := validate(t, initial, fencedCR, switchoverCR)
+
+	require.NoError(t, err)
+}
+
+// ===========================================================================
+// Fence blocks
+// ===========================================================================
+
+func TestValidateGatewayCRs_FencedCRHasNoFence(t *testing.T) {
+	// The silent failure this prevents: kcp reports "Gateway fenced and ready"
+	// and then promotes topics while producers are still writing to the source.
+	_, err := validate(t, initialCR, initialCR, switchoverCR)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the fenced gateway CR contains no fence block")
+}
+
+func TestValidateGatewayCRs_FencedCRHasNoRoutes(t *testing.T) {
+	_, err := validate(t, initialCR, `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 3
+`, switchoverCR)
+
+	require.ErrorContains(t, err, "declares no spec.routes")
+}
+
+func TestValidateGatewayCRs_FenceNotOnARouteWarnsOnly(t *testing.T) {
+	// A fence somewhere kcp cannot attribute to a route: don't refuse (the CRD
+	// may grow other placements), just say the fence could not be confirmed.
+	fenced := replaceFirst(t, initialCR, "spec:\n  replicas: 3", "spec:\n  replicas: 3\n  fence:\n    scope: ALL")
+
+	result, err := validate(t, initialCR, fenced, switchoverCR)
+
+	require.NoError(t, err)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "fence block that is not on a route")
+}
+
+func TestValidateGatewayCRs_SwitchoverStillFencesMigrationRoute(t *testing.T) {
+	// This is the mirror of the 2026-07-27 outcome: the migration completes and
+	// reports success while every client stays blocked.
+	_, err := validate(t, initialCR, fencedCR, replaceFirst(t, switchoverCR,
+		"    - name: migration-route\n      endpoint: gateway:9595",
+		"    - name: migration-route\n      endpoint: gateway:9595\n      fence:\n        scope: ALL"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the switchover gateway CR still fences the route(s) the fenced CR blocks (migration-route)")
+}
+
+func TestValidateGatewayCRs_SwitchoverFencesAnotherRouteWarnsOnly(t *testing.T) {
+	// kcp cannot know the intent behind fencing a route the migration never
+	// fenced, so this warns rather than refuses.
+	switchover := replaceFirst(t, switchoverCR, "  routes:\n", `  routes:
+    - name: legacy-route
+      endpoint: gateway:9596
+      fence:
+        scope: ALL
+      streamingDomain:
+        name: confluent-cloud
+        bootstrapServerId: SASL_PLAIN
+`)
+
+	result, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.NoError(t, err)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "fences route(s) the migration does not fence (legacy-route)")
+}
+
+// ===========================================================================
+// Wrong-file mistakes
+// ===========================================================================
+
+func TestValidateGatewayCRs_FencedAndSwitchoverIdentical(t *testing.T) {
+	_, err := validate(t, initialCR, fencedCR, fencedCR)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identical specs")
+}
+
+func TestValidateGatewayCRs_SwitchoverIdenticalToLiveGateway(t *testing.T) {
+	// Passing gateway_init.yaml as --switchover-cr-yaml: the apply is a no-op, so
+	// it does not even bump metadata.generation for the acceptance check to spot.
+	_, err := validate(t, initialCR, fencedCR, initialCR)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identical to the live gateway's")
+}
+
+// ===========================================================================
+// Streaming domain wiring
+// ===========================================================================
+
+func TestValidateGatewayCRs_DanglingStreamingDomain(t *testing.T) {
+	switchover := replaceFirst(t, switchoverCR, "        name: confluent-cloud\n        bootstrapServerId", "        name: typo-cloud\n        bootstrapServerId")
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `route migration-route points at streaming domain "typo-cloud", which the CR does not declare (declared: confluent-cloud)`)
+}
+
+func TestValidateGatewayCRs_UnknownBootstrapServerID(t *testing.T) {
+	switchover := replaceFirst(t, switchoverCR, "bootstrapServerId: SASL_PLAIN", "bootstrapServerId: NOPE")
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `points at bootstrapServerId "NOPE", which streaming domain "confluent-cloud" does not define (defined: SASL_PLAIN)`)
+}
+
+func TestValidateGatewayCRs_RouteWithoutStreamingDomainIsAllowed(t *testing.T) {
+	// Only what the file states is checked; an absent field is not assumed
+	// mandatory.
+	switchover := replaceFirst(t, switchoverCR,
+		"      streamingDomain:\n        name: confluent-cloud\n        bootstrapServerId: SASL_PLAIN\n", "")
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.NoError(t, err)
+}
+
+// ===========================================================================
+// Live secret references
+// ===========================================================================
+
+func TestValidateGatewayCRs_MissingSecret(t *testing.T) {
+	// The 2026-07-27 failure: the switchover CR named a Secret that did not
+	// exist, the operator refused the spec and the gateway stayed fenced.
+	cs := clientsetWithSecrets("vault-config", "msk-tls", "ccloud-tls")
+
+	_, err := validateGatewayCRs(context.Background(), cs, testNamespace, testGateway,
+		[]byte(initialCR), []byte(fencedCR), []byte(switchoverCR))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reference 1 secret(s) that do not exist in namespace kcp: plain-jaas")
+}
+
+func TestValidateGatewayCRs_AllMissingSecretsReportedTogether(t *testing.T) {
+	// One run must list every missing secret: fixing them one re-run at a time
+	// is exactly the loop this check exists to avoid.
+	_, err := validateGatewayCRs(context.Background(), clientsetWithSecrets("vault-config"),
+		testNamespace, testGateway, []byte(initialCR), []byte(fencedCR), []byte(switchoverCR))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reference 3 secret(s) that do not exist in namespace kcp: ccloud-tls, msk-tls, plain-jaas")
+}
+
+func TestValidateGatewayCRs_SecretsInOtherNamespaceDoNotCount(t *testing.T) {
+	objects := make([]runtime.Object, 0, len(allTestSecrets))
+	for _, name := range allTestSecrets {
+		objects = append(objects, newSecret("somewhere-else", name))
+	}
+
+	_, err := validateGatewayCRs(context.Background(), newFakeClientset(objects...),
+		testNamespace, testGateway, []byte(initialCR), []byte(fencedCR), []byte(switchoverCR))
+
+	require.ErrorContains(t, err, "reference 4 secret(s) that do not exist in namespace kcp")
+}
+
+func TestValidateGatewayCRs_InitialCRSecretsNotRequired(t *testing.T) {
+	// The live initial CR is already running, so its references resolve by
+	// construction. Requiring them again would fail migrations for no reason.
+	initial := replaceFirst(t, initialCR, "secretRef: msk-tls", "secretRef: long-deleted-secret")
+
+	result, err := validateGatewayCRs(context.Background(), clientsetWithSecrets(allTestSecrets...),
+		testNamespace, testGateway, []byte(initial), []byte(fencedCR), []byte(switchoverCR))
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.SecretRefsChecked, "long-deleted-secret is never looked up")
+}
+
+func TestValidateGatewayCRs_SecretReadForbiddenSkipsCheck(t *testing.T) {
+	// Reading secrets is a privilege many migration operators lack. A denial must
+	// not block a migration that would otherwise succeed.
+	cs := clientsetWithSecrets(allTestSecrets...)
+	cs.(*kubernetesfake.Clientset).PrependReactor("get", "secrets", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "", fmt.Errorf("no access"))
+	})
+
+	result, err := validateGatewayCRs(context.Background(), cs, testNamespace, testGateway,
+		[]byte(initialCR), []byte(fencedCR), []byte(switchoverCR))
+
+	require.NoError(t, err)
+	assert.Equal(t, "no permission to read secrets in namespace kcp", result.SecretCheckSkipped)
+	assert.Zero(t, result.SecretRefsChecked, "a partial count would read as a pass")
+}
+
+func TestValidateGatewayCRs_UnexpectedSecretAPIErrorFails(t *testing.T) {
+	// Neither NotFound nor a permission denial: the cluster is not answering, so
+	// don't pretend the check ran.
+	cs := clientsetWithSecrets(allTestSecrets...)
+	cs.(*kubernetesfake.Clientset).PrependReactor("get", "secrets", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(fmt.Errorf("etcd is having a moment"))
+	})
+
+	_, err := validateGatewayCRs(context.Background(), cs, testNamespace, testGateway,
+		[]byte(initialCR), []byte(fencedCR), []byte(switchoverCR))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check whether secret")
+	assert.Contains(t, err.Error(), "etcd is having a moment")
+}
+
+func TestValidateGatewayCRs_NoSecretRefs(t *testing.T) {
+	fenced := `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  routes:
+    - name: migration-route
+      fence:
+        scope: ALL
+`
+	switchover := `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  routes:
+    - name: migration-route
+      endpoint: gateway:9595
+`
+
+	result, err := validateGatewayCRs(context.Background(), newFakeClientset(),
+		testNamespace, testGateway, []byte(initialCR), []byte(fenced), []byte(switchover))
+
+	require.NoError(t, err)
+	assert.Zero(t, result.SecretRefsChecked)
+	assert.Empty(t, result.SecretCheckSkipped)
+}
+
+// ===========================================================================
+// Aggregation
+// ===========================================================================
+
+func TestValidateGatewayCRs_MissingSecretsFoundAlongsideStaticProblems(t *testing.T) {
+	// Regression: the secret sweep used to stop as soon as any problem existed,
+	// so a static failure earlier in the run masked every missing secret but the
+	// first — the operator fixed one, re-ran, and found another.
+	fenced := replaceFirst(t, fencedCR, "name: migration-gateway", "name: migration-gatway")
+
+	_, err := validateGatewayCRs(context.Background(), clientsetWithSecrets("vault-config"),
+		testNamespace, testGateway, []byte(initialCR), []byte(fenced), []byte(switchoverCR))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `is named "migration-gatway"`)
+	assert.Contains(t, err.Error(), "reference 3 secret(s) that do not exist in namespace kcp: ccloud-tls, msk-tls, plain-jaas")
+}
+
+func TestValidateGatewayCRs_ReportsEveryProblemInOneRun(t *testing.T) {
+	// A broken switchover CR: wrong gateway name, no spec.routes fence lifted,
+	// dangling streaming domain, and a secret that does not exist.
+	switchover := `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: wrong-gateway
+spec:
+  streamingDomains:
+    - name: confluent-cloud
+      type: kafka
+  routes:
+    - name: migration-route
+      fence:
+        scope: ALL
+      streamingDomain:
+        name: nope
+      security:
+        cluster:
+          authentication:
+            jaasConfigPassThrough:
+              secretRef: missing-secret
+`
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "4 problem(s) found:")
+	assert.Contains(t, err.Error(), `is named "wrong-gateway"`)
+	assert.Contains(t, err.Error(), "still fences the route(s)")
+	assert.Contains(t, err.Error(), `streaming domain "nope"`)
+	assert.Contains(t, err.Error(), "missing-secret")
+}
+
+// ===========================================================================
+// Helper unit tests
+// ===========================================================================
+
+func TestCollectSecretRefs_WalksEveryDepth(t *testing.T) {
+	cr, err := parseGatewayCR(roleSwitchover, []byte(switchoverCR))
+	require.NoError(t, err)
+
+	refs := map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs)
+
+	assert.Equal(t, map[string]struct{}{
+		"vault-config": {}, // secretStores[].provider.configSecretRef
+		"ccloud-tls":   {}, // streamingDomains[].kafkaCluster.bootstrapServers[].tls.secretRef
+		"plain-jaas":   {}, // routes[].security.cluster.authentication.jaasConfigPassThrough.secretRef
+	}, refs)
+}
+
+func TestCollectSecretRefs_DescendsIntoNonStringSecretRef(t *testing.T) {
+	// A future object-valued secretRef must still be walked, not swallowed.
+	cr, err := parseGatewayCR(roleFenced, []byte(`
+kind: Gateway
+spec:
+  routes:
+    - secretRef:
+        secretRef: nested-secret
+`))
+	require.NoError(t, err)
+
+	refs := map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs)
+
+	assert.Equal(t, map[string]struct{}{"nested-secret": {}}, refs)
+}
+
+func TestFencedRouteNames(t *testing.T) {
+	cr, err := parseGatewayCR(roleFenced, []byte(`
+kind: Gateway
+spec:
+  routes:
+    - name: b-route
+      fence: {scope: ALL}
+    - name: a-route
+      fence: {scope: ALL}
+    - name: unfenced-route
+    - fence: {scope: ALL}
+`))
+	require.NoError(t, err)
+
+	fenced, present := fencedRouteNames(cr)
+
+	assert.True(t, present)
+	assert.Equal(t, []string{"a-route", "b-route", "routes[3]"}, fenced, "sorted, unnamed routes labelled by index")
+}
+
+func TestFencedRouteNames_NoRoutesKey(t *testing.T) {
+	cr, err := parseGatewayCR(roleFenced, []byte("kind: Gateway\nspec:\n  replicas: 1\n"))
+	require.NoError(t, err)
+
+	fenced, present := fencedRouteNames(cr)
+
+	assert.False(t, present, "no spec.routes is a different failure from routes-but-none-fenced")
+	assert.Empty(t, fenced)
+}
+
+func TestSplitAPIVersion(t *testing.T) {
+	group, version := splitAPIVersion("platform.confluent.io/v1beta1")
+	assert.Equal(t, "platform.confluent.io", group)
+	assert.Equal(t, "v1beta1", version)
+
+	group, version = splitAPIVersion("v1")
+	assert.Empty(t, group, "a bare version belongs to the core group")
+	assert.Equal(t, "v1", version)
+}
+
+// replaceFirst substitutes the first occurrence of old in s, failing the test if
+// it is absent — a silently unmatched fixture edit would leave a test asserting
+// against the unmodified CR.
+func replaceFirst(t *testing.T, s, old, new string) string {
+	t.Helper()
+	i := strings.Index(s, old)
+	require.GreaterOrEqual(t, i, 0, "fixture does not contain %q", old)
+	return s[:i] + new + s[i+len(old):]
+}

--- a/internal/services/gateway/validate_test.go
+++ b/internal/services/gateway/validate_test.go
@@ -3,10 +3,13 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,8 +33,8 @@ import (
 // Secret references are spread across three depths on purpose (secret store
 // config, per-bootstrap-server TLS, route cluster authentication) and
 // vault-config is referenced by both CRs so deduplication is exercised.
-// nodeIdRanges carries plain ints, which is what makes the tree unsafe to walk
-// with unstructured.Nested* — see mapField's comment.
+// nodeIdRanges carries integers, which goccy parses as uint64 — the reason the
+// tree is unsafe to walk with unstructured.Nested*; see mapField's comment.
 // ===========================================================================
 
 const (
@@ -205,16 +208,16 @@ func TestValidateGatewayCRs_ShippedExamplesPass(t *testing.T) {
 			}
 			initial, fenced, switchover := read("gateway_init.yaml"), read("gateway_fenced.yaml"), read("gateway_switchover.yaml")
 
-			// Seed every secret the example references so the live check passes
-			// and the static checks are what this exercises.
-			refs := map[string]struct{}{}
-			for _, data := range [][]byte{fenced, switchover} {
-				cr, err := parseGatewayCR(roleFenced, data)
-				require.NoError(t, err)
-				collectSecretRefs(cr.obj, refs)
-			}
-			objects := make([]runtime.Object, 0, len(refs))
-			for name := range refs {
+			// Seed exactly the secrets each example's READMEs tell the operator to
+			// create. Deriving the fixture from collectSecretRefs instead would make
+			// this untestable: a secret the walker misses would also be absent from
+			// the fake cluster, so the test would pass while the check silently did
+			// nothing. That is how clientCredentialsRef went unnoticed.
+			expected, known := shippedExampleSecrets[filepath.Base(dir)]
+			require.True(t, known, "no expected secret list for %s; add one", filepath.Base(dir))
+
+			objects := make([]runtime.Object, 0, len(expected))
+			for _, name := range expected {
 				objects = append(objects, newSecret(testNamespace, name))
 			}
 
@@ -223,9 +226,50 @@ func TestValidateGatewayCRs_ShippedExamplesPass(t *testing.T) {
 
 			require.NoError(t, err, "a shipped example must pass validation")
 			assert.Empty(t, result.Warnings)
-			assert.Positive(t, result.SecretRefsChecked, "every example references at least one secret")
+			assert.Equal(t, len(expected), result.SecretRefsChecked,
+				"every secret the example references must be found and checked")
+
+			// And the walker must find precisely that set — no more, no less.
+			refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+			for _, data := range [][]byte{fenced, switchover} {
+				cr, err := parseGatewayCR(roleFenced, data)
+				require.NoError(t, err)
+				collectSecretRefs(cr.obj, refs, unrecognised)
+			}
+			assert.ElementsMatch(t, expected, slices.Sorted(maps.Keys(refs)))
+			assert.Empty(t, unrecognised, "an unrecognised *Ref field means a secret is going unchecked")
 		})
 	}
+}
+
+// shippedExampleSecrets is every Secret the fenced and switchover CRs of each
+// worked example reference, taken from the CRs and cross-checked against the
+// `kubectl create secret` commands in each example's README.
+var shippedExampleSecrets = map[string][]string{
+	"switchover-mtls-to-mtls": {
+		"ccloud-client-tls", "gateway-tls", "msk-client-tls",
+	},
+	"switchover-mtls-to-oauth": {
+		"file-store-config", "file-store-idp-credentials", "gateway-tls", "msk-client-tls", "oauth-jaas", "tls",
+	},
+	"switchover-mtls-to-sasl-plain": {
+		"file-store-ccloud-credentials", "file-store-config", "gateway-tls", "msk-client-tls", "plain-jaas", "tls",
+	},
+	"switchover-none-to-mtls": {
+		"ccloud-client-tls",
+	},
+	"switchover-none-to-oauth": {
+		"file-store-config", "file-store-idp-credentials", "oauth-jaas", "tls",
+	},
+	"switchover-none-to-saslplain": {
+		"file-store-config", "file-store-noauth-credentials", "plain-jaas", "tls",
+	},
+	"switchover-sasl-scram-to-oauth": {
+		"msk-tls", "oauth-jaas", "scram-admin-credentials", "tls", "vault-config",
+	},
+	"switchover-sasl-scram-to-sasl-plain": {
+		"msk-tls", "plain-jaas", "scram-admin-credentials", "tls", "vault-config",
+	},
 }
 
 // ===========================================================================
@@ -279,18 +323,47 @@ spec:
 	require.ErrorContains(t, err, "expected group \"platform.confluent.io\"")
 }
 
-func TestValidateGatewayCRs_UnexpectedAPIVersionWarnsOnly(t *testing.T) {
-	// kcp applies through the pinned v1beta1 GVR whatever the file says, so this
-	// is worth telling the operator about but not worth refusing a migration for.
+func TestValidateGatewayCRs_UnexpectedAPIVersionIsRefused(t *testing.T) {
+	// Server-side apply rejects a patch whose apiVersion disagrees with the
+	// endpoint's ("Incorrect version specified in apply patch"), so a mismatch
+	// fails the apply mid-migration — refuse it up front rather than warn.
 	switchover := replaceFirst(t, switchoverCR,
 		"apiVersion: platform.confluent.io/v1beta1",
 		"apiVersion: platform.confluent.io/v1alpha1")
 
-	result, err := validate(t, initialCR, fencedCR, switchover)
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `declares apiVersion "platform.confluent.io/v1alpha1"`)
+}
+
+func TestValidateGatewayCRs_ManagedFieldsIsRefused(t *testing.T) {
+	// A file derived from `kubectl get gateway -o yaml`. client-go refuses to
+	// apply it outright, before any request leaves the process, so without this
+	// check the apply fails after the fence with clients already blocked.
+	switchover := replaceFirst(t, switchoverCR, "  name: migration-gateway", `  name: migration-gateway
+  resourceVersion: "12345"
+  managedFields:
+    - manager: confluent-operator
+      operation: Update`)
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "carries metadata.managedFields, which server-side apply refuses")
+}
+
+func TestValidateGatewayCRs_InitialCRManagedFieldsAllowed(t *testing.T) {
+	// The initial CR always carries managedFields — it is fetched from the
+	// cluster — and unfenceGateway strips them before re-applying it.
+	initial := replaceFirst(t, initialCR, "  name: migration-gateway", `  name: migration-gateway
+  managedFields:
+    - manager: confluent-operator
+      operation: Update`)
+
+	_, err := validate(t, initial, fencedCR, switchoverCR)
 
 	require.NoError(t, err)
-	require.Len(t, result.Warnings, 1)
-	assert.Contains(t, result.Warnings[0], "declares apiVersion \"platform.confluent.io/v1alpha1\"")
 }
 
 func TestValidateGatewayCRs_MissingSpec(t *testing.T) {
@@ -314,6 +387,16 @@ func TestValidateGatewayCRs_NameMismatch(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `the fenced gateway CR is named "some-other-gateway" but the migration targets gateway "migration-gateway"`)
+}
+
+func TestValidateGatewayCRs_AbsentNameIsAllowed(t *testing.T) {
+	// ApplyGatewayYAML fills the name in, so a CR file that omits it works today
+	// and must keep working — only a name that is present and wrong is a refusal.
+	fenced := replaceFirst(t, fencedCR, "metadata:\n  name: migration-gateway\n", "metadata:\n  labels:\n    app: gw\n")
+
+	_, err := validate(t, initialCR, fenced, switchoverCR)
+
+	require.NoError(t, err)
 }
 
 func TestValidateGatewayCRs_NamespaceMismatch(t *testing.T) {
@@ -401,6 +484,83 @@ func TestValidateGatewayCRs_SwitchoverFencesAnotherRouteWarnsOnly(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, result.Warnings, 1)
 	assert.Contains(t, result.Warnings[0], "fences route(s) the migration does not fence (legacy-route)")
+}
+
+func TestValidateGatewayCRs_UnnamedRoutesMatchedByEndpoint(t *testing.T) {
+	// Regression: routes used to be matched across the two files by position, so
+	// this — the same route (port 9595) still fenced after switchover, with the
+	// fenced CR holding an extra route ahead of it — passed with only a warning
+	// naming the wrong slot. Name is the identity when present; the endpoint is
+	// what distinguishes unnamed routes.
+	fenced := `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  routes:
+    - endpoint: gateway:9599
+    - endpoint: gateway:9595
+      fence:
+        scope: ALL
+`
+	switchover := `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  replicas: 1
+  routes:
+    - endpoint: gateway:9595
+      fence:
+        scope: ALL
+`
+
+	_, err := validateGatewayCRs(context.Background(), newFakeClientset(),
+		testNamespace, testGateway, []byte(initialCR), []byte(fenced), []byte(switchover))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still fences the route(s) the fenced CR blocks (routes[0] (endpoint gateway:9595))")
+}
+
+func TestValidateGatewayCRs_ExplicitlyNulledFenceIsNotAFence(t *testing.T) {
+	// `fence: null` is how a scripted edit removes a fence — server-side apply
+	// deletes a nulled field — so this switchover CR works and must not be
+	// refused as "still fences".
+	switchover := replaceFirst(t, switchoverCR,
+		"    - name: migration-route\n      endpoint: gateway:9595",
+		"    - name: migration-route\n      endpoint: gateway:9595\n      fence: null")
+
+	_, err := validate(t, initialCR, fencedCR, switchover)
+
+	require.NoError(t, err)
+}
+
+func TestValidateGatewayCRs_NulledFenceInFencedCRIsRefused(t *testing.T) {
+	// The mirror: a fenced CR whose only fence is nulled does not fence anything.
+	fenced := replaceFirst(t, fencedCR, "      fence:\n        scope: ALL\n        errorCode: BROKER_NOT_AVAILABLE", "      fence: null")
+
+	_, err := validate(t, initialCR, fenced, switchoverCR)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contains no fence block")
+}
+
+func TestValidateGatewayCRs_UnmatchableFencedRouteWarns(t *testing.T) {
+	// With neither a name nor an endpoint there is nothing to match on, so say
+	// that rather than guess either way.
+	fenced := replaceFirst(t, fencedCR, "    - name: migration-route\n      endpoint: gateway:9595\n", "    - \n")
+	switchover := replaceFirst(t, switchoverCR,
+		"    - name: migration-route\n      endpoint: gateway:9595\n",
+		"    - fence:\n        scope: ALL\n")
+
+	result, err := validateGatewayCRs(context.Background(), clientsetWithSecrets(allTestSecrets...),
+		testNamespace, testGateway, []byte(initialCR), []byte(fenced), []byte(switchover))
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Warnings)
+	assert.Contains(t, strings.Join(result.Warnings, "\n"), "neither a name nor an endpoint")
 }
 
 // ===========================================================================
@@ -630,14 +790,72 @@ func TestCollectSecretRefs_WalksEveryDepth(t *testing.T) {
 	cr, err := parseGatewayCR(roleSwitchover, []byte(switchoverCR))
 	require.NoError(t, err)
 
-	refs := map[string]struct{}{}
-	collectSecretRefs(cr.obj, refs)
+	refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs, unrecognised)
 
 	assert.Equal(t, map[string]struct{}{
 		"vault-config": {}, // secretStores[].provider.configSecretRef
 		"ccloud-tls":   {}, // streamingDomains[].kafkaCluster.bootstrapServers[].tls.secretRef
 		"plain-jaas":   {}, // routes[].security.cluster.authentication.jaasConfigPassThrough.secretRef
 	}, refs)
+	assert.Empty(t, unrecognised)
+}
+
+func TestCollectSecretRefs_ClientCredentialsRef(t *testing.T) {
+	// Regression: clientCredentialsRef names a Secret in four of the eight shipped
+	// switchover examples and was not collected, so the operator got a green tick
+	// over exactly the missing-secret failure this validation exists to catch.
+	cr, err := parseGatewayCR(roleSwitchover, []byte(`
+kind: Gateway
+spec:
+  secretStores:
+    - name: file-store
+      provider:
+        type: File
+        configSecretRef: file-store-config
+        clientCredentialsRef: file-store-ccloud-credentials
+`))
+	require.NoError(t, err)
+
+	refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs, unrecognised)
+
+	assert.Equal(t, map[string]struct{}{
+		"file-store-config":             {},
+		"file-store-ccloud-credentials": {},
+	}, refs)
+	assert.Empty(t, unrecognised)
+}
+
+func TestCollectSecretRefs_FlagsUnrecognisedRefFields(t *testing.T) {
+	// The tripwire for CRD growth: a Ref-suffixed field kcp does not know is a
+	// hole in the check, and must not sit behind a tick claiming a full pass.
+	cr, err := parseGatewayCR(roleSwitchover, []byte(`
+kind: Gateway
+spec:
+  routes:
+    - name: migration-route
+      security:
+        someFutureCredentialRef: a-secret-kcp-cannot-see
+`))
+	require.NoError(t, err)
+
+	refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs, unrecognised)
+
+	assert.Empty(t, refs)
+	assert.Equal(t, map[string]struct{}{"someFutureCredentialRef": {}}, unrecognised)
+}
+
+func TestValidateGatewayCRs_UnrecognisedRefFieldWarns(t *testing.T) {
+	switchover := replaceFirst(t, switchoverCR, "      secretRef: plain-jaas", "      someFutureCredentialRef: unseen-secret")
+
+	result, err := validateGatewayCRs(context.Background(), clientsetWithSecrets(allTestSecrets...),
+		testNamespace, testGateway, []byte(initialCR), []byte(fencedCR), []byte(switchover))
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Warnings)
+	assert.Contains(t, strings.Join(result.Warnings, "\n"), "someFutureCredentialRef")
 }
 
 func TestCollectSecretRefs_DescendsIntoNonStringSecretRef(t *testing.T) {
@@ -651,13 +869,111 @@ spec:
 `))
 	require.NoError(t, err)
 
-	refs := map[string]struct{}{}
-	collectSecretRefs(cr.obj, refs)
+	refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs, unrecognised)
 
 	assert.Equal(t, map[string]struct{}{"nested-secret": {}}, refs)
+	assert.Empty(t, unrecognised)
 }
 
-func TestFencedRouteNames(t *testing.T) {
+// aliasBombCR is a YAML anchor bomb: goccy/go-yaml resolves an alias by sharing
+// the anchored node rather than copying it, so this sub-kilobyte document parses
+// in microseconds while describing a logical tree of ~4^19 (2.7e11) nodes.
+//
+// The level count is deliberate. Measured on this machine an un-memoised walk
+// covers ~600M nodes/second, so a 4^12 bomb finishes in 50ms and would make the
+// test below pass with or without the walk guard. At 4^19 the unguarded walk
+// needs several minutes and the test is a real regression detector, while the
+// guarded walk stays at ~10µs because it only ever visits the parsed nodes.
+const aliasBombCR = `
+apiVersion: platform.confluent.io/v1beta1
+kind: Gateway
+metadata:
+  name: migration-gateway
+spec:
+  routes:
+    - name: migration-route
+      fence: {scope: ALL}
+  bomb:
+    a0: &a0 ["x","x","x","x"]
+    a1: &a1 [*a0,*a0,*a0,*a0]
+    a2: &a2 [*a1,*a1,*a1,*a1]
+    a3: &a3 [*a2,*a2,*a2,*a2]
+    a4: &a4 [*a3,*a3,*a3,*a3]
+    a5: &a5 [*a4,*a4,*a4,*a4]
+    a6: &a6 [*a5,*a5,*a5,*a5]
+    a7: &a7 [*a6,*a6,*a6,*a6]
+    a8: &a8 [*a7,*a7,*a7,*a7]
+    a9: &a9 [*a8,*a8,*a8,*a8]
+    a10: &a10 [*a9,*a9,*a9,*a9]
+    a11: &a11 [*a10,*a10,*a10,*a10]
+    a12: &a12 [*a11,*a11,*a11,*a11]
+    a13: &a13 [*a12,*a12,*a12,*a12]
+    a14: &a14 [*a13,*a13,*a13,*a13]
+    a15: &a15 [*a14,*a14,*a14,*a14]
+    a16: &a16 [*a15,*a15,*a15,*a15]
+    a17: &a17 [*a16,*a16,*a16,*a16]
+    a18: &a18 [*a17,*a17,*a17,*a17]
+    a19: [*a18,*a18,*a18,*a18]
+`
+
+func TestValidateGatewayCRs_AliasBombTerminates(t *testing.T) {
+	// Without the walk guard this pins one core for hours on a flat heap, with no
+	// ctx check to interrupt it — a sub-kilobyte CR file hanging `migration init`.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = validateGatewayCRs(context.Background(), clientsetWithSecrets(allTestSecrets...),
+			testNamespace, testGateway, []byte(initialCR), []byte(aliasBombCR), []byte(switchoverCR))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("validation did not terminate on an alias bomb: the walk guard is not working")
+	}
+}
+
+func TestCollectSecretRefs_AliasedNodeWalkedOnce(t *testing.T) {
+	// The guard must dedupe by node identity without losing content: the secret
+	// behind an alias still has to be found.
+	cr, err := parseGatewayCR(roleFenced, []byte(`
+kind: Gateway
+spec:
+  shared: &shared
+    tls:
+      secretRef: shared-secret
+  a: *shared
+  b: *shared
+`))
+	require.NoError(t, err)
+
+	refs, unrecognised := map[string]struct{}{}, map[string]struct{}{}
+	collectSecretRefs(cr.obj, refs, unrecognised)
+
+	assert.Equal(t, map[string]struct{}{"shared-secret": {}}, refs)
+	assert.Empty(t, unrecognised)
+}
+
+func TestTreeContainsNonNilKey_AliasBombTerminates(t *testing.T) {
+	cr, err := parseGatewayCR(roleFenced, []byte(aliasBombCR))
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// A key that is absent forces the full walk.
+		assert.False(t, treeContainsNonNilKey(cr.obj, "no-such-key"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("treeContainsNonNilKey did not terminate on an alias bomb")
+	}
+}
+
+func TestFencedRoutes(t *testing.T) {
 	cr, err := parseGatewayCR(roleFenced, []byte(`
 kind: Gateway
 spec:
@@ -667,21 +983,28 @@ spec:
     - name: a-route
       fence: {scope: ALL}
     - name: unfenced-route
+    - endpoint: gateway:9599
+      fence: {scope: ALL}
     - fence: {scope: ALL}
 `))
 	require.NoError(t, err)
 
-	fenced, present := fencedRouteNames(cr)
+	fenced, present := fencedRoutes(cr)
 
 	assert.True(t, present)
-	assert.Equal(t, []string{"a-route", "b-route", "routes[3]"}, fenced, "sorted, unnamed routes labelled by index")
+	assert.Equal(t, []routeFence{
+		{identity: "name=a-route", label: "a-route", matchable: true},
+		{identity: "name=b-route", label: "b-route", matchable: true},
+		{identity: "endpoint=gateway:9599", label: "routes[3] (endpoint gateway:9599)", matchable: true},
+		{identity: "", label: "routes[4]", matchable: false},
+	}, fenced, "name preferred, endpoint as fallback identity, neither means unmatchable")
 }
 
-func TestFencedRouteNames_NoRoutesKey(t *testing.T) {
+func TestFencedRoutes_NoRoutesKey(t *testing.T) {
 	cr, err := parseGatewayCR(roleFenced, []byte("kind: Gateway\nspec:\n  replicas: 1\n"))
 	require.NoError(t, err)
 
-	fenced, present := fencedRouteNames(cr)
+	fenced, present := fencedRoutes(cr)
 
 	assert.False(t, present, "no spec.routes is a different failure from routes-but-none-fenced")
 	assert.Empty(t, fenced)

--- a/internal/services/migration/mock_test.go
+++ b/internal/services/migration/mock_test.go
@@ -13,7 +13,7 @@ import (
 // mockGatewayService implements gateway.Service using function fields for test control.
 type mockGatewayService struct {
 	getGatewayYAMLFn                   func(ctx context.Context, namespace, name string) ([]byte, error)
-	validateGatewayCRsFn               func(initial, fenced, switchover []byte) error
+	validateGatewayCRsFn               func(ctx context.Context, namespace, name string, initial, fenced, switchover []byte) (gateway.CRValidationResult, error)
 	checkPermissionsFn                 func(ctx context.Context, verb, resource, group, namespace string) (bool, error)
 	applyGatewayYAMLFn                 func(ctx context.Context, namespace, name string, yaml []byte) error
 	waitForGatewayObservedGenerationFn func(ctx context.Context, namespace, name string, pollInterval, timeout time.Duration) error
@@ -29,11 +29,11 @@ func (m *mockGatewayService) GetGatewayYAML(ctx context.Context, namespace, name
 	return nil, fmt.Errorf("mockGatewayService.GetGatewayYAML not configured")
 }
 
-func (m *mockGatewayService) ValidateGatewayCRs(initial, fenced, switchover []byte) error {
+func (m *mockGatewayService) ValidateGatewayCRs(ctx context.Context, namespace, name string, initial, fenced, switchover []byte) (gateway.CRValidationResult, error) {
 	if m.validateGatewayCRsFn != nil {
-		return m.validateGatewayCRsFn(initial, fenced, switchover)
+		return m.validateGatewayCRsFn(ctx, namespace, name, initial, fenced, switchover)
 	}
-	return nil
+	return gateway.CRValidationResult{}, nil
 }
 
 func (m *mockGatewayService) CheckPermissions(ctx context.Context, verb, resource, group, namespace string) (bool, error) {

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -108,9 +108,7 @@ func newHappyPathOrchestrator(t *testing.T, initialState string, topics []string
 
 	gw := &mockGatewayService{
 		getGatewayYAMLFn: getGatewayYAMLFn,
-		validateGatewayCRsFn: func(initial, fenced, switchover []byte) error {
-			return nil
-		},
+		// validateGatewayCRsFn left unset: the mock's default passes validation.
 		applyGatewayYAMLFn: applyGatewayYAMLFn,
 		getGatewayPodUIDsFn: func(ctx context.Context, namespace, name string) (map[k8stypes.UID]struct{}, error) {
 			return map[k8stypes.UID]struct{}{

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -104,12 +104,28 @@ func (s *MigrationActions) Initialize(
 	}
 	config.InitialCrYAML = initialCrYAML
 
-	// Validate all three gateway CRs are consistent
-	if err := s.gatewayService.ValidateGatewayCRs(config.InitialCrYAML, config.FencedCrYAML, config.SwitchoverCrYAML); err != nil {
+	// Validate all three gateway CRs are consistent, and that the secrets they
+	// reference exist. Report what was actually verified rather than a bare tick:
+	// the live secret check can legitimately be skipped (no RBAC to read
+	// secrets), and claiming a check ran when it did not is how a missing
+	// secretRef reached a cutover in the first place.
+	validation, err := s.gatewayService.ValidateGatewayCRs(ctx, config.K8sNamespace, config.InitialCrName, config.InitialCrYAML, config.FencedCrYAML, config.SwitchoverCrYAML)
+	for _, warning := range validation.Warnings {
+		s.reporter.warn("%s", warning)
+	}
+	if err != nil {
 		return fmt.Errorf("gateway CR validation failed: %w", err)
 	}
-	slog.Debug("gateway CRs validated")
-	s.reporter.success("Gateway CRs validated")
+	slog.Debug("gateway CRs validated", "secretRefsChecked", validation.SecretRefsChecked, "secretCheckSkipped", validation.SecretCheckSkipped)
+
+	switch {
+	case validation.SecretCheckSkipped != "":
+		s.reporter.success("Gateway CRs validated (secret references not checked: %s)", validation.SecretCheckSkipped)
+	case validation.SecretRefsChecked > 0:
+		s.reporter.success("Gateway CRs validated (%d secret reference(s) present in %s)", validation.SecretRefsChecked, config.K8sNamespace)
+	default:
+		s.reporter.success("Gateway CRs validated (no secret references)")
+	}
 
 	// Validate cluster link and topics
 	clusterLinkConfig := clusterlink.Config{

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -120,7 +120,11 @@ func (s *MigrationActions) Initialize(
 
 	switch {
 	case validation.SecretCheckSkipped != "":
-		s.reporter.success("Gateway CRs validated (secret references not checked: %s)", validation.SecretCheckSkipped)
+		// A check that could not run gets ⚠️ and a Warn in kcp.log, not a green
+		// tick at Info. An operator scanning a wall of ticks minutes before
+		// cutover must be able to see that the live check never happened — that
+		// is the whole premise of this validation.
+		s.reporter.warn("Gateway CRs validated, but secret references were NOT checked: %s", validation.SecretCheckSkipped)
 	case validation.SecretRefsChecked > 0:
 		s.reporter.success("Gateway CRs validated (%d secret reference(s) present in %s)", validation.SecretRefsChecked, config.K8sNamespace)
 	default:

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -25,9 +26,7 @@ func TestWorkflow_Initialize_Success(t *testing.T) {
 		getGatewayYAMLFn: func(_ context.Context, _, _ string) ([]byte, error) {
 			return []byte("initial-yaml"), nil
 		},
-		validateGatewayCRsFn: func(_, _, _ []byte) error {
-			return nil
-		},
+		// validateGatewayCRsFn left unset: the mock's default passes validation.
 	}
 
 	cl := &mockClusterLinkService{
@@ -61,6 +60,155 @@ func TestWorkflow_Initialize_Success(t *testing.T) {
 	assert.Equal(t, "initial-yaml", string(config.InitialCrYAML))
 	assert.Len(t, config.ClusterLinkTopics, 3)
 	assert.Equal(t, "broker:9092", config.ClusterLinkConfigs["bootstrap.servers"])
+}
+
+// ===========================================================================
+// Gateway CR validation reporting
+//
+// Initialize used to print "✔ Gateway CRs validated" unconditionally, over a
+// validator that did nothing but log "not yet implemented". These tests pin the
+// reporter line to what was actually verified: a tick may only claim a check
+// that ran.
+// ===========================================================================
+
+// initializeWithValidation runs Initialize against a healthy cluster link with
+// the given validation outcome, returning what the reporter printed.
+func initializeWithValidation(t *testing.T, result gateway.CRValidationResult, validationErr error) (string, error) {
+	t.Helper()
+
+	gw := &mockGatewayService{
+		getGatewayYAMLFn: func(_ context.Context, _, _ string) ([]byte, error) {
+			return []byte("initial-yaml"), nil
+		},
+		validateGatewayCRsFn: func(_ context.Context, _, _ string, _, _, _ []byte) (gateway.CRValidationResult, error) {
+			return result, validationErr
+		},
+	}
+	cl := &mockClusterLinkService{
+		listMirrorTopicsFn: func(_ context.Context, _ clusterlink.Config) ([]clusterlink.MirrorTopic, error) {
+			return []clusterlink.MirrorTopic{{MirrorTopicName: "topic-a", MirrorStatus: "ACTIVE"}}, nil
+		},
+		listConfigsFn: func(_ context.Context, _ clusterlink.Config) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	}
+
+	wf := NewMigrationActions(gw, cl)
+	var out, errOut bytes.Buffer
+	wf.reporter = &reporter{out: &out, err: &errOut}
+
+	err := wf.Initialize(context.Background(), &MigrationConfig{
+		K8sNamespace:        "ns",
+		InitialCrName:       "my-gw",
+		ClusterRestEndpoint: "https://cluster",
+		ClusterId:           "lkc-123",
+		ClusterLinkName:     "link-1",
+		FencedCrYAML:        []byte("fenced"),
+		SwitchoverCrYAML:    []byte("switchover"),
+	}, "key", "secret")
+
+	return out.String() + errOut.String(), err
+}
+
+func TestWorkflow_Initialize_ReportsSecretsChecked(t *testing.T) {
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{SecretRefsChecked: 4}, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "Gateway CRs validated (4 secret reference(s) present in ns)")
+}
+
+func TestWorkflow_Initialize_ReportsSkippedSecretCheck(t *testing.T) {
+	// The honesty case: the static checks ran, the live one could not. The tick
+	// must say so rather than implying a full pass.
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{
+		SecretCheckSkipped: "no permission to read secrets in namespace ns",
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "Gateway CRs validated (secret references not checked: no permission to read secrets in namespace ns)")
+}
+
+func TestWorkflow_Initialize_ReportsNoSecretReferences(t *testing.T) {
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{}, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "Gateway CRs validated (no secret references)")
+}
+
+func TestWorkflow_Initialize_ValidationFailureIsNotReportedAsSuccess(t *testing.T) {
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{},
+		fmt.Errorf("1 problem(s) found:\n  - the fenced gateway CR contains no fence block"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway CR validation failed")
+	assert.Contains(t, err.Error(), "contains no fence block")
+	assert.NotContains(t, output, "Gateway CRs validated")
+}
+
+func TestWorkflow_Initialize_SurfacesValidationWarnings(t *testing.T) {
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{
+		SecretRefsChecked: 1,
+		Warnings:          []string{"the switchover gateway CR fences route(s) the migration does not fence (legacy-route)"},
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "fences route(s) the migration does not fence (legacy-route)")
+	assert.Contains(t, output, "Gateway CRs validated")
+}
+
+func TestWorkflow_Initialize_WarningsSurfaceEvenWhenValidationFails(t *testing.T) {
+	// Warnings are context for diagnosing the failure, so they must not be
+	// swallowed by the early return.
+	output, err := initializeWithValidation(t, gateway.CRValidationResult{
+		Warnings: []string{"the fenced gateway CR has a fence block that is not on a route"},
+	}, fmt.Errorf("1 problem(s) found:\n  - something else"))
+
+	require.Error(t, err)
+	assert.Contains(t, output, "fence block that is not on a route")
+}
+
+func TestWorkflow_Initialize_PassesNamespaceAndGatewayToValidator(t *testing.T) {
+	// The live secret lookup is namespace-scoped, and the identity check needs the
+	// target gateway name — both come from the migration config.
+	var gotNamespace, gotGateway string
+	var gotInitial, gotFenced, gotSwitchover []byte
+
+	gw := &mockGatewayService{
+		getGatewayYAMLFn: func(_ context.Context, _, _ string) ([]byte, error) {
+			return []byte("initial-yaml"), nil
+		},
+		validateGatewayCRsFn: func(_ context.Context, namespace, name string, initial, fenced, switchover []byte) (gateway.CRValidationResult, error) {
+			gotNamespace, gotGateway = namespace, name
+			gotInitial, gotFenced, gotSwitchover = initial, fenced, switchover
+			return gateway.CRValidationResult{}, nil
+		},
+	}
+	cl := &mockClusterLinkService{
+		listMirrorTopicsFn: func(_ context.Context, _ clusterlink.Config) ([]clusterlink.MirrorTopic, error) {
+			return []clusterlink.MirrorTopic{{MirrorTopicName: "topic-a", MirrorStatus: "ACTIVE"}}, nil
+		},
+		listConfigsFn: func(_ context.Context, _ clusterlink.Config) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	}
+
+	wf := NewMigrationActions(gw, cl)
+	err := wf.Initialize(context.Background(), &MigrationConfig{
+		K8sNamespace:        "kcp",
+		InitialCrName:       "migration-gateway",
+		ClusterRestEndpoint: "https://cluster",
+		ClusterId:           "lkc-123",
+		ClusterLinkName:     "link-1",
+		FencedCrYAML:        []byte("fenced"),
+		SwitchoverCrYAML:    []byte("switchover"),
+	}, "key", "secret")
+
+	require.NoError(t, err)
+	assert.Equal(t, "kcp", gotNamespace)
+	assert.Equal(t, "migration-gateway", gotGateway)
+	assert.Equal(t, "initial-yaml", string(gotInitial), "the live CR just fetched, not the stale config field")
+	assert.Equal(t, "fenced", string(gotFenced))
+	assert.Equal(t, "switchover", string(gotSwitchover))
 }
 
 func TestWorkflow_Initialize_GatewayFetchError(t *testing.T) {

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -118,14 +118,16 @@ func TestWorkflow_Initialize_ReportsSecretsChecked(t *testing.T) {
 }
 
 func TestWorkflow_Initialize_ReportsSkippedSecretCheck(t *testing.T) {
-	// The honesty case: the static checks ran, the live one could not. The tick
-	// must say so rather than implying a full pass.
+	// The honesty case: the static checks ran, the live one could not. A check
+	// that did not run gets ⚠️ and a Warn in kcp.log — NOT a green tick that an
+	// operator scanning output minutes before cutover will read as "verified".
 	output, err := initializeWithValidation(t, gateway.CRValidationResult{
 		SecretCheckSkipped: "no permission to read secrets in namespace ns",
 	}, nil)
 
 	require.NoError(t, err)
-	assert.Contains(t, output, "Gateway CRs validated (secret references not checked: no permission to read secrets in namespace ns)")
+	assert.Contains(t, output, "secret references were NOT checked: no permission to read secrets in namespace ns")
+	assert.NotContains(t, output, "✔ Gateway CRs validated", "a skipped check must not be reported under a success tick")
 }
 
 func TestWorkflow_Initialize_ReportsNoSecretReferences(t *testing.T) {


### PR DESCRIPTION
## Problem

`kcp migration init` printed a green tick claiming gateway CR validation passed, over a stub that did nothing:

```
WARN ⚠️  gateway CR validation not yet implemented, skipping
   ✔ Gateway CRs validated
```

`ValidateGatewayCRs` was a TODO, a `slog.Warn` and `return nil`; the caller treated `nil` as success and reported unconditionally. The tick meant "a function returned", not "a check passed".

**Context:** found while setting up the new live-cluster e2e migration test infrastructure, **not** in a production migration. A switchover CR referenced a Kubernetes secret that did not exist, the operator refused the spec, and the gateway silently stayed fenced.

## Why implement rather than just drop the tick

That failure was only discoverable at cutover — after client traffic had been fenced, when the way out is a rollback. `init` runs before anything is applied, and already had a correctly placed, correctly wired validation hook with a single call site. Deleting the tick would have closed the ticket by removing the one place the check belongs.

The separate bug (kcp reporting success for a switchover the operator refused) is handled in its own PR and is not touched here.

## What this changes about how kcp behaves

**The execute path is untouched — zero changes.** The only function modified in `workflow.go` is `Initialize`. Unchanged: `FenceGateway`, `SwitchGateway`, `PromoteTopics`, `unfenceGateway`, `CheckLags`, `VerifyFence`, `PauseOffsetSync`, the offset-sync bookends, the orchestrator/FSM transitions, and every wait in `gateway.go` (`ApplyGatewayYAML`, `WaitForGatewayObservedGeneration`, `WaitForGatewayPods`, `WaitForGatewayReady`). Once a migration starts it does exactly what it did before, in the same order, with the same timeouts and retries. No fencing, promotion, switchover or rollback semantics moved.

**`init` does change behaviour, and it is worth naming plainly:** it goes from a stage that always succeeded (the stub returned `nil` unconditionally) to a **gate that can refuse**. The migration's semantics are unchanged; whether it starts is not. The failure mode to weigh in review is a false positive blocking a migration that would have worked, so the refusals are listed below by how confident I am in each.

**Escape hatches, both unchanged in spirit:** `--skip-validate` bypasses every check, and a Kubernetes `Forbidden`/`Unauthorized` on the secret read degrades to a warning rather than a refusal — specifically so the new live check cannot block operators who lack that RBAC.

The only other user-visible change is output: the `init` line now states what was actually verified.

### Refusals that were fatal later anyway

Refusing at `init` strictly helps — the migration could not have succeeded:

| Check | Evidence |
|---|---|
| A referenced Kubernetes Secret does not exist | the 2026-07-27 failure |
| `metadata.managedFields` present | client-go refuses the apply outright, before any request leaves the process — `cannot apply an object with managed fields already set` (`client-go@v0.35.0/dynamic/simple.go:305`) |
| `apiVersion` version disagrees | the body is sent verbatim and the API server rejects the patch — `Incorrect version specified in apply patch` (`apimachinery/pkg/util/managedfields/internal/structuredmerge.go:126`) |
| `kind` is not `Gateway`, or the group is wrong, or there is no `spec` | `ApplyGatewayYAML` pushes whatever it is handed through the pinned Gateway GVR, so a Deployment would be applied *as* this gateway |

### Refusals for configs that would have "succeeded" while doing the wrong thing

These are the silent-failure cases, and the strongest argument for the PR:

- **the fenced CR carries no fence** — the migration promotes topics while producers are still writing to the source
- **the switchover CR re-fences the route the fenced CR blocked** — every client stays blocked while kcp reports a completed migration
- **the switchover spec is identical to the live gateway's, or to the fenced CR's** — a no-op apply does not bump `metadata.generation`, so nothing downstream notices
- **`metadata.name` is present and names a different gateway** — `ApplyGatewayYAML` calls `SetName`, so the wrong file is not rejected, it is silently applied over this one

### Two refusals I would like a reviewer's opinion on

- **dangling `streamingDomain` / `bootstrapServerId`.** I refuse this on the assumption that the CFK operator rejects an unresolvable reference. **I have not verified that against a real operator.** If CFK tolerates it, this refuses a config that works. Happy to downgrade to a warning.
- **`metadata.namespace` present and mismatched.** `ApplyGatewayYAML` calls `SetNamespace`, so this works today; I refuse it as a wrong-file signal. If anyone keeps the namespace baked into per-environment CR files while passing `--k8s-namespace`, this newly blocks them.

## What is checked

Static. The initial CR is excluded from checks the cluster already vouches for — it is fetched by name, and the operator has already accepted its spec:

- `kind`, `apiVersion` (group **and** version) and `spec` are present and describe a Confluent Gateway
- `metadata.name` / `namespace`, when present, name the gateway the migration targets; an absent value is the one `ApplyGatewayYAML` fills in, so it is tolerated
- `metadata.managedFields` is absent (the fingerprint of `kubectl get -o yaml` output)
- the fenced CR actually carries a fence, and the switchover CR lifts the one it applied
- fenced ≠ switchover spec, and switchover ≠ the live spec
- route `streamingDomain` / `bootstrapServerId` references resolve within the same CR

Live — needs a namespace lookup, which is why the signature gains a `ctx` and a namespace:

- every `secretRef`, `configSecretRef` and `clientCredentialsRef` in the fenced and switchover CRs names a Secret that exists in the namespace. Collected by walking the whole CR rather than by fixed paths: across `docs/assets/gateway-switchover` these appear at six different depths
- any **unrecognised** `*Ref`-suffixed field raises a warning, so a Secret-naming field this validator does not know about cannot sit silently behind a tick claiming the secrets were checked

Routes are identified across the two files by name, falling back to the endpoint they serve. Position is not usable: the fenced and switchover CRs routinely hold different numbers of routes (the switchover examples drop the source domain's route entirely), so `routes[0]` in one file is not `routes[0]` in the other. A fenced route with neither a name nor an endpoint is reported as unmatchable rather than guessed at.

`fence: null` is not counted as a fence — under server-side apply a nulled field is one being *removed* — so a switchover CR that unfences that way is not refused, and a fenced CR whose only fence is nulled is.

## What the review round found (commit 2)

A correctness review and a security review of commit 1 found that it had a hole in exactly the failure class it was written for, plus one way to hang `init`. Each claim below was verified independently before acting on it.

1. **`clientCredentialsRef` was not collected** — it names a Secret in **four of the eight shipped switchover examples** (`file-store-idp-credentials`, `file-store-ccloud-credentials`, `file-store-noauth-credentials`). For those auth combinations `init` reported `✔ 3 secret reference(s) present` while the one secret that breaks cutover went unchecked: the 2026-07-27 failure, reproduced under a green tick. Fixed, plus the unrecognised-`*Ref` tripwire above, because one missing key was the symptom and an allowlist that cannot notice its own gaps was the disease.

2. **The shipped-examples test could not have caught that.** It seeded the fake cluster's Secrets from `collectSecretRefs`' own output, so a secret the walker missed was also absent from the fixture — no `NotFound`, green test. It now asserts against explicit per-example secret lists taken from the CRs and cross-checked against each README's `kubectl create secret` commands. (Writing those lists, two of mine were wrong; the corrected test caught it immediately.)

3. **A YAML anchor bomb hung the walks.** goccy/go-yaml resolves an alias by *sharing* the anchored node, so an 822-byte CR describes ~4^19 logical nodes. The un-memoised recursion pinned one core for hours on a flat 3 MB heap — no OOM, no signal — with no `ctx` check to interrupt it, and validation then *passed*. Both walks now skip already-visited nodes. Ruled out by the reviewer, which narrowed the fix: stack exhaustion is not reachable (goccy caps decode depth at 10 000) and self-referential anchors do not build a cyclic structure. The regression test's bomb is deliberately sized so the unguarded walk cannot finish inside the timeout — at 4^12 it completed in 50 ms and the test passed with or without the fix.

4. **`metadata.managedFields` was not checked** — see the table above. `unfenceGateway` already strips this metadata for the same reason, so the hazard was documented in the file next door.

5. **An `apiVersion` version mismatch only warned.** My justification was wrong: I had assumed the pinned GVR made the declared version irrelevant. It is sent verbatim and rejected. The old test (`…UnexpectedAPIVersionWarnsOnly`) pinned the bug in place.

6. **Routes were matched across files by array position** — a switchover CR that still fenced the migration route passed with only a warning naming the wrong slot.

7. **An absent `metadata.name` refused a config that works today**, and was inconsistent with the namespace check, which already tolerated absence.

8. **A skipped secret check was reported under a green ✔ at Info.** `reporter.warn` exists and mirrors to `kcp.log` at Warn. A check that did not run must not look like one that passed — this PR's own premise, applied to itself.

9. **`fence: null`** (found while testing 6) — counting a nulled fence as a fence would refuse a working switchover CR.

Also corrected: a comment claiming goccy produces `int` for integers. It produces `uint64` for positive integers and `int64` for negative. The reason for avoiding `unstructured.Nested*` holds either way — `runtime.DeepCopyJSONValue` tolerates `int64` only, so it would panic on `nodeIdRanges.start`.

### Security review outcome

No credential leakage. The `Secrets().Get` result is discarded — only existence is used — verified by seeding Secrets with marker payloads and asserting the marker reaches no log line, error string or result field. Every CR-derived value that can surface in output is an identifier (kind, apiVersion, names, endpoints, bootstrap server ids, secret names); confirmed by planting 14 sensitive tokens (inline JAAS passwords, a Vault token, an OAuth client secret) in the CR trees and finding none in Debug-level output. Also clean: no change to what is persisted in `migration-state.json`, no reachable panic from malformed YAML, no path traversal, no TLS weakening, and no validate/apply divergence — the bytes validated at `init` are the bytes stored and later applied.

## Output

Findings aggregate into one error so an operator fixes everything in one pass:

```
gateway CR validation failed: 3 problem(s) found:
  - the switchover gateway CR is named "migration-gatway" but the migration targets gateway "migration-gateway" (kcp would apply this file under the target name)
  - the switchover gateway CR still fences the route(s) the fenced CR blocks (migration-route), so clients would stay blocked after switchover
  - the fenced/switchover gateway CRs reference 2 secret(s) that do not exist in namespace kcp: ccloud-tls, plain-jaas — the Confluent operator will refuse the spec and the gateway will stay fenced
```

On success the line states what was verified, and a check that could not run is a warning rather than a tick:

```
   ✔ Gateway CRs validated (4 secret reference(s) present in kcp)
   ✔ Gateway CRs validated (no secret references)
   ⚠️  Gateway CRs validated, but secret references were NOT checked: no permission to read secrets in namespace kcp
```

## Tests

75 tests in `internal/services/gateway/validate_test.go` (new file, alongside the new `validate.go`) and 12 added to `internal/services/migration/workflow_test.go`.

`TestValidateGatewayCRs_ShippedExamplesPass` runs all eight worked example trios in `docs/assets/gateway-switchover/` through the validator. It does double duty: no shipped example may be refused (the guard against a check being over-strict), and the collected secret set must match an explicit expected list exactly (the guard against an under-collecting walker, which is what finding 1 slipped through).

`make test-go` — 55 packages ok, 0 failures. `make lint` — 0 issues.

## Notes for review

- **Deliberate limitation:** the "switchover spec identical to the live gateway" check only fires on exact equality, and the live CR carries operator defaults the user's file omits — so it catches an obvious copy-paste and little else. The reliable half of that pair is fenced-vs-switchover, where both sides are user-authored. Documented in the code rather than papered over. (A related concern I had considered and rejected — that `int` vs `int64` typing would make `reflect.DeepEqual` useless — was independently verified as a non-issue: the live CR reaches the validator as YAML *text*, so both sides go through the same parse.)
- **Follow-up worth considering, not done here:** `CoreV1().Secrets().Get` pulls each Secret's plaintext into kcp's heap when only existence is needed. `k8s.io/client-go/metadata` gives identical semantics under identical RBAC without transporting the data — a cheap data-minimisation win for a tool whose job is handling migration credentials. Left out because it moves the test injection surface to `metadata/fake`.
- Branched off `origin/main`, so it does not carry the sibling switchover-verification commit. Expect a small textual conflict in the `Service` interface block and `mockGatewayService` when the second of the two merges — no logical overlap.
- `CheckPermissions` on the `Service` interface remains unused in production code. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
