### PR TITLE
feat: add kcp migration txn-discovery

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -131,6 +131,22 @@ blocks:
             - cd cmd/ui/frontend && yarn install && yarn build && cd -
             - make test-schema-registry
 
+  # Only the main txn-discovery suite runs here. The HA suite
+  # (make test-txn-discovery-ha) is deliberately excluded: it is opt-in, slow,
+  # and inherently timing-sensitive, since it kills a broker mid-stream and
+  # asserts on recovery.
+  - name: 'integration: txn discovery'
+    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
+    task:
+      jobs:
+        - name: 'txn discovery'
+          commands:
+            - cache restore frontend-dependencies
+            - cache restore go-mod-cache
+            - cache restore go-build-cache
+            - cd cmd/ui/frontend && yarn install && yarn build && cd -
+            - make test-txn-discovery
+
   - name: 'integration: migration e2e'
     dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     task:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pre-commit-install: ## Install git pre-commit hooks
 # Tests
 # ==============================================================================
 
-.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry
+.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry test-txn-discovery
 
 test-go: build-frontend ## Run Go unit tests (excludes Terraform validation; see test-tf-validation)
 	go test $(GOTEST_FLAGS) ./...
@@ -125,6 +125,16 @@ test-schema-registry: build ## Run Schema Registry scan tests (unauthenticated, 
 	@bash integration-tests/schema-registry/setup.sh
 	@bash integration-tests/schema-registry/run.sh || (bash integration-tests/schema-registry/teardown.sh; exit 1)
 	@bash integration-tests/schema-registry/teardown.sh
+
+# Depends on `build`, not `build-frontend`: the suite execs ./kcp as a
+# subprocess (KTD5), so the whole binary has to exist, not just the assets the
+# unit tests embed. Teardown is a trap rather than the duplicated
+# `|| (teardown; exit 1)` of the targets above so it also runs when the test
+# binary panics or the run is interrupted, neither of which reaches a `||`.
+test-txn-discovery: build ## Run transaction-discovery E2E tests against a docker-compose broker
+	@bash integration-tests/txn-discovery/setup.sh
+	@trap 'bash integration-tests/txn-discovery/teardown.sh' EXIT; \
+	go test -tags e2e_txndiscovery -timeout 20m -v ./integration-tests/txn-discovery/...
 
 # ==============================================================================
 # State-file backward-compat archive (real generated kcp-state.json fixtures)

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,9 @@ test-txn-discovery: build ## Run transaction-discovery E2E tests against a docke
 # is the one CI runs.
 #
 # Its build tag is separate from that suite's so that `test-txn-discovery` cannot
-# accidentally pick this file up — the two need different clusters on different
-# ports and would fight over them.
+# accidentally pick this file up, and its brokers listen on 29192-29194 rather
+# than 29092, so the two stacks can coexist instead of failing at `compose up`
+# over an already-bound host port.
 test-txn-discovery-ha: build ## Run transaction-discovery leader-failover E2E tests (opt-in, 3 brokers, slow)
 	@bash integration-tests/txn-discovery-ha/setup.sh
 	@trap 'bash integration-tests/txn-discovery-ha/teardown.sh' EXIT; \

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pre-commit-install: ## Install git pre-commit hooks
 # Tests
 # ==============================================================================
 
-.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry test-txn-discovery
+.PHONY: test-go test-tf-validation test-playwright test-go-coverage test-go-coverage-ui test-migration test-migration-setup test-migration-teardown test-osk-scan test-kafka-connect test-schema-registry test-txn-discovery test-txn-discovery-ha
 
 test-go: build-frontend ## Run Go unit tests (excludes Terraform validation; see test-tf-validation)
 	go test $(GOTEST_FLAGS) ./...
@@ -135,6 +135,19 @@ test-txn-discovery: build ## Run transaction-discovery E2E tests against a docke
 	@bash integration-tests/txn-discovery/setup.sh
 	@trap 'bash integration-tests/txn-discovery/teardown.sh' EXIT; \
 	go test -tags e2e_txndiscovery -timeout 20m -v ./integration-tests/txn-discovery/...
+
+# Opt-in and deliberately NOT wired into CI: it boots three brokers, kills one
+# mid-run, and spends a single observation window waiting for leadership to move,
+# so it is both slow and inherently timing-sensitive. The single-node suite above
+# is the one CI runs.
+#
+# Its build tag is separate from that suite's so that `test-txn-discovery` cannot
+# accidentally pick this file up — the two need different clusters on different
+# ports and would fight over them.
+test-txn-discovery-ha: build ## Run transaction-discovery leader-failover E2E tests (opt-in, 3 brokers, slow)
+	@bash integration-tests/txn-discovery-ha/setup.sh
+	@trap 'bash integration-tests/txn-discovery-ha/teardown.sh' EXIT; \
+	go test -tags e2e_txndiscovery_ha -timeout 30m -v ./integration-tests/txn-discovery-ha/...
 
 # ==============================================================================
 # State-file backward-compat archive (real generated kcp-state.json fixtures)

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -51,6 +51,7 @@ var commandOrder = map[string][]string{
 		"migrate-connectors",
 	},
 	"kcp migration": {
+		"txn-discovery",
 		"init",
 		"execute",
 		"lag-check",

--- a/cmd/migration/cmd_migration.go
+++ b/cmd/migration/cmd_migration.go
@@ -5,6 +5,7 @@ import (
 	i "github.com/confluentinc/kcp/cmd/migration/init"
 	"github.com/confluentinc/kcp/cmd/migration/lagcheck"
 	"github.com/confluentinc/kcp/cmd/migration/list"
+	"github.com/confluentinc/kcp/cmd/migration/txndiscovery"
 
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,7 @@ Supporting documentation:
 		execute.NewMigrationExecuteCmd(),
 		lagcheck.NewMigrationLagCheckCmd(),
 		list.NewMigrationListCmd(),
+		txndiscovery.NewMigrationTxnDiscoveryCmd(),
 	)
 
 	return migrationCmd

--- a/cmd/migration/cmd_migration_test.go
+++ b/cmd/migration/cmd_migration_test.go
@@ -1,0 +1,24 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// R1: the command is registered alongside init, execute, lag-check and list, and
+// so appears in `kcp migration --help`.
+func TestMigrationCmd_RegistersTxnDiscovery(t *testing.T) {
+	cmd := NewMigrationCmd()
+
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	require.Contains(t, names, "txn-discovery")
+
+	sub, _, err := cmd.Find([]string{"txn-discovery"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, sub.Short, "the subcommand needs a Short so it renders in the parent's help")
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -1,0 +1,20 @@
+// Package txndiscovery wires `kcp migration txn-discovery`: the flags, the
+// preflight, and the run orchestration that drives the txndiscovery services.
+package txndiscovery
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewMigrationTxnDiscoveryCmd builds the `kcp migration txn-discovery` command.
+func NewMigrationTxnDiscoveryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "txn-discovery",
+		Short:         "Discover which topics are coupled by Kafka transactions and must migrate together",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Args:          cobra.NoArgs,
+	}
+
+	return cmd
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -114,6 +114,21 @@ func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if useSaslIam {
+		_ = cmd.MarkFlagRequired("aws-region")
+	}
+
+	if useSaslPlain {
+		_ = cmd.MarkFlagRequired("sasl-plain-username")
+		_ = cmd.MarkFlagRequired("sasl-plain-password")
+	}
+
+	if useTls {
+		_ = cmd.MarkFlagRequired("tls-ca-cert")
+		_ = cmd.MarkFlagRequired("tls-client-cert")
+		_ = cmd.MarkFlagRequired("tls-client-key")
+	}
+
 	if useSaslScram {
 		_ = cmd.MarkFlagRequired("sasl-scram-username")
 		_ = cmd.MarkFlagRequired("sasl-scram-password")

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -39,6 +39,7 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,
+		PreRunE:       preRunTxnDiscovery,
 		RunE:          runTxnDiscovery,
 	}
 
@@ -99,6 +100,15 @@ var authFlagNames = []string{
 	"use-tls",
 	"use-unauthenticated-tls",
 	"use-unauthenticated-plaintext",
+}
+
+func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
+	if useSaslScram {
+		_ = cmd.MarkFlagRequired("sasl-scram-username")
+		_ = cmd.MarkFlagRequired("sasl-scram-password")
+	}
+
+	return nil
 }
 
 func runTxnDiscovery(cmd *cobra.Command, args []string) error {

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -3,6 +3,8 @@
 package txndiscovery
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -106,6 +108,17 @@ func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
 	if useSaslScram {
 		_ = cmd.MarkFlagRequired("sasl-scram-username")
 		_ = cmd.MarkFlagRequired("sasl-scram-password")
+
+		// NewKafkaClient assigns the SCRAM configuration error to _, so an
+		// unsupported mechanism there yields a client that simply cannot
+		// authenticate, reported as a connection failure hours of debugging
+		// away from its cause. Validate it here, while it is still a flag.
+		switch saslScramMechanism {
+		case "SHA256", "SHA512":
+			// supported
+		default:
+			return fmt.Errorf("invalid --sasl-scram-mechanism %q: must be SHA256 or SHA512", saslScramMechanism)
+		}
 	}
 
 	return nil

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -3,6 +3,7 @@
 package txndiscovery
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -251,6 +252,24 @@ func resolveAuth() authResolution {
 	return r
 }
 
+// runDiscovery is the command's action, behind a variable so the flag tests can
+// exercise validation without reaching a broker.
+var runDiscovery = func(ctx context.Context, opts Opts) error {
+	return NewRunner(opts).Run(ctx)
+}
+
 func runTxnDiscovery(cmd *cobra.Command, args []string) error {
-	return nil
+	opts := parseOpts()
+	// R5: the POC's --log-level is dropped in favour of the root --verbose,
+	// which is where kcp's console verbosity already lives. Looked up rather
+	// than imported, because cmd/migration importing cmd would be a cycle.
+	opts.Verbose = boolFlag(cmd, "verbose")
+	return runDiscovery(cmd.Context(), opts)
+}
+
+// boolFlag reads an inherited boolean flag, reporting false when it is absent —
+// which it is when the command is built standalone rather than under the root.
+func boolFlag(cmd *cobra.Command, name string) bool {
+	f := cmd.Flags().Lookup(name)
+	return f != nil && f.Value.String() == "true"
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -5,6 +5,7 @@ package txndiscovery
 import (
 	"fmt"
 
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -130,6 +131,55 @@ func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// authResolution is the source-cluster authentication choice, resolved from the
+// flags into the triple client.AdminOptionForAuthMethod takes.
+type authResolution struct {
+	AuthType      types.AuthType
+	Method        types.AuthMethodConfig
+	SkipTLSVerify bool
+}
+
+// resolveAuth turns the auth flags into that triple. MarkFlagsOneRequired and
+// MarkFlagsMutuallyExclusive guarantee exactly one branch is live.
+func resolveAuth() authResolution {
+	r := authResolution{SkipTLSVerify: insecureSkipTLSVerify}
+	switch {
+	case useSaslIam:
+		r.AuthType = types.AuthTypeIAM
+		r.Method.IAM = &types.IAMConfig{Use: true}
+	case useSaslScram:
+		r.AuthType = types.AuthTypeSASLSCRAM
+		r.Method.SASLScram = &types.SASLScramConfig{
+			Use:       true,
+			Username:  saslScramUsername,
+			Password:  saslScramPassword,
+			Mechanism: saslScramMechanism,
+		}
+	case useSaslPlain:
+		r.AuthType = types.AuthTypeSASLPlain
+		r.Method.SASLPlain = &types.SASLPlainConfig{
+			Use:      true,
+			Username: saslPlainUsername,
+			Password: saslPlainPassword,
+		}
+	case useTls:
+		r.AuthType = types.AuthTypeTLS
+		r.Method.TLS = &types.TLSConfig{
+			Use:        true,
+			CACert:     tlsCaCert,
+			ClientCert: tlsClientCert,
+			ClientKey:  tlsClientKey,
+		}
+	case useUnauthenticatedTLS:
+		r.AuthType = types.AuthTypeUnauthenticatedTLS
+		r.Method.UnauthenticatedTLS = &types.UnauthenticatedTLSConfig{Use: true}
+	case useUnauthenticatedPlaintext:
+		r.AuthType = types.AuthTypeUnauthenticatedPlaintext
+		r.Method.UnauthenticatedPlaintext = &types.UnauthenticatedPlaintextConfig{Use: true}
+	}
+	return r
 }
 
 func runTxnDiscovery(cmd *cobra.Command, args []string) error {

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -177,7 +177,7 @@ visible in the process list.`,
 	tlsFlags.StringVar(&tlsCaCert, "tls-ca-cert", "", "Path to the TLS CA certificate for the source cluster.")
 	tlsFlags.StringVar(&tlsClientCert, "tls-client-cert", "", "Path to the TLS client certificate for the source cluster.")
 	tlsFlags.StringVar(&tlsClientKey, "tls-client-key", "", "Path to the TLS client key for the source cluster.")
-	tlsFlags.BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for Kafka connections. Lab use only.")
+	tlsFlags.BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for Kafka connections. Supported with --use-sasl-scram only — the other authentication modes cannot honour it, and naming it alongside one of them is rejected rather than ignored. Lab use only.")
 	cmd.Flags().AddFlagSet(tlsFlags)
 
 	outputFlags := pflag.NewFlagSet("output", pflag.ExitOnError)
@@ -255,6 +255,28 @@ func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
 	}
 	if interval <= 0 {
 		return fmt.Errorf("--interval must be greater than zero (got %s)", interval)
+	}
+
+	// --insecure-skip-tls-verify reaches exactly one of the six auth modes.
+	//
+	// It is threaded correctly as far as client.AdminOptionForAuthMethod, but only
+	// WithSASLSCRAMAuth takes the parameter: WithIAMAuth, WithTLSAuth and
+	// WithUnauthenticatedTlsAuth have no such argument and drop it, and the two
+	// plaintext modes have no TLS for it to apply to. Ignoring it is fail-closed —
+	// verification stays ON — but the flag's own help offered it for "Kafka
+	// connections" without qualification, so an operator in a lab with a self-signed
+	// certificate and --use-tls got a certificate error they could not suppress and no
+	// indication why. Better a flag error now than that.
+	//
+	// Rejected rather than threaded through the other three constructors: those live in
+	// internal/client and are shared with other commands, so widening their signatures
+	// is a larger change than this one.
+	//
+	// Keyed on the resolved VALUE, so the environment path is covered too, and only
+	// when an auth mode is actually selected, so a run that named no mode still gets
+	// cobra's own message about that rather than this one.
+	if insecureSkipTLSVerify && (useSaslIam || useSaslPlain || useTls || useUnauthenticatedTLS || useUnauthenticatedPlaintext) {
+		return fmt.Errorf("--insecure-skip-tls-verify is only supported with --use-sasl-scram, the one authentication mode whose client accepts it: --use-sasl-iam, --use-tls and --use-unauthenticated-tls would ignore it and keep verifying certificates, and --use-sasl-plain and --use-unauthenticated-plaintext use no TLS at all")
 	}
 
 	if useSaslIam {

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -85,6 +85,7 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 
 	_ = cmd.MarkFlagRequired("source-bootstrap")
 	cmd.MarkFlagsMutuallyExclusive(authFlagNames...)
+	cmd.MarkFlagsOneRequired(authFlagNames...)
 
 	return cmd
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -5,6 +5,7 @@ package txndiscovery
 import (
 	"fmt"
 
+	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -105,6 +106,13 @@ var authFlagNames = []string{
 }
 
 func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
+	// Every flag also reads from its uppercase, underscored environment
+	// equivalent. For the two password flags that is the documented path: a
+	// value passed by flag is visible in the process list.
+	if err := utils.BindEnvToFlags(cmd); err != nil {
+		return err
+	}
+
 	if useSaslScram {
 		_ = cmd.MarkFlagRequired("sasl-scram-username")
 		_ = cmd.MarkFlagRequired("sasl-scram-password")

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -63,8 +63,65 @@ var (
 // NewMigrationTxnDiscoveryCmd builds the `kcp migration txn-discovery` command.
 func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "txn-discovery",
-		Short:         "Discover which topics are coupled by Kafka transactions and must migrate together",
+		Use:   "txn-discovery",
+		Short: "Discover which topics are coupled by Kafka transactions and must migrate together",
+		Long: `Observe a source cluster for a window and reconstruct which topics are coupled by transactions.
+
+Topics written inside one transaction must migrate together: move one without
+the others and an in-flight transaction spans two clusters, which no cluster
+link can reconcile.
+
+The command reads ` + "`__transaction_state`" + ` from the beginning as its source of truth,
+reconstructing each transaction's produced footprint. Two optional phases then
+recover the topics those transactions CONSUMED, which the footprint never names:
+consumer-group enrichment correlates by the Kafka Streams naming convention, and
+the consumer-offsets tail correlates by record-batch producer id, which needs no
+naming assumption. Both are on by default and each can be turned off.
+
+Nothing is written to the cluster and no message payloads are read — only the
+keys and values of internal metadata topics.
+
+Requires READ on the transaction-state topic, and optionally READ on the
+consumer-offsets log and DESCRIBE on consumer groups. Preflight fails fast when
+the transaction-state topic cannot be read, so managed offerings that do not
+expose it (Confluent Cloud, MSK Serverless) are rejected rather than silently
+producing an empty result.
+
+The terminal summary reports counts only. Topic names and transactional ids
+identify customer business structure, so they live in the artifacts:
+
+  txn-discovery.yaml         the groups, one entry per set of coupled topics
+  txn-discovery-audit.jsonl  a live JSONL trace of every grouping decision, so
+                             "which transaction coupled these two topics?" can
+                             be answered after the run
+  --stats-out                keep-up metrics and per-transaction footprints
+
+All three are written 0600. The command never deletes them; remove them when the
+engagement ends.
+
+Nothing in kcp reads txn-discovery.yaml — it is for a human to review.
+
+Credentials come from the flags below or their uppercase, underscored
+environment equivalents. Prefer the environment: a value passed by flag is
+visible in the process list.`,
+		Example: `  # MSK with IAM, observing for ten minutes
+  kcp migration txn-discovery \
+      --source-bootstrap b-1.cluster.kafka.us-east-1.amazonaws.com:9098 \
+      --use-sasl-iam --aws-region us-east-1 \
+      --duration 10m
+
+  # Apache Kafka with SASL/SCRAM, password from the environment
+  export SASL_SCRAM_PASSWORD=...
+  kcp migration txn-discovery \
+      --source-bootstrap broker1:9096,broker2:9096 \
+      --use-sasl-scram --sasl-scram-username kcp-reader --sasl-scram-mechanism SHA256 \
+      --out ./engagement/txn-discovery.yaml
+
+  # See what would be produced without writing anything
+  kcp migration txn-discovery \
+      --source-bootstrap broker1:9092 \
+      --use-unauthenticated-plaintext \
+      --duration 2m --dry-run`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,
@@ -131,6 +188,31 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 	outputFlags.BoolVar(&noAuditLog, "no-audit-log", false, "Do not write the audit trail. It is the only artifact that answers why two topics were grouped, so disabling it is rarely what you want.")
 	outputFlags.BoolVar(&dryRun, "dry-run", false, "Observe and print the summary but write no files. Does not suppress kcp.log.")
 	cmd.Flags().AddFlagSet(outputFlags)
+
+	groups := []struct {
+		name  string
+		flags *pflag.FlagSet
+	}{
+		{"Required Flags", requiredFlags},
+		{"Observation Flags", observationFlags},
+		{"Output Flags", outputFlags},
+		{"Source Cluster Authentication Flags", authFlags},
+		{"IAM Flags", iamFlags},
+		{"SASL/SCRAM Flags", saslScramFlags},
+		{"SASL/PLAIN Flags", saslPlainFlags},
+		{"TLS Flags", tlsFlags},
+	}
+	cmd.SetUsageFunc(func(c *cobra.Command) error {
+		w := c.OutOrStdout()
+		_, _ = fmt.Fprintf(w, "%s\n\n", c.Short)
+		for _, g := range groups {
+			if usage := g.flags.FlagUsages(); usage != "" {
+				_, _ = fmt.Fprintf(w, "%s:\n%s\n", g.name, usage)
+			}
+		}
+		_, _ = fmt.Fprintln(w, "All flags can be provided via environment variables (uppercase, with underscores).")
+		return nil
+	})
 
 	_ = cmd.MarkFlagRequired("source-bootstrap")
 	cmd.MarkFlagsMutuallyExclusive(authFlagNames...)

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -211,6 +211,12 @@ visible in the process list.`,
 			}
 		}
 		_, _ = fmt.Fprintln(w, "All flags can be provided via environment variables (uppercase, with underscores).")
+		// A custom usage function replaces cobra's default template, which is
+		// what would otherwise have rendered these. Without this they reach
+		// only the generated docs and never an operator running --help.
+		if c.Example != "" {
+			_, _ = fmt.Fprintf(w, "\nExamples:\n%s\n", c.Example)
+		}
 		return nil
 	})
 

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -4,11 +4,22 @@ package txndiscovery
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/confluentinc/kcp/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+)
+
+const (
+	// DefaultOutPath is where the discovered groups land unless --out says otherwise.
+	DefaultOutPath = "txn-discovery.yaml"
+	// DefaultAuditBasename is the audit trail's filename. It is resolved against
+	// --out's directory, so pointing --out at another directory takes the trail
+	// with it rather than stranding it in the working directory.
+	DefaultAuditBasename = "txn-discovery-audit.jsonl"
 )
 
 var (
@@ -33,6 +44,19 @@ var (
 	tlsClientCert         string
 	tlsClientKey          string
 	insecureSkipTLSVerify bool
+
+	duration              time.Duration
+	interval              time.Duration
+	txnStateTopic         string
+	enrichConsumerGroups  bool
+	tailConsumerOffsets   bool
+	includeInternalTopics bool
+
+	outPath      string
+	statsOutPath string
+	auditLogPath string
+	noAuditLog   bool
+	dryRun       bool
 )
 
 // NewMigrationTxnDiscoveryCmd builds the `kcp migration txn-discovery` command.
@@ -51,6 +75,16 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 	requiredFlags.SortFlags = false
 	requiredFlags.StringVar(&sourceBootstrap, "source-bootstrap", "", "Bootstrap server(s) of the source Kafka cluster (e.g. broker1:9092,broker2:9092).")
 	cmd.Flags().AddFlagSet(requiredFlags)
+
+	observationFlags := pflag.NewFlagSet("observation", pflag.ExitOnError)
+	observationFlags.SortFlags = false
+	observationFlags.DurationVar(&duration, "duration", 5*time.Minute, "How long to observe the cluster. A longer window observes more transactions; a workload whose footprint records were compacted before the window opened is unrecoverable.")
+	observationFlags.DurationVar(&interval, "interval", 30*time.Second, "Cadence at which consumer-group enrichment refreshes and buffered producer-id sightings are resolved.")
+	observationFlags.StringVar(&txnStateTopic, "txn-state-topic", discovery.DefaultTxnStateTopic, "Name of the transaction-state internal topic — the source of truth, read from the beginning.")
+	observationFlags.BoolVar(&enrichConsumerGroups, "enrich-consumer-groups", true, "Recover the consumed input topics of read-process-write applications from consumer-group offsets, correlated by the Kafka Streams transactional.id/group.id naming convention. Needs describe on consumer groups.")
+	observationFlags.BoolVar(&tailConsumerOffsets, "tail-consumer-offsets", true, "Recover consumed inputs of arbitrary (non-Streams) exactly-once applications by exact producer-id correlation, tailing the consumer-offsets log. Needs read on that internal topic; the run warns and continues on the naming convention alone where it is unreadable.")
+	observationFlags.BoolVar(&includeInternalTopics, "include-internal-topics", false, "Keep internal (__-prefixed) topics in the grouping. Debug only: the consumer-offsets log is shared by every exactly-once application, so including it chains unrelated workloads into one group.")
+	cmd.Flags().AddFlagSet(observationFlags)
 
 	authFlags := pflag.NewFlagSet("auth", pflag.ExitOnError)
 	authFlags.SortFlags = false
@@ -88,6 +122,15 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 	tlsFlags.BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for Kafka connections. Lab use only.")
 	cmd.Flags().AddFlagSet(tlsFlags)
 
+	outputFlags := pflag.NewFlagSet("output", pflag.ExitOnError)
+	outputFlags.SortFlags = false
+	outputFlags.StringVar(&outPath, "out", DefaultOutPath, "Path to write the discovered groups to. Written 0600: it enumerates customer topic names.")
+	outputFlags.StringVar(&statsOutPath, "stats-out", "", "Also write a JSON diagnostics report — per-partition keep-up metrics, decode-failure counts, and the full per-transaction footprints — to this path. Written 0600.")
+	outputFlags.StringVar(&auditLogPath, "audit-log-out", "", "Path for the JSONL audit trail explaining every grouping decision. Defaults to "+DefaultAuditBasename+" beside --out. Written 0600.")
+	outputFlags.BoolVar(&noAuditLog, "no-audit-log", false, "Do not write the audit trail. It is the only artifact that answers why two topics were grouped, so disabling it is rarely what you want.")
+	outputFlags.BoolVar(&dryRun, "dry-run", false, "Observe and print the summary but write no files. Does not suppress kcp.log.")
+	cmd.Flags().AddFlagSet(outputFlags)
+
 	_ = cmd.MarkFlagRequired("source-bootstrap")
 	cmd.MarkFlagsMutuallyExclusive(authFlagNames...)
 	cmd.MarkFlagsOneRequired(authFlagNames...)
@@ -112,6 +155,16 @@ func preRunTxnDiscovery(cmd *cobra.Command, args []string) error {
 	// value passed by flag is visible in the process list.
 	if err := utils.BindEnvToFlags(cmd); err != nil {
 		return err
+	}
+
+	// A non-positive window would start every reader, observe nothing and write
+	// an authoritative-looking empty result; a non-positive interval would panic
+	// time.NewTicker part-way through the run.
+	if duration <= 0 {
+		return fmt.Errorf("--duration must be greater than zero (got %s)", duration)
+	}
+	if interval <= 0 {
+		return fmt.Errorf("--interval must be greater than zero (got %s)", interval)
 	}
 
 	if useSaslIam {

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -4,6 +4,31 @@ package txndiscovery
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	sourceBootstrap string
+	awsRegion       string
+
+	useSaslIam                  bool
+	useSaslScram                bool
+	useSaslPlain                bool
+	useTls                      bool
+	useUnauthenticatedTLS       bool
+	useUnauthenticatedPlaintext bool
+
+	saslScramUsername  string
+	saslScramPassword  string
+	saslScramMechanism string
+
+	saslPlainUsername string
+	saslPlainPassword string
+
+	tlsCaCert             string
+	tlsClientCert         string
+	tlsClientKey          string
+	insecureSkipTLSVerify bool
 )
 
 // NewMigrationTxnDiscoveryCmd builds the `kcp migration txn-discovery` command.
@@ -14,7 +39,67 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,
+		RunE:          runTxnDiscovery,
 	}
 
+	requiredFlags := pflag.NewFlagSet("required", pflag.ExitOnError)
+	requiredFlags.SortFlags = false
+	requiredFlags.StringVar(&sourceBootstrap, "source-bootstrap", "", "Bootstrap server(s) of the source Kafka cluster (e.g. broker1:9092,broker2:9092).")
+	cmd.Flags().AddFlagSet(requiredFlags)
+
+	authFlags := pflag.NewFlagSet("auth", pflag.ExitOnError)
+	authFlags.SortFlags = false
+	authFlags.BoolVar(&useSaslIam, "use-sasl-iam", false, "Use IAM authentication for the source MSK cluster.")
+	authFlags.BoolVar(&useSaslScram, "use-sasl-scram", false, "Use SASL/SCRAM authentication for the source cluster.")
+	authFlags.BoolVar(&useSaslPlain, "use-sasl-plain", false, "Use SASL/PLAIN authentication for the source cluster.")
+	authFlags.BoolVar(&useTls, "use-tls", false, "Use TLS (mutual TLS) authentication for the source cluster.")
+	authFlags.BoolVar(&useUnauthenticatedTLS, "use-unauthenticated-tls", false, "Use unauthenticated (TLS encryption) for the source cluster.")
+	authFlags.BoolVar(&useUnauthenticatedPlaintext, "use-unauthenticated-plaintext", false, "Use unauthenticated (plaintext) for the source cluster.")
+	cmd.Flags().AddFlagSet(authFlags)
+
+	iamFlags := pflag.NewFlagSet("iam", pflag.ExitOnError)
+	iamFlags.SortFlags = false
+	iamFlags.StringVar(&awsRegion, "aws-region", "", "AWS region of the source MSK cluster (e.g. us-east-1).")
+	cmd.Flags().AddFlagSet(iamFlags)
+
+	saslScramFlags := pflag.NewFlagSet("sasl-scram", pflag.ExitOnError)
+	saslScramFlags.SortFlags = false
+	saslScramFlags.StringVar(&saslScramUsername, "sasl-scram-username", "", "SASL/SCRAM username for the source cluster.")
+	saslScramFlags.StringVar(&saslScramPassword, "sasl-scram-password", "", "SASL/SCRAM password for the source cluster. Prefer the SASL_SCRAM_PASSWORD environment variable: a flag value is visible in the process list.")
+	saslScramFlags.StringVar(&saslScramMechanism, "sasl-scram-mechanism", "SHA512", "SASL/SCRAM mechanism (SHA256 or SHA512). Defaults to SHA512 for MSK compatibility.")
+	cmd.Flags().AddFlagSet(saslScramFlags)
+
+	saslPlainFlags := pflag.NewFlagSet("sasl-plain", pflag.ExitOnError)
+	saslPlainFlags.SortFlags = false
+	saslPlainFlags.StringVar(&saslPlainUsername, "sasl-plain-username", "", "SASL/PLAIN username for the source cluster.")
+	saslPlainFlags.StringVar(&saslPlainPassword, "sasl-plain-password", "", "SASL/PLAIN password for the source cluster. Prefer the SASL_PLAIN_PASSWORD environment variable: a flag value is visible in the process list.")
+	cmd.Flags().AddFlagSet(saslPlainFlags)
+
+	tlsFlags := pflag.NewFlagSet("tls", pflag.ExitOnError)
+	tlsFlags.SortFlags = false
+	tlsFlags.StringVar(&tlsCaCert, "tls-ca-cert", "", "Path to the TLS CA certificate for the source cluster.")
+	tlsFlags.StringVar(&tlsClientCert, "tls-client-cert", "", "Path to the TLS client certificate for the source cluster.")
+	tlsFlags.StringVar(&tlsClientKey, "tls-client-key", "", "Path to the TLS client key for the source cluster.")
+	tlsFlags.BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for Kafka connections. Lab use only.")
+	cmd.Flags().AddFlagSet(tlsFlags)
+
+	_ = cmd.MarkFlagRequired("source-bootstrap")
+	cmd.MarkFlagsMutuallyExclusive(authFlagNames...)
+
 	return cmd
+}
+
+// authFlagNames are the mutually exclusive source-cluster authentication flags,
+// exactly as `kcp migration execute` declares them.
+var authFlagNames = []string{
+	"use-sasl-iam",
+	"use-sasl-scram",
+	"use-sasl-plain",
+	"use-tls",
+	"use-unauthenticated-tls",
+	"use-unauthenticated-plaintext",
+}
+
+func runTxnDiscovery(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -134,6 +134,7 @@ func NewMigrationTxnDiscoveryCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("source-bootstrap")
 	cmd.MarkFlagsMutuallyExclusive(authFlagNames...)
 	cmd.MarkFlagsOneRequired(authFlagNames...)
+	cmd.MarkFlagsMutuallyExclusive("audit-log-out", "no-audit-log")
 
 	return cmd
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery.go
@@ -148,7 +148,7 @@ visible in the process list.`,
 	authFlags.SortFlags = false
 	authFlags.BoolVar(&useSaslIam, "use-sasl-iam", false, "Use IAM authentication for the source MSK cluster.")
 	authFlags.BoolVar(&useSaslScram, "use-sasl-scram", false, "Use SASL/SCRAM authentication for the source cluster.")
-	authFlags.BoolVar(&useSaslPlain, "use-sasl-plain", false, "Use SASL/PLAIN authentication for the source cluster.")
+	authFlags.BoolVar(&useSaslPlain, "use-sasl-plain", false, "Use SASL/PLAIN authentication for the source cluster. The listener is treated as SASL_PLAINTEXT: TLS is disabled, so the password is transmitted in cleartext and anything on the network path can read it.")
 	authFlags.BoolVar(&useTls, "use-tls", false, "Use TLS (mutual TLS) authentication for the source cluster.")
 	authFlags.BoolVar(&useUnauthenticatedTLS, "use-unauthenticated-tls", false, "Use unauthenticated (TLS encryption) for the source cluster.")
 	authFlags.BoolVar(&useUnauthenticatedPlaintext, "use-unauthenticated-plaintext", false, "Use unauthenticated (plaintext) for the source cluster.")

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -230,19 +230,28 @@ func TestTxnDiscovery_ScramWithoutCredentials_Rejected(t *testing.T) {
 func TestTxnDiscovery_UnsupportedScramMechanism_Rejected(t *testing.T) {
 	for _, mechanism := range []string{"SHA1", "sha512", "PLAIN", ""} {
 		t.Run("mechanism="+mechanism, func(t *testing.T) {
-			cmd := newTestCmd(t, []string{
+			resetFlags()
+			cmd := NewMigrationTxnDiscoveryCmd()
+			clearFlagEnv(t, cmd)
+			reached := false
+			previous := runDiscovery
+			runDiscovery = func(context.Context, Opts) error { reached = true; return nil }
+			t.Cleanup(func() { runDiscovery = previous })
+
+			cmd.SetArgs([]string{
 				"--source-bootstrap", "broker:9092",
 				"--use-sasl-scram",
 				"--sasl-scram-username", "reader",
 				"--sasl-scram-password", "hunter2",
 				"--sasl-scram-mechanism", mechanism,
-			}...)
+			})
 
 			err := cmd.Execute()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "--sasl-scram-mechanism")
 			assert.Contains(t, err.Error(), "SHA256")
 			assert.Contains(t, err.Error(), "SHA512")
+			assert.False(t, reached, "rejection happens during flag validation, before any client is built")
 		})
 	}
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -1,0 +1,53 @@
+package txndiscovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags clears the package-level flag variables between cases.
+//
+// Cobra binds these once per NewMigrationTxnDiscoveryCmd call, but the variables
+// themselves outlive the command, so a value set by one case leaks into the next.
+// Mirrors the helper in cmd/migration/init. Cases must therefore not run in
+// parallel.
+func resetFlags() {
+	sourceBootstrap = ""
+	awsRegion = ""
+
+	useSaslIam = false
+	useSaslScram = false
+	useSaslPlain = false
+	useTls = false
+	useUnauthenticatedTLS = false
+	useUnauthenticatedPlaintext = false
+
+	saslScramUsername = ""
+	saslScramPassword = ""
+	saslScramMechanism = ""
+	saslPlainUsername = ""
+	saslPlainPassword = ""
+
+	tlsCaCert = ""
+	tlsClientCert = ""
+	tlsClientKey = ""
+	insecureSkipTLSVerify = false
+}
+
+// R2: the auth flags mirror `kcp migration execute` — mutually exclusive, one required.
+func TestTxnDiscovery_TwoAuthMethods_Rejected(t *testing.T) {
+	resetFlags()
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--use-unauthenticated-plaintext",
+		"--use-unauthenticated-tls",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "were all set")
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -63,3 +63,40 @@ func TestTxnDiscovery_NoAuthMethod_Rejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one of the flags")
 }
+
+// R2: SCRAM is unusable without credentials, so the omission is a flag error
+// rather than an authentication failure discovered against the broker.
+func TestTxnDiscovery_ScramWithoutCredentials_Rejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "no username and no password",
+			args: []string{"--use-sasl-scram"},
+			want: "sasl-scram-username",
+		},
+		{
+			name: "username without password",
+			args: []string{"--use-sasl-scram", "--sasl-scram-username", "reader"},
+			want: "sasl-scram-password",
+		},
+		{
+			name: "password without username",
+			args: []string{"--use-sasl-scram", "--sasl-scram-password", "hunter2"},
+			want: "sasl-scram-username",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags()
+
+			cmd := NewMigrationTxnDiscoveryCmd()
+			cmd.SetArgs(append([]string{"--source-bootstrap", "broker:9092"}, tc.args...))
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -1,8 +1,10 @@
 package txndiscovery
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/confluentinc/kcp/internal/client"
 	"github.com/confluentinc/kcp/internal/types"
@@ -56,15 +58,75 @@ func clearFlagEnv(t *testing.T, cmd *cobra.Command) {
 	})
 }
 
-// newTestCmd builds a command with the package flag variables reset and the
-// ambient environment blanked, so a case depends only on the args it passes.
+// newTestCmd builds a command with the package flag variables reset, the
+// ambient environment blanked, and the run itself stubbed out, so a case
+// depends only on the args it passes and never reaches a broker.
 func newTestCmd(t *testing.T, args ...string) *cobra.Command {
 	t.Helper()
 	resetFlags()
 	cmd := NewMigrationTxnDiscoveryCmd()
 	clearFlagEnv(t, cmd)
 	cmd.SetArgs(args)
+	stubRun(t)
 	return cmd
+}
+
+// stubRun replaces the command's action with a recorder and returns a pointer to
+// what it was handed. Flag handling is what these cases exercise; connecting to
+// a cluster is the runner's own suite.
+func stubRun(t *testing.T) *Opts {
+	t.Helper()
+	previous := runDiscovery
+	var captured Opts
+	runDiscovery = func(_ context.Context, o Opts) error {
+		captured = o
+		return nil
+	}
+	t.Cleanup(func() { runDiscovery = previous })
+	return &captured
+}
+
+// R4, R5: the command hands the runner exactly what the flags say, including
+// the root --verbose that replaced the POC's --log-level.
+func TestTxnDiscovery_TheCommandRunsWithTheParsedOptions(t *testing.T) {
+	resetFlags()
+	root := &cobra.Command{Use: "kcp"}
+	root.PersistentFlags().Bool("verbose", false, "Enable verbose logging to console")
+	cmd := NewMigrationTxnDiscoveryCmd()
+	root.AddCommand(cmd)
+	clearFlagEnv(t, cmd)
+	got := stubRun(t)
+
+	root.SetArgs([]string{
+		"txn-discovery",
+		"--verbose",
+		"--source-bootstrap", "b1:9092, b2:9092,",
+		"--use-sasl-iam", "--aws-region", "eu-west-2",
+		"--duration", "90s",
+		"--interval", "15s",
+		"--txn-state-topic", "__txn_state_custom",
+		"--enrich-consumer-groups=false",
+		"--tail-consumer-offsets=false",
+		"--include-internal-topics",
+		"--out", "/tmp/engagement/groups.yaml",
+		"--stats-out", "/tmp/engagement/stats.json",
+	})
+	require.NoError(t, root.Execute())
+
+	assert.Equal(t, []string{"b1:9092", "b2:9092"}, got.Brokers, "a trailing comma must not become an empty broker")
+	assert.Equal(t, "eu-west-2", got.Region)
+	assert.Equal(t, types.AuthTypeIAM, got.Auth.AuthType)
+	assert.Equal(t, 90*time.Second, got.Duration)
+	assert.Equal(t, 15*time.Second, got.Interval)
+	assert.Equal(t, "__txn_state_custom", got.TxnStateTopic)
+	assert.False(t, got.EnrichConsumerGroups)
+	assert.False(t, got.TailConsumerOffsets)
+	assert.True(t, got.IncludeInternalTopics)
+	assert.Equal(t, "/tmp/engagement/groups.yaml", got.OutPath)
+	assert.Equal(t, "/tmp/engagement/stats.json", got.StatsOutPath)
+	assert.Equal(t, "/tmp/engagement/"+DefaultAuditBasename, got.AuditLogPath)
+	assert.True(t, got.Verbose, "the root --verbose gates the detailed keep-up block")
+	assert.NotNil(t, got.Stdout)
 }
 
 // R2: the auth flags mirror `kcp migration execute` — mutually exclusive, one required.

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -1,6 +1,7 @@
 package txndiscovery
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -127,6 +128,44 @@ func TestTxnDiscovery_TheCommandRunsWithTheParsedOptions(t *testing.T) {
 	assert.Equal(t, "/tmp/engagement/"+DefaultAuditBasename, got.AuditLogPath)
 	assert.True(t, got.Verbose, "the root --verbose gates the detailed keep-up block")
 	assert.NotNil(t, got.Stdout)
+}
+
+// R1/R4: --help renders the flags in named groups, as every other migration
+// subcommand does. Sixty-odd ungrouped flags in alphabetical order is not a
+// usable help page.
+func TestTxnDiscovery_Help_RendersGroupedFlags(t *testing.T) {
+	resetFlags()
+	cmd := NewMigrationTxnDiscoveryCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	require.NoError(t, cmd.Usage())
+	help := out.String()
+
+	for _, group := range []string{
+		"Required Flags",
+		"Observation Flags",
+		"Output Flags",
+		"Source Cluster Authentication Flags",
+		"IAM Flags",
+		"SASL/SCRAM Flags",
+		"SASL/PLAIN Flags",
+		"TLS Flags",
+	} {
+		assert.Contains(t, help, group+":")
+	}
+
+	// Every declared flag appears under some group, so adding one to the
+	// command without adding it to a group cannot leave it undocumented.
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" {
+			return
+		}
+		assert.Contains(t, help, "--"+f.Name, "flag is missing from the grouped usage")
+	})
+
+	assert.Contains(t, help, "environment variables", "the environment-variable path is the documented one for credentials")
 }
 
 // R2: the auth flags mirror `kcp migration execute` — mutually exclusive, one required.

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -343,3 +343,40 @@ func TestTxnDiscovery_IncompleteCredentialSet_Rejected(t *testing.T) {
 		})
 	}
 }
+
+// R4, abuse case: a window of zero or less would open every reader, observe
+// nothing, and write a confident, empty txn-discovery.yaml — an artifact that
+// reads as "this cluster has no transactional coupling".
+func TestTxnDiscovery_NonPositiveDuration_Rejected(t *testing.T) {
+	for _, d := range []string{"0", "0s", "-1s", "-5m"} {
+		t.Run("duration="+d, func(t *testing.T) {
+			cmd := newTestCmd(t,
+				"--source-bootstrap", "broker:9092",
+				"--use-unauthenticated-plaintext",
+				"--duration", d,
+			)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--duration")
+		})
+	}
+}
+
+// R4, abuse case: --interval feeds time.NewTicker, which panics on a
+// non-positive period. A crash mid-observation loses the whole window.
+func TestTxnDiscovery_NonPositiveInterval_Rejected(t *testing.T) {
+	for _, i := range []string{"0", "0s", "-1s"} {
+		t.Run("interval="+i, func(t *testing.T) {
+			cmd := newTestCmd(t,
+				"--source-bootstrap", "broker:9092",
+				"--use-unauthenticated-plaintext",
+				"--interval", i,
+			)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--interval")
+		})
+	}
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -147,3 +147,21 @@ func TestTxnDiscovery_SupportedScramMechanism_Accepted(t *testing.T) {
 		})
 	}
 }
+
+// R3: credentials come from flags or their auto-bound uppercase environment
+// equivalents. The environment path is the documented recommendation, because a
+// flag value is visible in the process list.
+func TestTxnDiscovery_PasswordFromEnvironment_IsPickedUp(t *testing.T) {
+	resetFlags()
+	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--use-sasl-scram",
+		"--sasl-scram-username", "reader",
+	})
+
+	require.NoError(t, cmd.Execute(), "the environment value must satisfy the required-flag check")
+	assert.Equal(t, "from-the-environment", saslScramPassword)
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -3,6 +3,8 @@ package txndiscovery
 import (
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/client"
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,4 +186,117 @@ func TestTxnDiscovery_ExplicitFlag_BeatsEnvironment(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, "from-the-flag", saslScramPassword)
 	assert.Equal(t, "flag-broker:9092", sourceBootstrap)
+}
+
+// R2: each auth flag resolves to the kcp auth type whose branch in
+// NewKafkaClient sets the TLS state the flag names. Getting this mapping wrong
+// is not a loud failure — resolving --use-unauthenticated-plaintext to the TLS
+// variant produces a client that hangs on a handshake the broker never expects.
+func TestTxnDiscovery_AuthFlags_ResolveToTheirAuthType(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want types.AuthType
+		// tlsEnabled is the TLS state NewKafkaClient's branch for want puts on
+		// the sarama config.
+		tlsEnabled bool
+	}{
+		{
+			name:       "iam",
+			args:       []string{"--use-sasl-iam", "--aws-region", "us-east-1"},
+			want:       types.AuthTypeIAM,
+			tlsEnabled: true,
+		},
+		{
+			name:       "sasl scram",
+			args:       []string{"--use-sasl-scram", "--sasl-scram-username", "reader", "--sasl-scram-password", "hunter2"},
+			want:       types.AuthTypeSASLSCRAM,
+			tlsEnabled: true,
+		},
+		{
+			name:       "sasl plain",
+			args:       []string{"--use-sasl-plain", "--sasl-plain-username", "reader", "--sasl-plain-password", "hunter2"},
+			want:       types.AuthTypeSASLPlain,
+			tlsEnabled: false,
+		},
+		{
+			name:       "mutual tls",
+			args:       []string{"--use-tls", "--tls-ca-cert", "ca.pem", "--tls-client-cert", "client.pem", "--tls-client-key", "client.key"},
+			want:       types.AuthTypeTLS,
+			tlsEnabled: true,
+		},
+		{
+			name:       "unauthenticated tls",
+			args:       []string{"--use-unauthenticated-tls"},
+			want:       types.AuthTypeUnauthenticatedTLS,
+			tlsEnabled: true,
+		},
+		{
+			name:       "unauthenticated plaintext",
+			args:       []string{"--use-unauthenticated-plaintext"},
+			want:       types.AuthTypeUnauthenticatedPlaintext,
+			tlsEnabled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags()
+
+			cmd := NewMigrationTxnDiscoveryCmd()
+			cmd.SetArgs(append([]string{"--source-bootstrap", "broker:9092"}, tc.args...))
+			require.NoError(t, cmd.Execute())
+
+			got := resolveAuth()
+			assert.Equal(t, tc.want, got.AuthType)
+			assert.Equal(t, tc.tlsEnabled, tlsEnabledFor(tc.want), "the auth type must be the one whose branch sets the expected TLS state")
+
+			// AdminOptionForAuthMethod is the erroring variant: it rejects an
+			// auth type whose sub-config was left nil rather than degrading to
+			// IAM the way AdminOptionForAuth does.
+			_, err := client.AdminOptionForAuthMethod(got.AuthType, got.Method, got.SkipTLSVerify)
+			require.NoError(t, err, "the resolved method config must be populated for its auth type")
+		})
+	}
+}
+
+// tlsEnabledFor mirrors the TLS decision NewKafkaClient's auth switch makes, so
+// the table above states the observable consequence of the mapping rather than
+// only restating the constant.
+func tlsEnabledFor(a types.AuthType) bool {
+	switch a {
+	case types.AuthTypeIAM, types.AuthTypeSASLSCRAM, types.AuthTypeTLS, types.AuthTypeUnauthenticatedTLS:
+		return true
+	default:
+		// SASL/PLAIN resolves to kcp's no-TLS PLAIN variant, and unauthenticated
+		// plaintext is plaintext by name.
+		return false
+	}
+}
+
+// R2: --insecure-skip-tls-verify defaults to false, so a run that does not name
+// it is not quietly making a TLS-verification decision.
+func TestTxnDiscovery_InsecureSkipTLSVerify_DefaultsToFalse(t *testing.T) {
+	resetFlags()
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{"--source-bootstrap", "broker:9092", "--use-unauthenticated-tls"})
+	require.NoError(t, cmd.Execute())
+
+	assert.False(t, resolveAuth().SkipTLSVerify)
+}
+
+// R2: and it reaches the auth helper's third argument when it is set.
+func TestTxnDiscovery_InsecureSkipTLSVerify_IsCarried(t *testing.T) {
+	resetFlags()
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "broker:9092",
+		"--use-sasl-scram",
+		"--sasl-scram-username", "reader",
+		"--sasl-scram-password", "hunter2",
+		"--insecure-skip-tls-verify",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, resolveAuth().SkipTLSVerify)
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -416,6 +416,85 @@ func TestTxnDiscovery_InsecureSkipTLSVerify_IsCarried(t *testing.T) {
 	assert.True(t, resolveAuth().SkipTLSVerify)
 }
 
+// --insecure-skip-tls-verify reaches exactly one of the six auth modes.
+//
+// The flag is threaded correctly as far as client.AdminOptionForAuthMethod, but only
+// WithSASLSCRAMAuth takes the parameter: WithIAMAuth, WithTLSAuth and
+// WithUnauthenticatedTlsAuth drop it on the floor, and the two plaintext modes have no
+// TLS for it to apply to. Accepting it anyway is fail-closed rather than a
+// vulnerability — verification stays ON — but the help text offers it for "Kafka
+// connections" without qualification, so an operator in a lab with a self-signed cert
+// and --use-tls gets a certificate error they cannot suppress and no clue why. It is
+// rejected while it is still a flag, rather than silently ignored for hours.
+//
+// Rejecting rather than widening the three shared constructors is deliberate: those
+// live in internal/client and are used by other commands, so changing their signatures
+// is a separate change with a wider blast radius.
+func TestTxnDiscovery_InsecureSkipTLSVerify_RejectedForAuthModesThatCannotHonourIt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "iam drops it",
+			args: []string{"--use-sasl-iam", "--aws-region", "us-east-1"},
+		},
+		{
+			name: "mutual tls drops it",
+			args: []string{"--use-tls", "--tls-ca-cert", "ca.pem", "--tls-client-cert", "client.pem", "--tls-client-key", "client.key"},
+		},
+		{
+			name: "unauthenticated tls drops it",
+			args: []string{"--use-unauthenticated-tls"},
+		},
+		{
+			name: "sasl plain has no tls at all",
+			args: []string{"--use-sasl-plain", "--sasl-plain-username", "reader", "--sasl-plain-password", "hunter2"},
+		},
+		{
+			name: "unauthenticated plaintext has no tls at all",
+			args: []string{"--use-unauthenticated-plaintext"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags()
+			cmd := NewMigrationTxnDiscoveryCmd()
+			clearFlagEnv(t, cmd)
+			reached := false
+			previous := runDiscovery
+			runDiscovery = func(context.Context, Opts) error { reached = true; return nil }
+			t.Cleanup(func() { runDiscovery = previous })
+
+			cmd.SetArgs(append([]string{
+				"--source-bootstrap", "broker:9092",
+				"--insecure-skip-tls-verify",
+			}, tc.args...))
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--insecure-skip-tls-verify")
+			assert.Contains(t, err.Error(), "--use-sasl-scram", "the error must name the mode that does honour the flag")
+			assert.False(t, reached, "rejection happens during flag validation, before any client is built")
+		})
+	}
+}
+
+// R3: and by the flag's VALUE, not by whether it was typed, so the environment path
+// cannot slip past the check. Every flag binds to its uppercase, underscored
+// equivalent, and INSECURE_SKIP_TLS_VERIFY exported in a shell reaches the same
+// resolution as the flag does.
+func TestTxnDiscovery_InsecureSkipTLSVerify_FromEnvironment_IsRejectedToo(t *testing.T) {
+	cmd := newTestCmd(t,
+		"--source-bootstrap", "broker:9092",
+		"--use-unauthenticated-tls",
+	)
+	t.Setenv("INSECURE_SKIP_TLS_VERIFY", "true")
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--insecure-skip-tls-verify")
+}
+
 // R2: an auth method selected without its full credential set is a flag error,
 // not a connection failure discovered minutes later against the broker.
 func TestTxnDiscovery_IncompleteCredentialSet_Rejected(t *testing.T) {

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -1,10 +1,13 @@
 package txndiscovery
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/confluentinc/kcp/internal/client"
 	"github.com/confluentinc/kcp/internal/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,16 +41,39 @@ func resetFlags() {
 	insecureSkipTLSVerify = false
 }
 
+// clearFlagEnv blanks the environment variable behind every flag the command
+// declares.
+//
+// R3 binds each flag to its uppercase, underscored name, and several of those —
+// AWS_REGION above all — are routinely exported in a developer's shell. Without
+// this a case asserting that a missing flag is rejected passes or fails on the
+// machine it runs on. Viper treats an empty variable as unset, so blanking is
+// the same as unsetting for the binder.
+func clearFlagEnv(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		t.Setenv(strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_")), "")
+	})
+}
+
+// newTestCmd builds a command with the package flag variables reset and the
+// ambient environment blanked, so a case depends only on the args it passes.
+func newTestCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	resetFlags()
+	cmd := NewMigrationTxnDiscoveryCmd()
+	clearFlagEnv(t, cmd)
+	cmd.SetArgs(args)
+	return cmd
+}
+
 // R2: the auth flags mirror `kcp migration execute` — mutually exclusive, one required.
 func TestTxnDiscovery_TwoAuthMethods_Rejected(t *testing.T) {
-	resetFlags()
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{
+	cmd := newTestCmd(t, []string{
 		"--source-bootstrap", "broker:9092",
 		"--use-unauthenticated-plaintext",
 		"--use-unauthenticated-tls",
-	})
+	}...)
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -56,10 +82,7 @@ func TestTxnDiscovery_TwoAuthMethods_Rejected(t *testing.T) {
 
 // R2: an auth method is not optional — a run with none would silently pick one.
 func TestTxnDiscovery_NoAuthMethod_Rejected(t *testing.T) {
-	resetFlags()
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{"--source-bootstrap", "broker:9092"})
+	cmd := newTestCmd(t, []string{"--source-bootstrap", "broker:9092"}...)
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -91,10 +114,7 @@ func TestTxnDiscovery_ScramWithoutCredentials_Rejected(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			resetFlags()
-
-			cmd := NewMigrationTxnDiscoveryCmd()
-			cmd.SetArgs(append([]string{"--source-bootstrap", "broker:9092"}, tc.args...))
+			cmd := newTestCmd(t, append([]string{"--source-bootstrap", "broker:9092"}, tc.args...)...)
 
 			err := cmd.Execute()
 			require.Error(t, err)
@@ -109,16 +129,13 @@ func TestTxnDiscovery_ScramWithoutCredentials_Rejected(t *testing.T) {
 func TestTxnDiscovery_UnsupportedScramMechanism_Rejected(t *testing.T) {
 	for _, mechanism := range []string{"SHA1", "sha512", "PLAIN", ""} {
 		t.Run("mechanism="+mechanism, func(t *testing.T) {
-			resetFlags()
-
-			cmd := NewMigrationTxnDiscoveryCmd()
-			cmd.SetArgs([]string{
+			cmd := newTestCmd(t, []string{
 				"--source-bootstrap", "broker:9092",
 				"--use-sasl-scram",
 				"--sasl-scram-username", "reader",
 				"--sasl-scram-password", "hunter2",
 				"--sasl-scram-mechanism", mechanism,
-			})
+			}...)
 
 			err := cmd.Execute()
 			require.Error(t, err)
@@ -134,16 +151,13 @@ func TestTxnDiscovery_UnsupportedScramMechanism_Rejected(t *testing.T) {
 func TestTxnDiscovery_SupportedScramMechanism_Accepted(t *testing.T) {
 	for _, mechanism := range []string{"SHA256", "SHA512"} {
 		t.Run("mechanism="+mechanism, func(t *testing.T) {
-			resetFlags()
-
-			cmd := NewMigrationTxnDiscoveryCmd()
-			cmd.SetArgs([]string{
+			cmd := newTestCmd(t, []string{
 				"--source-bootstrap", "broker:9092",
 				"--use-sasl-scram",
 				"--sasl-scram-username", "reader",
 				"--sasl-scram-password", "hunter2",
 				"--sasl-scram-mechanism", mechanism,
-			})
+			}...)
 
 			require.NoError(t, cmd.Execute())
 		})
@@ -154,15 +168,12 @@ func TestTxnDiscovery_SupportedScramMechanism_Accepted(t *testing.T) {
 // equivalents. The environment path is the documented recommendation, because a
 // flag value is visible in the process list.
 func TestTxnDiscovery_PasswordFromEnvironment_IsPickedUp(t *testing.T) {
-	resetFlags()
-	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{
+	cmd := newTestCmd(t,
 		"--source-bootstrap", "broker:9092",
 		"--use-sasl-scram",
 		"--sasl-scram-username", "reader",
-	})
+	)
+	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
 
 	require.NoError(t, cmd.Execute(), "the environment value must satisfy the required-flag check")
 	assert.Equal(t, "from-the-environment", saslScramPassword)
@@ -171,17 +182,14 @@ func TestTxnDiscovery_PasswordFromEnvironment_IsPickedUp(t *testing.T) {
 // R3: an explicitly supplied flag beats the environment. An operator overriding
 // an exported credential on one invocation must not silently get the exported one.
 func TestTxnDiscovery_ExplicitFlag_BeatsEnvironment(t *testing.T) {
-	resetFlags()
-	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
-	t.Setenv("SOURCE_BOOTSTRAP", "env-broker:9092")
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{
+	cmd := newTestCmd(t,
 		"--source-bootstrap", "flag-broker:9092",
 		"--use-sasl-scram",
 		"--sasl-scram-username", "reader",
 		"--sasl-scram-password", "from-the-flag",
-	})
+	)
+	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
+	t.Setenv("SOURCE_BOOTSTRAP", "env-broker:9092")
 
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, "from-the-flag", saslScramPassword)
@@ -239,10 +247,7 @@ func TestTxnDiscovery_AuthFlags_ResolveToTheirAuthType(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			resetFlags()
-
-			cmd := NewMigrationTxnDiscoveryCmd()
-			cmd.SetArgs(append([]string{"--source-bootstrap", "broker:9092"}, tc.args...))
+			cmd := newTestCmd(t, append([]string{"--source-bootstrap", "broker:9092"}, tc.args...)...)
 			require.NoError(t, cmd.Execute())
 
 			got := resolveAuth()
@@ -275,10 +280,7 @@ func tlsEnabledFor(a types.AuthType) bool {
 // R2: --insecure-skip-tls-verify defaults to false, so a run that does not name
 // it is not quietly making a TLS-verification decision.
 func TestTxnDiscovery_InsecureSkipTLSVerify_DefaultsToFalse(t *testing.T) {
-	resetFlags()
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{"--source-bootstrap", "broker:9092", "--use-unauthenticated-tls"})
+	cmd := newTestCmd(t, []string{"--source-bootstrap", "broker:9092", "--use-unauthenticated-tls"}...)
 	require.NoError(t, cmd.Execute())
 
 	assert.False(t, resolveAuth().SkipTLSVerify)
@@ -286,17 +288,58 @@ func TestTxnDiscovery_InsecureSkipTLSVerify_DefaultsToFalse(t *testing.T) {
 
 // R2: and it reaches the auth helper's third argument when it is set.
 func TestTxnDiscovery_InsecureSkipTLSVerify_IsCarried(t *testing.T) {
-	resetFlags()
-
-	cmd := NewMigrationTxnDiscoveryCmd()
-	cmd.SetArgs([]string{
+	cmd := newTestCmd(t, []string{
 		"--source-bootstrap", "broker:9092",
 		"--use-sasl-scram",
 		"--sasl-scram-username", "reader",
 		"--sasl-scram-password", "hunter2",
 		"--insecure-skip-tls-verify",
-	})
+	}...)
 	require.NoError(t, cmd.Execute())
 
 	assert.True(t, resolveAuth().SkipTLSVerify)
+}
+
+// R2: an auth method selected without its full credential set is a flag error,
+// not a connection failure discovered minutes later against the broker.
+func TestTxnDiscovery_IncompleteCredentialSet_Rejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "iam without a region",
+			args: []string{"--use-sasl-iam"},
+			want: "aws-region",
+		},
+		{
+			name: "plain without credentials",
+			args: []string{"--use-sasl-plain"},
+			want: "sasl-plain-username",
+		},
+		{
+			name: "plain username without password",
+			args: []string{"--use-sasl-plain", "--sasl-plain-username", "reader"},
+			want: "sasl-plain-password",
+		},
+		{
+			name: "mutual tls without certificates",
+			args: []string{"--use-tls"},
+			want: "tls-ca-cert",
+		},
+		{
+			name: "mutual tls missing the client key",
+			args: []string{"--use-tls", "--tls-ca-cert", "ca.pem", "--tls-client-cert", "client.pem"},
+			want: "tls-client-key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newTestCmd(t, append([]string{"--source-bootstrap", "broker:9092"}, tc.args...)...)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
 }

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -100,3 +100,50 @@ func TestTxnDiscovery_ScramWithoutCredentials_Rejected(t *testing.T) {
 		})
 	}
 }
+
+// R6: NewKafkaClient discards the mechanism error (it is assigned to _), so an
+// unsupported mechanism there silently produces a client that cannot
+// authenticate. Validation therefore has to happen during flag handling.
+func TestTxnDiscovery_UnsupportedScramMechanism_Rejected(t *testing.T) {
+	for _, mechanism := range []string{"SHA1", "sha512", "PLAIN", ""} {
+		t.Run("mechanism="+mechanism, func(t *testing.T) {
+			resetFlags()
+
+			cmd := NewMigrationTxnDiscoveryCmd()
+			cmd.SetArgs([]string{
+				"--source-bootstrap", "broker:9092",
+				"--use-sasl-scram",
+				"--sasl-scram-username", "reader",
+				"--sasl-scram-password", "hunter2",
+				"--sasl-scram-mechanism", mechanism,
+			})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--sasl-scram-mechanism")
+			assert.Contains(t, err.Error(), "SHA256")
+			assert.Contains(t, err.Error(), "SHA512")
+		})
+	}
+}
+
+// R6: the two mechanisms kcp supports pass validation. Without this the previous
+// test is satisfied by rejecting every mechanism.
+func TestTxnDiscovery_SupportedScramMechanism_Accepted(t *testing.T) {
+	for _, mechanism := range []string{"SHA256", "SHA512"} {
+		t.Run("mechanism="+mechanism, func(t *testing.T) {
+			resetFlags()
+
+			cmd := NewMigrationTxnDiscoveryCmd()
+			cmd.SetArgs([]string{
+				"--source-bootstrap", "broker:9092",
+				"--use-sasl-scram",
+				"--sasl-scram-username", "reader",
+				"--sasl-scram-password", "hunter2",
+				"--sasl-scram-mechanism", mechanism,
+			})
+
+			require.NoError(t, cmd.Execute())
+		})
+	}
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -51,3 +51,15 @@ func TestTxnDiscovery_TwoAuthMethods_Rejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "were all set")
 }
+
+// R2: an auth method is not optional — a run with none would silently pick one.
+func TestTxnDiscovery_NoAuthMethod_Rejected(t *testing.T) {
+	resetFlags()
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{"--source-bootstrap", "broker:9092"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of the flags")
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -166,6 +166,12 @@ func TestTxnDiscovery_Help_RendersGroupedFlags(t *testing.T) {
 	})
 
 	assert.Contains(t, help, "environment variables", "the environment-variable path is the documented one for credentials")
+
+	// A custom usage function replaces cobra's default template, which is what
+	// would otherwise have rendered Examples. Without this the examples exist
+	// only in the generated docs and an operator running --help never sees them.
+	assert.Contains(t, help, "Examples:")
+	assert.Contains(t, help, cmd.Example)
 }
 
 // R2: the auth flags mirror `kcp migration execute` — mutually exclusive, one required.

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -165,3 +165,23 @@ func TestTxnDiscovery_PasswordFromEnvironment_IsPickedUp(t *testing.T) {
 	require.NoError(t, cmd.Execute(), "the environment value must satisfy the required-flag check")
 	assert.Equal(t, "from-the-environment", saslScramPassword)
 }
+
+// R3: an explicitly supplied flag beats the environment. An operator overriding
+// an exported credential on one invocation must not silently get the exported one.
+func TestTxnDiscovery_ExplicitFlag_BeatsEnvironment(t *testing.T) {
+	resetFlags()
+	t.Setenv("SASL_SCRAM_PASSWORD", "from-the-environment")
+	t.Setenv("SOURCE_BOOTSTRAP", "env-broker:9092")
+
+	cmd := NewMigrationTxnDiscoveryCmd()
+	cmd.SetArgs([]string{
+		"--source-bootstrap", "flag-broker:9092",
+		"--use-sasl-scram",
+		"--sasl-scram-username", "reader",
+		"--sasl-scram-password", "from-the-flag",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "from-the-flag", saslScramPassword)
+	assert.Equal(t, "flag-broker:9092", sourceBootstrap)
+}

--- a/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
+++ b/cmd/migration/txndiscovery/cmd_migration_txn_discovery_test.go
@@ -380,3 +380,65 @@ func TestTxnDiscovery_NonPositiveInterval_Rejected(t *testing.T) {
 		})
 	}
 }
+
+// R18: the audit trail follows --out's directory. Pointing --out at an
+// engagement folder and leaving the trail in the working directory splits the
+// two artifacts an operator has to read together.
+func TestTxnDiscovery_AuditLogPath_DefaultsBesideOut(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "no paths given",
+			args: nil,
+			want: DefaultAuditBasename,
+		},
+		{
+			name: "out in another directory",
+			args: []string{"--out", "/tmp/engagement/groups.yaml"},
+			want: "/tmp/engagement/" + DefaultAuditBasename,
+		},
+		{
+			name: "out is a bare filename",
+			args: []string{"--out", "groups.yaml"},
+			want: DefaultAuditBasename,
+		},
+		{
+			name: "explicit audit path wins",
+			args: []string{"--out", "/tmp/engagement/groups.yaml", "--audit-log-out", "/var/log/trail.jsonl"},
+			want: "/var/log/trail.jsonl",
+		},
+		{
+			name: "no-audit-log disables it",
+			args: []string{"--no-audit-log"},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newTestCmd(t, append([]string{
+				"--source-bootstrap", "broker:9092",
+				"--use-unauthenticated-plaintext",
+			}, tc.args...)...)
+			require.NoError(t, cmd.Execute())
+
+			assert.Equal(t, tc.want, parseOpts().AuditLogPath)
+		})
+	}
+}
+
+// R18: naming a path for a trail that will not be written is a contradiction, so
+// it is rejected rather than silently resolved one way.
+func TestTxnDiscovery_AuditPathAndNoAuditLog_AreMutuallyExclusive(t *testing.T) {
+	cmd := newTestCmd(t,
+		"--source-bootstrap", "broker:9092",
+		"--use-unauthenticated-plaintext",
+		"--audit-log-out", "/tmp/trail.jsonl",
+		"--no-audit-log",
+	)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "were all set")
+}

--- a/cmd/migration/txndiscovery/txn_discovery_harness_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_harness_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/report"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/require"
 )
@@ -259,13 +260,17 @@ func (h *harness) runner(t *testing.T, opts Opts) *Runner {
 	if opts.Stdout == nil {
 		opts.Stdout = &bytes.Buffer{}
 	}
+	// Only topics the run will actually tail: a probe failure keeps the
+	// consumer-offsets log out of the assignment, so waiting on its fetch count
+	// would wait for a fetch that never comes.
 	topics := []string{opts.TxnStateTopic}
-	if opts.TailConsumerOffsets {
+	if opts.TailConsumerOffsets && h.probeErr == nil {
 		topics = append(topics, discovery.DefaultConsumerOffsetsTopic)
 	}
 	return &Runner{
-		opts:    opts,
-		connect: h.connect,
+		opts:     opts,
+		connect:  h.connect,
+		newAudit: report.NewAuditWriter,
 		window: func(ctx context.Context, _ time.Duration) {
 			deadline := time.Now().Add(30 * time.Second)
 			for {

--- a/cmd/migration/txndiscovery/txn_discovery_harness_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_harness_test.go
@@ -237,15 +237,22 @@ func (h *harness) connect(Opts) (*cluster, error) {
 	if h.connectErr != nil {
 		return nil, h.connectErr
 	}
-	return &cluster{
+	c := &cluster{
 		Describer: h.describer,
 		Tail:      h.tailClient,
-		Admin:     h.admin,
 		OffsetsProbe: func(context.Context) error {
 			return h.probeErr
 		},
 		Close: func() error { h.closes++; return nil },
-	}, nil
+	}
+	// Assigned only when there is one, so a nil admin reaches the runner as a nil
+	// INTERFACE rather than as a non-nil interface holding a nil pointer. That is
+	// the shape connectSarama produces when the enrichment connection could not be
+	// opened, and the difference decides whether the run degrades or panics.
+	if h.admin != nil {
+		c.Admin = h.admin
+	}
+	return c, nil
 }
 
 // runner builds a Runner over the harness whose observation window closes once

--- a/cmd/migration/txndiscovery/txn_discovery_harness_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_harness_test.go
@@ -1,0 +1,319 @@
+package txndiscovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/stretchr/testify/require"
+)
+
+// --- wire-format fixture builders -------------------------------------------
+//
+// Hand-assembled bytes against Kafka's TransactionLogKey/Value and
+// OffsetCommitKey schemas rather than an encoder from the packages under test,
+// so a decoder that only agrees with itself still fails here.
+
+func be16(v int16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(v))
+	return b
+}
+
+func be32(v int32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(v))
+	return b
+}
+
+func be64(v int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+func kstr(s string) []byte { return append(be16(int16(len(s))), s...) }
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// txnKey encodes a __transaction_state record key at schema v0.
+func txnKey(txnID string) []byte { return concat(be16(0), kstr(txnID)) }
+
+// txnValue encodes a __transaction_state record value at schema v0, status
+// Ongoing (1), with one partition per named topic.
+func txnValue(producerID int64, topics ...string) []byte {
+	parts := [][]byte{
+		be16(0),
+		be64(producerID),
+		be16(1),
+		be32(60000),
+		{1}, // Ongoing — a footprint-bearing status
+		be32(int32(len(topics))),
+	}
+	for _, tp := range topics {
+		parts = append(parts, kstr(tp), be32(1), be32(0))
+	}
+	parts = append(parts, be64(1000), be64(900))
+	return concat(parts...)
+}
+
+// commitKey encodes an OffsetCommitKey v1 — what an exactly-once app's
+// sendOffsetsToTransaction writes for one consumed topic-partition.
+func commitKey(group, topic string, partition int32) []byte {
+	return concat(be16(1), kstr(group), kstr(topic), be32(partition))
+}
+
+// stateRecordBatch is a non-transactional batch of transaction-state records.
+func stateRecordBatch(firstOffset int64, keys, values [][]byte) *sarama.RecordBatch {
+	rb := &sarama.RecordBatch{
+		Version:         2,
+		FirstOffset:     firstOffset,
+		LastOffsetDelta: int32(len(keys) - 1),
+		ProducerID:      -1,
+	}
+	for i := range keys {
+		rb.Records = append(rb.Records, &sarama.Record{
+			OffsetDelta: int64(i),
+			Key:         keys[i],
+			Value:       values[i],
+		})
+	}
+	return rb
+}
+
+// commitRecordBatch is the transactional batch a transactional offset commit
+// arrives in: the header carries the producer id that ties it to its transaction.
+func commitRecordBatch(firstOffset, producerID int64, keys ...[]byte) *sarama.RecordBatch {
+	rb := &sarama.RecordBatch{
+		Version:         2,
+		FirstOffset:     firstOffset,
+		LastOffsetDelta: int32(len(keys) - 1),
+		ProducerID:      producerID,
+		ProducerEpoch:   1,
+		IsTransactional: true,
+	}
+	for i, k := range keys {
+		rb.Records = append(rb.Records, &sarama.Record{
+			OffsetDelta: int64(i),
+			Key:         k,
+			Value:       []byte{0, 1},
+		})
+	}
+	return rb
+}
+
+// --- fakes -------------------------------------------------------------------
+
+// fakeTailClient serves a scripted set of record batches once per topic, then
+// answers empty. One partition per topic keeps the assignment predictable.
+type fakeTailClient struct {
+	mu      sync.Mutex
+	scripts map[string][]*sarama.RecordBatch
+	served  map[string]bool
+	fetches map[string]int
+}
+
+func newFakeTailClient() *fakeTailClient {
+	return &fakeTailClient{
+		scripts: map[string][]*sarama.RecordBatch{},
+		served:  map[string]bool{},
+		fetches: map[string]int{},
+	}
+}
+
+func (f *fakeTailClient) script(topic string, batches ...*sarama.RecordBatch) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.scripts[topic] = append(f.scripts[topic], batches...)
+}
+
+func (f *fakeTailClient) Partitions(string) ([]int32, error) { return []int32{0}, nil }
+
+func (f *fakeTailClient) Offset(string, int32, tail.StartPosition) (int64, error) { return 0, nil }
+
+func (f *fakeTailClient) Leader(string, int32) (tail.Leader, error) {
+	return tail.Leader{ID: 1, Addr: "broker:9092", FetchVersion: 11}, nil
+}
+
+func (f *fakeTailClient) RefreshMetadata(...string) error { return nil }
+
+func (f *fakeTailClient) Fetch(_ tail.Leader, spec tail.FetchSpec) (*sarama.FetchResponse, error) {
+	r := &sarama.FetchResponse{Version: 11}
+	r.AddError(spec.Topic, spec.Partition, sarama.ErrNoError)
+
+	f.mu.Lock()
+	f.fetches[spec.Topic]++
+	batches := f.scripts[spec.Topic]
+	first := !f.served[spec.Topic]
+	f.served[spec.Topic] = true
+	f.mu.Unlock()
+
+	var records int64
+	for _, rb := range batches {
+		records += int64(len(rb.Records))
+	}
+	if first {
+		for _, rb := range batches {
+			blk := r.GetBlock(spec.Topic, spec.Partition)
+			blk.RecordsSet = append(blk.RecordsSet, &sarama.Records{RecordBatch: rb})
+		}
+	}
+	// The reader is caught up once it has read the script, so lag is zero and
+	// the health line can report OK.
+	r.SetLastStableOffset(spec.Topic, spec.Partition, records)
+	r.GetBlock(spec.Topic, spec.Partition).HighWaterMarkOffset = records
+	return r, nil
+}
+
+// fetchesFor reports how many times a topic's partition has been fetched.
+func (f *fakeTailClient) fetchesFor(topic string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fetches[topic]
+}
+
+// fakeGroupAdmin is the consumer-group slice of sarama.ClusterAdmin.
+type fakeGroupAdmin struct {
+	groups  map[string]string
+	offsets map[string][]string // group -> consumed topics
+	err     error
+}
+
+func (f *fakeGroupAdmin) ListConsumerGroups() (map[string]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.groups, nil
+}
+
+func (f *fakeGroupAdmin) ListConsumerGroupOffsets(group string, _ map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	resp := &sarama.OffsetFetchResponse{Blocks: map[string]map[int32]*sarama.OffsetFetchResponseBlock{}}
+	for _, topic := range f.offsets[group] {
+		resp.Blocks[topic] = map[int32]*sarama.OffsetFetchResponseBlock{
+			0: {Offset: 10},
+		}
+	}
+	return resp, nil
+}
+
+// harness assembles the fakes into the cluster surface the runner connects to.
+type harness struct {
+	tailClient *fakeTailClient
+	describer  *fakeDescriber
+	admin      *fakeGroupAdmin
+	probeErr   error
+
+	connectErr error
+	closes     int
+}
+
+func newHarness() *harness {
+	return &harness{
+		tailClient: newFakeTailClient(),
+		describer:  &fakeDescriber{md: metadataFor(discovery.DefaultTxnStateTopic, sarama.ErrNoError, 1)},
+		admin:      &fakeGroupAdmin{groups: map[string]string{}, offsets: map[string][]string{}},
+	}
+}
+
+func (h *harness) connect(Opts) (*cluster, error) {
+	if h.connectErr != nil {
+		return nil, h.connectErr
+	}
+	return &cluster{
+		Describer: h.describer,
+		Tail:      h.tailClient,
+		Admin:     h.admin,
+		OffsetsProbe: func(context.Context) error {
+			return h.probeErr
+		},
+		Close: func() error { h.closes++; return nil },
+	}, nil
+}
+
+// runner builds a Runner over the harness whose observation window closes once
+// the tail has fetched every scripted topic several times over.
+//
+// The window is tied to observed progress rather than to a sleep: a partition
+// loop cannot issue its next fetch until every batch from the previous one has
+// been accepted downstream, so a topic fetched repeatedly after its script was
+// served has certainly delivered it.
+func (h *harness) runner(t *testing.T, opts Opts) *Runner {
+	t.Helper()
+	if opts.Stdout == nil {
+		opts.Stdout = &bytes.Buffer{}
+	}
+	topics := []string{opts.TxnStateTopic}
+	if opts.TailConsumerOffsets {
+		topics = append(topics, discovery.DefaultConsumerOffsetsTopic)
+	}
+	return &Runner{
+		opts:    opts,
+		connect: h.connect,
+		window: func(ctx context.Context, _ time.Duration) {
+			deadline := time.Now().Add(30 * time.Second)
+			for {
+				if ctx.Err() != nil {
+					return
+				}
+				settled := true
+				for _, topic := range topics {
+					if h.tailClient.fetchesFor(topic) < 5 {
+						settled = false
+					}
+				}
+				if settled || time.Now().After(deadline) {
+					return
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		},
+	}
+}
+
+// baseOpts is a complete run configuration writing into dir.
+func baseOpts(dir string) Opts {
+	return Opts{
+		Brokers:              []string{"broker:9092"},
+		Auth:                 authResolution{},
+		Duration:             time.Minute,
+		Interval:             50 * time.Millisecond,
+		TxnStateTopic:        discovery.DefaultTxnStateTopic,
+		EnrichConsumerGroups: true,
+		TailConsumerOffsets:  true,
+		OutPath:              filepath.Join(dir, "txn-discovery.yaml"),
+		AuditLogPath:         filepath.Join(dir, DefaultAuditBasename),
+		Stdout:               &bytes.Buffer{},
+	}
+}
+
+// readFile is a require-wrapped os.ReadFile.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// exists reports whether a path is present on disk.
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/migration/txndiscovery/txn_discovery_harness_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_harness_test.go
@@ -192,9 +192,16 @@ type fakeGroupAdmin struct {
 	groups  map[string]string
 	offsets map[string][]string // group -> consumed topics
 	err     error
+
+	// delay makes every call take this long, standing in for a broker that has
+	// stopped answering. sarama's two consumer-group calls take no context, so
+	// this is the only shape a slow one has: a call nothing can abandon from the
+	// inside. Set before the run starts and never written again.
+	delay time.Duration
 }
 
 func (f *fakeGroupAdmin) ListConsumerGroups() (map[string]string, error) {
+	time.Sleep(f.delay)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -202,6 +209,7 @@ func (f *fakeGroupAdmin) ListConsumerGroups() (map[string]string, error) {
 }
 
 func (f *fakeGroupAdmin) ListConsumerGroupOffsets(group string, _ map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	time.Sleep(f.delay)
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -148,6 +148,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	defer func() { _ = closeAudit() }()
 
 	// SIGINT and SIGTERM end the window early; the artifacts are still written.
+	//
+	// The registration is given up the moment the window is over — see below. It is
+	// still deferred as well, for the paths that return before the window opens; the
+	// stop NotifyContext hands back is safe to call more than once.
 	sigCtx, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
 
@@ -264,6 +268,24 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.window(sigCtx, r.opts.Duration)
+
+	// The window has done its job, so the signal handler is given back to Go
+	// BEFORE the drain — and before cancel(), which is what starts the drain.
+	//
+	// signal.NotifyContext's goroutine is one-shot: it cancels on the first signal
+	// and exits, leaving the registration in place on a size-1 channel nobody will
+	// read again, so every later signal is buffered and discarded. Held for the whole
+	// drain, that makes the run uninterruptible over exactly the stretch where an
+	// operator has reason to interrupt it: the drain is the last thing that talks to
+	// the broker, and a broker that has stopped answering is what makes it hang.
+	// SIGKILL would then be the only way out, and it takes all three artifacts —
+	// hours of observation — with it.
+	//
+	// Handing the signal back restores Go's default disposition, so a second Ctrl-C
+	// kills the process. Nothing before this point loses a signal by it: the window
+	// returns either because the duration elapsed or because a signal cancelled
+	// sigCtx, and in both cases the first signal has already had its effect.
+	stopSignals()
 
 	// BEFORE cancel. Every partition loop clears its running flag as it exits,
 	// so a snapshot taken after shutdown reports zero partitions live and the

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -1,0 +1,91 @@
+package txndiscovery
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Opts is the resolved configuration of one discovery run: everything the
+// runner needs, with no dependency on the flag variables it came from.
+type Opts struct {
+	// Brokers are the source cluster's bootstrap addresses and Region the AWS
+	// region IAM signing needs.
+	Brokers []string
+	Region  string
+	Auth    authResolution
+
+	// Duration is the observation window; Interval the cadence at which
+	// enrichment refreshes and buffered producer-id sightings are resolved.
+	Duration time.Duration
+	Interval time.Duration
+
+	TxnStateTopic         string
+	EnrichConsumerGroups  bool
+	TailConsumerOffsets   bool
+	IncludeInternalTopics bool
+
+	// OutPath is the groups YAML. StatsOutPath and AuditLogPath are empty when
+	// their artifact is not wanted — AuditLogPath is empty for --no-audit-log,
+	// which the runner turns into a nil AuditWriter whose methods are all no-ops.
+	OutPath      string
+	StatsOutPath string
+	AuditLogPath string
+
+	// DryRun suppresses every artifact write. It does not suppress kcp.log.
+	DryRun bool
+
+	// Verbose mirrors the root --verbose flag and gates the detailed keep-up block.
+	Verbose bool
+
+	// Stdout is where the terminal narrative goes.
+	Stdout io.Writer
+}
+
+// parseOpts snapshots the flag variables into an Opts.
+func parseOpts() Opts {
+	return Opts{
+		Brokers:               splitCSV(sourceBootstrap),
+		Region:                awsRegion,
+		Auth:                  resolveAuth(),
+		Duration:              duration,
+		Interval:              interval,
+		TxnStateTopic:         txnStateTopic,
+		EnrichConsumerGroups:  enrichConsumerGroups,
+		TailConsumerOffsets:   tailConsumerOffsets,
+		IncludeInternalTopics: includeInternalTopics,
+		OutPath:               outPath,
+		StatsOutPath:          statsOutPath,
+		AuditLogPath:          resolveAuditLogPath(outPath, auditLogPath, noAuditLog),
+		DryRun:                dryRun,
+		Stdout:                os.Stdout,
+	}
+}
+
+// resolveAuditLogPath decides where the audit trail is written, or that it is
+// not. An explicit path wins; otherwise the trail lands beside --out, because
+// an operator reading txn-discovery.yaml is the one who needs the trail that
+// explains it.
+func resolveAuditLogPath(out, explicit string, disabled bool) string {
+	if disabled {
+		return ""
+	}
+	if explicit != "" {
+		return explicit
+	}
+	return filepath.Join(filepath.Dir(out), DefaultAuditBasename)
+}
+
+// splitCSV parses a comma-separated bootstrap list, dropping blanks so a
+// trailing comma does not become an empty broker address.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -61,17 +61,18 @@ type Opts struct {
 // cluster is the broker-facing surface one run needs, behind one seam so the
 // orchestration is testable without a broker.
 type cluster struct {
-	// Describer answers the preflight.
+	// Describer answers the preflight. It rides the tail's connection, which is
+	// idle until the fetch loops start.
 	Describer topicDescriber
 	// Tail is the fetch seam both readers share.
 	Tail tail.Client
-	// Admin is the narrow consumer-group slice of sarama.ClusterAdmin. U7
-	// deliberately did not widen kcp's KafkaAdmin interface for it, so it is
-	// built here from the same sarama.Client the tail holds — and closed here.
+	// Admin is the narrow consumer-group slice of sarama.ClusterAdmin, on a
+	// connection of its own — see connectSaramaWith. Nil when enrichment is off,
+	// or when its connection could not be built, which the run degrades on.
 	Admin discovery.ConsumerGroupAdmin
 	// OffsetsProbe reports whether the consumer-offsets log can be read (R13).
 	OffsetsProbe discovery.TopicProbe
-	// Close releases the sarama client and the cluster admin built over it.
+	// Close releases every client this cluster opened, and the admins over them.
 	Close func() error
 }
 
@@ -179,7 +180,13 @@ func (r *Runner) Run(ctx context.Context) error {
 			offsetsActive = true
 		}
 	}
-	if r.opts.EnrichConsumerGroups {
+	// Gated on the admin rather than on the flag: connect degrades to a nil Admin when
+	// enrichment's own connection could not be opened, and a run that named the phase
+	// anyway would have every artifact report it as having found nothing rather than as
+	// never having run. Whether the phase ran is now read off ActiveSources by the
+	// report, exactly as the offsets phase's activity already was.
+	enrichActive := r.opts.EnrichConsumerGroups && cl.Admin != nil
+	if enrichActive {
 		activeSources = append(activeSources, discovery.SourceConsumerGroups)
 	}
 
@@ -241,7 +248,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Declared outside the branch so its counters can be read after the window; a
 	// nil enricher is the --enrich-consumer-groups=false case.
 	var enricher *discovery.ConsumerGroupEnricher
-	if r.opts.EnrichConsumerGroups {
+	if enrichActive {
 		enricher = &discovery.ConsumerGroupEnricher{
 			Admin:    cl.Admin,
 			Catalog:  catalog,
@@ -351,47 +358,147 @@ func (r *Runner) writeArtifacts(summary report.Summary, run report.Run) error {
 	return nil
 }
 
-// connectSarama builds the real cluster surface: one sarama.Client, the tail
-// seam over it, and a cluster admin built from the same client.
+// clusterAdmin is every cluster-admin call this command makes: the preflight's topic
+// description, enrichment's two consumer-group calls, and the close that releases the
+// client underneath. *sarama.ClusterAdmin satisfies it as-is.
 //
-// AdminOptionForAuthMethod is the erroring variant. AdminOptionForAuth, the
-// other one, logs a warning and falls back to IAM when it cannot resolve the
-// auth type — which against a non-MSK cluster is a puzzling authentication
-// failure rather than the configuration error it actually is.
+// It is declared here rather than reached through kcp's KafkaAdmin for the same reason
+// discovery.ConsumerGroupAdmin is: that interface exposes five unrelated methods and
+// keeps its sarama.ClusterAdmin unexported, so widening it would ripple through every
+// mock in the repo.
+type clusterAdmin interface {
+	topicDescriber
+	discovery.ConsumerGroupAdmin
+	Close() error
+}
+
+// clientFactory and adminFactory are the two constructors connectSaramaWith uses,
+// seamed so the suite can prove which client each admin was built over — the whole
+// question this wiring answers.
+type clientFactory func(brokers []string, region string, opts ...client.AdminOption) (sarama.Client, error)
+
+type adminFactory func(sarama.Client) (clusterAdmin, error)
+
+// connectSarama builds the real cluster surface.
 func connectSarama(opts Opts) (*cluster, error) {
+	return connectSaramaWith(opts, client.NewKafkaClient, newSaramaClusterAdmin)
+}
+
+func newSaramaClusterAdmin(c sarama.Client) (clusterAdmin, error) {
+	return sarama.NewClusterAdminFromClient(c)
+}
+
+// connectSaramaWith builds the cluster surface over TWO sarama clients: one the tail
+// fetches on and the preflight borrows, and one that exists solely so consumer-group
+// enrichment's admin calls do not queue behind those fetches.
+//
+// The second connection is the point. sarama pipelines requests on a connection and
+// delivers responses strictly in order, and both client.Brokers() (which
+// ListConsumerGroups uses) and client.Coordinator() (which ListConsumerGroupOffsets
+// uses) hand back the very *sarama.Broker the tail's hundred fetch loops are long-polling
+// on. Measured against the compose broker with those loops running, one pass's two calls
+// took 16-37s over the shared connection and 0-2ms over an independent one — which is
+// why --interval 5s over a 60s window achieved four or five enrichment passes rather
+// than thirteen. The POC did not have this problem because it built a separate
+// kgo.Client per role.
+//
+// The preflight admin stays on the tail's client deliberately: DescribeTopics is issued
+// before tl.Start, when that connection is idle, so it costs nothing and saves an
+// authentication.
+//
+// AdminOptionForAuthMethod is the erroring variant of the auth resolution, resolved ONCE
+// and applied to both clients so the two connections cannot drift in credentials, TLS
+// settings or --insecure-skip-tls-verify handling. AdminOptionForAuth, the other one,
+// logs a warning and falls back to IAM when it cannot resolve the auth type — which
+// against a non-MSK cluster is a puzzling authentication failure rather than the
+// configuration error it actually is.
+func connectSaramaWith(opts Opts, newClient clientFactory, newAdmin adminFactory) (*cluster, error) {
 	authOpt, err := client.AdminOptionForAuthMethod(opts.Auth.AuthType, opts.Auth.Method, opts.Auth.SkipTLSVerify)
 	if err != nil {
 		return nil, err
 	}
 
-	sc, err := client.NewKafkaClient(opts.Brokers, opts.Region, authOpt)
+	sc, err := newClient(opts.Brokers, opts.Region, authOpt)
 	if err != nil {
 		return nil, err
 	}
 
-	// U7 deliberately did not widen kcp's KafkaAdmin interface for the two
-	// consumer-group calls, so the admin is built here over the same client.
-	// NewClusterAdminFromClient does not take ownership of it, which is why the
-	// close below releases both, admin first.
-	admin, err := sarama.NewClusterAdminFromClient(sc)
+	admin, err := newAdmin(sc)
 	if err != nil {
 		_ = sc.Close()
 		return nil, fmt.Errorf("failed to build a cluster admin for the source cluster: %w", err)
 	}
 
-	return &cluster{
+	// closers releases everything opened so far, newest first. Every exit path below
+	// runs it, including the ones that fail: a preflight that never gets to run must
+	// not leave two authenticated sessions on the broker.
+	closers := []func() error{admin.Close}
+
+	cl := &cluster{
 		Describer: admin,
 		Tail:      tail.NewSaramaClient(sc, 0),
-		Admin:     admin,
 		OffsetsProbe: func(context.Context) error {
 			return probeReadableTopic(admin, discovery.DefaultConsumerOffsetsTopic)
 		},
-		Close: func() error {
-			// Closing the admin closes the client it was built from, so the
-			// client is not closed again here.
-			return admin.Close()
-		},
-	}, nil
+	}
+
+	// Only when something will use it: a second client is a second authentication to
+	// the broker, and --enrich-consumer-groups=false has nothing to spend it on.
+	if opts.EnrichConsumerGroups {
+		enrichAdmin, cerr := enrichmentAdmin(opts, newClient, newAdmin, authOpt)
+		if cerr != nil {
+			// R13's precedent: an optional enrichment source that cannot be set up
+			// warns and the run continues, rather than a second connection becoming a
+			// hard precondition of a command whose primary job needs only the first.
+			// The degradation is not silent — Run leaves consumer-group enrichment out
+			// of the run's active sources, so every artifact reports the phase as not
+			// having run rather than as having found nothing.
+			//
+			// The error is carried but the credentials are not: this warning reaches the
+			// console as well as kcp.log.
+			slog.Warn("⚠️ consumer-group enrichment is disabled for this run: its connection to the source cluster could not be opened",
+				"err", cerr)
+		} else {
+			cl.Admin = enrichAdmin
+			closers = append(closers, enrichAdmin.Close)
+		}
+	}
+
+	cl.Close = func() error {
+		var firstErr error
+		// Newest first, and every one attempted: a close that errors must not strand
+		// the connections behind it.
+		for i := len(closers) - 1; i >= 0; i-- {
+			if err := closers[i](); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+	return cl, nil
+}
+
+// enrichmentAdmin opens the connection enrichment gets to itself and builds its admin,
+// closing the client again if the admin cannot be built over it.
+//
+// The returned admin owns its client: closing it closes the connection, which is why the
+// caller only has to add its Close to the cluster's closers.
+//
+// authOpt is the caller's already-resolved auth, passed in rather than resolved again:
+// both connections must present identical credentials, TLS settings and
+// --insecure-skip-tls-verify handling, and resolving twice is how they would come to
+// differ.
+func enrichmentAdmin(opts Opts, newClient clientFactory, newAdmin adminFactory, authOpt client.AdminOption) (clusterAdmin, error) {
+	sc, err := newClient(opts.Brokers, opts.Region, authOpt)
+	if err != nil {
+		return nil, err
+	}
+	admin, err := newAdmin(sc)
+	if err != nil {
+		_ = sc.Close()
+		return nil, fmt.Errorf("failed to build a cluster admin for consumer-group enrichment: %w", err)
+	}
+	return admin, nil
 }
 
 // probeReadableTopic reports whether an internal topic can be described, which

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -183,6 +183,17 @@ func (r *Runner) Run(ctx context.Context) error {
 		activeSources = append(activeSources, discovery.SourceConsumerGroups)
 	}
 
+	// The log narrative for a run measured in hours. Counts and parameters only:
+	// kcp.log's file leg is unconditionally Debug+ and is what operators attach
+	// to support tickets, so no topic name or transactional id may appear.
+	slog.Info("🚀 starting transaction discovery",
+		"duration", r.opts.Duration.String(),
+		"interval", r.opts.Interval.String(),
+		"sources", len(activeSources),
+		"dry_run", r.opts.DryRun,
+		"audit_log", r.opts.AuditLogPath != "",
+	)
+
 	tl := tail.New(cl.Tail, tail.Options{})
 	batches, err := tl.Start(runCtx, specs)
 	if err != nil {
@@ -286,6 +297,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	summary := report.Summarize(run)
+	slog.Info("✅ transaction discovery complete",
+		"transactions", len(footprints),
+		"groups", len(run.Result.Groups),
+		"individual_topics", len(run.Result.IndividualTopics),
+		"records_read", tailStats.RecordsRead,
+		"partitions_running", tailStats.PartitionsRunning,
+		"partitions_assigned", tailStats.PartitionsAssigned,
+	)
 	report.PrintTerminal(r.opts.Stdout, summary)
 	if r.opts.Verbose {
 		// KTD4: the detailed keep-up block is behind --verbose; the summary

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -86,11 +86,16 @@ type Runner struct {
 	// configured duration, or as soon as ctx is done, which is how SIGINT ends
 	// a run early.
 	window func(ctx context.Context, d time.Duration)
+
+	// newAudit opens the audit trail. Seamed so the suite can drive the
+	// incomplete-trace path, whose only realistic production cause is a disk
+	// that fills mid-run.
+	newAudit func(path string) (*report.AuditWriter, error)
 }
 
 // NewRunner builds a runner over a real cluster.
 func NewRunner(opts Opts) *Runner {
-	return &Runner{opts: opts, connect: connectSarama, window: waitWindow}
+	return &Runner{opts: opts, connect: connectSarama, window: waitWindow, newAudit: report.NewAuditWriter}
 }
 
 // waitWindow is the production observation window: the configured duration, or
@@ -133,7 +138,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// check at each call site.
 	var audit *report.AuditWriter
 	if !r.opts.DryRun && r.opts.AuditLogPath != "" {
-		audit, err = report.NewAuditWriter(r.opts.AuditLogPath)
+		audit, err = r.newAudit(r.opts.AuditLogPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -238,8 +238,11 @@ func (r *Runner) Run(ctx context.Context) error {
 			_ = offsets.Run(runCtx, dests[1], obs)
 		}()
 	}
+	// Declared outside the branch so its counters can be read after the window; a
+	// nil enricher is the --enrich-consumer-groups=false case.
+	var enricher *discovery.ConsumerGroupEnricher
 	if r.opts.EnrichConsumerGroups {
-		enricher := &discovery.ConsumerGroupEnricher{
+		enricher = &discovery.ConsumerGroupEnricher{
 			Admin:    cl.Admin,
 			Catalog:  catalog,
 			Interval: r.opts.Interval,
@@ -282,18 +285,22 @@ func (r *Runner) Run(ctx context.Context) error {
 	_ = closeAudit()
 
 	run := report.Run{
-		Duration:         r.opts.Duration,
-		Interval:         r.opts.Interval,
-		ActiveSources:    activeSources,
-		Footprints:       footprints,
-		Result:           grouping.Build(txns, grouping.Options{IncludeInternalTopics: r.opts.IncludeInternalTopics}),
-		Tail:             tailStats,
-		TxnState:         txnReader.Stats(),
-		AuditErrors:      audit.Errors(),
-		EnrichmentActive: r.opts.EnrichConsumerGroups,
+		Duration:      r.opts.Duration,
+		Interval:      r.opts.Interval,
+		ActiveSources: activeSources,
+		Footprints:    footprints,
+		Result:        grouping.Build(txns, grouping.Options{IncludeInternalTopics: r.opts.IncludeInternalTopics}),
+		Tail:          tailStats,
+		TxnState:      txnReader.Stats(),
+		AuditErrors:   audit.Errors(),
 	}
 	if offsets != nil {
 		run.Offsets = offsets.Stats()
+	}
+	// Read after srcWG.Wait(), so the final pass at the window's close — the one
+	// most likely to carry a correlation — is included rather than raced.
+	if enricher != nil {
+		run.Enrichment = enricher.Stats()
 	}
 
 	summary := report.Summarize(run)

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -2,14 +2,23 @@ package txndiscovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/client"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/report"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 )
 
@@ -47,6 +56,330 @@ type Opts struct {
 
 	// Stdout is where the terminal narrative goes.
 	Stdout io.Writer
+}
+
+// cluster is the broker-facing surface one run needs, behind one seam so the
+// orchestration is testable without a broker.
+type cluster struct {
+	// Describer answers the preflight.
+	Describer topicDescriber
+	// Tail is the fetch seam both readers share.
+	Tail tail.Client
+	// Admin is the narrow consumer-group slice of sarama.ClusterAdmin. U7
+	// deliberately did not widen kcp's KafkaAdmin interface for it, so it is
+	// built here from the same sarama.Client the tail holds — and closed here.
+	Admin discovery.ConsumerGroupAdmin
+	// OffsetsProbe reports whether the consumer-offsets log can be read (R13).
+	OffsetsProbe discovery.TopicProbe
+	// Close releases the sarama client and the cluster admin built over it.
+	Close func() error
+}
+
+// Runner orchestrates one discovery run.
+type Runner struct {
+	opts Opts
+
+	// connect builds the broker-facing surface.
+	connect func(Opts) (*cluster, error)
+
+	// window blocks until the observation window should end — after the
+	// configured duration, or as soon as ctx is done, which is how SIGINT ends
+	// a run early.
+	window func(ctx context.Context, d time.Duration)
+}
+
+// NewRunner builds a runner over a real cluster.
+func NewRunner(opts Opts) *Runner {
+	return &Runner{opts: opts, connect: connectSarama, window: waitWindow}
+}
+
+// waitWindow is the production observation window: the configured duration, or
+// as soon as ctx is done — which is how SIGINT ends a run early.
+func waitWindow(ctx context.Context, d time.Duration) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+}
+
+// observationBuffer decouples the three sources from the single accumulator
+// goroutine, so a burst on one source does not stall the fetch loops feeding
+// the others.
+const observationBuffer = 256
+
+// Run performs one discovery run.
+//
+// The ordering is load-bearing: start the sources, hold the window, snapshot the
+// tail's stats, cancel, drain the sources (which is where the offsets tail's
+// final flush happens, on a fresh context), and only then write the artifacts.
+// Writing before the final flush ships a YAML missing the late producer-id
+// resolutions that phase exists to produce.
+func (r *Runner) Run(ctx context.Context) error {
+	cl, err := r.connect(r.opts)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cl.Close() }()
+
+	// R12: fail before anything is created on disk or observed.
+	if err := probeTxnStateTopic(cl.Describer, r.opts.TxnStateTopic); err != nil {
+		return err
+	}
+
+	// R18/R20. A nil writer is the --no-audit-log (and --dry-run) case; every
+	// AuditWriter method tolerates nil, so this is one branch rather than a nil
+	// check at each call site.
+	var audit *report.AuditWriter
+	if !r.opts.DryRun && r.opts.AuditLogPath != "" {
+		audit, err = report.NewAuditWriter(r.opts.AuditLogPath)
+		if err != nil {
+			return err
+		}
+	}
+	closeAudit := sync.OnceValue(audit.Close)
+	defer func() { _ = closeAudit() }()
+
+	// SIGINT and SIGTERM end the window early; the artifacts are still written.
+	sigCtx, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The catalog is populated by the transaction-state reader and read by both
+	// enrichment phases, so neither calls the transaction admin APIs.
+	catalog := discovery.NewTxnCatalog()
+	acc := discovery.NewAccumulator()
+
+	txnReader := discovery.NewTxnStateReader(r.opts.TxnStateTopic, catalog)
+	specs := []tail.TopicSpec{{Topic: r.opts.TxnStateTopic, Start: tail.StartEarliest}}
+	activeSources := []string{discovery.SourceTxnStateLog}
+
+	// R9/R13: the offsets tail is gated on an availability probe. When the topic
+	// is unreadable the object is kept anyway — its Stats carry the flag the
+	// report needs to distinguish "ran and found nothing" from "never ran".
+	var offsets *discovery.ConsumerOffsetsTail
+	offsetsActive := false
+	if r.opts.TailConsumerOffsets {
+		offsets = discovery.NewConsumerOffsetsTail(catalog, discovery.ConsumerOffsetsOptions{
+			Topic:    discovery.DefaultConsumerOffsetsTopic,
+			Interval: r.opts.Interval,
+			Probe:    cl.OffsetsProbe,
+		})
+		if offsets.Available(runCtx) {
+			specs = append(specs, tail.TopicSpec{Topic: discovery.DefaultConsumerOffsetsTopic, Start: tail.StartLatest})
+			activeSources = append(activeSources, discovery.SourceConsumerOffsets)
+			offsetsActive = true
+		}
+	}
+	if r.opts.EnrichConsumerGroups {
+		activeSources = append(activeSources, discovery.SourceConsumerGroups)
+	}
+
+	tl := tail.New(cl.Tail, tail.Options{})
+	batches, err := tl.Start(runCtx, specs)
+	if err != nil {
+		if errors.Is(err, tail.ErrFetchVersionUnsupported) {
+			return fmt.Errorf("the source cluster cannot serve the reads this command needs: %w", err)
+		}
+		return fmt.Errorf("failed to start reading the source cluster: %w", err)
+	}
+
+	obs := make(chan discovery.Observation, observationBuffer)
+	var accWG sync.WaitGroup
+	accWG.Add(1)
+	go func() {
+		defer accWG.Done()
+		// KTD7: the accumulator is the only component that knows whether an
+		// observation grew a transaction's topic set, so the audit line
+		// originates here rather than in the sources.
+		for o := range obs {
+			audit.Record(o, acc.Add(o))
+		}
+	}()
+
+	dests := []chan tail.Batch{make(chan tail.Batch)}
+	if offsetsActive {
+		dests = append(dests, make(chan tail.Batch))
+	}
+	go fanOut(runCtx, batches, dests)
+
+	var srcWG sync.WaitGroup
+	srcWG.Add(1)
+	go func() {
+		defer srcWG.Done()
+		_ = txnReader.Run(runCtx, dests[0], obs)
+	}()
+	if offsetsActive {
+		srcWG.Add(1)
+		go func() {
+			defer srcWG.Done()
+			// Run performs the final flush itself when its input closes, on a
+			// fresh context, because runCtx is already cancelled by then and
+			// that flush is where most resolutions land.
+			_ = offsets.Run(runCtx, dests[1], obs)
+		}()
+	}
+	if r.opts.EnrichConsumerGroups {
+		enricher := &discovery.ConsumerGroupEnricher{
+			Admin:    cl.Admin,
+			Catalog:  catalog,
+			Interval: r.opts.Interval,
+			// Log must be set: the enricher dereferences it on a failed pass.
+			Log: slog.Default(),
+		}
+		srcWG.Add(1)
+		go func() {
+			defer srcWG.Done()
+			_ = enricher.Run(runCtx, obs)
+		}()
+	}
+
+	r.window(sigCtx, r.opts.Duration)
+
+	// BEFORE cancel. Every partition loop clears its running flag as it exits,
+	// so a snapshot taken after shutdown reports zero partitions live and the
+	// health line condemns a perfectly healthy run as failed.
+	tailStats := tl.Stats()
+
+	cancel()
+	srcWG.Wait()
+	close(obs)
+	accWG.Wait()
+	tl.Wait()
+
+	footprints := acc.Snapshot()
+	txns := make([]grouping.Transaction, 0, len(footprints))
+	for _, fp := range footprints {
+		txns = append(txns, grouping.Transaction{
+			ID:               fp.TxnID,
+			Topics:           fp.Topics,
+			ReadProcessWrite: fp.ReadProcessWrite,
+		})
+	}
+
+	// Closed before the counters are read: on a buffered or network filesystem
+	// the deferred write error surfaces at close, and a failed close means lines
+	// are missing just as a failed write does.
+	_ = closeAudit()
+
+	run := report.Run{
+		Duration:         r.opts.Duration,
+		Interval:         r.opts.Interval,
+		ActiveSources:    activeSources,
+		Footprints:       footprints,
+		Result:           grouping.Build(txns, grouping.Options{IncludeInternalTopics: r.opts.IncludeInternalTopics}),
+		Tail:             tailStats,
+		TxnState:         txnReader.Stats(),
+		AuditErrors:      audit.Errors(),
+		EnrichmentActive: r.opts.EnrichConsumerGroups,
+	}
+	if offsets != nil {
+		run.Offsets = offsets.Stats()
+	}
+
+	summary := report.Summarize(run)
+	report.PrintTerminal(r.opts.Stdout, summary)
+	if r.opts.Verbose {
+		// KTD4: the detailed keep-up block is behind --verbose; the summary
+		// carries one health line.
+		report.PrintKeepUp(r.opts.Stdout, run)
+	}
+
+	if err := r.writeArtifacts(summary, run); err != nil {
+		return err
+	}
+
+	// The exit code is this command's, not the report's: a truncated audit log
+	// reads downstream as "no transaction coupled these topics", which is
+	// indistinguishable from a clean run unless the run itself fails.
+	if n := audit.Errors(); n > 0 {
+		return fmt.Errorf("the audit trail is incomplete: %d line(s) could not be written, so it cannot be relied on to explain a grouping", n)
+	}
+	return nil
+}
+
+// writeArtifacts writes the YAML and, when asked for, the stats JSON. R20:
+// --dry-run writes nothing at all — it does not suppress kcp.log.
+func (r *Runner) writeArtifacts(summary report.Summary, run report.Run) error {
+	if r.opts.DryRun {
+		_, _ = fmt.Fprintf(r.opts.Stdout, "\nDry run: no files written.\n")
+		return nil
+	}
+	if err := report.WriteYAML(r.opts.OutPath, summary); err != nil {
+		return err
+	}
+	if r.opts.StatsOutPath != "" {
+		if err := report.WriteStatsJSON(r.opts.StatsOutPath, run); err != nil {
+			return err
+		}
+	}
+	_, _ = fmt.Fprintf(r.opts.Stdout, "\nWrote %d group(s) to %s\n", len(summary.Result.Groups), r.opts.OutPath)
+	return nil
+}
+
+// connectSarama builds the real cluster surface: one sarama.Client, the tail
+// seam over it, and a cluster admin built from the same client.
+//
+// AdminOptionForAuthMethod is the erroring variant. AdminOptionForAuth, the
+// other one, logs a warning and falls back to IAM when it cannot resolve the
+// auth type — which against a non-MSK cluster is a puzzling authentication
+// failure rather than the configuration error it actually is.
+func connectSarama(opts Opts) (*cluster, error) {
+	authOpt, err := client.AdminOptionForAuthMethod(opts.Auth.AuthType, opts.Auth.Method, opts.Auth.SkipTLSVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	sc, err := client.NewKafkaClient(opts.Brokers, opts.Region, authOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	// U7 deliberately did not widen kcp's KafkaAdmin interface for the two
+	// consumer-group calls, so the admin is built here over the same client.
+	// NewClusterAdminFromClient does not take ownership of it, which is why the
+	// close below releases both, admin first.
+	admin, err := sarama.NewClusterAdminFromClient(sc)
+	if err != nil {
+		_ = sc.Close()
+		return nil, fmt.Errorf("failed to build a cluster admin for the source cluster: %w", err)
+	}
+
+	return &cluster{
+		Describer: admin,
+		Tail:      tail.NewSaramaClient(sc, 0),
+		Admin:     admin,
+		OffsetsProbe: func(context.Context) error {
+			return probeReadableTopic(admin, discovery.DefaultConsumerOffsetsTopic)
+		},
+		Close: func() error {
+			// Closing the admin closes the client it was built from, so the
+			// client is not closed again here.
+			return admin.Close()
+		},
+	}, nil
+}
+
+// probeReadableTopic reports whether an internal topic can be described, which
+// is R13's availability check for the consumer-offsets log.
+//
+// The reason it returns reaches the console and kcp.log verbatim, so it names
+// the failure without naming the topic.
+func probeReadableTopic(d topicDescriber, topic string) error {
+	md, err := d.DescribeTopics([]string{topic})
+	if err != nil {
+		return err
+	}
+	if len(md) == 0 || md[0] == nil {
+		return fmt.Errorf("the broker returned no metadata for the consumer-offsets log")
+	}
+	if md[0].Err != sarama.ErrNoError {
+		return md[0].Err
+	}
+	return nil
 }
 
 // topicDescriber is the one cluster-admin call the preflight makes.

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -1,11 +1,14 @@
 package txndiscovery
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/IBM/sarama"
 )
 
 // Opts is the resolved configuration of one discovery run: everything the
@@ -42,6 +45,42 @@ type Opts struct {
 
 	// Stdout is where the terminal narrative goes.
 	Stdout io.Writer
+}
+
+// topicDescriber is the one cluster-admin call the preflight makes.
+//
+// DescribeTopics is used rather than the client's offset lookup because it
+// returns a per-topic Kafka error code, which is what separates a mistyped
+// --txn-state-topic from a missing ACL. The client's Exists path collapses both
+// into "not in the topic list".
+type topicDescriber interface {
+	DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error)
+}
+
+// probeTxnStateTopic verifies the transaction-state log is there and readable.
+//
+// No error it returns carries the topic name: main slog.Error's every command
+// error, so all of them land in kcp.log, and --txn-state-topic is
+// operator-supplied.
+func probeTxnStateTopic(d topicDescriber, topic string) error {
+	md, err := d.DescribeTopics([]string{topic})
+	if err != nil {
+		return fmt.Errorf("could not read the transaction-state topic's metadata: check --source-bootstrap, the source authentication flags and that the credentials carry an ACL granting DESCRIBE and READ on it: %w", err)
+	}
+	if len(md) == 0 || md[0] == nil {
+		return fmt.Errorf("the broker returned no metadata for the transaction-state topic named by --txn-state-topic, so it could not be confirmed readable")
+	}
+
+	switch md[0].Err {
+	case sarama.ErrNoError:
+		return nil
+	case sarama.ErrUnknownTopicOrPartition:
+		// kcp disables auto topic creation, so an unknown name stays unknown
+		// rather than being created by the probe.
+		return fmt.Errorf("the topic named by --txn-state-topic does not exist on this cluster: check the flag for a typo, and note that managed offerings such as Confluent Cloud and MSK Serverless do not expose it at all")
+	default:
+		return fmt.Errorf("the transaction-state topic named by --txn-state-topic is not readable: check the source authentication flags' credentials and that they carry an ACL granting DESCRIBE and READ on it: %w", md[0].Err)
+	}
 }
 
 // parseOpts snapshots the flag variables into an Opts.

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -1,6 +1,7 @@
 package txndiscovery
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 )
 
 // Opts is the resolved configuration of one discovery run: everything the
@@ -80,6 +82,40 @@ func probeTxnStateTopic(d topicDescriber, topic string) error {
 		return fmt.Errorf("the topic named by --txn-state-topic does not exist on this cluster: check the flag for a typo, and note that managed offerings such as Confluent Cloud and MSK Serverless do not expose it at all")
 	default:
 		return fmt.Errorf("the transaction-state topic named by --txn-state-topic is not readable: check the source authentication flags' credentials and that they carry an ACL granting DESCRIBE and READ on it: %w", md[0].Err)
+	}
+}
+
+// fanOut copies every batch from the tail's single channel to each reader's own.
+//
+// tail.Tail deliberately exposes ONE channel carrying every partition of both
+// topics, because both readers need the same lifecycle and shutdown ordering.
+// A Go channel delivers each value to exactly one receiver, so handing that
+// channel to both readers would split the stream between them: half the
+// transaction-state records would arrive at the offsets tail, which drops
+// anything not on its topic, and vice versa. Nothing would error — the run
+// would simply observe half of what it read. Hence a copy per destination, and
+// hence both readers also filter on Batch.Topic.
+//
+// Every destination is closed on the way out, whichever way that happens. Those
+// closes are load-bearing: they are what makes the transaction-state reader
+// return and what triggers the offsets tail's final flush.
+func fanOut(ctx context.Context, src <-chan tail.Batch, dests []chan tail.Batch) {
+	defer func() {
+		for _, d := range dests {
+			close(d)
+		}
+	}()
+	for b := range src {
+		for _, d := range dests {
+			select {
+			case d <- b:
+			case <-ctx.Done():
+				// A reader that has stopped receiving must not wedge shutdown.
+				// The tail's own emit is cancellable, so abandoning the source
+				// here leaves nothing blocked behind us.
+				return
+			}
+		}
 	}
 }
 

--- a/cmd/migration/txndiscovery/txn_discovery_runner.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/report"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/confluentinc/kcp/internal/types"
 )
 
 // Opts is the resolved configuration of one discovery run: everything the
@@ -438,6 +439,20 @@ func connectSaramaWith(opts Opts, newClient clientFactory, newAdmin adminFactory
 	authOpt, err := client.AdminOptionForAuthMethod(opts.Auth.AuthType, opts.Auth.Method, opts.Auth.SkipTLSVerify)
 	if err != nil {
 		return nil, err
+	}
+
+	// --use-sasl-plain has no TLS. AdminOptionForAuthMethod maps it to
+	// WithSASLPlainAuthNoTLS, which sets disableTLS, and NewKafkaClient then configures
+	// SASL/PLAIN with encryption off — so the password crosses the network in the clear
+	// on both of the connections opened below. The SCRAM path warns when certificate
+	// verification is merely weakened; a mode that dispenses with encryption altogether
+	// cannot say less than that.
+	//
+	// Here rather than per client, because this command opens two and one problem
+	// reported twice reads as two problems. No attributes: this reaches the console as
+	// well as kcp.log, and the credential is exactly what it must not carry.
+	if opts.Auth.AuthType == types.AuthTypeSASLPlain {
+		slog.Warn("⚠️ --use-sasl-plain transmits the source-cluster password in cleartext: this mode configures SASL/PLAIN with TLS disabled, so anything on the network path between kcp and the brokers can read it")
 	}
 
 	sc, err := newClient(opts.Brokers, opts.Region, authOpt)

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -53,9 +53,9 @@ func TestPreflight_ReadableTopic_Passes(t *testing.T) {
 // it as an ACL problem sends the operator to their Kafka administrator for a
 // typo they can fix themselves.
 func TestPreflight_UnknownTopic_IsNotReportedAsAuthorization(t *testing.T) {
-	d := &fakeDescriber{md: metadataFor("__transaciton_state", sarama.ErrUnknownTopicOrPartition, 0)}
+	d := &fakeDescriber{md: metadataFor("_transaction_state", sarama.ErrUnknownTopicOrPartition, 0)}
 
-	err := probeTxnStateTopic(d, "__transaciton_state")
+	err := probeTxnStateTopic(d, "_transaction_state")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
 	assert.Contains(t, err.Error(), "--txn-state-topic")

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -7,14 +7,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/client"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/report"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,6 +40,214 @@ func metadataFor(name string, err sarama.KError, partitions int) []*sarama.Topic
 		md.Partitions = append(md.Partitions, &sarama.PartitionMetadata{ID: int32(i)})
 	}
 	return []*sarama.TopicMetadata{md}
+}
+
+// --- the two-client wiring -------------------------------------------------
+
+// stubSaramaClient answers only what building a cluster admin over it needs. Its
+// Close count is what proves no connection is leaked.
+type stubSaramaClient struct {
+	sarama.Client
+	id     int
+	closes int
+}
+
+func (s *stubSaramaClient) Controller() (*sarama.Broker, error) { return &sarama.Broker{}, nil }
+func (s *stubSaramaClient) Config() *sarama.Config              { return sarama.NewConfig() }
+func (s *stubSaramaClient) Close() error                        { s.closes++; return nil }
+
+// stubAdmin is a cluster admin that remembers which client it was built over, which
+// is the whole question: sarama pipelines per connection and answers in order, so an
+// admin sharing the tail's client has its requests queue behind long-poll fetches.
+type stubAdmin struct {
+	over   *stubSaramaClient
+	closes int
+}
+
+func (s *stubAdmin) DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error) {
+	return metadataFor(topics[0], sarama.ErrNoError, 1), nil
+}
+
+func (s *stubAdmin) ListConsumerGroups() (map[string]string, error) { return nil, nil }
+
+func (s *stubAdmin) ListConsumerGroupOffsets(string, map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	return &sarama.OffsetFetchResponse{}, nil
+}
+
+// Close releases the client, exactly as sarama's own ClusterAdmin.Close does.
+func (s *stubAdmin) Close() error { s.closes++; return s.over.Close() }
+
+// stubConnect records every client and admin one connect built, and the auth options
+// each client was built with.
+type stubConnect struct {
+	clients []*stubSaramaClient
+	admins  []*stubAdmin
+	auth    [][]client.AdminOption
+	failAt  int // 1-based call number the client factory fails on; 0 never fails
+}
+
+func (s *stubConnect) newClient(_ []string, _ string, opts ...client.AdminOption) (sarama.Client, error) {
+	if s.failAt == len(s.clients)+1 {
+		return nil, errors.New("no route to broker")
+	}
+	s.auth = append(s.auth, opts)
+	c := &stubSaramaClient{id: len(s.clients)}
+	s.clients = append(s.clients, c)
+	return c, nil
+}
+
+func (s *stubConnect) newAdmin(c sarama.Client) (clusterAdmin, error) {
+	a := &stubAdmin{over: c.(*stubSaramaClient)}
+	s.admins = append(s.admins, a)
+	return a, nil
+}
+
+// The regression this change closes. sarama pipelines requests on one connection and
+// delivers responses strictly in order, so an admin built over the client the tail
+// holds has every ListConsumerGroups and ListConsumerGroupOffsets queue behind the
+// tail's long-poll fetches — measured at 6.3-8.1s and 8.1-30.9s against the compose
+// broker, versus 0-2ms on a connection of its own. That turns --interval 5s over a
+// 60s window into four or five enrichment passes instead of thirteen.
+//
+// U7's reason for sharing was to avoid widening kcp's KafkaAdmin interface, and that
+// reason is untouched: the narrow ConsumerGroupAdmin interface still stands, and a
+// second client satisfies it identically.
+func TestConnect_TheEnrichmentAdminDoesNotShareTheTailsConnection(t *testing.T) {
+	s := &stubConnect{}
+	opts := baseOpts(t.TempDir())
+	opts.Auth = plaintextAuth()
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+	require.NoError(t, err)
+
+	require.Len(t, s.clients, 2, "enrichment needs a connection of its own, so two clients are built")
+	require.Len(t, s.admins, 2)
+
+	preflight, ok := cl.Describer.(*stubAdmin)
+	require.True(t, ok)
+	enrichment, ok := cl.Admin.(*stubAdmin)
+	require.True(t, ok)
+
+	assert.Same(t, s.clients[0], preflight.over,
+		"the preflight admin rides the tail's client, which is free before the fetch loops start")
+	assert.NotSame(t, preflight.over, enrichment.over,
+		"the enrichment admin is on the tail's connection, so its calls queue behind the fetches")
+	assert.Same(t, s.clients[1], enrichment.over)
+
+	// A second connection is a second authentication, and the two must present
+	// identical credentials, TLS settings and --insecure-skip-tls-verify handling. The
+	// auth is resolved once and handed to both, which is what this compares: the same
+	// closure, not two resolutions that could diverge.
+	require.Len(t, s.auth, 2)
+	require.Len(t, s.auth[0], 1)
+	require.Len(t, s.auth[1], 1)
+	assert.Equal(t,
+		reflect.ValueOf(s.auth[0][0]).Pointer(), reflect.ValueOf(s.auth[1][0]).Pointer(),
+		"the two connections were given separately-resolved auth, so they can drift")
+}
+
+// plaintextAuth is the auth resolution --use-unauthenticated-plaintext produces, which
+// is what the compose broker in the integration suite speaks.
+func plaintextAuth() authResolution {
+	return authResolution{
+		AuthType: types.AuthTypeUnauthenticatedPlaintext,
+		Method:   types.AuthMethodConfig{UnauthenticatedPlaintext: &types.UnauthenticatedPlaintextConfig{Use: true}},
+	}
+}
+
+// Two connections mean two things to release. A run that closed only the first would
+// leak a socket and an authenticated session per invocation.
+func TestConnect_CloseReleasesBothConnections(t *testing.T) {
+	s := &stubConnect{}
+
+	opts := baseOpts(t.TempDir())
+	opts.Auth = plaintextAuth()
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+	require.NoError(t, err)
+	require.NoError(t, cl.Close())
+
+	for i, c := range s.clients {
+		assert.Positive(t, c.closes, "client %d was never closed", i)
+	}
+}
+
+// A second connection is a second authentication to the broker, so it is not opened
+// unless something is going to use it.
+func TestConnect_EnrichmentDisabledBuildsNoSecondConnection(t *testing.T) {
+	s := &stubConnect{}
+	opts := baseOpts(t.TempDir())
+	opts.Auth = plaintextAuth()
+	opts.EnrichConsumerGroups = false
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+	require.NoError(t, err)
+
+	assert.Len(t, s.clients, 1, "--enrich-consumer-groups=false must not authenticate a second time")
+	assert.Nil(t, cl.Admin, "with no enrichment client there is no enrichment admin")
+
+	require.NoError(t, cl.Close())
+	assert.Positive(t, s.clients[0].closes)
+}
+
+// R13's precedent applied to this phase: an optional enrichment source whose
+// connection cannot be opened warns and the run continues. Failing here would make a
+// SECOND authenticated connection a hard precondition of a command whose primary job —
+// the transaction-state footprints — needs only the first, and would throw the run away
+// before it observed anything.
+//
+// The first connection is still released: a failure part-way through must not leave an
+// authenticated session behind.
+func TestConnect_EnrichmentConnectionFailureDegradesRatherThanFailingTheRun(t *testing.T) {
+	s := &stubConnect{failAt: 2}
+	opts := baseOpts(t.TempDir())
+	opts.Auth = plaintextAuth()
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+
+	require.NoError(t, err, "a second connection is not a precondition of reading the transaction-state log")
+	require.NotNil(t, cl)
+	assert.Nil(t, cl.Admin, "enrichment has no admin, so the run must not start the phase")
+	assert.NotNil(t, cl.Describer, "the preflight and the tail are unaffected")
+
+	require.NoError(t, cl.Close())
+	require.Len(t, s.clients, 1)
+	assert.Positive(t, s.clients[0].closes, "the first connection leaked when the second failed")
+}
+
+// The other half of that degradation: the run must not claim a phase it did not start.
+// A run whose enrichment connection failed and which still named consumer-group
+// enrichment among its sources would have every artifact report the phase as having
+// found nothing rather than as never having run — the exact confusion R13's Unavailable
+// flag exists to prevent for the offsets tail.
+func TestRun_NoEnrichmentAdminMeansThePhaseIsNotClaimedAsActive(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.admin = nil // the enrichment connection could not be opened
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("payments-processor-abc12")},
+		[][]byte{txnValue(4242, "payments.out")},
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()),
+		"an unopenable enrichment connection must not fail the run")
+
+	var doc struct {
+		ActiveSources []string `json:"active_sources"`
+		Enrichment    struct {
+			Passes int `json:"passes"`
+		} `json:"consumer_group_enrichment"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, opts.StatsOutPath)), &doc))
+
+	assert.NotContains(t, doc.ActiveSources, discovery.SourceConsumerGroups,
+		"the run claims a phase it never started")
+	assert.Contains(t, doc.ActiveSources, discovery.SourceTxnStateLog, "the primary source still ran")
+	assert.Zero(t, doc.Enrichment.Passes)
+	assert.Contains(t, readFile(t, opts.OutPath), "payments.out", "the footprints are still worth having")
 }
 
 // R12: a readable transaction-state topic is the whole precondition of the run,
@@ -402,6 +613,10 @@ func TestRun_PreflightFailure_ExitsNonZeroAndWritesNothing(t *testing.T) {
 	entries, rerr := os.ReadDir(dir)
 	require.NoError(t, rerr)
 	assert.Empty(t, entries, "a failed preflight writes no files at all")
+	// Both of the run's connections are open by the time the preflight runs, and a
+	// preflight that exits without releasing them leaks two authenticated sessions on
+	// every misconfigured invocation — which is the invocation an operator repeats.
+	assert.Equal(t, 1, h.closes, "the preflight failure path released the cluster's connections")
 }
 
 // R21: the enrichment phase's counters have to reach the stats document, or a

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -3,11 +3,13 @@ package txndiscovery
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,4 +182,34 @@ func TestFanOut_UnreadDestination_DoesNotWedgeShutdown(t *testing.T) {
 	}
 	_, open := <-blocked
 	assert.False(t, open, "the destination is closed even on the cancellation path")
+}
+
+// R7, R9, R16, R17: the run holds the window, then produces the artifacts. This
+// is the whole happy path — a transaction's produced footprint from
+// __transaction_state, its consumed input recovered from __consumer_offsets by
+// producer id, both in one group in the YAML.
+func TestRun_TheWindowEndsTheRunAndTheArtifactsAreWritten(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("payments-txn-0")},
+		[][]byte{txnValue(4242, "payments.out", "__consumer_offsets")},
+	))
+	h.tailClient.script(discovery.DefaultConsumerOffsetsTopic, commitRecordBatch(0, 4242,
+		commitKey("payments-group", "payments.in", 0),
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	yaml := readFile(t, opts.OutPath)
+	assert.Contains(t, yaml, "payments.out", "the produced footprint reaches the YAML")
+	assert.Contains(t, yaml, "payments.in", "the consumed input recovered by producer id reaches the YAML")
+	assert.Contains(t, yaml, "payments-txn-0")
+
+	assert.True(t, exists(t, opts.StatsOutPath), "--stats-out is written")
+	assert.True(t, exists(t, opts.AuditLogPath), "the audit trail is on by default")
+	assert.Equal(t, 1, h.closes, "the sarama client and cluster admin are released")
 }

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -1,11 +1,14 @@
 package txndiscovery
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,4 +113,71 @@ func TestPreflight_EmptyMetadata_Fails(t *testing.T) {
 	d := &fakeDescriber{md: nil}
 
 	require.Error(t, probeTxnStateTopic(d, "__transaction_state"))
+}
+
+// R10: one tail.Tail serves both readers over ONE channel carrying both topics.
+// A shared channel delivers each batch to exactly one receiver, so handing the
+// same channel to both readers silently splits the stream between them —
+// records vanish with no error anywhere. Every batch must be COPIED to every
+// destination.
+func TestFanOut_CopiesEveryBatchToEveryDestination(t *testing.T) {
+	src := make(chan tail.Batch, 2)
+	src <- tail.Batch{Topic: "__transaction_state", Partition: 3, Records: []tail.Record{{Offset: 7}}}
+	src <- tail.Batch{Topic: "__consumer_offsets", Partition: 11, ProducerID: 4242}
+	close(src)
+
+	a, b := make(chan tail.Batch, 4), make(chan tail.Batch, 4)
+	fanOut(context.Background(), src, []chan tail.Batch{a, b})
+
+	got := func(ch chan tail.Batch) []tail.Batch {
+		var out []tail.Batch
+		for batch := range ch {
+			out = append(out, batch)
+		}
+		return out
+	}
+	first, second := got(a), got(b)
+
+	require.Len(t, first, 2, "every destination sees every batch")
+	assert.Equal(t, first, second, "both destinations see the same batches, in the same order")
+	assert.Equal(t, "__transaction_state", first[0].Topic)
+	assert.Equal(t, "__consumer_offsets", first[1].Topic)
+}
+
+// The fan-out closes its destinations when the source ends: that close is what
+// makes the __transaction_state reader return and, crucially, what triggers the
+// consumer-offsets tail's final flush.
+func TestFanOut_ClosesDestinationsWhenTheSourceEnds(t *testing.T) {
+	src := make(chan tail.Batch)
+	close(src)
+
+	a := make(chan tail.Batch, 1)
+	fanOut(context.Background(), src, []chan tail.Batch{a})
+
+	_, open := <-a
+	assert.False(t, open, "the destination must be closed, not merely empty")
+}
+
+// A reader that has stopped receiving must not wedge the fan-out: the
+// destinations still close, so the other readers still finish and flush.
+func TestFanOut_UnreadDestination_DoesNotWedgeShutdown(t *testing.T) {
+	src := make(chan tail.Batch, 1)
+	src <- tail.Batch{Topic: "__transaction_state"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	blocked := make(chan tail.Batch) // unbuffered and never read
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fanOut(ctx, src, []chan tail.Batch{blocked})
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fanOut blocked on an unread destination after cancellation")
+	}
+	_, open := <-blocked
+	assert.False(t, open, "the destination is closed even on the cancellation path")
 }

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -2,7 +2,10 @@ package txndiscovery
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +13,7 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/report"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,4 +216,218 @@ func TestRun_TheWindowEndsTheRunAndTheArtifactsAreWritten(t *testing.T) {
 	assert.True(t, exists(t, opts.StatsOutPath), "--stats-out is written")
 	assert.True(t, exists(t, opts.AuditLogPath), "the audit trail is on by default")
 	assert.Equal(t, 1, h.closes, "the sarama client and cluster admin are released")
+}
+
+// R10, integration constraint: one tail serves both readers over one channel,
+// so the command must fan it out BY COPY. A shared channel delivers each batch
+// to exactly one receiver — the offsets tail would swallow transaction-state
+// batches and vice versa, losing roughly half of each stream with no error
+// anywhere.
+//
+// Enough batches on each topic that the split cannot go unnoticed: a shared
+// channel would have to route all sixteen correctly by chance.
+func TestRun_BothReadersSeeEveryBatch(t *testing.T) {
+	const n = 8
+
+	dir := t.TempDir()
+	h := newHarness()
+	for i := range n {
+		h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(int64(i),
+			[][]byte{txnKey(fmt.Sprintf("txn-%d", i))},
+			[][]byte{txnValue(int64(100+i), fmt.Sprintf("out.%d", i), "__consumer_offsets")},
+		))
+		h.tailClient.script(discovery.DefaultConsumerOffsetsTopic, commitRecordBatch(int64(i), int64(100+i),
+			commitKey(fmt.Sprintf("group-%d", i), fmt.Sprintf("in.%d", i), 0),
+		))
+	}
+
+	opts := baseOpts(dir)
+	opts.EnrichConsumerGroups = false
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	yaml := readFile(t, opts.OutPath)
+	for i := range n {
+		assert.Contains(t, yaml, fmt.Sprintf("out.%d", i), "every transaction-state batch reached its reader")
+		assert.Contains(t, yaml, fmt.Sprintf("in.%d", i), "every consumer-offsets batch reached its reader")
+	}
+}
+
+// R21, integration constraint: the tail's stats must be snapshotted BEFORE the
+// run's context is cancelled. Every partition loop clears its running flag as it
+// exits, so a snapshot taken after shutdown reports zero partitions live and the
+// health line condemns a perfectly healthy run as failed.
+func TestRun_TailStatsAreSnapshottedBeforeShutdown(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("txn-a")},
+		[][]byte{txnValue(11, "topic.a")},
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	var doc struct {
+		Tail struct {
+			PartitionsAssigned int `json:"partitions_assigned"`
+			PartitionsRunning  int `json:"partitions_running"`
+		} `json:"tail"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, opts.StatsOutPath)), &doc))
+
+	require.Positive(t, doc.Tail.PartitionsAssigned, "the run must actually have assigned partitions")
+	assert.Equal(t, doc.Tail.PartitionsAssigned, doc.Tail.PartitionsRunning,
+		"every assigned partition was live when the window closed; a post-cancel snapshot would report zero")
+}
+
+// R20: --dry-run suppresses every artifact write. It does not suppress kcp.log.
+func TestRun_DryRun_WritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("txn-a")},
+		[][]byte{txnValue(11, "topic.a", "topic.b")},
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+	opts.DryRun = true
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.False(t, exists(t, opts.OutPath), "no groups YAML")
+	assert.False(t, exists(t, opts.StatsOutPath), "no stats JSON")
+	assert.False(t, exists(t, opts.AuditLogPath), "no audit trail — the audit log is a file write like any other")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a dry run leaves the output directory untouched")
+}
+
+// R18: --no-audit-log suppresses the audit trail and nothing else.
+func TestRun_NoAuditLog_SuppressesOnlyTheAuditTrail(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("txn-a")},
+		[][]byte{txnValue(11, "topic.a", "topic.b")},
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+	opts.AuditLogPath = "" // what --no-audit-log resolves to
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.True(t, exists(t, opts.OutPath), "the groups YAML is still written")
+	assert.True(t, exists(t, opts.StatsOutPath), "the stats JSON is still written")
+	assert.False(t, exists(t, filepath.Join(dir, DefaultAuditBasename)), "no audit trail")
+	assert.Contains(t, readFile(t, opts.OutPath), "topic.a")
+}
+
+// R18, integration constraint: a truncated audit trail reads downstream as "no
+// transaction coupled these topics", which is indistinguishable from a clean
+// run. The exit code is the only thing that tells them apart.
+func TestRun_AuditWriteErrors_ProduceANonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("txn-a")},
+		[][]byte{txnValue(11, "topic.a", "topic.b")},
+	))
+
+	opts := baseOpts(dir)
+	runner := h.runner(t, opts)
+	// A writer whose file is already gone: every Record fails, exactly as a
+	// disk that filled part-way through the run would.
+	runner.newAudit = func(path string) (*report.AuditWriter, error) {
+		w, err := report.NewAuditWriter(path)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		return w, nil
+	}
+
+	err := runner.Run(context.Background())
+
+	require.Error(t, err, "an incomplete audit trail must not exit zero")
+	assert.Contains(t, err.Error(), "audit")
+	assert.True(t, exists(t, opts.OutPath), "the groups YAML is still written; only the exit code reports the gap")
+}
+
+// R9, integration constraint: the artifacts are written only after the offsets
+// tail's final flush. Here the resolve interval is longer than any plausible
+// run, so the producer-id correlation can ONLY be resolved by that final flush —
+// if the YAML were written first, the recovered input would be missing from it.
+func TestRun_ArtifactsAreWrittenAfterTheFinalFlush(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("eos-app-txn")},
+		[][]byte{txnValue(777, "eos.output", "__consumer_offsets")},
+	))
+	h.tailClient.script(discovery.DefaultConsumerOffsetsTopic, commitRecordBatch(0, 777,
+		// A group id bearing no naming relationship to the transactional id, so
+		// only the exact producer-id join can recover this input.
+		commitKey("unrelated-group-name", "eos.input", 0),
+	))
+
+	opts := baseOpts(dir)
+	opts.Interval = time.Hour
+	opts.EnrichConsumerGroups = false
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.Contains(t, readFile(t, opts.OutPath), "eos.input",
+		"the late producer-id resolution must reach the YAML, so the write happens after the final flush")
+}
+
+// R12, abuse case: preflight failure exits non-zero and leaves nothing behind —
+// not even the audit trail, which is opened after the probe for exactly this
+// reason.
+func TestRun_PreflightFailure_ExitsNonZeroAndWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.describer = &fakeDescriber{md: metadataFor(discovery.DefaultTxnStateTopic, sarama.ErrTopicAuthorizationFailed, 0)}
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+
+	err := h.runner(t, opts).Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "credential")
+	assert.Contains(t, strings.ToLower(err.Error()), "acl")
+
+	entries, rerr := os.ReadDir(dir)
+	require.NoError(t, rerr)
+	assert.Empty(t, entries, "a failed preflight writes no files at all")
+}
+
+// R13: an unreadable consumer-offsets log degrades the run to consumer-group
+// enrichment alone rather than failing it.
+func TestRun_UnreadableConsumerOffsets_DegradesRatherThanFailing(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.probeErr = sarama.ErrTopicAuthorizationFailed
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("txn-a")},
+		[][]byte{txnValue(11, "topic.a", "topic.b")},
+	))
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.Contains(t, readFile(t, opts.OutPath), "topic.a", "the transaction-state footprints are still worth having")
+
+	var doc struct {
+		Offsets struct {
+			Unavailable bool `json:"unavailable"`
+		} `json:"consumer_offsets_log"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, opts.StatsOutPath)), &doc))
+	assert.True(t, doc.Offsets.Unavailable,
+		"the phase must be recorded as never having run, so the summary does not present it as having found nothing")
 }

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -404,6 +404,44 @@ func TestRun_PreflightFailure_ExitsNonZeroAndWritesNothing(t *testing.T) {
 	assert.Empty(t, entries, "a failed preflight writes no files at all")
 }
 
+// R21: the enrichment phase's counters have to reach the stats document, or a
+// captured run cannot say whether the cadence --interval asked for was achieved.
+// Every other source's counters are wired through; this one's were not collected
+// at all, which is why a run that enriched four times in a window sized for
+// thirteen looked identical to one that enriched thirteen.
+func TestRun_EnrichmentCountersReachTheStatsDocument(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("payments-processor-abc12")},
+		[][]byte{txnValue(4242, "payments.out")},
+	))
+	// A group the Streams naming convention correlates to that transaction, so the
+	// pass has something to find rather than merely something to count.
+	h.admin.groups = map[string]string{"payments-processor": "consumer"}
+	h.admin.offsets = map[string][]string{"payments-processor": {"payments.in"}}
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	var doc struct {
+		Enrichment struct {
+			Passes       int `json:"passes"`
+			PassFailures int `json:"pass_failures"`
+			GroupsListed int `json:"groups_listed"`
+			Correlations int `json:"correlations"`
+		} `json:"consumer_group_enrichment"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, opts.StatsOutPath)), &doc))
+
+	assert.Positive(t, doc.Enrichment.Passes, "the run completed enrichment passes and the document reports none")
+	assert.Equal(t, 1, doc.Enrichment.GroupsListed, "the pass listed one group")
+	assert.Equal(t, 1, doc.Enrichment.Correlations, "the group correlated to the transaction")
+	assert.Zero(t, doc.Enrichment.PassFailures)
+}
+
 // R13: an unreadable consumer-offsets log degrades the run to consumer-group
 // enrichment alone rather than failing it.
 func TestRun_UnreadableConsumerOffsets_DegradesRatherThanFailing(t *testing.T) {

--- a/cmd/migration/txndiscovery/txn_discovery_runner_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_runner_test.go
@@ -1,0 +1,113 @@
+package txndiscovery
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDescriber stands in for the cluster admin's DescribeTopics.
+type fakeDescriber struct {
+	md      []*sarama.TopicMetadata
+	err     error
+	askedes [][]string
+}
+
+func (f *fakeDescriber) DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error) {
+	f.askedes = append(f.askedes, topics)
+	return f.md, f.err
+}
+
+func metadataFor(name string, err sarama.KError, partitions int) []*sarama.TopicMetadata {
+	md := &sarama.TopicMetadata{Name: name, Err: err, IsInternal: true}
+	for i := range partitions {
+		md.Partitions = append(md.Partitions, &sarama.PartitionMetadata{ID: int32(i)})
+	}
+	return []*sarama.TopicMetadata{md}
+}
+
+// R12: a readable transaction-state topic is the whole precondition of the run,
+// so it passes preflight.
+func TestPreflight_ReadableTopic_Passes(t *testing.T) {
+	d := &fakeDescriber{md: metadataFor("__transaction_state", sarama.ErrNoError, 50)}
+
+	require.NoError(t, probeTxnStateTopic(d, "__transaction_state"))
+	assert.Equal(t, [][]string{{"__transaction_state"}}, d.askedes)
+}
+
+// R12, abuse case: U1 turned auto-creation off, so a mistyped --txn-state-topic
+// now reaches preflight as an unknown topic rather than being created. Reporting
+// it as an ACL problem sends the operator to their Kafka administrator for a
+// typo they can fix themselves.
+func TestPreflight_UnknownTopic_IsNotReportedAsAuthorization(t *testing.T) {
+	d := &fakeDescriber{md: metadataFor("__transaciton_state", sarama.ErrUnknownTopicOrPartition, 0)}
+
+	err := probeTxnStateTopic(d, "__transaciton_state")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, err.Error(), "--txn-state-topic")
+	assert.NotContains(t, strings.ToLower(err.Error()), "acl")
+	assert.NotContains(t, strings.ToLower(err.Error()), "credential")
+}
+
+// R12: an authorization failure names the two things that can fix it.
+func TestPreflight_AuthorizationFailure_NamesCredentialsAndACLs(t *testing.T) {
+	for _, kerr := range []sarama.KError{
+		sarama.ErrTopicAuthorizationFailed,
+		sarama.ErrClusterAuthorizationFailed,
+		sarama.ErrSASLAuthenticationFailed,
+	} {
+		t.Run(kerr.Error(), func(t *testing.T) {
+			d := &fakeDescriber{md: metadataFor("__transaction_state", kerr, 0)}
+
+			err := probeTxnStateTopic(d, "__transaction_state")
+			require.Error(t, err)
+			assert.Contains(t, strings.ToLower(err.Error()), "credential")
+			assert.Contains(t, strings.ToLower(err.Error()), "acl")
+			assert.NotContains(t, err.Error(), "does not exist")
+		})
+	}
+}
+
+// R12: a broker that cannot be reached at all is the same fail-fast, and its
+// cause is still credentials or connectivity rather than a missing topic.
+func TestPreflight_UnreachableBroker_FailsNamingCredentialsAndACLs(t *testing.T) {
+	d := &fakeDescriber{err: errors.New("dial tcp 10.0.0.1:9092: connect: connection refused")}
+
+	err := probeTxnStateTopic(d, "__transaction_state")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "credential")
+	assert.Contains(t, strings.ToLower(err.Error()), "acl")
+	assert.Contains(t, err.Error(), "connection refused", "the underlying cause has to survive")
+}
+
+// Data sensitivity: every command error is slog.Error'd by main, so it lands in
+// kcp.log — the file operators attach to support tickets. The topic name is
+// operator-supplied and must not travel with it.
+func TestPreflight_Errors_DoNotCarryTheTopicName(t *testing.T) {
+	const distinctive = "acme.payments.settlements.txnstate"
+
+	for _, d := range []*fakeDescriber{
+		{md: metadataFor(distinctive, sarama.ErrUnknownTopicOrPartition, 0)},
+		{md: metadataFor(distinctive, sarama.ErrTopicAuthorizationFailed, 0)},
+		{err: errors.New("connection refused")},
+		{md: nil},
+	} {
+		err := probeTxnStateTopic(d, distinctive)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), distinctive)
+	}
+}
+
+// R12: a response that names no topic at all is a failure, not a pass. Treating
+// an empty metadata list as success would let the run start against a cluster
+// that never confirmed the topic.
+func TestPreflight_EmptyMetadata_Fails(t *testing.T) {
+	d := &fakeDescriber{md: nil}
+
+	require.Error(t, probeTxnStateTopic(d, "__transaction_state"))
+}

--- a/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
@@ -1,0 +1,165 @@
+package txndiscovery
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLog redirects the default slog logger — the one that feeds kcp.log's
+// unconditionally Debug+ file leg — into a buffer for the duration of a test.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &buf
+}
+
+// Distinctive fixture names, chosen so a leak cannot hide behind a common word.
+const (
+	leakTopicProduced = "zqx-acme-payments-settlements-out"
+	leakTopicConsumed = "zqx-acme-payments-settlements-in"
+	leakTxnID         = "zqx-acme-eos-writer-txn"
+	leakGroupID       = "zqx-acme-settlements-consumer"
+	leakCredential    = "zqx-not-a-real-credential-value"
+)
+
+// leakHarness scripts a run over the distinctive fixtures above.
+func leakHarness(t *testing.T, dir string) (*harness, Opts) {
+	t.Helper()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey(leakTxnID)},
+		[][]byte{txnValue(9001, leakTopicProduced, "__consumer_offsets")},
+	))
+	h.tailClient.script(discovery.DefaultConsumerOffsetsTopic, commitRecordBatch(0, 9001,
+		commitKey(leakGroupID, leakTopicConsumed, 0),
+	))
+	h.admin.groups = map[string]string{leakGroupID: "consumer"}
+	h.admin.offsets = map[string][]string{leakGroupID: {leakTopicConsumed}}
+
+	opts := baseOpts(dir)
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+	opts.Auth = authResolution{
+		AuthType: types.AuthTypeSASLSCRAM,
+		Method: types.AuthMethodConfig{
+			SASLScram: &types.SASLScramConfig{
+				Use:       true,
+				Username:  "zqx-reader",
+				Password:  leakCredential,
+				Mechanism: "SHA512",
+			},
+		},
+	}
+	return h, opts
+}
+
+// Security: kcp.log's file leg is unconditionally Debug+ and is the file
+// operators attach to support tickets. Topic names and transactional ids
+// identify customer business structure, so the counts-only terminal buys
+// nothing if a Debug line carries them — and under --verbose those same lines
+// reach the console too.
+func TestRun_KcpLogCarriesNoTopicNameOrTransactionalID(t *testing.T) {
+	dir := t.TempDir()
+	logs := captureLog(t)
+	h, opts := leakHarness(t, dir)
+	opts.Verbose = true
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	// The run really did observe the fixtures — otherwise this asserts nothing.
+	require.Contains(t, readFile(t, opts.OutPath), leakTopicProduced)
+	require.Contains(t, readFile(t, opts.OutPath), leakTopicConsumed)
+
+	for _, name := range []string{leakTopicProduced, leakTopicConsumed, leakTxnID, leakGroupID} {
+		assert.NotContains(t, logs.String(), name, "kcp.log must carry no customer identifier")
+	}
+}
+
+// Security: the same must hold on the failure paths, which is where a
+// well-meaning diagnostic is most tempting.
+func TestRun_KcpLogStaysCleanWhenTheEnrichmentPathsFail(t *testing.T) {
+	dir := t.TempDir()
+	logs := captureLog(t)
+	h, opts := leakHarness(t, dir)
+	opts.Verbose = true
+	h.probeErr = sarama.ErrTopicAuthorizationFailed
+	h.admin.err = errors.New("broker rejected the group listing")
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	require.NotEmpty(t, logs.String(), "the failing paths must actually have logged something")
+	for _, name := range []string{leakTopicProduced, leakTopicConsumed, leakTxnID, leakGroupID} {
+		assert.NotContains(t, logs.String(), name)
+	}
+}
+
+// Security: the SASL credential reaches the command by flag or environment and
+// must not be persisted anywhere — not in kcp.log, not on the terminal, and not
+// in any of the three artifacts.
+func TestRun_TheCredentialReachesNoLogLineAndNoArtifact(t *testing.T) {
+	dir := t.TempDir()
+	logs := captureLog(t)
+	h, opts := leakHarness(t, dir)
+	terminal := &bytes.Buffer{}
+	opts.Stdout = terminal
+	opts.Verbose = true
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.NotContains(t, logs.String(), leakCredential, "kcp.log")
+	assert.NotContains(t, terminal.String(), leakCredential, "the terminal")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "the run must have written artifacts for this to assert anything")
+	for _, e := range entries {
+		assert.NotContains(t, readFile(t, filepath.Join(dir, e.Name())), leakCredential, e.Name())
+	}
+}
+
+// Security: the same holds when the run fails at preflight, where the error
+// text is assembled from the connection parameters.
+func TestRun_TheCredentialReachesNoErrorMessage(t *testing.T) {
+	dir := t.TempDir()
+	logs := captureLog(t)
+	h, opts := leakHarness(t, dir)
+	h.describer = &fakeDescriber{err: errors.New("SASL authentication failed for user zqx-reader")}
+
+	err := h.runner(t, opts).Run(context.Background())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), leakCredential)
+	assert.NotContains(t, logs.String(), leakCredential)
+}
+
+// R16: the terminal summary reports counts, never names. The artifacts carry
+// the names; a real run produces hundreds of topics and printing them buries
+// the numbers that matter.
+func TestRun_TheTerminalSummaryCarriesNoNames(t *testing.T) {
+	dir := t.TempDir()
+	h, opts := leakHarness(t, dir)
+	terminal := &bytes.Buffer{}
+	opts.Stdout = terminal
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	require.Contains(t, readFile(t, opts.OutPath), leakTopicProduced, "the run observed the fixture")
+	for _, name := range []string{leakTopicProduced, leakTopicConsumed, leakTxnID, leakGroupID} {
+		assert.NotContains(t, terminal.String(), name)
+	}
+	assert.NotEmpty(t, strings.TrimSpace(terminal.String()), "the summary is not simply empty")
+}

--- a/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
@@ -180,6 +180,96 @@ func TestConnect_TheEnrichmentConnectionFailureWarningCarriesNoCredential(t *tes
 	assert.NotContains(t, logs.String(), "zqx-reader", "the username is a credential too")
 }
 
+// Security: --use-sasl-plain puts the password on the wire in cleartext, and this
+// command must say so itself, once, when it connects.
+//
+// AdminOptionForAuthMethod maps AuthTypeSASLPlain to WithSASLPlainAuthNoTLS, which sets
+// disableTLS, and NewKafkaClient then configures SASL/PLAIN with TLS off — so the
+// credential crosses the network unencrypted on both of this command's connections. The
+// SCRAM path warns when verification is merely weakened; a mode that dispenses with
+// encryption altogether cannot say less.
+//
+// Once, not once per connection: this command opens two, and a warning repeated per
+// connection reads as two separate problems.
+//
+// The line itself carries no credential. It is a Warn, so unlike the Debug diagnostics
+// it reaches the console as well as kcp.log, and the value it is warning about is
+// exactly the value it must not print.
+func TestConnect_SASLPlainWarnsOnceThatTheCredentialCrossesTheNetworkInCleartext(t *testing.T) {
+	logs := captureLog(t)
+	s := &stubConnect{}
+	opts := baseOpts(t.TempDir())
+	opts.Auth = plainAuth()
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+	require.NoError(t, err)
+	require.NoError(t, cl.Close())
+
+	got := logs.String()
+	require.Len(t, s.clients, 2, "the run opens two connections, so 'once' is a real claim")
+	assert.Equal(t, 1, strings.Count(got, "cleartext"),
+		"the cleartext warning must fire exactly once per run; log was:\n%s", got)
+	assert.Contains(t, got, "--use-sasl-plain", "the warning names the flag that caused it")
+	assert.Contains(t, got, "⚠️", "a caveat carries the warning emoji, one, at the start")
+	assert.NotContains(t, got, leakCredential, "the warning printed the password it is warning about")
+	assert.NotContains(t, got, "zqx-reader", "the username is a credential too")
+}
+
+// The other side of it: no other auth mode transmits credentials in cleartext, and a
+// warning that fired for all of them would be noise an operator learns to ignore.
+func TestConnect_TheCleartextWarningFiresForNoOtherAuthMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		auth authResolution
+	}{
+		{
+			name: "iam",
+			auth: authResolution{AuthType: types.AuthTypeIAM, Method: types.AuthMethodConfig{IAM: &types.IAMConfig{Use: true}}},
+		},
+		{
+			name: "sasl scram",
+			auth: authResolution{AuthType: types.AuthTypeSASLSCRAM, Method: types.AuthMethodConfig{SASLScram: &types.SASLScramConfig{Use: true, Username: "zqx-reader", Password: leakCredential, Mechanism: "SHA512"}}},
+		},
+		{
+			name: "mutual tls",
+			auth: authResolution{AuthType: types.AuthTypeTLS, Method: types.AuthMethodConfig{TLS: &types.TLSConfig{Use: true, CACert: "ca.pem", ClientCert: "client.pem", ClientKey: "client.key"}}},
+		},
+		{
+			name: "unauthenticated tls",
+			auth: authResolution{AuthType: types.AuthTypeUnauthenticatedTLS, Method: types.AuthMethodConfig{UnauthenticatedTLS: &types.UnauthenticatedTLSConfig{Use: true}}},
+		},
+		{
+			// Plaintext, but with no credential to expose: there is nothing to warn about.
+			name: "unauthenticated plaintext",
+			auth: plaintextAuth(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureLog(t)
+			s := &stubConnect{}
+			opts := baseOpts(t.TempDir())
+			opts.Auth = tc.auth
+
+			cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+			require.NoError(t, err)
+			require.NoError(t, cl.Close())
+
+			assert.NotContains(t, logs.String(), "cleartext", "log was:\n%s", logs.String())
+		})
+	}
+}
+
+// plainAuth is the auth resolution --use-sasl-plain produces, carrying the distinctive
+// credential fixture so a leak cannot hide.
+func plainAuth() authResolution {
+	return authResolution{
+		AuthType: types.AuthTypeSASLPlain,
+		Method: types.AuthMethodConfig{
+			SASLPlain: &types.SASLPlainConfig{Use: true, Username: "zqx-reader", Password: leakCredential},
+		},
+	}
+}
+
 // R16: the terminal summary reports counts, never names. The artifacts carry
 // the names; a real run produces hundreds of topics and printing them buries
 // the numbers that matter.

--- a/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
@@ -101,10 +101,25 @@ func TestRun_KcpLogStaysCleanWhenTheEnrichmentPathsFail(t *testing.T) {
 
 	require.NoError(t, h.runner(t, opts).Run(context.Background()))
 
-	require.NotEmpty(t, logs.String(), "the failing paths must actually have logged something")
+	require.Contains(t, logs.String(), "consumer-offsets", "the unreadable offsets log must actually have warned")
 	for _, name := range []string{leakTopicProduced, leakTopicConsumed, leakTxnID, leakGroupID} {
 		assert.NotContains(t, logs.String(), name)
 	}
+}
+
+// The log narrative: a run measured in hours must leave a record in kcp.log of
+// having started and finished, and what it found — as counts, never names.
+// Without it a support ticket's kcp.log is silent about the command entirely.
+func TestRun_KcpLogRecordsTheRunAsCounts(t *testing.T) {
+	dir := t.TempDir()
+	logs := captureLog(t)
+	h, opts := leakHarness(t, dir)
+
+	require.NoError(t, h.runner(t, opts).Run(context.Background()))
+
+	assert.Contains(t, logs.String(), "🚀", "the command's start is a top-level entry point")
+	assert.Contains(t, logs.String(), "✅", "and its completion")
+	assert.Contains(t, logs.String(), "transactions=1", "the counts are what the log carries")
 }
 
 // Security: the SASL credential reaches the command by flag or environment and

--- a/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_secrets_test.go
@@ -161,6 +161,25 @@ func TestRun_TheCredentialReachesNoErrorMessage(t *testing.T) {
 	assert.NotContains(t, logs.String(), leakCredential)
 }
 
+// Security, on the second connection this command now opens. It is a second
+// authentication to the broker, so its failure path is assembled from the same
+// credentials the first one used — and it warns rather than returning an error, which
+// puts it on the console as well as in kcp.log.
+func TestConnect_TheEnrichmentConnectionFailureWarningCarriesNoCredential(t *testing.T) {
+	logs := captureLog(t)
+	s := &stubConnect{failAt: 2}
+	_, opts := leakHarness(t, t.TempDir()) // SCRAM auth carrying leakCredential
+
+	cl, err := connectSaramaWith(opts, s.newClient, s.newAdmin)
+	require.NoError(t, err)
+	require.NoError(t, cl.Close())
+
+	// The warning must actually have fired, or the assertion below is vacuous.
+	require.Contains(t, logs.String(), "consumer-group enrichment is disabled")
+	assert.NotContains(t, logs.String(), leakCredential, "kcp.log")
+	assert.NotContains(t, logs.String(), "zqx-reader", "the username is a credential too")
+}
+
 // R16: the terminal summary reports counts, never names. The artifacts carry
 // the names; a real run produces hundreds of topics and printing them buries
 // the numbers that matter.

--- a/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
@@ -4,6 +4,8 @@ package txndiscovery
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -67,4 +69,169 @@ func TestRun_SIGINT_EndsTheWindowEarlyAndStillWritesTheArtifacts(t *testing.T) {
 	assert.True(t, exists(t, opts.StatsOutPath))
 	assert.True(t, exists(t, opts.AuditLogPath))
 	assert.Equal(t, 1, h.closes, "the signal path released the cluster's connections exactly once")
+}
+
+// The environment a child process is driven by. The case below has to run in a
+// process of its own: what it asserts is that a signal TERMINATES that process,
+// which cannot be asserted from inside the process it would terminate.
+const (
+	signalChildEnv    = "KCP_TXNDISCOVERY_SIGNAL_CHILD"
+	signalChildDirEnv = "KCP_TXNDISCOVERY_SIGNAL_DIR"
+
+	readyMarker       = "child-reading"
+	windowEndedMarker = "child-window-ended"
+)
+
+// R4/F1's other half: a SECOND signal, sent while the run is draining, must kill the
+// process.
+//
+// signal.NotifyContext runs a one-shot goroutine that cancels the context on the first
+// signal and then exits, leaving os/signal's registration in place on a size-1 channel
+// nobody will ever read again. Every later signal is therefore delivered into that
+// buffer and discarded. With stopSignals() deferred to the end of Run, that state lasts
+// for the whole drain — precisely the stretch where the operator has reason to want out,
+// because the drain is where the run talks to the broker for the last time and where an
+// unresponsive one makes it hang. The operator's Ctrl-C does nothing, twice, three
+// times, and SIGKILL — which loses all three artifacts, the entire product of the run —
+// is the only escape.
+//
+// So stopSignals() is called as soon as the window is over, before the drain starts,
+// which hands SIGINT back to Go's default disposition.
+func TestRun_ASecondSignalDuringTheDrainTerminatesTheProcess(t *testing.T) {
+	if os.Getenv(signalChildEnv) != "" {
+		t.Skip("this process IS the child")
+	}
+
+	dir := t.TempDir()
+	// The child's output goes to a FILE rather than to a bytes.Buffer: exec copies
+	// into a non-*os.File on a goroutine of its own, and this case has to read that
+	// output before Wait has returned, which would be a data race.
+	logPath := filepath.Join(dir, "child.log")
+	childLog, err := os.Create(logPath) //nolint:gosec // a path this test built
+	require.NoError(t, err)
+	defer func() { _ = childLog.Close() }()
+
+	child := exec.Command(os.Args[0], "-test.run=^TestRun_SignalDrainChild$", "-test.timeout=120s") //nolint:gosec // the test binary re-executing itself
+	child.Env = append(os.Environ(), signalChildEnv+"=1", signalChildDirEnv+"="+dir)
+	child.Stdout = childLog
+	child.Stderr = childLog
+	require.NoError(t, child.Start())
+	t.Cleanup(func() { _ = child.Process.Kill() })
+
+	// The handler is installed before the tail starts fetching, so a child that is
+	// demonstrably reading is a child that will not die of the first signal.
+	waitForMarker(t, filepath.Join(dir, readyMarker), 60*time.Second, "the child never started reading", logPath)
+
+	t.Log("sending SIGINT #1 (should end the observation window)")
+	require.NoError(t, syscall.Kill(child.Process.Pid, syscall.SIGINT))
+	waitForMarker(t, filepath.Join(dir, windowEndedMarker), 60*time.Second, "the first signal did not end the child's observation window", logPath)
+
+	exited := make(chan error, 1)
+	go func() { exited <- child.Wait() }()
+
+	// The operator aborting a drain that has stopped responding: repeated, spaced
+	// out, because that is what a person does — and because the first of them can
+	// land in the microseconds between the window ending and stopSignals() running,
+	// where it is still swallowed by design.
+	jab := time.NewTicker(250 * time.Millisecond)
+	defer jab.Stop()
+	giveUp := time.After(8 * time.Second)
+
+	var waitErr error
+wait:
+	for {
+		select {
+		case waitErr = <-exited:
+			break wait
+		case <-jab.C:
+			t.Log("sending another SIGINT (the operator aborting a hung drain)")
+			_ = syscall.Kill(child.Process.Pid, syscall.SIGINT)
+		case <-giveUp:
+			t.Fatalf("child STILL ALIVE after repeated SIGINTs: the process was never interruptible, so SIGKILL and the loss of every artifact is the only way out.\nchild output:\n%s", tailOf(logPath))
+		}
+	}
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, waitErr, &exitErr, "child output:\n%s", tailOf(logPath))
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	require.True(t, ok)
+	require.True(t, status.Signaled(),
+		"the child exited on its own (code %d) rather than being terminated by a signal: the drain finished before the SIGINTs did anything, so this proves nothing about interruptibility.\nchild output:\n%s",
+		status.ExitStatus(), tailOf(logPath))
+	assert.Equal(t, syscall.SIGINT, status.Signal(), "terminated by the wrong signal")
+}
+
+// TestRun_SignalDrainChild is the child half of the case above: a run whose drain is
+// stuck talking to a broker that has stopped answering. It is skipped unless its parent
+// started it.
+func TestRun_SignalDrainChild(t *testing.T) {
+	dir := os.Getenv(signalChildDirEnv)
+	if os.Getenv(signalChildEnv) == "" || dir == "" {
+		t.Skip("driven by TestRun_ASecondSignalDuringTheDrainTerminatesTheProcess")
+	}
+
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("hung-drain-txn")},
+		[][]byte{txnValue(31337, "hung.out")},
+	))
+	// Enrichment's closing pass is the last thing the run does before it writes
+	// anything, and it talks to the broker. A broker that does not answer is what
+	// puts the drain in the state the operator wants out of.
+	h.admin.groups = map[string]string{"hung-drain": "consumer"}
+	h.admin.delay = 30 * time.Second
+
+	opts := baseOpts(dir)
+	opts.Duration = time.Hour // only the signal can end this window
+	// No tick fires, so the pass that stalls is the closing one rather than one
+	// that happened to be in flight.
+	opts.Interval = time.Hour
+	opts.TailConsumerOffsets = false
+	opts.EnrichConsumerGroups = true
+
+	runner := h.runner(t, opts)
+	runner.window = func(ctx context.Context, d time.Duration) {
+		waitWindow(ctx, d)
+		touch(filepath.Join(dir, windowEndedMarker))
+	}
+
+	go func() {
+		for h.tailClient.fetchesFor(discovery.DefaultTxnStateTopic) < 3 {
+			time.Sleep(5 * time.Millisecond)
+		}
+		touch(filepath.Join(dir, readyMarker))
+	}()
+
+	_ = runner.Run(context.Background())
+}
+
+// touch writes a marker the parent process polls for. Errors are not reported: the
+// parent's own timeout is what fails the case, and this runs on a goroutine where a
+// t.Fatal would be a data race with the run under test.
+func touch(path string) {
+	_ = os.WriteFile(path, []byte("x"), 0o600)
+}
+
+// waitForMarker blocks until the child has written path, failing with the child's
+// output when it does not.
+func waitForMarker(t *testing.T, path string, within time.Duration, what, logPath string) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s within %s.\nchild output:\n%s", what, within, tailOf(logPath))
+}
+
+// tailOf reads whatever the child has written so far, for a failure message. The
+// child holds the file open, so a partial read is expected and fine.
+func tailOf(logPath string) string {
+	b, err := os.ReadFile(logPath) //nolint:gosec // a path this test built
+	if err != nil {
+		return "<unreadable: " + err.Error() + ">"
+	}
+	return string(b)
 }

--- a/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
@@ -35,7 +35,10 @@ func TestRun_SIGINT_EndsTheWindowEarlyAndStillWritesTheArtifacts(t *testing.T) {
 	opts.Duration = time.Hour
 	opts.StatsOutPath = filepath.Join(dir, "stats.json")
 	opts.TailConsumerOffsets = false
-	opts.EnrichConsumerGroups = false
+	// Enrichment on, so the run holds its own second connection to the broker: SIGINT
+	// is the exit path most likely to skip a release, and a signalled run that leaked
+	// an authenticated session would do so once per interrupted invocation.
+	opts.EnrichConsumerGroups = true
 
 	runner := h.runner(t, opts)
 	// The real production window: wait for the duration or for ctx, which
@@ -63,4 +66,5 @@ func TestRun_SIGINT_EndsTheWindowEarlyAndStillWritesTheArtifacts(t *testing.T) {
 	assert.Contains(t, yaml, "interrupted.out.b")
 	assert.True(t, exists(t, opts.StatsOutPath))
 	assert.True(t, exists(t, opts.AuditLogPath))
+	assert.Equal(t, 1, h.closes, "the signal path released the cluster's connections exactly once")
 }

--- a/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
+++ b/cmd/migration/txndiscovery/txn_discovery_signal_unix_test.go
@@ -1,0 +1,66 @@
+//go:build unix
+
+package txndiscovery
+
+import (
+	"context"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// R4/F1: SIGINT ends the observation window early and the artifacts are still
+// written. An operator who has seen enough must be able to stop the run and
+// keep what it observed; exiting empty-handed would make a long window
+// unusable, because stopping it would throw the whole run away.
+//
+// kcp ships a Windows binary and syscall.Kill does not exist there, so this
+// file is unix-gated: a runtime GOOS skip cannot save a package that will not
+// compile.
+func TestRun_SIGINT_EndsTheWindowEarlyAndStillWritesTheArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness()
+	h.tailClient.script(discovery.DefaultTxnStateTopic, stateRecordBatch(0,
+		[][]byte{txnKey("interrupted-txn")},
+		[][]byte{txnValue(31337, "interrupted.out.a", "interrupted.out.b")},
+	))
+
+	opts := baseOpts(dir)
+	// Far longer than the test may take, so only the signal can end this run.
+	opts.Duration = time.Hour
+	opts.StatsOutPath = filepath.Join(dir, "stats.json")
+	opts.TailConsumerOffsets = false
+	opts.EnrichConsumerGroups = false
+
+	runner := h.runner(t, opts)
+	// The real production window: wait for the duration or for ctx, which
+	// signal.NotifyContext cancels on SIGINT. Nothing here fakes the signal
+	// path — the point is that the wiring in Run works.
+	runner.window = waitWindow
+
+	// Send the signal only once the tail is demonstrably reading, so it cannot
+	// arrive before Run has installed its handler — where the process default
+	// for SIGINT would terminate the test binary.
+	go func() {
+		for h.tailClient.fetchesFor(discovery.DefaultTxnStateTopic) < 3 {
+			time.Sleep(5 * time.Millisecond)
+		}
+		require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
+	}()
+
+	started := time.Now()
+	require.NoError(t, runner.Run(context.Background()))
+
+	assert.Less(t, time.Since(started), 30*time.Second, "the signal, not the hour-long window, ended the run")
+
+	yaml := readFile(t, opts.OutPath)
+	assert.Contains(t, yaml, "interrupted.out.a", "everything observed before the signal is kept")
+	assert.Contains(t, yaml, "interrupted.out.b")
+	assert.True(t, exists(t, opts.StatsOutPath))
+	assert.True(t, exists(t, opts.AuditLogPath))
+}

--- a/integration-tests/txn-discovery-ha/docker-compose.yml
+++ b/integration-tests/txn-discovery-ha/docker-compose.yml
@@ -1,0 +1,147 @@
+name: kcp-txn-discovery-ha
+
+# Three-node KRaft cluster for the leader-failover half of R11.
+#
+# This is the only place `kcp migration txn-discovery` runs against a
+# realistically-replicated internal topic: __transaction_state at replication
+# factor three, so a broker can be killed mid-run and the partitions it led get
+# a new leader from the surviving in-sync replicas. Everything the single-node
+# suite (integration-tests/txn-discovery) proves about grouping is proved there;
+# what is proved here is that the reader re-resolves and keeps reading.
+#
+# Every node runs in combined mode (broker + controller). Killing one leaves a
+# two-of-three controller quorum, so the cluster stays writable while the
+# partitions the dead node led are re-elected.
+x-kafka-env: &kafka-env
+  # 22 characters: a KRaft cluster id is a base64-encoded 16-byte UUID and the
+  # broker refuses to boot on anything else.
+  CLUSTER_ID: 'TxNdIsCoVeRyHaClUsTer0'
+  KAFKA_PROCESS_ROLES: broker,controller
+  KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka1:9093,2@kafka2:9093,3@kafka3:9093'
+
+  # (1) DUAL LISTENERS. Carried from the single-node suite, where a single
+  # localhost-advertised listener broke the transaction coordinator, and needed
+  # twice over here: INTERNAL is how the three brokers replicate to each other
+  # and how a coordinator is reached from inside the network, EXTERNAL is what
+  # the host-side test and the kcp binary use. A single listener advertising
+  # "localhost" would make every broker believe its two peers were itself.
+  KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+  KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+  KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+
+  # (2) REPLICATION FACTOR THREE AND MIN-ISR TWO ON THE INTERNAL TOPICS. This is
+  # the whole point of the file. At RF 1 the partitions the killed broker led
+  # would have no surviving replica to be re-elected from, so the reader would be
+  # waiting on a partition that no longer exists anywhere rather than on a leader
+  # that moved — which is a different failure, and not R11's.
+  #
+  # min-ISR two, not three: at three, killing one broker takes the ISR below the
+  # minimum and __transaction_state stops accepting writes, so the post-failover
+  # transactions could never be produced and the ledger would be unsatisfiable
+  # for a reason that has nothing to do with the reader.
+  KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+  KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+
+  # Twelve rather than the default fifty on each internal topic. The behaviour
+  # under test is leadership moving between brokers, which twelve partitions
+  # spread over three nodes exercises just as well as fifty; what fifty adds is
+  # 300 replicas to bring into full ISR on a laptop before the window can even
+  # open, and 100 fetch loops cycling through a cap of 16 concurrent fetches
+  # instead of 24. The suite waits for full ISR before producing, so that cost is
+  # paid in wall-clock time on every run.
+  KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS: 12
+  KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 12
+
+  # Fixture topics are created at replication factor three by the suite, and this
+  # makes an auto-created one match. An RF-1 fixture topic whose only replica sat
+  # on the killed broker would fail the post-failover producer outright — the
+  # ledger would show the phase missing, which is exactly the negative control's
+  # signature, from a cause that is not the reader.
+  KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+  KAFKA_MIN_INSYNC_REPLICAS: 1
+  KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+
+  # Keeps the transaction coordinator from expiring the suite's short-lived
+  # transactional ids while a run is still observing them.
+  KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS: 3600000
+  KAFKA_TRANSACTION_MAX_TIMEOUT_MS: 900000
+
+  # (3) LOG CLEANER OFF. __transaction_state is a COMPACTED topic and a
+  # transaction's footprint lives only in its Ongoing and PrepareCommit records.
+  # Once the transaction completes, the latest record under that key is
+  # CompleteCommit, whose partition set is EMPTY — so a compaction pass erases
+  # the footprint and leaves a record that says nothing about which topics were
+  # coupled.
+  #
+  # That is a real production blind spot the tool documents, and it is why it
+  # must not be live here: it would make a phase's discovery depend on whether
+  # the cleaner happened to run. It cost the single-node suite three flakes,
+  # including pre-restart transactions vanishing because the restart itself
+  # triggered a cleaning pass — and this suite kills a broker, which is the same
+  # trigger.
+  #
+  # The ratio is belt-and-braces in case a later image force-enables the cleaner:
+  # at 1.0 a log must be entirely dirty before it is cleanable.
+  KAFKA_LOG_CLEANER_ENABLE: 'false'
+  KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO: '1.0'
+
+x-kafka-node: &kafka-node
+  image: confluentinc/cp-kafka:7.6.0
+  # No restart policy, deliberately: `docker kill` must leave the node down for
+  # the rest of the run. A restarting broker would make the reader's recovery
+  # ambiguous — it could have resumed against the returning node rather than
+  # against the new leader.
+  restart: "no"
+
+services:
+  kafka1:
+    <<: *kafka-node
+    hostname: kafka1
+    container_name: kcp-test-txn-discovery-ha-kafka1
+    ports:
+      - "29092:29092"
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:9092,EXTERNAL://localhost:29092
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+
+  kafka2:
+    <<: *kafka-node
+    hostname: kafka2
+    container_name: kcp-test-txn-discovery-ha-kafka2
+    ports:
+      - "29093:29093"
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 2
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:9092,EXTERNAL://localhost:29093
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+
+  kafka3:
+    <<: *kafka-node
+    hostname: kafka3
+    container_name: kcp-test-txn-discovery-ha-kafka3
+    ports:
+      - "29094:29094"
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 3
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29094
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:9092,EXTERNAL://localhost:29094
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 5s
+      timeout: 10s
+      retries: 30

--- a/integration-tests/txn-discovery-ha/docker-compose.yml
+++ b/integration-tests/txn-discovery-ha/docker-compose.yml
@@ -12,6 +12,12 @@ name: kcp-txn-discovery-ha
 # Every node runs in combined mode (broker + controller). Killing one leaves a
 # two-of-three controller quorum, so the cluster stays writable while the
 # partitions the dead node led are re-elected.
+#
+# The external listeners are on 29192-29194 rather than the 29092 the single-node
+# suite uses. That is not cosmetic: docker refuses to start a container whose host
+# port is already bound, so an overlapping port makes this suite fail at
+# `compose up` whenever the other one happens to be running — a failure that says
+# nothing about either suite and costs a full boot to diagnose.
 x-kafka-env: &kafka-env
   # 22 characters: a KRaft cluster id is a base64-encoded 16-byte UUID and the
   # broker refuses to boot on anything else.
@@ -100,12 +106,12 @@ services:
     hostname: kafka1
     container_name: kcp-test-txn-discovery-ha-kafka1
     ports:
-      - "29092:29092"
+      - "29192:29192"
     environment:
       <<: *kafka-env
       KAFKA_NODE_ID: 1
-      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:9092,EXTERNAL://localhost:29092
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29192
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:9092,EXTERNAL://localhost:29192
     healthcheck:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 5s
@@ -117,12 +123,12 @@ services:
     hostname: kafka2
     container_name: kcp-test-txn-discovery-ha-kafka2
     ports:
-      - "29093:29093"
+      - "29193:29193"
     environment:
       <<: *kafka-env
       KAFKA_NODE_ID: 2
-      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29093
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:9092,EXTERNAL://localhost:29093
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29193
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:9092,EXTERNAL://localhost:29193
     healthcheck:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 5s
@@ -134,12 +140,12 @@ services:
     hostname: kafka3
     container_name: kcp-test-txn-discovery-ha-kafka3
     ports:
-      - "29094:29094"
+      - "29194:29194"
     environment:
       <<: *kafka-env
       KAFKA_NODE_ID: 3
-      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29094
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:9092,EXTERNAL://localhost:29094
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29194
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:9092,EXTERNAL://localhost:29194
     healthcheck:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 5s

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -645,7 +645,8 @@ func pinnedTxnIDs(t *testing.T, client sarama.Client, base string, want int, bro
 
 // earliestOffsets reads each partition's current log start offset.
 //
-// The continuity check needs this: the reader is assigned %s from EARLIEST, so
+// The continuity check needs this: the reader is assigned the transaction-state
+// log from EARLIEST, so
 // its final next offset minus the log start is the span of offsets it was
 // responsible for, and the number of records it read must account for all of
 // them.

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -17,14 +17,23 @@
 package txndiscoveryha_test
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -306,17 +315,27 @@ func produceTxn(f txnFixture) error {
 // what a real exactly-once client does when its coordinator moves.
 func produceTxnWithRetry(t *testing.T, f txnFixture, within time.Duration) {
 	t.Helper()
+	require.NoError(t, produceWithin(f, within),
+		"could not produce a transaction within %s", within)
+}
+
+// produceWithin is produceTxnWithRetry without the *testing.T, for the phase
+// produced on its own goroutine.
+//
+// t.Fatalf may only be called from the goroutine running the test, so the
+// during-the-kill phase has to hand its failure back over a channel instead.
+func produceWithin(f txnFixture, within time.Duration) error {
 	deadline := time.Now().Add(within)
 	var last error
-	for attempt := 1; time.Now().Before(deadline); attempt++ {
+	for time.Now().Before(deadline) {
 		if err := produceTxn(f); err == nil {
-			return
+			return nil
 		} else {
 			last = err
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Fatalf("could not produce a transaction within %s; last error: %v", within, last)
+	return fmt.Errorf("gave up after %s; last error: %w", within, last)
 }
 
 // ensureInternalTopics brings __transaction_state and __consumer_offsets into
@@ -368,4 +387,728 @@ func awaitFullISR(t *testing.T) {
 	}
 	require.Eventually(t, ok, 3*time.Minute, 3*time.Second,
 		"the internal topics never reached a full in-sync replica set, so a leader could not survive being killed:\n%s", last)
+}
+
+// newClient returns a plain sarama client, used for the two questions the admin
+// API cannot answer: which broker coordinates a given transactional id, and
+// where a partition's log currently starts.
+func newClient(t *testing.T) sarama.Client {
+	t.Helper()
+	c, err := sarama.NewClient(bootstrapAddrs(), baseConfig())
+	require.NoError(t, err, "failed to connect a client to %s", bootstrapAddr)
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+// txnStateLeaders maps each __transaction_state partition to the node currently
+// leading it.
+func txnStateLeaders(t *testing.T) map[int32]int32 {
+	t.Helper()
+	md, ok := internalTopicMetadata(t)
+	require.True(t, ok, "could not describe the internal topics")
+	out := map[int32]int32{}
+	for _, tm := range md {
+		if tm.Name != txnStateTopic {
+			continue
+		}
+		for _, p := range tm.Partitions {
+			out[p.ID] = p.Leader
+		}
+	}
+	require.NotEmpty(t, out, "%s reports no partitions", txnStateTopic)
+	return out
+}
+
+// pickTargetBroker chooses the node to kill: the one leading the most
+// __transaction_state partitions, and the partitions it leads.
+//
+// Most, rather than any, so the kill disrupts as many fetch loops as the layout
+// allows. Which node that is varies from run to run — leadership is assigned by
+// the controller, not by this suite — so it is resolved from metadata rather
+// than hardcoded, and reported in every failure message.
+func pickTargetBroker(t *testing.T) (int32, []int32) {
+	t.Helper()
+	leaders := txnStateLeaders(t)
+	led := map[int32][]int32{}
+	for part, leader := range leaders {
+		led[leader] = append(led[leader], part)
+	}
+
+	var best int32 = -1
+	for broker, parts := range led {
+		if best == -1 || len(parts) > len(led[best]) || (len(parts) == len(led[best]) && broker < best) {
+			best = broker
+		}
+	}
+	require.Contains(t, brokerContainer, best,
+		"the busiest %s leader is node %d, which maps to no container", txnStateTopic, best)
+
+	parts := append([]int32(nil), led[best]...)
+	sort.Slice(parts, func(i, j int) bool { return parts[i] < parts[j] })
+	require.NotEmpty(t, parts,
+		"no node leads any %s partition, so killing one would disrupt no fetch loop", txnStateTopic)
+	return best, parts
+}
+
+// pinnedTxnIDs finds want transactional ids whose transaction coordinator is
+// broker, by asking the cluster rather than by reimplementing its hashing.
+//
+// This is what makes the ledger sharp instead of probabilistic. A transactional
+// id's coordinator IS the leader of the __transaction_state partition its
+// footprint is written to, so an id coordinated by the node about to be killed
+// has its records land in a partition whose fetch loop must re-resolve a new
+// leader to keep reading. Left to chance — three transactions over twelve
+// partitions on three nodes — roughly a third of them would land on an
+// undisturbed partition, and a reader that recovered on none of them could
+// still satisfy the ledger.
+//
+// The salt in the name is what makes the search deterministic within a run: the
+// ids are enumerated in order and reported in every failure message.
+func pinnedTxnIDs(t *testing.T, client sarama.Client, base string, want int, broker int32) []string {
+	t.Helper()
+	var out []string
+	for salt := 0; len(out) < want && salt < 500; salt++ {
+		id := fmt.Sprintf("%s-c%d-txn", base, salt)
+		b, err := client.TransactionCoordinator(id)
+		if err != nil {
+			continue
+		}
+		if b.ID() == broker {
+			out = append(out, id)
+		}
+	}
+	require.Len(t, out, want,
+		"could not find %d transactional ids coordinated by node %d after 500 candidates", want, broker)
+	return out
+}
+
+// earliestOffsets reads each partition's current log start offset.
+//
+// The continuity check needs this: the reader is assigned %s from EARLIEST, so
+// its final next offset minus the log start is the span of offsets it was
+// responsible for, and the number of records it read must account for all of
+// them.
+func earliestOffsets(t *testing.T, topic string) map[int32]int64 {
+	t.Helper()
+	client := newClient(t)
+	require.NoError(t, client.RefreshMetadata(topic), "failed to refresh metadata for the offset scan")
+	parts, err := client.Partitions(topic)
+	require.NoError(t, err, "failed to list partitions for the offset scan")
+	out := make(map[int32]int64, len(parts))
+	for _, p := range parts {
+		off, err := client.GetOffset(topic, p, sarama.OffsetOldest)
+		require.NoError(t, err, "failed to read the log start offset of partition %d", p)
+		out[p] = off
+	}
+	return out
+}
+
+// killBroker removes a node from the cluster without letting it hand over.
+//
+// `docker kill`, not `docker stop`: SIGTERM triggers a controlled shutdown, in
+// which the broker asks the controller to move its leaderships before it goes
+// and closes its connections tidily. That is the easy case. SIGKILL is the one
+// worth testing — the socket simply stops answering, the controller has to
+// notice through the broker session timeout, and the reader's cached connection
+// is left latched on an error with no Kafka error code to classify.
+func killBroker(t *testing.T, broker int32) {
+	t.Helper()
+	container, ok := brokerContainer[broker]
+	require.True(t, ok, "node %d maps to no container", broker)
+	out, err := exec.Command("docker", "kill", container).CombinedOutput()
+	require.NoError(t, err, "failed to kill the broker leading the target partitions: %s", out)
+}
+
+// awaitLeadershipMovedOff blocks until no __transaction_state or
+// __consumer_offsets partition is still led by broker, and every partition has a
+// leader again. It returns the __transaction_state leadership afterwards.
+//
+// Both topics, not just the one under test: the reader is assigned partitions
+// from both, and one of the other topic's partitions left without a leader would
+// stall a fetch loop and fail the liveness assertion for an unrelated reason.
+func awaitLeadershipMovedOff(t *testing.T, broker int32) map[int32]int32 {
+	t.Helper()
+	var last string
+	require.Eventually(t, func() bool {
+		md, ok := internalTopicMetadata(t)
+		if !ok {
+			last = "the internal topics are not describable"
+			return false
+		}
+		for _, tm := range md {
+			for _, p := range tm.Partitions {
+				if p.Leader == broker {
+					last = fmt.Sprintf("%s partition %d is still led by node %d", tm.Name, p.ID, broker)
+					return false
+				}
+				if p.Leader < 0 {
+					last = fmt.Sprintf("%s partition %d has no leader", tm.Name, p.ID)
+					return false
+				}
+			}
+		}
+		return true
+	}, 2*time.Minute, 2*time.Second,
+		"leadership never moved off the killed node %d, so the cluster itself did not recover and the reader cannot be judged: %s", broker, last)
+	return txnStateLeaders(t)
+}
+
+// ---------------------------------------------------------------------------
+// Running the binary under test
+// ---------------------------------------------------------------------------
+
+// repoRoot resolves the checkout root from this package's directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root, err := filepath.Abs(filepath.Join(wd, "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// kcpBinary returns the path to the binary the Makefile target built.
+func kcpBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "kcp")
+	_, err := os.Stat(path)
+	require.NoError(t, err, "the kcp binary is missing — run `make test-txn-discovery-ha`, which builds it")
+	return path
+}
+
+// artifact filenames, fixed so every run's assertions look in the same place.
+const (
+	outFile   = "txn-discovery.yaml"
+	statsFile = "txn-discovery-stats.json"
+	auditFile = "txn-discovery-audit.jsonl"
+	logFile   = "kcp.log"
+)
+
+// kcpProc is a discovery run in flight.
+type kcpProc struct {
+	cmd    *exec.Cmd
+	dir    string
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+}
+
+// startKCP launches `kcp migration txn-discovery` in its own directory, which is
+// where the artifacts and kcp.log land.
+func startKCP(t *testing.T, args ...string) *kcpProc {
+	t.Helper()
+	dir := t.TempDir()
+
+	full := append([]string{"migration", "txn-discovery"}, args...)
+	cmd := exec.Command(kcpBinary(t), full...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Start(), "failed to start the kcp binary")
+
+	p := &kcpProc{cmd: cmd, dir: dir, stdout: &stdout, stderr: &stderr}
+	t.Cleanup(func() {
+		if p.cmd.ProcessState == nil && p.cmd.Process != nil {
+			_ = p.cmd.Process.Kill()
+			_ = p.cmd.Wait()
+		}
+	})
+	return p
+}
+
+// running reports whether the observation window is still open.
+//
+// It is the guard that keeps a harness timing failure from being read as a
+// reader failure: a window that closed before the post-failover phase was
+// produced would leave that phase missing from the ledger, which is exactly what
+// a reader that never recovered looks like.
+func (p *kcpProc) running() bool { return p.cmd.ProcessState == nil }
+
+// awaitObserving blocks until the run has begun reading the cluster.
+func (p *kcpProc) awaitObserving(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(filepath.Join(p.dir, logFile))
+		if err == nil && strings.Contains(string(data), "starting transaction discovery") {
+			time.Sleep(5 * time.Second)
+			return
+		}
+		if p.cmd.ProcessState != nil {
+			t.Fatalf("the run exited before it began observing:\n%s\n%s", p.stdout.String(), p.stderr.String())
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("the run never reported that it had started observing:\n%s\n%s", p.stdout.String(), p.stderr.String())
+}
+
+// wait blocks for the run to finish and collects everything it produced.
+func (p *kcpProc) wait(t *testing.T) *runResult {
+	t.Helper()
+	err := p.cmd.Wait()
+	code := 0
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("failed to wait for the kcp binary: %v", err)
+	}
+	return collect(t, p.dir, code, p.stdout.String(), p.stderr.String())
+}
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+// discoveryDoc mirrors txn-discovery.yaml. It is redeclared here rather than
+// imported: the suite is a consumer of the on-disk format, and sharing the
+// producer's struct would let a field rename pass unnoticed.
+type discoveryDoc struct {
+	Groups               []discoveryGroup `yaml:"groups"`
+	IndividualTopicCount int              `yaml:"individual_topic_count"`
+	IndividualTopics     []string         `yaml:"individual_topics"`
+}
+
+type discoveryGroup struct {
+	Name             string   `yaml:"name"`
+	ReadProcessWrite bool     `yaml:"read_process_write"`
+	Topics           []string `yaml:"topics"`
+	TransactionalIDs []string `yaml:"transactional_ids"`
+}
+
+// statsDoc is the slice of txn-discovery-stats.json this suite reads. Unlike the
+// single-node suite it needs the PER-PARTITION array as well as the aggregates:
+// the continuity and liveness scenarios are about individual partitions, and an
+// aggregate cannot say which partition stopped advancing.
+type statsDoc struct {
+	Tail struct {
+		PartitionsAssigned int   `json:"partitions_assigned"`
+		PartitionsRunning  int   `json:"partitions_running"`
+		PartitionsStalled  int   `json:"partitions_stalled"`
+		RecordsRead        int64 `json:"records_read"`
+		Lag                int64 `json:"lag"`
+		OpenTxnBacklog     int64 `json:"open_txn_backlog"`
+		DecodeErrors       int64 `json:"decode_errors"`
+		LeadershipErrors   int64 `json:"leadership_errors"`
+		UnclassifiedErrors int64 `json:"unclassified_errors"`
+		OffsetResets       int64 `json:"offset_resets"`
+		TransportErrors    int64 `json:"transport_errors"`
+
+		Partitions []statsPartition `json:"partitions"`
+	} `json:"tail"`
+}
+
+type statsPartition struct {
+	Topic            string `json:"topic"`
+	Partition        int32  `json:"partition"`
+	NextOffset       int64  `json:"next_offset"`
+	LastStableOffset int64  `json:"last_stable_offset"`
+	HighWaterMark    int64  `json:"high_water_mark"`
+	Lag              int64  `json:"lag"`
+	OpenTxnBacklog   int64  `json:"open_txn_backlog"`
+	Running          bool   `json:"running"`
+	Stalled          bool   `json:"stalled"`
+	RecordsRead      int64  `json:"records_read"`
+	AbortedBatches   int64  `json:"aborted_batches"`
+	LeadershipErrors int64  `json:"leadership_errors"`
+	TransportErrors  int64  `json:"transport_errors"`
+	LastError        string `json:"last_error"`
+}
+
+// auditLine mirrors one line of txn-discovery-audit.jsonl.
+type auditLine struct {
+	Timestamp time.Time `json:"timestamp"`
+	TxnID     string    `json:"transactional_id"`
+	Source    string    `json:"source"`
+	Added     []string  `json:"added"`
+	Topics    []string  `json:"topics"`
+}
+
+// runResult is everything one run left behind.
+type runResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+
+	doc   *discoveryDoc
+	audit []auditLine
+	stats *statsDoc
+
+	// files is every name the run left in its directory. It is captured when the
+	// run finishes rather than read on demand, because the directory is a
+	// t.TempDir() belonging to whichever test first triggered the shared run and
+	// is removed when THAT test returns.
+	files []string
+}
+
+// collect reads a finished run's directory.
+func collect(t *testing.T, dir string, code int, stdout, stderr string) *runResult {
+	t.Helper()
+	r := &runResult{exitCode: code, stdout: stdout, stderr: stderr}
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "failed to list the run's directory")
+	for _, e := range entries {
+		r.files = append(r.files, e.Name())
+	}
+
+	if data, err := os.ReadFile(filepath.Join(dir, outFile)); err == nil {
+		var doc discoveryDoc
+		require.NoError(t, yaml.Unmarshal(data, &doc), "the discovery YAML did not parse:\n%s", data)
+		r.doc = &doc
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, auditFile)); err == nil {
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			var al auditLine
+			require.NoError(t, json.Unmarshal([]byte(line), &al), "an audit line did not parse: %s", line)
+			r.audit = append(r.audit, al)
+		}
+		require.NoError(t, scanner.Err(), "failed to read the audit log")
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, statsFile)); err == nil {
+		var sd statsDoc
+		require.NoError(t, json.Unmarshal(data, &sd), "the stats JSON did not parse:\n%s", data)
+		r.stats = &sd
+	}
+	return r
+}
+
+// groupWith returns the group containing topic, or nil.
+func (r *runResult) groupWith(topic string) *discoveryGroup {
+	for i := range r.doc.Groups {
+		for _, tp := range r.doc.Groups[i].Topics {
+			if tp == topic {
+				return &r.doc.Groups[i]
+			}
+		}
+	}
+	return nil
+}
+
+// auditForTxn returns every audit line for one transactional id.
+func (r *runResult) auditForTxn(txnID string) []auditLine {
+	var out []auditLine
+	for _, l := range r.audit {
+		if l.TxnID == txnID {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// The failover run
+// ---------------------------------------------------------------------------
+
+const (
+	// failoverWindow is the observation window. It has to cover the whole
+	// choreography — three production phases, a broker kill, a leader election
+	// and the reader's own capped backoff — plus a quiet tail long enough for the
+	// reader to catch up to the last stable offset on every partition.
+	failoverWindow = 240 * time.Second
+
+	// phaseTxns is how many transactions each phase produces. Small on purpose:
+	// every id is pinned to the coordinator being killed, so three is already an
+	// exhaustive ledger over the disrupted partitions rather than a sample.
+	phaseTxns = 3
+
+	// postPhaseQuietTail is how much of the window must still be open after the
+	// post-failover phase is produced. It is asserted rather than calculated:
+	// the run staying alive this long after the last fixture is what proves the
+	// reader was given time to see it.
+	postPhaseQuietTail = 30 * time.Second
+
+	// prePhaseSettle lets the pre-failover phase be read before the broker goes
+	// away, so a failure afterwards is unambiguously about resumption.
+	prePhaseSettle = 12 * time.Second
+
+	// postKillSettle gives the reader room to re-resolve before it is judged on
+	// records produced after the kill. The fetch loop's backoff is capped at five
+	// seconds and a metadata refresh has to land behind it.
+	postKillSettle = 15 * time.Second
+)
+
+// phase is one group of transactions and when it was produced relative to the
+// kill.
+type phase struct {
+	// name is "pre", "mid" or "post" and appears in every failure message: which
+	// phase went missing is the whole diagnosis.
+	name     string
+	fixtures []txnFixture
+}
+
+// failoverResult is the run plus everything about the failover needed to judge
+// it.
+type failoverResult struct {
+	*runResult
+
+	// killedBroker is the node whose container was killed mid-run.
+	killedBroker int32
+	// killedPartitions are the __transaction_state partitions it led at the
+	// moment of the kill: the fetch loops that had to re-resolve.
+	killedPartitions []int32
+	// leadersAfter is __transaction_state leadership once the cluster settled.
+	leadersAfter map[int32]int32
+
+	phases []phase
+
+	// txnStateEarliest is each __transaction_state partition's log start offset,
+	// captured before the run began. It is the left-hand end of the offset span
+	// the continuity check accounts for.
+	txnStateEarliest map[int32]int64
+}
+
+var (
+	failoverOnce sync.Once
+	failover     *failoverResult
+)
+
+// failoverRun performs one observation window with a broker killed in the middle
+// of it, and returns its artifacts.
+//
+// One window shared by every test, because each window costs its full
+// --duration and the choreography inside it cannot be repeated cheaply. The
+// scenarios are all assertions about the same run.
+func failoverRun(t *testing.T) *failoverResult {
+	t.Helper()
+	failoverOnce.Do(func() { failover = doFailoverRun(t) })
+	require.NotNil(t, failover, "the failover run did not complete; see the first failing test in this package")
+	return failover
+}
+
+func doFailoverRun(t *testing.T) *failoverResult {
+	t.Helper()
+
+	ensureInternalTopics(t)
+	awaitFullISR(t)
+
+	client := newClient(t)
+	target, ledParts := pickTargetBroker(t)
+	t.Logf("target node %d leads %s partitions %v", target, txnStateTopic, ledParts)
+
+	// Every transactional id in every phase is coordinated by the node about to
+	// be killed, so all three phases exercise the same disrupted partitions and
+	// only their timing differs.
+	phases := make([]phase, 0, 3)
+	for _, name := range []string{"pre", "mid", "post"} {
+		ids := pinnedTxnIDs(t, client, fixturePrefix+name, phaseTxns, target)
+		fixtures := make([]txnFixture, 0, len(ids))
+		for i, id := range ids {
+			base := fmt.Sprintf("%s%s-%d", fixturePrefix, name, i)
+			fixtures = append(fixtures, txnFixture{TxnID: id, Produce: []string{base + "-a", base + "-b"}})
+		}
+		phases = append(phases, phase{name: name, fixtures: fixtures})
+	}
+	for _, ph := range phases {
+		createTopics(t, topicsOf(ph.fixtures)...)
+	}
+
+	earliest := earliestOffsets(t, txnStateTopic)
+
+	proc := startKCP(t,
+		"--source-bootstrap", bootstrapAddr,
+		"--use-unauthenticated-plaintext",
+		"--duration", failoverWindow.String(),
+		"--interval", "5s",
+		"--out", outFile,
+		"--stats-out", statsFile,
+		"--audit-log-out", auditFile,
+	)
+	proc.awaitObserving(t)
+
+	// Phase one: before the kill.
+	for _, f := range phases[0].fixtures {
+		produceTxnWithRetry(t, f, 60*time.Second)
+	}
+	time.Sleep(prePhaseSettle)
+
+	// Phase two: across the kill. Started first so the kill lands while these
+	// transactions are in flight, and run on its own goroutine because a
+	// transactional producer whose coordinator disappears blocks until it can
+	// find the new one.
+	midErr := make(chan error, 1)
+	go func() {
+		for _, f := range phases[1].fixtures {
+			if err := produceWithin(f, 90*time.Second); err != nil {
+				midErr <- err
+				return
+			}
+		}
+		midErr <- nil
+	}()
+
+	killBroker(t, target)
+	require.NoError(t, <-midErr,
+		"the during-the-kill phase could not be produced at all, so the cluster rather than the reader failed")
+
+	leadersAfter := awaitLeadershipMovedOff(t, target)
+	time.Sleep(postKillSettle)
+
+	// Phase three: strictly after the kill. This is the phase that separates a
+	// recovered reader from a silently stalled one — everything before it is
+	// already in the accumulator, which is in-memory and append-only, so a reader
+	// that died at the kill would still satisfy a ledger built only from phases
+	// one and two.
+	for _, f := range phases[2].fixtures {
+		produceTxnWithRetry(t, f, 90*time.Second)
+	}
+
+	require.True(t, proc.running(),
+		"the observation window closed before the post-failover phase was produced: this is a harness timing failure, not a reader failure — raise failoverWindow")
+	time.Sleep(postPhaseQuietTail)
+	require.True(t, proc.running(),
+		"the observation window closed less than %s after the post-failover phase was produced, so the reader was never given time to see it: this is a harness timing failure, not a reader failure — raise failoverWindow",
+		postPhaseQuietTail)
+
+	res := proc.wait(t)
+	require.Equal(t, 0, res.exitCode, "the discovery run failed:\nSTDOUT\n%s\nSTDERR\n%s", res.stdout, res.stderr)
+	require.NotNil(t, res.doc, "the run wrote no %s:\nSTDOUT\n%s", outFile, res.stdout)
+	require.NotNil(t, res.stats, "the run wrote no %s, so the reader's own account of itself is unavailable", statsFile)
+
+	return &failoverResult{
+		runResult:        res,
+		killedBroker:     target,
+		killedPartitions: ledParts,
+		leadersAfter:     leadersAfter,
+		phases:           phases,
+		txnStateEarliest: earliest,
+	}
+}
+
+// topicsOf flattens the topics a set of fixtures produces to.
+func topicsOf(fs []txnFixture) []string {
+	var out []string
+	for _, f := range fs {
+		out = append(out, f.Produce...)
+	}
+	return out
+}
+
+// describe renders the run for a failure message.
+func (r *failoverResult) describe() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "killed node %d, which led %s partitions %v\n", r.killedBroker, txnStateTopic, r.killedPartitions)
+	fmt.Fprintf(&b, "exit=%d\n--- STDOUT ---\n%s", r.exitCode, r.stdout)
+	if r.stderr != "" {
+		fmt.Fprintf(&b, "--- STDERR ---\n%s", r.stderr)
+	}
+	t := r.stats.Tail
+	fmt.Fprintf(&b, "--- TAIL ---\n  %d/%d live, %d stalled, %d read, lag %d, backlog %d\n",
+		t.PartitionsRunning, t.PartitionsAssigned, t.PartitionsStalled, t.RecordsRead, t.Lag, t.OpenTxnBacklog)
+	fmt.Fprintf(&b, "  errors: %d transport, %d leadership, %d unclassified, %d decode, %d offset reset\n",
+		t.TransportErrors, t.LeadershipErrors, t.UnclassifiedErrors, t.DecodeErrors, t.OffsetResets)
+	for _, p := range t.Partitions {
+		if p.Stalled || !p.Running || p.Lag > 0 || p.LastError != "" {
+			fmt.Fprintf(&b, "  %s[%d]: next %d, LSO %d, HWM %d, lag %d, read %d, running=%v stalled=%v err=%q\n",
+				p.Topic, p.Partition, p.NextOffset, p.LastStableOffset, p.HighWaterMark, p.Lag, p.RecordsRead,
+				p.Running, p.Stalled, p.LastError)
+		}
+	}
+	fmt.Fprintf(&b, "--- PHASES ---\n")
+	for _, ph := range r.phases {
+		for _, f := range ph.fixtures {
+			present := r.groupWith(f.Produce[0]) != nil
+			fmt.Fprintf(&b, "  %s %s present=%v\n", ph.name, f.TxnID, present)
+		}
+	}
+	return b.String()
+}
+
+// TestFailoverActuallyDisruptedTheReader is the non-vacuity gate for every
+// scenario below it, and the reason they are worth asserting at all.
+//
+// Two things have to be true before a passing ledger means anything. The cluster
+// must really have moved leadership off the killed node — otherwise nothing was
+// re-resolved. And the reader must really have noticed: a run that sailed
+// through without a single failed fetch never exercised recovery, so the ledger
+// would be proving that a healthy reader reads, which is not R11.
+//
+// The error counters are used here and ONLY here. A passing failover run is
+// EXPECTED to show transport or leadership errors — that is the recovery
+// happening, not a fault — so they are a premise, never a health signal. What
+// health looks like is asserted separately, on partition liveness.
+func TestFailoverActuallyDisruptedTheReader(t *testing.T) {
+	r := failoverRun(t)
+
+	require.NotEmpty(t, r.killedPartitions,
+		"the killed node led no %s partition, so no fetch loop had to re-resolve anything", txnStateTopic)
+	for _, part := range r.killedPartitions {
+		leader, ok := r.leadersAfter[part]
+		require.True(t, ok, "%s partition %d vanished from metadata after the kill", txnStateTopic, part)
+		require.NotEqual(t, r.killedBroker, leader,
+			"%s partition %d is still led by the killed node %d, so its leader never moved", txnStateTopic, part, r.killedBroker)
+	}
+
+	disruptions := r.stats.Tail.TransportErrors + r.stats.Tail.LeadershipErrors
+	require.Positive(t, disruptions,
+		"killing node %d caused the reader no transport or leadership error, so it was never disrupted and every assertion in this file proves nothing\n%s",
+		r.killedBroker, r.describe())
+}
+
+// TestEveryPhaseAppearsInTheGrouping is the ledger: every transaction produced
+// before, during and after the failover is in the final grouping.
+//
+// It is a ledger rather than a spot check because the obvious assertions are all
+// satisfiable by a reader that died at the kill. The accumulator is in-memory
+// and append-only, so "nothing observed before the failover was lost" holds
+// trivially for a reader that never resumed. Enumerating the phases is what
+// makes the absence of one of them the thing that fails.
+func TestEveryPhaseAppearsInTheGrouping(t *testing.T) {
+	r := failoverRun(t)
+
+	missing := map[string][]string{}
+	for _, ph := range r.phases {
+		for _, f := range ph.fixtures {
+			if r.groupWith(f.Produce[0]) == nil {
+				missing[ph.name] = append(missing[ph.name], f.TxnID)
+			}
+		}
+	}
+	require.Empty(t, missing,
+		"transactions are missing from the output, by phase: %v\n%s", missing, r.describe())
+
+	for _, ph := range r.phases {
+		for _, f := range ph.fixtures {
+			g := r.groupWith(f.Produce[0])
+			assert.ElementsMatch(t, f.Produce, g.Topics,
+				"the %s-failover transaction %s did not produce its own group of topics\n%s", ph.name, f.TxnID, r.describe())
+			assert.Contains(t, g.TransactionalIDs, f.TxnID,
+				"the group is not credited to the %s-failover transaction %s\n%s", ph.name, f.TxnID, r.describe())
+		}
+	}
+}
+
+// TestPostFailoverTransactionsAreObserved is the discriminator the whole suite
+// exists for, called out on its own so a failure names it directly.
+//
+// Every other signal a stalled reader produces is ambiguous. It reports its
+// partitions live, because a loop retrying a dead connection has not exited. It
+// reports zero lag, because a partition that never fetched successfully holds a
+// zero last stable offset. It reports no duplicate group, most easily of all,
+// because it stopped. The one thing it cannot do is show a transaction that was
+// produced after it stopped reading.
+func TestPostFailoverTransactionsAreObserved(t *testing.T) {
+	r := failoverRun(t)
+
+	post := r.phases[len(r.phases)-1]
+	require.Equal(t, "post", post.name, "the last phase is %q, not the post-failover one", post.name)
+	require.NotEmpty(t, post.fixtures, "the post-failover phase produced nothing, so this test proves nothing")
+
+	for _, f := range post.fixtures {
+		g := r.groupWith(f.Produce[0])
+		require.NotNil(t, g,
+			"a transaction produced STRICTLY AFTER the failover is absent from the grouping: the reader did not resume.\n"+
+				"Its transactional id is coordinated by the node that was killed, so its footprint was written to a %s "+
+				"partition whose fetch loop had to re-resolve a new leader. A loop that kept retrying the dead broker "+
+				"instead still reports itself running with zero lag, so this absence is the only signal that says so.\n%s",
+			txnStateTopic, r.describe())
+		assert.Contains(t, g.TransactionalIDs, f.TxnID,
+			"the post-failover group is not credited to %s\n%s", f.TxnID, r.describe())
+	}
 }

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -43,7 +43,7 @@ const (
 	// bootstrapped only against that one could not refresh metadata afterwards,
 	// so the reader's recovery would be untestable for a reason that has nothing
 	// to do with the reader.
-	bootstrapAddr = "localhost:29092,localhost:29093,localhost:29094"
+	bootstrapAddr = "localhost:29192,localhost:29193,localhost:29194"
 
 	// txnStateTopic is the internal topic the command reads by default, and whose
 	// partition leadership this suite moves.
@@ -103,7 +103,7 @@ func newAdmin(t *testing.T) sarama.ClusterAdmin {
 
 // bootstrapAddrs splits the bootstrap string sarama wants as a slice.
 func bootstrapAddrs() []string {
-	return []string{"localhost:29092", "localhost:29093", "localhost:29094"}
+	return []string{"localhost:29192", "localhost:29193", "localhost:29194"}
 }
 
 // liveBrokerIDs returns the node ids the cluster currently reports, reporting
@@ -216,6 +216,28 @@ const (
 	warmupOut   = fixturePrefix + "warmup-out"
 	warmupIn    = fixturePrefix + "warmup-in"
 	warmupGroup = fixturePrefix + "warmup-cg"
+)
+
+// The open-transaction fixture, left uncommitted until after the window closes.
+//
+// It exists for one assertion: KTD9's, that lag is measured against the last
+// stable offset and not the high watermark. On a quiet cluster the two
+// definitions agree and the difference cannot be observed at all, so the suite
+// has to create the condition — a transaction that has written a transactional
+// offset commit to __consumer_offsets and not yet been decided, which is the
+// normal state on an exactly-once cluster and the reason a high-watermark-based
+// lag would have a permanent floor.
+const (
+	openTxn   = fixturePrefix + "open-txn"
+	openIn    = fixturePrefix + "open-in"
+	openGroup = fixturePrefix + "open-cg"
+
+	// openTxnTimeout has to outlast the rest of the observation window, or the
+	// coordinator aborts the transaction, the last stable offset catches up to the
+	// high watermark, and the condition under test disappears before the window
+	// closes. It must stay under the broker's transaction.max.timeout.ms, which
+	// docker-compose.yml sets to fifteen minutes.
+	openTxnTimeout = 14 * time.Minute
 )
 
 // createTopics creates each topic at the cluster's replication factor, ignoring
@@ -336,6 +358,89 @@ func produceWithin(f txnFixture, within time.Duration) error {
 		time.Sleep(2 * time.Second)
 	}
 	return fmt.Errorf("gave up after %s; last error: %w", within, last)
+}
+
+// beginOpenTransaction leaves a transactional offset commit sitting in
+// __consumer_offsets under a transaction that is never decided, and returns a
+// function that abandons it.
+//
+// That record is what pins the partition's last stable offset below its high
+// watermark for as long as the transaction is open, and that gap is the entire
+// point: it is the condition under which a high-watermark-based lag can never
+// reach zero. Without it, both definitions of lag report the same zero and the
+// assertion below cannot tell them apart.
+//
+// It is written through the raw protocol rather than through a transactional
+// producer because sarama's AddOffsetsToTxn only BUFFERS the offsets — nothing
+// reaches __consumer_offsets until CommitTxn, and a committed transaction leaves
+// no gap. So the four requests a commit would have issued are issued here, minus
+// the EndTxn that would close it: InitProducerId to claim a producer id and
+// epoch, AddOffsetsToTxn to put the group's offsets partition into the
+// transaction, and TxnOffsetCommit to write the record.
+func beginOpenTransaction(t *testing.T) func() {
+	t.Helper()
+	createTopics(t, openIn)
+
+	client := newClient(t)
+	id := openTxn
+
+	coordinator, err := client.TransactionCoordinator(id)
+	require.NoError(t, err, "failed to resolve the transaction coordinator for the deliberately-open transaction")
+
+	// Versions chosen to match what sarama's own transaction manager sends at the
+	// configured Kafka version, so this fixture speaks the same protocol the
+	// committed fixtures do. A fresh producer id is claimed with -1/-1.
+	init, err := coordinator.InitProducerID(&sarama.InitProducerIDRequest{
+		Version:            4,
+		TransactionalID:    &id,
+		TransactionTimeout: openTxnTimeout,
+		ProducerID:         -1,
+		ProducerEpoch:      -1,
+	})
+	require.NoError(t, err, "InitProducerId failed for the deliberately-open transaction")
+	require.Equal(t, sarama.ErrNoError, init.Err, "InitProducerId was refused: %v", init.Err)
+
+	added, err := coordinator.AddOffsetsToTxn(&sarama.AddOffsetsToTxnRequest{
+		Version:         2,
+		TransactionalID: id,
+		ProducerID:      init.ProducerID,
+		ProducerEpoch:   init.ProducerEpoch,
+		GroupID:         openGroup,
+	})
+	require.NoError(t, err, "AddOffsetsToTxn failed for the deliberately-open transaction")
+	require.Equal(t, sarama.ErrNoError, added.Err, "AddOffsetsToTxn was refused: %v", added.Err)
+
+	groupCoordinator, err := client.Coordinator(openGroup)
+	require.NoError(t, err, "failed to resolve the group coordinator for the deliberately-open transaction")
+
+	committed, err := groupCoordinator.TxnOffsetCommit(&sarama.TxnOffsetCommitRequest{
+		Version:         2,
+		TransactionalID: id,
+		GroupID:         openGroup,
+		ProducerID:      init.ProducerID,
+		ProducerEpoch:   init.ProducerEpoch,
+		Topics: map[string][]*sarama.PartitionOffsetMetadata{
+			openIn: {{Partition: 0, Offset: 1, LeaderEpoch: -1}},
+		},
+	})
+	require.NoError(t, err, "TxnOffsetCommit failed for the deliberately-open transaction")
+	for topic, parts := range committed.Topics {
+		for _, pe := range parts {
+			require.Equal(t, sarama.ErrNoError, pe.Err,
+				"the transactional offset commit was refused for %s[%d]: %v", topic, pe.Partition, pe.Err)
+		}
+	}
+
+	// Deliberately no EndTxn here. That is the whole fixture.
+	return func() {
+		_, _ = coordinator.EndTxn(&sarama.EndTxnRequest{
+			Version:           2,
+			TransactionalID:   id,
+			ProducerID:        init.ProducerID,
+			ProducerEpoch:     init.ProducerEpoch,
+			TransactionResult: false,
+		})
+	}
 }
 
 // ensureInternalTopics brings __transaction_state and __consumer_offsets into
@@ -961,6 +1066,14 @@ func doFailoverRun(t *testing.T) *failoverResult {
 
 	require.True(t, proc.running(),
 		"the observation window closed before the post-failover phase was produced: this is a harness timing failure, not a reader failure — raise failoverWindow")
+
+	// Opened here so it is still undecided when the window closes and the tail
+	// snapshot is taken. Its own recovery is not under test; what it provides is
+	// the high-watermark-to-last-stable-offset gap the lag assertion needs in
+	// order to be about anything.
+	abandonOpen := beginOpenTransaction(t)
+	t.Cleanup(abandonOpen)
+
 	time.Sleep(postPhaseQuietTail)
 	require.True(t, proc.running(),
 		"the observation window closed less than %s after the post-failover phase was produced, so the reader was never given time to see it: this is a harness timing failure, not a reader failure — raise failoverWindow",
@@ -1110,5 +1223,244 @@ func TestPostFailoverTransactionsAreObserved(t *testing.T) {
 			txnStateTopic, r.describe())
 		assert.Contains(t, g.TransactionalIDs, f.TxnID,
 			"the post-failover group is not credited to %s\n%s", f.TxnID, r.describe())
+	}
+}
+
+// TestEveryAssignedPartitionIsLiveAndReadingAtTheEnd is R11's liveness half:
+// no partition gave up and no partition is stuck retrying when the window closes.
+//
+// Both numbers are needed and neither is enough. A loop that exited stops being
+// counted as running, which is the loud failure. A loop stuck retrying a dead
+// connection is still counted as running, contributes no lag, and is otherwise
+// indistinguishable from a healthy idle partition — that is the quiet one, and
+// PartitionsStalled is the only signal that separates them.
+//
+// This asserts on liveness rather than on the error counters deliberately. The
+// counters are expected to be positive on a passing run.
+func TestEveryAssignedPartitionIsLiveAndReadingAtTheEnd(t *testing.T) {
+	r := failoverRun(t)
+	tl := r.stats.Tail
+
+	require.Positive(t, tl.PartitionsAssigned,
+		"the reader was assigned no partitions at all, so its liveness says nothing\n%s", r.describe())
+	assert.Equal(t, tl.PartitionsAssigned, tl.PartitionsRunning,
+		"%d of %d partitions stopped across the failover, so part of the window went unobserved\n%s",
+		tl.PartitionsAssigned-tl.PartitionsRunning, tl.PartitionsAssigned, r.describe())
+	assert.Zero(t, tl.PartitionsStalled,
+		"%d partitions were still retrying a failed fetch when the window closed, so they never recovered from the failover — and their zero lag means nothing was read, not that they caught up\n%s",
+		tl.PartitionsStalled, r.describe())
+
+	for _, p := range tl.Partitions {
+		assert.True(t, p.Running,
+			"%s[%d] stopped early\n%s", p.Topic, p.Partition, r.describe())
+		assert.False(t, p.Stalled,
+			"%s[%d] is retrying rather than reading; its last error was %q\n%s",
+			p.Topic, p.Partition, p.LastError, r.describe())
+	}
+
+	// Not a keep-up signal but a format-drift alarm, asserted here because a
+	// failover is exactly when a reader might start misreading a batch header: a
+	// new leader serves the same records from its own log, and a reader that
+	// mishandled the boundary would decode rather than fail outright.
+	assert.Zero(t, tl.DecodeErrors,
+		"records failed to decode across the failover\n%s", r.describe())
+}
+
+// TestNoOffsetRangeSkippedAcrossTheResume is the continuity scenario: the reader
+// resumed where it left off rather than jumping ahead.
+//
+// A skipped range is the quietest failure this component has. Every other signal
+// reads clean — the partition is running, its offset advanced, its lag is zero,
+// and the records it did read decoded fine — while the transactions in the gap
+// are simply absent, which downstream is indistinguishable from a cluster on
+// which those transactions never happened.
+//
+// It is derived from an identity the stats document makes checkable. The
+// transaction-state log is assigned from EARLIEST, its records are written by the
+// coordinator as ordinary non-transactional records so its offsets are dense, and
+// the reader only ever advances past records it actually decoded. So for each of
+// its partitions the number of records read must account for the ENTIRE offset
+// span between the log start and where the reader finished. Anything less is a
+// gap, whatever else the numbers say.
+func TestNoOffsetRangeSkippedAcrossTheResume(t *testing.T) {
+	r := failoverRun(t)
+
+	// The left-hand end of every span has to still be where it was, or the
+	// arithmetic below is measuring against the wrong origin. The compose file
+	// disables the log cleaner precisely so this holds.
+	now := earliestOffsets(t, txnStateTopic)
+	for part, start := range r.txnStateEarliest {
+		require.Equal(t, start, now[part],
+			"the log start offset of %s partition %d moved from %d to %d during the run, so the offset span cannot be accounted for — has the log cleaner been re-enabled?",
+			txnStateTopic, part, start, now[part])
+	}
+
+	killed := map[int32]bool{}
+	for _, p := range r.killedPartitions {
+		killed[p] = true
+	}
+
+	var totalSpan, killedSpan int64
+	for _, p := range r.stats.Tail.Partitions {
+		if p.Topic != txnStateTopic {
+			// __consumer_offsets is assigned from LATEST, so its log start is not
+			// where the reader began and the span identity does not apply.
+			continue
+		}
+		start, ok := r.txnStateEarliest[p.Partition]
+		require.True(t, ok, "%s partition %d has no captured log start offset", txnStateTopic, p.Partition)
+
+		span := p.NextOffset - start
+		require.GreaterOrEqual(t, span, int64(0),
+			"%s[%d] finished at offset %d, behind its log start %d\n%s", p.Topic, p.Partition, p.NextOffset, start, r.describe())
+
+		// The identity only holds while nothing was filtered out. The transaction
+		// coordinator writes plain records, so a dropped batch here would mean the
+		// reader is misreading the log rather than that the assertion is too
+		// strict.
+		require.Zero(t, p.AbortedBatches,
+			"%s[%d] dropped %d batches as aborted, which the transaction-state log should never contain\n%s",
+			p.Topic, p.Partition, p.AbortedBatches, r.describe())
+
+		assert.Equal(t, span, p.RecordsRead,
+			"%s[%d] read %d records over an offset span of %d (log start %d, finished at %d): %d offsets went unread, so a range was skipped rather than resumed\n%s",
+			p.Topic, p.Partition, p.RecordsRead, span, start, p.NextOffset, span-p.RecordsRead, r.describe())
+
+		totalSpan += span
+		if killed[p.Partition] {
+			killedSpan += span
+		}
+	}
+
+	require.Positive(t, totalSpan,
+		"the reader consumed no %s offsets at all, so continuity is vacuous\n%s", txnStateTopic, r.describe())
+	// And specifically across the resume point: continuity over partitions that
+	// were never disrupted would prove nothing about the failover.
+	require.Positive(t, killedSpan,
+		"no partition led by the killed node %d carried any record, so continuity was not checked across the resume point at all\n%s",
+		r.killedBroker, r.describe())
+}
+
+// TestReconnectDuplicatedNoGroupAndNoAuditLine is the other half of resuming
+// correctly: the reader did not re-read a range it had already consumed.
+//
+// Re-reading is the mirror image of skipping, and it is not harmless. A
+// transaction observed twice would be credited twice, so a topic could appear in
+// two groups — and an operator reading that would migrate the same topic in two
+// separate batches, or conclude the tool cannot be trusted about either.
+//
+// The audit half is asserted as growth-only per resulting topic set rather than
+// as one line per transaction. A transaction that produces to two topics may
+// legitimately be observed first with one of them and then with both, because
+// the Ongoing record is written as partitions are added — two genuine growth
+// events. What must never happen is the SAME topic set being recorded twice,
+// which is what a re-read range would produce.
+func TestReconnectDuplicatedNoGroupAndNoAuditLine(t *testing.T) {
+	r := failoverRun(t)
+
+	seen := map[string]int{}
+	for _, g := range r.doc.Groups {
+		seen[g.Name]++
+	}
+	for name, n := range seen {
+		assert.Equal(t, 1, n, "group name %s appears %d times in the document", name, n)
+	}
+
+	for _, ph := range r.phases {
+		for _, f := range ph.fixtures {
+			var in []string
+			for _, g := range r.doc.Groups {
+				for _, tp := range g.Topics {
+					if tp == f.Produce[0] {
+						in = append(in, g.Name)
+					}
+				}
+			}
+			assert.Len(t, in, 1,
+				"the %s-failover transaction %s has its topic in groups %v, so the reconnect duplicated it\n%s",
+				ph.name, f.TxnID, in, r.describe())
+		}
+	}
+
+	require.NotEmpty(t, r.audit, "the run wrote no audit log at all, so duplication in it cannot be checked\n%s", r.describe())
+	for _, ph := range r.phases {
+		for _, f := range ph.fixtures {
+			lines := r.auditForTxn(f.TxnID)
+			require.NotEmpty(t, lines,
+				"the %s-failover transaction %s has no audit line, so its grouping cannot be explained\n%s", ph.name, f.TxnID, r.describe())
+
+			bySet := map[string]int{}
+			for _, l := range lines {
+				set := append([]string(nil), l.Topics...)
+				sort.Strings(set)
+				bySet[strings.Join(set, ",")]++
+			}
+			for set, n := range bySet {
+				assert.Equal(t, 1, n,
+					"the %s-failover transaction %s has %d audit lines recording the identical topic set {%s}, so the reconnect re-read a range it had already consumed\n%s",
+					ph.name, f.TxnID, n, set, r.describe())
+			}
+
+			final := append([]string(nil), f.Produce...)
+			sort.Strings(final)
+			assert.Contains(t, bySet, strings.Join(final, ","),
+				"no audit line records the %s-failover transaction %s reaching its full topic set\n%s", ph.name, f.TxnID, r.describe())
+		}
+	}
+}
+
+// TestLagRecoversToZeroAgainstTheLastStableOffset is the keep-up scenario, and
+// KTD9 is the whole of its subtlety.
+//
+// Under ReadCommitted the broker serves nothing past the last stable offset, so
+// measuring lag against the HIGH WATERMARK gives a figure with a permanent floor
+// of the high-watermark-to-LSO gap whenever any transaction is open — which on
+// __consumer_offsets is the normal state on an exactly-once cluster. A reader
+// that had fully observed the window would report itself permanently behind, and
+// operators would learn to ignore the one indicator that says the window was
+// covered.
+//
+// So the test does two things a plain "lag is zero" would not. It checks the
+// arithmetic from the artifact, that lag is the last-stable-offset gap and the
+// high-watermark gap is reported separately. And it requires a partition to
+// actually HAVE an open transaction at the end, because on a quiet cluster the
+// two definitions agree and the distinction cannot be observed at all.
+func TestLagRecoversToZeroAgainstTheLastStableOffset(t *testing.T) {
+	r := failoverRun(t)
+	tl := r.stats.Tail
+
+	// Non-vacuity, and the confusion the stalled flag exists to prevent: a reader
+	// that never fetched successfully holds a zero last stable offset, so its lag
+	// computes as zero too.
+	require.Positive(t, tl.RecordsRead,
+		"the reader read no records at all, so zero lag would mean nothing was read rather than that it caught up\n%s", r.describe())
+
+	assert.Zero(t, tl.Lag,
+		"the reader never caught up to the last stable offset after the failover\n%s", r.describe())
+
+	for _, p := range tl.Partitions {
+		assert.Zero(t, p.Lag,
+			"%s[%d] is %d records behind its last stable offset\n%s", p.Topic, p.Partition, p.Lag, r.describe())
+		assert.Equal(t, max(int64(0), p.LastStableOffset-p.NextOffset), p.Lag,
+			"%s[%d] reports lag %d, which is not its last-stable-offset gap (LSO %d, next %d)\n%s",
+			p.Topic, p.Partition, p.Lag, p.LastStableOffset, p.NextOffset, r.describe())
+		assert.Equal(t, max(int64(0), p.HighWaterMark-p.LastStableOffset), p.OpenTxnBacklog,
+			"%s[%d] reports an open-transaction backlog of %d, which is not its high-watermark gap (HWM %d, LSO %d)\n%s",
+			p.Topic, p.Partition, p.OpenTxnBacklog, p.HighWaterMark, p.LastStableOffset, r.describe())
+	}
+
+	var withOpenTxn []statsPartition
+	for _, p := range tl.Partitions {
+		if p.OpenTxnBacklog > 0 {
+			withOpenTxn = append(withOpenTxn, p)
+		}
+	}
+	require.NotEmpty(t, withOpenTxn,
+		"no partition had an open transaction when the window closed, so an LSO-based lag and a high-watermark-based one would report the same zero and this test cannot tell them apart\n%s",
+		r.describe())
+	for _, p := range withOpenTxn {
+		assert.Zero(t, p.Lag,
+			"%s[%d] has an open transaction (HWM %d, LSO %d) and reports lag %d: the lag is being measured against the high watermark, so it can never reach zero while any transaction is open\n%s",
+			p.Topic, p.Partition, p.HighWaterMark, p.LastStableOffset, p.Lag, r.describe())
 	}
 }

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -238,6 +238,11 @@ const (
 	// closes. It must stay under the broker's transaction.max.timeout.ms, which
 	// docker-compose.yml sets to fifteen minutes.
 	openTxnTimeout = 14 * time.Minute
+
+	// openTxnBudget bounds how long the fixture retries. It is part of the window
+	// budget: everything it spends is window the reader does not get for its quiet
+	// tail, which is why failoverWindow carries slack for it.
+	openTxnBudget = 90 * time.Second
 )
 
 // createTopics creates each topic at the cluster's replication factor, ignoring
@@ -373,22 +378,61 @@ func produceWithin(f txnFixture, within time.Duration) error {
 // It is written through the raw protocol rather than through a transactional
 // producer because sarama's AddOffsetsToTxn only BUFFERS the offsets — nothing
 // reaches __consumer_offsets until CommitTxn, and a committed transaction leaves
-// no gap. So the four requests a commit would have issued are issued here, minus
-// the EndTxn that would close it: InitProducerId to claim a producer id and
-// epoch, AddOffsetsToTxn to put the group's offsets partition into the
-// transaction, and TxnOffsetCommit to write the record.
+// no gap.
+//
+// It is retried AS A WHOLE, and that is not defensiveness. This fixture is
+// opened moments after a broker was killed, which is exactly when the brokers
+// that took over its coordinator duties are still loading state and answer
+// COORDINATOR_LOAD_IN_PROGRESS, NOT_COORDINATOR or UNKNOWN_TOPIC_OR_PARTITION.
+// sarama's own transaction manager retries all of those; this hand-rolled path
+// has to as well. Both failure modes were observed, and each one failed the
+// fixture and every assertion below it — which is indistinguishable from the
+// reader having broken, and so would make this suite useless as a negative
+// control. Every attempt is a fresh InitProducerId, which bumps the epoch and
+// fences the abandoned one, exactly as a real client's retry does.
 func beginOpenTransaction(t *testing.T) func() {
 	t.Helper()
 
 	client := newClient(t)
+	var abandon func()
+	var last error
+
+	require.Eventually(t, func() bool {
+		f, err := tryOpenTransaction(client)
+		if err != nil {
+			last = err
+			// The coordinators are the thing most likely to have moved, so both
+			// cached resolutions are dropped before the next attempt.
+			_ = client.RefreshTransactionCoordinator(openTxn)
+			_ = client.RefreshCoordinator(openGroup)
+			_ = client.RefreshMetadata(openIn)
+			return false
+		}
+		abandon = f
+		return true
+	}, openTxnBudget, 3*time.Second,
+		"could not leave a transaction open on %s; last error: %v", offsetsTopic, last)
+
+	return abandon
+}
+
+// tryOpenTransaction makes one attempt at the three requests a commit would have
+// issued, minus the EndTxn that would close the transaction: InitProducerId to
+// claim a producer id and epoch, AddOffsetsToTxn to put the group's offsets
+// partition into the transaction, and TxnOffsetCommit to write the record that
+// pins the last stable offset.
+//
+// The request versions match what sarama's own transaction manager sends at the
+// configured Kafka version, so this fixture speaks the same protocol the
+// committed fixtures do.
+func tryOpenTransaction(client sarama.Client) (func(), error) {
 	id := openTxn
 
 	coordinator, err := client.TransactionCoordinator(id)
-	require.NoError(t, err, "failed to resolve the transaction coordinator for the deliberately-open transaction")
+	if err != nil {
+		return nil, fmt.Errorf("resolving the transaction coordinator: %w", err)
+	}
 
-	// Versions chosen to match what sarama's own transaction manager sends at the
-	// configured Kafka version, so this fixture speaks the same protocol the
-	// committed fixtures do. A fresh producer id is claimed with -1/-1.
 	init, err := coordinator.InitProducerID(&sarama.InitProducerIDRequest{
 		Version:            4,
 		TransactionalID:    &id,
@@ -396,8 +440,12 @@ func beginOpenTransaction(t *testing.T) func() {
 		ProducerID:         -1,
 		ProducerEpoch:      -1,
 	})
-	require.NoError(t, err, "InitProducerId failed for the deliberately-open transaction")
-	require.Equal(t, sarama.ErrNoError, init.Err, "InitProducerId was refused: %v", init.Err)
+	if err != nil {
+		return nil, fmt.Errorf("InitProducerId: %w", err)
+	}
+	if init.Err != sarama.ErrNoError {
+		return nil, fmt.Errorf("InitProducerId refused: %w", init.Err)
+	}
 
 	added, err := coordinator.AddOffsetsToTxn(&sarama.AddOffsetsToTxnRequest{
 		Version:         2,
@@ -406,46 +454,38 @@ func beginOpenTransaction(t *testing.T) func() {
 		ProducerEpoch:   init.ProducerEpoch,
 		GroupID:         openGroup,
 	})
-	require.NoError(t, err, "AddOffsetsToTxn failed for the deliberately-open transaction")
-	require.Equal(t, sarama.ErrNoError, added.Err, "AddOffsetsToTxn was refused: %v", added.Err)
+	if err != nil {
+		return nil, fmt.Errorf("AddOffsetsToTxn: %w", err)
+	}
+	if added.Err != sarama.ErrNoError {
+		return nil, fmt.Errorf("AddOffsetsToTxn refused: %w", added.Err)
+	}
 
 	groupCoordinator, err := client.Coordinator(openGroup)
-	require.NoError(t, err, "failed to resolve the group coordinator for the deliberately-open transaction")
+	if err != nil {
+		return nil, fmt.Errorf("resolving the group coordinator: %w", err)
+	}
 
-	// Retried rather than issued once, because the group coordinator validates the
-	// topic-partition against its OWN metadata. A topic that the controller has
-	// already created can still be unknown to whichever broker coordinates this
-	// group for a moment afterwards, and the commit is then refused with
-	// UNKNOWN_TOPIC_OR_PARTITION. That cost this suite one run: the fixture failed
-	// and every assertion below it failed with it, which is indistinguishable from
-	// the reader having broken.
-	var lastErr sarama.KError
-	require.Eventually(t, func() bool {
-		_ = client.RefreshMetadata(openIn)
-		committed, cerr := groupCoordinator.TxnOffsetCommit(&sarama.TxnOffsetCommitRequest{
-			Version:         2,
-			TransactionalID: id,
-			GroupID:         openGroup,
-			ProducerID:      init.ProducerID,
-			ProducerEpoch:   init.ProducerEpoch,
-			Topics: map[string][]*sarama.PartitionOffsetMetadata{
-				openIn: {{Partition: 0, Offset: 1, LeaderEpoch: -1}},
-			},
-		})
-		if cerr != nil {
-			return false
-		}
-		lastErr = sarama.ErrNoError
-		for _, parts := range committed.Topics {
-			for _, pe := range parts {
-				if pe.Err != sarama.ErrNoError {
-					lastErr = pe.Err
-				}
+	committed, err := groupCoordinator.TxnOffsetCommit(&sarama.TxnOffsetCommitRequest{
+		Version:         2,
+		TransactionalID: id,
+		GroupID:         openGroup,
+		ProducerID:      init.ProducerID,
+		ProducerEpoch:   init.ProducerEpoch,
+		Topics: map[string][]*sarama.PartitionOffsetMetadata{
+			openIn: {{Partition: 0, Offset: 1, LeaderEpoch: -1}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("TxnOffsetCommit: %w", err)
+	}
+	for topic, parts := range committed.Topics {
+		for _, pe := range parts {
+			if pe.Err != sarama.ErrNoError {
+				return nil, fmt.Errorf("TxnOffsetCommit refused for %s[%d]: %w", topic, pe.Partition, pe.Err)
 			}
 		}
-		return lastErr == sarama.ErrNoError
-	}, 60*time.Second, 2*time.Second,
-		"the transactional offset commit for the deliberately-open transaction was never accepted; last error: %v", lastErr)
+	}
 
 	// Deliberately no EndTxn here. That is the whole fixture.
 	return func() {
@@ -456,7 +496,7 @@ func beginOpenTransaction(t *testing.T) func() {
 			ProducerEpoch:     init.ProducerEpoch,
 			TransactionResult: false,
 		})
-	}
+	}, nil
 }
 
 // ensureInternalTopics brings __transaction_state and __consumer_offsets into
@@ -929,10 +969,15 @@ func (r *runResult) auditForTxn(txnID string) []auditLine {
 
 const (
 	// failoverWindow is the observation window. It has to cover the whole
-	// choreography — three production phases, a broker kill, a leader election
-	// and the reader's own capped backoff — plus a quiet tail long enough for the
-	// reader to catch up to the last stable offset on every partition.
-	failoverWindow = 240 * time.Second
+	// choreography — three production phases, a broker kill, a leader election,
+	// the reader's own capped backoff and the open-transaction fixture's retry
+	// budget — plus a quiet tail long enough for the reader to catch up to the
+	// last stable offset on every partition.
+	//
+	// It is generous rather than tight because the failure mode of being too tight
+	// is the worst one available: the window closing before the post-failover
+	// phase is read looks exactly like the reader never having resumed.
+	failoverWindow = 300 * time.Second
 
 	// phaseTxns is how many transactions each phase produces. Small on purpose:
 	// every id is pinned to the coordinator being killed, so three is already an

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -1,0 +1,371 @@
+//go:build e2e_txndiscovery_ha
+
+// Package txndiscoveryha_test exercises `kcp migration txn-discovery` across a
+// partition leadership change, against a real three-broker Kafka cluster started
+// by docker-compose.
+//
+// It is the leader-failover half of R11. The single-node suite
+// (integration-tests/txn-discovery) proves the eight functional grouping
+// scenarios and a whole-broker restart; this suite proves the narrower and
+// quieter thing: that when the leader of a __transaction_state partition
+// disappears mid-run, the reader re-resolves the new leader and keeps reading.
+// It is also the only place the tool runs against a realistically-replicated
+// internal topic.
+//
+// Per KTD5 the suite runs the BUILT BINARY as a subprocess and asserts on the
+// files it wrote, exactly as the single-node suite does.
+package txndiscoveryha_test
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// bootstrapAddr lists ALL THREE external listeners, and that is load-bearing
+	// rather than belt-and-braces. The suite kills one broker mid-run; a client
+	// bootstrapped only against that one could not refresh metadata afterwards,
+	// so the reader's recovery would be untestable for a reason that has nothing
+	// to do with the reader.
+	bootstrapAddr = "localhost:29092,localhost:29093,localhost:29094"
+
+	// txnStateTopic is the internal topic the command reads by default, and whose
+	// partition leadership this suite moves.
+	txnStateTopic = "__transaction_state"
+	// offsetsTopic is the other topic the reader is assigned. It is named here
+	// because the ISR and leadership gates have to cover both: a partition of
+	// either one that never got a leader back would stall a fetch loop.
+	offsetsTopic = "__consumer_offsets"
+
+	// fixturePrefix is what every topic and transactional id this suite creates
+	// carries, so a name cannot collide with anything the cluster made itself.
+	fixturePrefix = "zzha-"
+
+	// wantReplicas is the replication factor the compose file gives the internal
+	// topics. Asserted rather than assumed: at RF 1 the partitions the killed
+	// broker led would have no surviving replica to be re-elected from, and this
+	// suite would be testing an unavailable partition instead of a moved leader.
+	wantReplicas = 3
+)
+
+// brokerContainer maps a KRaft node id to the container running it, so a test can
+// kill the broker leading a particular partition. The ids come from
+// KAFKA_NODE_ID in docker-compose.yml.
+var brokerContainer = map[int32]string{
+	1: "kcp-test-txn-discovery-ha-kafka1",
+	2: "kcp-test-txn-discovery-ha-kafka2",
+	3: "kcp-test-txn-discovery-ha-kafka3",
+}
+
+// kafkaVersion is the brokers' protocol version. cp-kafka 7.6.0 is Kafka 3.6.
+var kafkaVersion = sarama.V3_6_0_0
+
+// baseConfig is the shared sarama configuration for every fixture client.
+func baseConfig() *sarama.Config {
+	cfg := sarama.NewConfig()
+	cfg.Version = kafkaVersion
+	cfg.ClientID = "kcp-txn-discovery-ha-e2e"
+	// Generous metadata retries: every fixture client in this suite may be asked
+	// a question while a leader election is in flight.
+	cfg.Metadata.Retry.Max = 20
+	cfg.Metadata.Retry.Backoff = 500 * time.Millisecond
+	return cfg
+}
+
+// newAdmin returns a cluster admin against the cluster.
+//
+// A fresh one per call, never a cached package-level client: this suite kills a
+// broker, and a client built before the kill holds stale metadata and a dead
+// connection, so reusing it would keep reporting the pre-kill view.
+func newAdmin(t *testing.T) sarama.ClusterAdmin {
+	t.Helper()
+	admin, err := sarama.NewClusterAdmin(bootstrapAddrs(), baseConfig())
+	require.NoError(t, err, "failed to connect a cluster admin to %s — is the compose cluster up?", bootstrapAddr)
+	t.Cleanup(func() { _ = admin.Close() })
+	return admin
+}
+
+// bootstrapAddrs splits the bootstrap string sarama wants as a slice.
+func bootstrapAddrs() []string {
+	return []string{"localhost:29092", "localhost:29093", "localhost:29094"}
+}
+
+// liveBrokerIDs returns the node ids the cluster currently reports, reporting
+// failure rather than failing the test so it can be polled.
+func liveBrokerIDs(t *testing.T) ([]int32, bool) {
+	t.Helper()
+	admin, err := sarama.NewClusterAdmin(bootstrapAddrs(), baseConfig())
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = admin.Close() }()
+	brokers, _, err := admin.DescribeCluster()
+	if err != nil {
+		return nil, false
+	}
+	ids := make([]int32, 0, len(brokers))
+	for _, b := range brokers {
+		ids = append(ids, b.ID())
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, true
+}
+
+// internalTopicMetadata describes both internal topics, reporting failure rather
+// than failing the test so it can be polled.
+func internalTopicMetadata(t *testing.T) ([]*sarama.TopicMetadata, bool) {
+	t.Helper()
+	admin, err := sarama.NewClusterAdmin(bootstrapAddrs(), baseConfig())
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = admin.Close() }()
+	md, err := admin.DescribeTopics([]string{txnStateTopic, offsetsTopic})
+	if err != nil {
+		return nil, false
+	}
+	for _, tm := range md {
+		if tm.Err != sarama.ErrNoError {
+			return nil, false
+		}
+		if len(tm.Partitions) == 0 {
+			return nil, false
+		}
+	}
+	return md, true
+}
+
+// describeISR renders the internal topics' replication state for a failure
+// message: which partitions are short of a full ISR, and by how much.
+func describeISR(md []*sarama.TopicMetadata) string {
+	out := ""
+	for _, tm := range md {
+		short := 0
+		for _, p := range tm.Partitions {
+			if len(p.Isr) < wantReplicas || len(p.Replicas) < wantReplicas {
+				short++
+			}
+		}
+		out += fmt.Sprintf("  %s: %d partitions, %d short of %d in-sync replicas\n",
+			tm.Name, len(tm.Partitions), short, wantReplicas)
+	}
+	return out
+}
+
+// TestClusterIsThreeBrokersWithReplicatedInternalTopics is the premise every
+// other test in this file rests on, asserted rather than assumed.
+//
+// A failover test on a cluster whose __transaction_state is replicated once
+// would not be testing failover: killing the leader of a single-replica
+// partition makes that partition unavailable for the rest of the run, so the
+// reader would be waiting on data that no longer exists anywhere rather than
+// re-resolving a leader that moved. Both look like a stalled partition from the
+// outside, and only one of them is R11.
+func TestClusterIsThreeBrokersWithReplicatedInternalTopics(t *testing.T) {
+	ids, ok := liveBrokerIDs(t)
+	require.True(t, ok, "could not describe the cluster at %s", bootstrapAddr)
+	require.Len(t, ids, 3, "the cluster reports %v, not three brokers — this suite needs a leader to be able to move", ids)
+	for _, id := range ids {
+		require.Contains(t, brokerContainer, id,
+			"the cluster reports node id %d, which maps to no container: brokerContainer is out of step with docker-compose.yml", id)
+	}
+
+	ensureInternalTopics(t)
+	awaitFullISR(t)
+
+	md, ok := internalTopicMetadata(t)
+	require.True(t, ok, "the internal topics are not both describable yet")
+	for _, tm := range md {
+		for _, p := range tm.Partitions {
+			require.Len(t, p.Replicas, wantReplicas,
+				"%s partition %d has %d replicas, want %d\n%s", tm.Name, p.ID, len(p.Replicas), wantReplicas, describeISR(md))
+			require.Len(t, p.Isr, wantReplicas,
+				"%s partition %d has %d in-sync replicas, want %d — killing a leader would take it below min-ISR\n%s",
+				tm.Name, p.ID, len(p.Isr), wantReplicas, describeISR(md))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Kafka fixture helpers
+// ---------------------------------------------------------------------------
+
+// Warm-up fixture names. Producing one full consume-transform-produce
+// transaction is what brings BOTH internal topics into existence: the
+// transaction coordinator creates __transaction_state on the first
+// InitProducerId, and the group coordinator creates __consumer_offsets on the
+// first offset commit. Neither exists on a fresh cluster.
+const (
+	warmupTxn   = fixturePrefix + "warmup-txn"
+	warmupOut   = fixturePrefix + "warmup-out"
+	warmupIn    = fixturePrefix + "warmup-in"
+	warmupGroup = fixturePrefix + "warmup-cg"
+)
+
+// createTopics creates each topic at the cluster's replication factor, ignoring
+// "already exists".
+//
+// Replication factor three, not one, and it matters as much as the internal
+// topics' does: a single-replica fixture topic whose only replica sat on the
+// broker this suite kills could never be produced to again, so the
+// post-failover phase would be missing from the ledger for a reason that is not
+// the reader. That is precisely the negative control's signature, which would
+// make the negative control prove nothing.
+//
+// One partition each, so a transaction's footprint is a single growth event
+// rather than one per partition added.
+func createTopics(t *testing.T, names ...string) {
+	t.Helper()
+	admin := newAdmin(t)
+	for _, name := range names {
+		err := admin.CreateTopic(name, &sarama.TopicDetail{NumPartitions: 1, ReplicationFactor: wantReplicas}, false)
+		if err != nil && !errors.Is(err, sarama.ErrTopicAlreadyExists) &&
+			!strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("failed to create topic: %v", err)
+		}
+	}
+}
+
+// txnFixture describes one transaction to produce.
+type txnFixture struct {
+	// TxnID is the transactional.id the transaction-state log records the
+	// footprint under, and the key whose hash selects the __transaction_state
+	// partition — and therefore the coordinating broker.
+	TxnID string
+	// Produce are the topics the transaction writes to. They become its
+	// footprint and therefore its group.
+	Produce []string
+	// ConsumeTopic and Group, when set, make this a consume-transform-produce
+	// transaction, committing the offsets inside the transaction.
+	ConsumeTopic string
+	Group        string
+}
+
+// produceTxn runs one transaction to completion, returning an error rather than
+// failing the test.
+//
+// The error return is what the during-the-kill phase needs: a transactional
+// producer whose commit fails is not recoverable — sarama puts the transaction
+// into a fatal state — so retrying means building a new producer, which the
+// caller decides to do, not this function.
+func produceTxn(f txnFixture) error {
+	cfg := baseConfig()
+	cfg.Producer.Idempotent = true
+	cfg.Producer.RequiredAcks = sarama.WaitForAll
+	cfg.Producer.Return.Successes = true
+	cfg.Producer.Return.Errors = true
+	cfg.Net.MaxOpenRequests = 1
+	cfg.Producer.Transaction.ID = f.TxnID
+	cfg.Producer.Transaction.Timeout = 60 * time.Second
+
+	producer, err := sarama.NewSyncProducer(bootstrapAddrs(), cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create a transactional producer: %w", err)
+	}
+	defer func() { _ = producer.Close() }()
+
+	if err := producer.BeginTxn(); err != nil {
+		return fmt.Errorf("BeginTxn failed: %w", err)
+	}
+	for _, topic := range f.Produce {
+		if _, _, err := producer.SendMessage(&sarama.ProducerMessage{
+			Topic: topic,
+			Key:   sarama.StringEncoder("k"),
+			Value: sarama.StringEncoder("v"),
+		}); err != nil {
+			return fmt.Errorf("failed to produce inside the transaction: %w", err)
+		}
+	}
+	if f.ConsumeTopic != "" {
+		if err := producer.AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata{
+			f.ConsumeTopic: {{Partition: 0, Offset: 1}},
+		}, f.Group); err != nil {
+			return fmt.Errorf("AddOffsetsToTxn failed: %w", err)
+		}
+	}
+	if err := producer.CommitTxn(); err != nil {
+		return fmt.Errorf("CommitTxn failed: %w", err)
+	}
+	return nil
+}
+
+// produceTxnWithRetry runs one transaction, rebuilding the producer on each
+// attempt until the deadline.
+//
+// Rebuilding rather than retrying in place is required, not defensive: once a
+// transactional producer's commit fails sarama marks it fatally errored and
+// every later call on it fails too. A fresh producer re-runs InitProducerId,
+// which fences the abandoned attempt and starts a new epoch — which is exactly
+// what a real exactly-once client does when its coordinator moves.
+func produceTxnWithRetry(t *testing.T, f txnFixture, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	var last error
+	for attempt := 1; time.Now().Before(deadline); attempt++ {
+		if err := produceTxn(f); err == nil {
+			return
+		} else {
+			last = err
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("could not produce a transaction within %s; last error: %v", within, last)
+}
+
+// ensureInternalTopics brings __transaction_state and __consumer_offsets into
+// existence by running one full consume-transform-produce transaction.
+//
+// Neither exists on a fresh cluster: the coordinators create them on first use.
+// Without them the command's preflight fails and the offsets tail reports itself
+// unavailable — both for reasons that have nothing to do with failover.
+func ensureInternalTopics(t *testing.T) {
+	t.Helper()
+	createTopics(t, warmupOut, warmupIn)
+	produceTxnWithRetry(t, txnFixture{
+		TxnID:        warmupTxn,
+		Produce:      []string{warmupOut},
+		ConsumeTopic: warmupIn,
+		Group:        warmupGroup,
+	}, 2*time.Minute)
+
+	require.Eventually(t, func() bool { _, ok := internalTopicMetadata(t); return ok },
+		2*time.Minute, 2*time.Second,
+		"the coordinators did not create both internal topics after a full consume-transform-produce transaction")
+}
+
+// awaitFullISR blocks until every partition of both internal topics has all
+// three replicas in sync.
+//
+// This gate is why the suite can kill a broker at all. A partition whose ISR is
+// still catching up has only one replica eligible for leadership, so killing its
+// leader leaves it offline rather than re-elected — and an offline partition and
+// a reader that failed to re-resolve look identical from the artifacts.
+func awaitFullISR(t *testing.T) {
+	t.Helper()
+	var last string
+	ok := func() bool {
+		md, ok := internalTopicMetadata(t)
+		if !ok {
+			last = "  the internal topics are not describable\n"
+			return false
+		}
+		last = describeISR(md)
+		for _, tm := range md {
+			for _, p := range tm.Partitions {
+				if len(p.Replicas) < wantReplicas || len(p.Isr) < wantReplicas {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	require.Eventually(t, ok, 3*time.Minute, 3*time.Second,
+		"the internal topics never reached a full in-sync replica set, so a leader could not survive being killed:\n%s", last)
+}

--- a/integration-tests/txn-discovery-ha/failover_e2e_test.go
+++ b/integration-tests/txn-discovery-ha/failover_e2e_test.go
@@ -379,7 +379,6 @@ func produceWithin(f txnFixture, within time.Duration) error {
 // transaction, and TxnOffsetCommit to write the record.
 func beginOpenTransaction(t *testing.T) func() {
 	t.Helper()
-	createTopics(t, openIn)
 
 	client := newClient(t)
 	id := openTxn
@@ -413,23 +412,40 @@ func beginOpenTransaction(t *testing.T) func() {
 	groupCoordinator, err := client.Coordinator(openGroup)
 	require.NoError(t, err, "failed to resolve the group coordinator for the deliberately-open transaction")
 
-	committed, err := groupCoordinator.TxnOffsetCommit(&sarama.TxnOffsetCommitRequest{
-		Version:         2,
-		TransactionalID: id,
-		GroupID:         openGroup,
-		ProducerID:      init.ProducerID,
-		ProducerEpoch:   init.ProducerEpoch,
-		Topics: map[string][]*sarama.PartitionOffsetMetadata{
-			openIn: {{Partition: 0, Offset: 1, LeaderEpoch: -1}},
-		},
-	})
-	require.NoError(t, err, "TxnOffsetCommit failed for the deliberately-open transaction")
-	for topic, parts := range committed.Topics {
-		for _, pe := range parts {
-			require.Equal(t, sarama.ErrNoError, pe.Err,
-				"the transactional offset commit was refused for %s[%d]: %v", topic, pe.Partition, pe.Err)
+	// Retried rather than issued once, because the group coordinator validates the
+	// topic-partition against its OWN metadata. A topic that the controller has
+	// already created can still be unknown to whichever broker coordinates this
+	// group for a moment afterwards, and the commit is then refused with
+	// UNKNOWN_TOPIC_OR_PARTITION. That cost this suite one run: the fixture failed
+	// and every assertion below it failed with it, which is indistinguishable from
+	// the reader having broken.
+	var lastErr sarama.KError
+	require.Eventually(t, func() bool {
+		_ = client.RefreshMetadata(openIn)
+		committed, cerr := groupCoordinator.TxnOffsetCommit(&sarama.TxnOffsetCommitRequest{
+			Version:         2,
+			TransactionalID: id,
+			GroupID:         openGroup,
+			ProducerID:      init.ProducerID,
+			ProducerEpoch:   init.ProducerEpoch,
+			Topics: map[string][]*sarama.PartitionOffsetMetadata{
+				openIn: {{Partition: 0, Offset: 1, LeaderEpoch: -1}},
+			},
+		})
+		if cerr != nil {
+			return false
 		}
-	}
+		lastErr = sarama.ErrNoError
+		for _, parts := range committed.Topics {
+			for _, pe := range parts {
+				if pe.Err != sarama.ErrNoError {
+					lastErr = pe.Err
+				}
+			}
+		}
+		return lastErr == sarama.ErrNoError
+	}, 60*time.Second, 2*time.Second,
+		"the transactional offset commit for the deliberately-open transaction was never accepted; last error: %v", lastErr)
 
 	// Deliberately no EndTxn here. That is the whole fixture.
 	return func() {
@@ -1013,6 +1029,10 @@ func doFailoverRun(t *testing.T) *failoverResult {
 	for _, ph := range phases {
 		createTopics(t, topicsOf(ph.fixtures)...)
 	}
+	// Created here rather than where it is used, minutes before the open
+	// transaction commits an offset for it, so its metadata has propagated to
+	// whichever broker ends up coordinating that group.
+	createTopics(t, openIn)
 
 	earliest := earliestOffsets(t, txnStateTopic)
 

--- a/integration-tests/txn-discovery-ha/setup.sh
+++ b/integration-tests/txn-discovery-ha/setup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Start the three-broker cluster for the txn-discovery leader-failover suite.
+#
+# Self-contained by design, like the single-node suite: the Go suite (build tag
+# e2e_txndiscovery_ha) creates every topic and produces every transaction
+# in-process with sarama, so there are no seed scripts here and nothing to keep
+# in sync with the assertions.
+#
+# This script only waits for the three brokers to answer. Waiting for the
+# internal topics to reach full ISR is the Go suite's job, because those topics
+# do not exist until the first transaction is produced — the coordinators create
+# them on first use, not at boot.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINERS=(
+    kcp-test-txn-discovery-ha-kafka1
+    kcp-test-txn-discovery-ha-kafka2
+    kcp-test-txn-discovery-ha-kafka3
+)
+
+echo "Starting txn-discovery HA cluster (3 brokers)..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+echo "Waiting for all three brokers to be ready..."
+MAX_WAIT=180
+WAIT_TIME=0
+while [ $WAIT_TIME -lt $MAX_WAIT ]; do
+    READY=0
+    for c in "${CONTAINERS[@]}"; do
+        if docker exec "$c" kafka-broker-api-versions --bootstrap-server localhost:9092 > /dev/null 2>&1; then
+            READY=$((READY + 1))
+        fi
+    done
+    if [ $READY -eq ${#CONTAINERS[@]} ]; then
+        echo "All $READY brokers are ready!"
+        break
+    fi
+    echo "$READY/${#CONTAINERS[@]} brokers ready, waiting... ($WAIT_TIME/$MAX_WAIT seconds)"
+    sleep 3
+    WAIT_TIME=$((WAIT_TIME + 3))
+done
+
+if [ $WAIT_TIME -ge $MAX_WAIT ]; then
+    echo "Timeout waiting for the cluster"
+    docker compose -f "$SCRIPT_DIR/docker-compose.yml" logs --tail 100
+    exit 1
+fi
+
+# A broker answering its own api-versions is not yet a formed cluster: the
+# controller quorum has to have elected a leader before a replicated topic can be
+# created at all. Asking one broker to describe the cluster is the cheapest proof
+# that it can see its peers.
+echo "Waiting for the cluster to report three brokers..."
+QUORUM_WAIT=0
+while [ $QUORUM_WAIT -lt 60 ]; do
+    COUNT=$(docker exec "${CONTAINERS[0]}" kafka-broker-api-versions --bootstrap-server localhost:9092 2>/dev/null | grep -c "id: " || true)
+    if [ "$COUNT" -ge 3 ]; then
+        echo "Cluster reports $COUNT brokers."
+        break
+    fi
+    echo "Cluster reports $COUNT/3 brokers, waiting... ($QUORUM_WAIT/60 seconds)"
+    sleep 3
+    QUORUM_WAIT=$((QUORUM_WAIT + 3))
+done
+
+echo ""
+echo "Environment is ready."
+echo "  Plaintext bootstrap: localhost:29092,localhost:29093,localhost:29094"

--- a/integration-tests/txn-discovery-ha/setup.sh
+++ b/integration-tests/txn-discovery-ha/setup.sh
@@ -67,4 +67,4 @@ done
 
 echo ""
 echo "Environment is ready."
-echo "  Plaintext bootstrap: localhost:29092,localhost:29093,localhost:29094"
+echo "  Plaintext bootstrap: localhost:29192,localhost:29193,localhost:29194"

--- a/integration-tests/txn-discovery-ha/teardown.sh
+++ b/integration-tests/txn-discovery-ha/teardown.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Tear down the txn-discovery HA cluster and its volumes.
+#
+# Invoked from the Makefile target's EXIT trap, so it runs on a failing test run
+# as well as a passing one. That matters more here than in the single-node suite:
+# this suite deliberately kills a broker mid-run, so a failure part-way through
+# leaves a stack with one dead container that `docker compose down` still has to
+# clean up.
+#
+# It must therefore never fail the build itself: a teardown that errored on an
+# already-removed stack would turn a clean failure into a confusing one.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Tearing down txn-discovery HA cluster..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" down -v --remove-orphans || true
+echo "Done."

--- a/integration-tests/txn-discovery/docker-compose.yml
+++ b/integration-tests/txn-discovery/docker-compose.yml
@@ -54,6 +54,26 @@ services:
       # transactional ids while a run is still observing them.
       KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS: 3600000
       KAFKA_TRANSACTION_MAX_TIMEOUT_MS: 900000
+
+      # (4) LOG CLEANER OFF. __transaction_state is a COMPACTED topic, and a
+      # transaction's footprint lives only in its Ongoing and PrepareCommit
+      # records. Once the transaction completes, the latest record under that
+      # key is CompleteCommit, whose partition set is EMPTY — so a compaction
+      # pass erases the footprint and leaves a record that says nothing about
+      # which topics were coupled.
+      #
+      # That is a real production blind spot the tool documents, and it is
+      # exactly why it must not be live here: it makes a fixture's discovery
+      # depend on whether the cleaner happened to run, which is nondeterministic
+      # and has nothing to do with the behaviour under test. It bit this suite
+      # three times before being tracked down — twice as an intermittently
+      # missing group, and once as pre-restart transactions vanishing when the
+      # restart itself triggered a cleaning pass.
+      #
+      # The ratio is belt-and-braces in case a later image force-enables the
+      # cleaner: at 1.0 a log must be entirely dirty before it is cleanable.
+      KAFKA_LOG_CLEANER_ENABLE: 'false'
+      KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO: '1.0'
     healthcheck:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 5s

--- a/integration-tests/txn-discovery/docker-compose.yml
+++ b/integration-tests/txn-discovery/docker-compose.yml
@@ -1,0 +1,61 @@
+name: kcp-txn-discovery
+
+services:
+  # Single-node KRaft broker for the `kcp migration txn-discovery` suite.
+  #
+  # Three settings below are load-bearing rather than stylistic. Each one, if
+  # dropped, turns a scenario into something that either cannot run or passes
+  # for the wrong reason.
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: kafka
+    container_name: kcp-test-txn-discovery-kafka
+    ports:
+      - "29092:29092"
+    environment:
+      # 22 characters: a KRaft cluster id is a base64-encoded 16-byte UUID and
+      # the broker refuses to boot on anything else.
+      CLUSTER_ID: 'TxNdIsCoVeRyClUsTerId0'
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+
+      # (1) DUAL LISTENERS. A single localhost-advertised listener breaks the
+      # transaction coordinator on a one-node cluster: the broker's own
+      # AddPartitionsToTxnManager connects to the coordinator through the
+      # advertised inter-broker address, and "localhost" from inside the
+      # container is the container, not the host-mapped port. INTERNAL is what
+      # the broker uses to talk to itself; EXTERNAL is what the host-side test
+      # and the kcp binary use.
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+
+      # (2) REPLICATION FACTOR AND MIN-ISR OF 1 ON ALL THREE INTERNAL TOPICS.
+      # The image defaults to 3. On one node the transaction-state log then
+      # never reaches its minimum ISR, __transaction_state never becomes
+      # available, and every transaction fails at InitProducerId — so the whole
+      # suite would have nothing to discover.
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+
+      # (3) BROKER-SIDE AUTO-CREATE LEFT ON, deliberately, mirroring a typical
+      # MSK cluster. TestNoTopicCreationOnProbe points --txn-state-topic at a
+      # name that does not exist and then checks the broker still does not have
+      # it. With auto-create off the broker would refuse to create it anyway and
+      # the test would prove nothing about kcp's client-side
+      # Metadata.AllowAutoTopicCreation=false guard (U1).
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+
+      # Keeps the transaction coordinator from expiring the suite's short-lived
+      # transactional ids while a run is still observing them.
+      KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS: 3600000
+      KAFKA_TRANSACTION_MAX_TIMEOUT_MS: 900000
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 5s
+      timeout: 10s
+      retries: 30

--- a/integration-tests/txn-discovery/setup.sh
+++ b/integration-tests/txn-discovery/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Start the broker for the `kcp migration txn-discovery` integration suite.
+#
+# Self-contained by design: the Go suite (build tag e2e_txndiscovery) creates
+# every topic and produces every transaction in-process with sarama, so there
+# are no seed scripts here and nothing to keep in sync with the assertions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_NAME="kcp-test-txn-discovery-kafka"
+
+echo "Starting txn-discovery broker..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+echo "Waiting for Kafka to be ready..."
+MAX_WAIT=90
+WAIT_TIME=0
+while [ $WAIT_TIME -lt $MAX_WAIT ]; do
+    if docker exec "$CONTAINER_NAME" kafka-broker-api-versions --bootstrap-server localhost:9092 > /dev/null 2>&1; then
+        echo "Kafka is ready!"
+        break
+    fi
+    echo "Kafka not ready yet, waiting... ($WAIT_TIME/$MAX_WAIT seconds)"
+    sleep 2
+    WAIT_TIME=$((WAIT_TIME + 2))
+done
+
+if [ $WAIT_TIME -ge $MAX_WAIT ]; then
+    echo "Timeout waiting for Kafka"
+    docker compose -f "$SCRIPT_DIR/docker-compose.yml" logs --tail 100 kafka
+    exit 1
+fi
+
+echo ""
+echo "Environment is ready."
+echo "  Plaintext bootstrap: localhost:29092"

--- a/integration-tests/txn-discovery/teardown.sh
+++ b/integration-tests/txn-discovery/teardown.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Tear down the txn-discovery broker and its volumes.
+#
+# Invoked from the Makefile target's EXIT trap, so it runs on a failing test run
+# as well as a passing one. It must therefore never fail the build itself: a
+# teardown that errors on an already-removed stack would turn a clean failure
+# into a confusing one.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Tearing down txn-discovery broker..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" down -v --remove-orphans || true
+echo "Done."

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -536,7 +536,75 @@ const (
 	billingGroup = fixturePrefix + "wobble-consumer"
 	billingIn    = fixturePrefix + "billing-in"
 	billingOut   = fixturePrefix + "billing-out"
+
+	// AE8 audit growth-only. One transactional id, one output topic, several
+	// transactions: an unchanging topic set observed over and over.
+	repeatTxn   = fixturePrefix + "repeat-txn"
+	repeatTopic = fixturePrefix + "repeat-only"
+
+	// repeatRuns is how many transactions the repeat fixture runs. Each writes
+	// at least an Ongoing and a PrepareCommit record to the transaction-state
+	// log, and both carry the footprint — so the reader observes this topic set
+	// many times over.
+	repeatRuns = 3
 )
+
+// TestAuditLogExplainsAUnion is F2, the flow the audit log exists for: an
+// operator looking at a group in txn-discovery.yaml asks why two topics ended
+// up together, filters the trace by one of the topic names, and gets back the
+// transaction that coupled them.
+//
+// The terminal deliberately reports counts only, so this file is the ONLY
+// artifact that answers "why" — and by the time the question is asked the
+// __transaction_state records behind the answer may well have been compacted
+// away, which is what makes reconstructing it after the fact impossible.
+func TestAuditLogExplainsAUnion(t *testing.T) {
+	r := sharedRun(t)
+	require.NotEmpty(t, r.audit, "the run wrote no audit log at all\n%s", r.describe())
+
+	lines := r.auditFor(unionShared)
+	require.NotEmpty(t, lines,
+		"filtering the audit trail by a grouped topic name yielded nothing, so a union cannot be traced")
+
+	// Both transactions that touched the shared topic must be recoverable from
+	// the trace: one line naming only one of them would explain half a union.
+	var txns []string
+	for _, l := range lines {
+		txns = append(txns, l.TxnID)
+	}
+	assert.Contains(t, txns, unionTxnA, "the trace does not name the first coupling transaction: %+v", lines)
+	assert.Contains(t, txns, unionTxnB, "the trace does not name the second coupling transaction: %+v", lines)
+
+	for _, l := range lines {
+		assert.NotEmpty(t, l.Source, "an audit line does not say which phase observed the edge: %+v", l)
+		assert.NotEmpty(t, l.Added, "a growth line records no added topic: %+v", l)
+		assert.False(t, l.Timestamp.IsZero(), "an audit line carries no timestamp: %+v", l)
+	}
+}
+
+// TestAuditLogRecordsGrowthOnly is AE8: a transaction observed repeatedly with
+// an unchanged topic set produces exactly ONE audit line, written when the set
+// was first populated.
+//
+// R19 is not deduplication for tidiness. The audit log exists so an operator
+// can find the edge that coupled two topics; a line per observation would bury
+// those edges under thousands of restatements of what was already known, and on
+// a run measured in hours the file would grow with elapsed time rather than
+// with the number of distinct couplings.
+func TestAuditLogRecordsGrowthOnly(t *testing.T) {
+	r := sharedRun(t)
+	require.NotEmpty(t, r.audit, "the run wrote no audit log at all\n%s", r.describe())
+
+	lines := r.auditForTxn(repeatTxn)
+	require.Len(t, lines, 1,
+		"a transaction observed %d times over with an unchanged topic set wrote %d audit lines, not one: %+v",
+		repeatRuns, len(lines), lines)
+
+	assert.Equal(t, []string{repeatTopic}, lines[0].Added,
+		"the single line does not report the topic it added")
+	assert.Equal(t, []string{repeatTopic}, lines[0].Topics,
+		"the single line does not report the resulting topic set")
+}
 
 // TestUnrelatedExactlyOnceWorkloadsStaySeparate is AE5: two exactly-once
 // workloads that share nothing but __consumer_offsets must stay in separate
@@ -649,6 +717,15 @@ func TestTransitiveUnion(t *testing.T) {
 	assert.Same(t, g, r.groupWith(unionGamma), "the second transaction's topic landed in a different group")
 }
 
+// Shared-window timings. The live rounds finish at roughly liveRounds *
+// liveRoundGap into a sharedWindow-long run, leaving the rest of the window as
+// catch-up time for the transaction-state reader.
+const (
+	sharedWindow = 60 * time.Second
+	liveRounds   = 4
+	liveRoundGap = 6 * time.Second
+)
+
 var (
 	sharedOnce sync.Once
 	shared     *runResult
@@ -677,7 +754,7 @@ func doSharedRun(t *testing.T) *runResult {
 	proc := startKCP(t,
 		"--source-bootstrap", bootstrapAddr,
 		"--use-unauthenticated-plaintext",
-		"--duration", "45s",
+		"--duration", sharedWindow.String(),
 		"--interval", "5s",
 		"--out", outFile,
 		"--stats-out", statsFile,
@@ -685,13 +762,19 @@ func doSharedRun(t *testing.T) *runResult {
 	)
 	proc.awaitObserving(t)
 
-	// Produced in rounds rather than once. The consumer-offsets tail starts at
-	// latest and a single-node broker's first fetch after start can land either
-	// side of a one-shot fixture; repeating an identical transaction cannot
-	// create a second group, so the redundancy costs nothing.
-	for round := 0; round < 3; round++ {
+	// Produced in rounds rather than once, and finishing well before the window
+	// closes. Producer-id correlation needs BOTH halves of a join to have been
+	// observed — the transactional offset commit on the consumer-offsets log,
+	// which the tail reads from latest, and the producer-id-to-transaction
+	// mapping from the transaction-state log, which the reader works towards
+	// from the beginning across every partition. A fixture produced close to the
+	// end can have its commit seen and its transaction not yet reached, and the
+	// final flush cannot resolve what the catalog does not hold. Repeating an
+	// identical transaction cannot create a second group, so the redundancy is
+	// free; the quiet tail of the window is what makes the correlation land.
+	for round := 0; round < liveRounds; round++ {
 		seedDuringWindow(t)
-		time.Sleep(5 * time.Second)
+		time.Sleep(liveRoundGap)
 	}
 
 	res := proc.wait(t)
@@ -732,7 +815,21 @@ func seedBeforeWindow(t *testing.T) {
 	// The during-window fixtures' topics are created here so the observation
 	// window carries transactions rather than topic-creation churn. An unused
 	// topic is invisible to discovery, which reports only what it observed.
-	createTopics(t, ordersIn, ordersOut)
+	// AE8. One transactional id writing the SAME single topic several times
+	// over. Each transaction contributes at least an Ongoing and a
+	// PrepareCommit record and both carry the footprint, so the reader observes
+	// this set many times — and exactly one of those observations grew it.
+	//
+	// One topic on one partition, deliberately. A transaction's Ongoing record
+	// is written as partitions are added to it, so a two-topic fixture could
+	// legitimately produce a footprint of {a} followed by {a,b} — two growth
+	// events, and an exact line count at the mercy of broker timing.
+	createTopics(t, repeatTopic)
+	for i := 0; i < repeatRuns; i++ {
+		produceTxn(t, txnFixture{TxnID: repeatTxn, Produce: []string{repeatTopic}})
+	}
+
+	createTopics(t, ordersIn, ordersOut, billingIn, billingOut)
 }
 
 // seedDuringWindow produces the fixtures that must land inside the observation
@@ -748,5 +845,14 @@ func seedDuringWindow(t *testing.T) {
 		Produce:      []string{ordersOut},
 		ConsumeTopic: ordersIn,
 		Group:        ordersGroup,
+	})
+
+	// AE5. A second exactly-once workload sharing nothing with the first except
+	// the __consumer_offsets both commit into.
+	produceTxn(t, txnFixture{
+		TxnID:        billingTxn,
+		Produce:      []string{billingOut},
+		ConsumeTopic: billingIn,
+		Group:        billingGroup,
 	})
 }

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -374,12 +374,32 @@ type runResult struct {
 	audit []auditLine
 	// kcpLog is the run's log file, empty when it wrote none.
 	kcpLog string
+
+	// files is every name the run left in its directory, and modes their
+	// permission bits.
+	//
+	// Both are captured when the run finishes rather than read on demand,
+	// because the directory is a t.TempDir() belonging to whichever test first
+	// triggered the shared run and is removed when THAT test returns. Reading a
+	// mode later would find nothing there and a "writes nothing" assertion
+	// would pass against a deleted directory.
+	files []string
+	modes map[string]os.FileMode
 }
 
 // collect reads a finished run's directory.
 func collect(t *testing.T, dir string, code int, stdout, stderr string) *runResult {
 	t.Helper()
-	r := &runResult{dir: dir, exitCode: code, stdout: stdout, stderr: stderr}
+	r := &runResult{dir: dir, exitCode: code, stdout: stdout, stderr: stderr, modes: map[string]os.FileMode{}}
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "failed to list the run's directory")
+	for _, e := range entries {
+		r.files = append(r.files, e.Name())
+		info, ierr := e.Info()
+		require.NoError(t, ierr, "failed to stat an artifact")
+		r.modes[e.Name()] = info.Mode().Perm()
+	}
 
 	if data, err := os.ReadFile(filepath.Join(dir, outFile)); err == nil {
 		var doc discoveryDoc
@@ -547,7 +567,102 @@ const (
 	// log, and both carry the footprint — so the reader observes this topic set
 	// many times over.
 	repeatRuns = 3
+
+	// Aborted transaction. Its consumed input must never be credited.
+	abortedTxn   = fixturePrefix + "aborted-txn"
+	abortedGroup = fixturePrefix + "abort-consumer"
+	abortedIn    = fixturePrefix + "aborted-in"
+	abortedOut   = fixturePrefix + "aborted-out"
 )
+
+// TestSummaryCarriesNoTopicNames is R16's abuse case: the terminal reports
+// counts, never names.
+//
+// A topic name like acme.payments.settlements discloses a customer's business
+// structure, and a summary is the thing that gets pasted into a ticket or
+// screen-shared in a workshop. The names live in the 0600 YAML instead.
+func TestSummaryCarriesNoTopicNames(t *testing.T) {
+	r := sharedRun(t)
+
+	// Non-vacuity: there must have been names available to leak. Against an
+	// empty run this assertion would hold for the wrong reason.
+	require.NotEmpty(t, r.observedTopics(), "the run discovered no topics, so this test proves nothing")
+	require.Contains(t, strings.Join(r.observedTopics(), ","), fixturePrefix,
+		"the run's own artifacts carry no fixture-prefixed name, so this test proves nothing")
+
+	assert.NotContains(t, r.stdout, fixturePrefix,
+		"a topic name or transactional id reached the terminal summary\n--- STDOUT ---\n%s", r.stdout)
+	assert.NotContains(t, r.stderr, fixturePrefix,
+		"a topic name or transactional id reached stderr\n--- STDERR ---\n%s", r.stderr)
+
+	// The summary is still expected to say something: an empty stdout would
+	// satisfy the assertions above and report nothing to the operator.
+	assert.Contains(t, r.stdout, "Transaction discovery summary", "the summary was not printed at all")
+	assert.Contains(t, r.stdout, "Transaction groups", "the group table was not printed at all")
+}
+
+// TestKcpLogCarriesNoNames is the same abuse case applied to the fourth sink.
+//
+// kcp.log's file leg is unconditionally Debug+ with no level control, and it is
+// the file operators attach to support tickets. A single Debug line carrying a
+// topic name defeats the counts-only terminal entirely — and under --verbose
+// those same lines reach the console.
+func TestKcpLogCarriesNoNames(t *testing.T) {
+	r := sharedRun(t)
+
+	require.NotEmpty(t, r.kcpLog, "the run wrote no kcp.log, so this test proves nothing")
+	require.Contains(t, r.kcpLog, "transaction discovery",
+		"kcp.log does not contain this command's own log narrative, so it is not the file under test")
+
+	assert.NotContains(t, r.kcpLog, fixturePrefix,
+		"a topic name or transactional id reached kcp.log\n--- KCP.LOG ---\n%s", r.kcpLog)
+}
+
+// TestArtifactsAreOwnerOnly is the artifact-permission abuse case: all three
+// files are written 0600, verified by stat rather than by inspection.
+//
+// The YAML and the audit log enumerate customer topic names, and the stats
+// document is included because it is not a counts-only file — it carries the
+// full per-transaction footprints, transactional ids and all. The POC wrote
+// that one 0644; the mode must not port across.
+func TestArtifactsAreOwnerOnly(t *testing.T) {
+	r := sharedRun(t)
+
+	for _, name := range []string{outFile, statsFile, auditFile} {
+		mode, ok := r.modes[name]
+		require.True(t, ok, "%s was never written, so its mode cannot be checked (files: %v)", name, r.files)
+		assert.Equal(t, os.FileMode(0600), mode,
+			"%s is mode %#o, not 0600: it enumerates customer topic names", name, mode)
+	}
+}
+
+// TestAbortedTransactionInputIsNotGrouped is the abuse case behind the abort
+// filter: an offset commit belonging to a rolled-back transaction must not be
+// credited as a consumed input.
+//
+// ReadCommitted does NOT remove aborted records at the wire level — it bounds
+// the fetch at the last stable offset and attaches an AbortedTransactions list,
+// leaving the discarding to the client. A raw fetch loop inherits none of that
+// from sarama's consumer, so without an explicit filter the aborted commit
+// reads exactly like a committed one. Zombie-fenced and rebalance-aborted
+// transactions are routine on an exactly-once cluster, so this is the normal
+// case, not a corner one: the consequence would be a migration group built
+// around a topic the application never actually consumed.
+func TestAbortedTransactionInputIsNotGrouped(t *testing.T) {
+	r := sharedRun(t)
+
+	// The premise first. A PrepareAbort record carries a footprint, so the
+	// aborted transaction's PRODUCED topic must be visible — that is what proves
+	// the transaction was observed at all. Without this guard the test would
+	// pass just as well against a fixture that never ran.
+	require.Contains(t, r.observedTopics(), abortedOut,
+		"the aborted transaction was never observed, so this test cannot show its input was filtered\n%s", r.describe())
+
+	assert.NotContains(t, r.observedTopics(), abortedIn,
+		"the consumed input of an ABORTED transaction was credited as a real input\n%s", r.describe())
+	assert.Nil(t, r.groupWith(abortedIn),
+		"the consumed input of an ABORTED transaction was grouped\n%s", r.describe())
+}
 
 // TestAuditLogExplainsAUnion is F2, the flow the audit log exists for: an
 // operator looking at a group in txn-discovery.yaml asks why two topics ended
@@ -829,7 +944,7 @@ func seedBeforeWindow(t *testing.T) {
 		produceTxn(t, txnFixture{TxnID: repeatTxn, Produce: []string{repeatTopic}})
 	}
 
-	createTopics(t, ordersIn, ordersOut, billingIn, billingOut)
+	createTopics(t, ordersIn, ordersOut, billingIn, billingOut, abortedIn, abortedOut)
 }
 
 // seedDuringWindow produces the fixtures that must land inside the observation
@@ -854,5 +969,15 @@ func seedDuringWindow(t *testing.T) {
 		Produce:      []string{billingOut},
 		ConsumeTopic: billingIn,
 		Group:        billingGroup,
+	})
+
+	// An exactly-once workload that rolls back. Its offset commit still reaches
+	// __consumer_offsets — that is what the abort filter has to discard.
+	produceTxn(t, txnFixture{
+		TxnID:        abortedTxn,
+		Produce:      []string{abortedOut},
+		ConsumeTopic: abortedIn,
+		Group:        abortedGroup,
+		Abort:        true,
 	})
 }

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -180,13 +180,27 @@ func commitGroupOffsets(t *testing.T, group, topic string) {
 
 	om, err := sarama.NewOffsetManagerFromClient(group, client)
 	require.NoError(t, err, "failed to create an offset manager")
-	defer func() { _ = om.Close() }()
 
 	pom, err := om.ManagePartition(topic, 0)
 	require.NoError(t, err, "failed to manage the partition's offsets")
 	pom.MarkOffset(1, "")
 	om.Commit()
-	require.NoError(t, pom.Close(), "failed to close the partition offset manager")
+
+	// om.Close(), never pom.Close(). With AutoCommit disabled sarama never
+	// starts the offset manager's main loop, and it is that loop which releases
+	// a partition manager and closes the error channel pom.Close() drains — so
+	// pom.Close() deadlocks. om.Close() releases every partition manager itself.
+	require.NoError(t, om.Close(), "failed to close the offset manager")
+
+	// The fixture verifies itself. A commit that silently did not land would
+	// make the enrichment scenario fail for a reason three components away from
+	// the one under test.
+	admin := newAdmin(t)
+	resp, err := admin.ListConsumerGroupOffsets(group, nil)
+	require.NoError(t, err, "failed to read back the committed offsets")
+	block := resp.GetBlock(topic, 0)
+	require.NotNil(t, block, "the offset commit did not land: the group has no offset for the topic")
+	require.GreaterOrEqual(t, block.Offset, int64(0), "the offset commit did not land: the group's offset is unset")
 }
 
 // topicExists reports whether the broker has topic, using a listing rather than
@@ -506,7 +520,44 @@ const (
 	streamsTxn   = streamsGroup + "-0_0"
 	streamsIn    = fixturePrefix + "streams-in"
 	streamsOut   = fixturePrefix + "streams-out"
+
+	// AE4 exact correlation where naming fails. The group id and the
+	// transactional id are deliberately unrelated words: "orders" shares no
+	// prefix with "quibble", so correlateByStreamsConvention cannot match them
+	// and only the record-batch producer id can.
+	ordersTxn   = fixturePrefix + "orders-txn-77"
+	ordersGroup = fixturePrefix + "quibble-consumer"
+	ordersIn    = fixturePrefix + "orders-in"
+	ordersOut   = fixturePrefix + "orders-out"
 )
+
+// TestProducerIDRecoversConsumedInput is AE4: a non-Streams exactly-once
+// application whose group id bears no naming relationship to its transactional
+// id still has its consumed input folded into the produced group, joined on the
+// record-batch producer id.
+//
+// This is the scenario the whole raw-Broker.Fetch decision exists for: sarama's
+// consumer API discards the batch header, so nothing above it can see the
+// producer id that makes this join possible.
+func TestProducerIDRecoversConsumedInput(t *testing.T) {
+	r := sharedRun(t)
+
+	// Guard the premise rather than assume it: if the names DID correlate, the
+	// test would pass through the naming path and prove nothing about
+	// producer-id correlation.
+	require.False(t, strings.HasPrefix(ordersTxn, ordersGroup+"-"),
+		"the fixture names correlate by the Streams convention, so this test cannot isolate producer-id correlation")
+
+	g := r.groupWith(ordersOut)
+	require.NotNil(t, g, "the produced output topic is in no group\n%s", r.describe())
+
+	assert.Contains(t, g.Topics, ordersIn,
+		"the consumed input was not recovered by producer-id correlation\n%s", r.describe())
+	assert.True(t, g.ReadProcessWrite,
+		"a group whose inputs came from a transactional offset commit is not marked read-process-write\n%s", r.describe())
+	assert.Contains(t, g.Warning, "producer-id correlation",
+		"the group's warning does not credit producer-id correlation\n%s", r.describe())
+}
 
 // TestStreamsNamingRecoversConsumedInput is AE3: a transaction's footprint
 // names only what it PRODUCED, so the consumed input has to be recovered from
@@ -632,6 +683,13 @@ func seedBeforeWindow(t *testing.T) {
 	// AE2. One transaction, one topic: nothing to couple it to.
 	createTopics(t, soloTopic)
 	produceTxn(t, txnFixture{TxnID: soloTxn, Produce: []string{soloTopic}})
+
+	// AE3. The offsets are committed OUTSIDE the transaction, so producer-id
+	// correlation cannot see them and only the naming convention can join the
+	// group's input to the transaction's output.
+	createTopics(t, streamsIn, streamsOut)
+	commitGroupOffsets(t, streamsGroup, streamsIn)
+	produceTxn(t, txnFixture{TxnID: streamsTxn, Produce: []string{streamsOut}})
 }
 
 // seedDuringWindow produces the fixtures that must land inside the observation

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -214,32 +214,71 @@ func restartBroker(t *testing.T) {
 	t.Helper()
 	out, err := exec.Command("docker", "restart", containerName).CombinedOutput()
 	require.NoError(t, err, "failed to restart the broker: %s", out)
-	awaitBrokerReady(t)
+	awaitBrokerUp(t)
+	// Only meaningful AFTER a restart, where the log demonstrably existed
+	// beforehand. Requiring it on a fresh cluster would wait forever: the
+	// coordinator creates __transaction_state on the first transaction, not at
+	// boot.
+	awaitTxnStateLoaded(t)
 }
 
-// awaitBrokerReady blocks until the broker answers AND the transaction-state
-// log is loaded.
+// awaitBrokerUp blocks until the broker answers a metadata request.
+func awaitBrokerUp(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, func() bool { _, ok := listTopics(t); return ok },
+		120*time.Second, 2*time.Second, "the broker never came back up")
+}
+
+// awaitTxnStateLoaded blocks until the transaction-state log is listable again.
 //
-// Answering is not enough: the broker accepts API-version requests well before
-// the transaction coordinator has loaded its state, and a test that produced
-// into that gap would fail on the fixture rather than on the behaviour.
-func awaitBrokerReady(t *testing.T) {
+// Answering a metadata request is not enough on its own: the broker accepts
+// requests well before the transaction coordinator has loaded its state, and a
+// fixture produced into that gap fails on the fixture rather than on the
+// behaviour under test.
+func awaitTxnStateLoaded(t *testing.T) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		// A fresh admin per attempt: a client built before the restart holds
-		// stale metadata and a dead connection.
-		admin, err := sarama.NewClusterAdmin([]string{bootstrapAddr}, baseConfig())
-		if err != nil {
+		topics, ok := listTopics(t)
+		if !ok {
 			return false
 		}
-		defer func() { _ = admin.Close() }()
-		topics, err := admin.ListTopics()
-		if err != nil {
-			return false
-		}
-		_, ok := topics[txnStateTopic]
-		return ok
+		_, exists := topics[txnStateTopic]
+		return exists
 	}, 120*time.Second, 2*time.Second, "the broker did not come back with a loaded transaction-state log")
+}
+
+// listTopics lists the cluster's topics through a throwaway admin client,
+// reporting failure rather than failing the test.
+//
+// A fresh client per call is deliberate: one built before a restart holds stale
+// metadata and a dead connection, so reusing it would keep reporting the
+// pre-restart view.
+func listTopics(t *testing.T) (map[string]sarama.TopicDetail, bool) {
+	t.Helper()
+	admin, err := sarama.NewClusterAdmin([]string{bootstrapAddr}, baseConfig())
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = admin.Close() }()
+	topics, err := admin.ListTopics()
+	if err != nil {
+		return nil, false
+	}
+	return topics, true
+}
+
+// ensureInternalTopics makes sure __transaction_state and __consumer_offsets
+// exist, by running one full consume-transform-produce transaction.
+//
+// Neither topic exists on a fresh cluster: the coordinators create them on
+// first use. Without them the command's preflight fails and the offsets tail
+// reports itself unavailable — both for reasons that have nothing to do with
+// whatever a test is actually asserting.
+func ensureInternalTopics(t *testing.T) {
+	t.Helper()
+	createTopics(t, warmupOut, warmupIn)
+	produceTxn(t, txnFixture{TxnID: warmupTxn, Produce: []string{warmupOut}, ConsumeTopic: warmupIn, Group: warmupGroup})
+	awaitTxnStateLoaded(t)
 }
 
 // txnStateTopic is the internal topic the command reads by default.
@@ -662,7 +701,11 @@ const (
 // produced strictly AFTER the restart distinguish recovery from a silent stall,
 // so every phase is enumerated and every id must be present.
 func TestReaderResumesAcrossBrokerRestart(t *testing.T) {
-	awaitBrokerReady(t)
+	awaitBrokerUp(t)
+	// The transaction-state log does not exist on a fresh cluster — the
+	// coordinator creates it on the first transaction — so it has to be brought
+	// into being before the command can be asked to read it.
+	ensureInternalTopics(t)
 
 	pre := restartFixtures(t, "pre")
 	post := restartFixtures(t, "post")
@@ -1216,11 +1259,7 @@ func doSharedRun(t *testing.T) *runResult {
 func seedBeforeWindow(t *testing.T) {
 	t.Helper()
 
-	createTopics(t, warmupOut, warmupIn)
-	// A full consume-transform-produce cycle, so both internal topics exist
-	// before any run: without __transaction_state the preflight fails, and
-	// without __consumer_offsets the offsets tail reports itself unavailable.
-	produceTxn(t, txnFixture{TxnID: warmupTxn, Produce: []string{warmupOut}, ConsumeTopic: warmupIn, Group: warmupGroup})
+	ensureInternalTopics(t)
 
 	// AE1. Two transactions overlapping on unionShared, which the union-find
 	// must collapse into one group of three.

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -493,7 +493,52 @@ const (
 	unionAlpha  = fixturePrefix + "union-alpha"
 	unionShared = fixturePrefix + "union-shared"
 	unionGamma  = fixturePrefix + "union-gamma"
+
+	// AE2 isolated topic: a transaction touching exactly one topic.
+	soloTxn   = fixturePrefix + "solo-txn"
+	soloTopic = fixturePrefix + "solo-topic"
+
+	// AE3 Streams naming recovery. streamsTxn follows the Kafka Streams
+	// convention "<application.id>-<taskId>" over streamsGroup, which is what
+	// lets enrichment join the group's committed input to the transaction's
+	// produced output.
+	streamsGroup = fixturePrefix + "streams-app"
+	streamsTxn   = streamsGroup + "-0_0"
+	streamsIn    = fixturePrefix + "streams-in"
+	streamsOut   = fixturePrefix + "streams-out"
 )
+
+// TestStreamsNamingRecoversConsumedInput is AE3: a transaction's footprint
+// names only what it PRODUCED, so the consumed input has to be recovered from
+// the consumer group whose id the transactional id is derived from.
+func TestStreamsNamingRecoversConsumedInput(t *testing.T) {
+	r := sharedRun(t)
+
+	g := r.groupWith(streamsOut)
+	require.NotNil(t, g, "the produced output topic is in no group\n%s", r.describe())
+
+	assert.Contains(t, g.Topics, streamsIn,
+		"the consumed input was not folded into the produced group by the Streams naming convention\n%s", r.describe())
+	assert.True(t, g.ReadProcessWrite,
+		"a group whose inputs came from a consumer group is not marked read-process-write\n%s", r.describe())
+	assert.Contains(t, g.Warning, "naming convention",
+		"the group's warning does not name the mechanism that recovered its inputs\n%s", r.describe())
+}
+
+// TestIsolatedTopicIsIndividual is AE2: a topic that only ever appeared alone
+// in a transaction is reported as individually migratable, not as a group.
+//
+// The negative half is the load-bearing one. A one-topic "group" would satisfy
+// "the topic appears in the output" while telling an operator to batch a
+// migration they do not need to batch.
+func TestIsolatedTopicIsIndividual(t *testing.T) {
+	r := sharedRun(t)
+
+	assert.True(t, r.isIndividual(soloTopic),
+		"a topic seen alone in a transaction was not reported as individually migratable\n%s", r.describe())
+	assert.Nil(t, r.groupWith(soloTopic),
+		"a topic seen alone in a transaction was reported as coupled to others\n%s", r.describe())
+}
 
 // TestTransitiveUnion is AE1: coupling is transitive, so two transactions that
 // share a single topic collapse into ONE group of three rather than two groups
@@ -583,6 +628,10 @@ func seedBeforeWindow(t *testing.T) {
 	createTopics(t, unionAlpha, unionShared, unionGamma)
 	produceTxn(t, txnFixture{TxnID: unionTxnA, Produce: []string{unionAlpha, unionShared}})
 	produceTxn(t, txnFixture{TxnID: unionTxnB, Produce: []string{unionShared, unionGamma}})
+
+	// AE2. One transaction, one topic: nothing to couple it to.
+	createTopics(t, soloTopic)
+	produceTxn(t, txnFixture{TxnID: soloTxn, Produce: []string{soloTopic}})
 }
 
 // seedDuringWindow produces the fixtures that must land inside the observation

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -573,7 +573,125 @@ const (
 	abortedGroup = fixturePrefix + "abort-consumer"
 	abortedIn    = fixturePrefix + "aborted-in"
 	abortedOut   = fixturePrefix + "aborted-out"
+
+	// AE6/AE7. A transaction-state topic name that does not exist and must not
+	// come to exist.
+	ghostTxnStateTopic = fixturePrefix + "ghost-txn-state"
 )
+
+// TestPreflightDeniesUnreadableTxnStateAndWritesNothing is AE6: when the
+// transaction-state log cannot be read the command fails fast, exits non-zero,
+// and leaves no artifact behind.
+//
+// Writing nothing is the half that matters. A zero-group txn-discovery.yaml
+// from a run that never read anything is indistinguishable from a genuine
+// finding that the cluster has no transactional coupling — and an operator
+// acting on it would migrate coupled topics apart.
+//
+// The denial is provoked by naming a topic that does not exist rather than by
+// revoking an ACL: this broker runs no authorizer, so an existing-but-forbidden
+// __transaction_state is not expressible here. See the note in the package
+// README of scenarios — the ACL branch of the preflight is covered by U11's
+// unit tests instead.
+func TestPreflightDeniesUnreadableTxnStateAndWritesNothing(t *testing.T) {
+	require.False(t, topicExists(t, ghostTxnStateTopic),
+		"the fixture topic already exists, so the preflight would not be denied")
+
+	r := runKCP(t,
+		"--source-bootstrap", bootstrapAddr,
+		"--use-unauthenticated-plaintext",
+		"--duration", "30s",
+		"--interval", "5s",
+		"--txn-state-topic", ghostTxnStateTopic,
+		"--out", outFile,
+		"--stats-out", statsFile,
+		"--audit-log-out", auditFile,
+	)
+
+	assert.NotEqual(t, 0, r.exitCode, "an unreadable transaction-state log did not fail the run\n%s", r.describe())
+
+	// It must fail FAST — at the preflight, not after holding the window open.
+	// The run above asked for 30 seconds; a preflight that ran anyway would be
+	// visible as a summary.
+	assert.NotContains(t, r.stdout, "Transaction discovery summary",
+		"the run printed a summary despite failing preflight\n%s", r.describe())
+
+	// The message has to tell the operator which of the two causes it was. An
+	// unknown topic is a typo in a flag; an authorization failure is a missing
+	// grant. Reporting both the same way sends them to the wrong fix.
+	combined := r.stdout + r.stderr
+	assert.Contains(t, combined, "--txn-state-topic",
+		"the failure does not name the flag responsible\n%s", r.describe())
+	assert.Contains(t, combined, "does not exist",
+		"the failure does not distinguish an unknown topic from an authorization problem\n%s", r.describe())
+
+	for _, name := range []string{outFile, statsFile, auditFile} {
+		assert.NotContains(t, r.files, name,
+			"a failed preflight still wrote %s (files: %v)", name, r.files)
+	}
+	// kcp.log is the exception, and its presence is also what proves the
+	// assertions above are about a run that actually happened.
+	assert.Contains(t, r.files, logFile, "the run wrote no kcp.log, so it may not have run at all")
+}
+
+// TestNoTopicCreationOnProbe is AE7: probing a topic that does not exist must
+// not bring it into existence, on a broker whose own auto-create is ON.
+//
+// sarama defaults Metadata.AllowAutoTopicCreation to true and kcp never set it,
+// so any topic-scoped metadata request could materialise the topic it asked
+// about. For a command whose entire job is to probe internal topic names by
+// name, that turns a read-only discovery tool into one that mutates the cluster
+// it is inspecting. U1 closed it in the shared client construction; this is the
+// proof against a real broker.
+func TestNoTopicCreationOnProbe(t *testing.T) {
+	// Non-vacuity, and the reason compose leaves auto-create ON. If the broker
+	// would refuse to create a topic anyway, the whole scenario proves nothing
+	// about kcp's client-side guard.
+	requireBrokerAutoCreatesTopics(t)
+
+	require.False(t, topicExists(t, ghostTxnStateTopic),
+		"the probe target already exists, so its absence afterwards would prove nothing")
+
+	r := runKCP(t,
+		"--source-bootstrap", bootstrapAddr,
+		"--use-unauthenticated-plaintext",
+		"--duration", "30s",
+		"--interval", "5s",
+		"--txn-state-topic", ghostTxnStateTopic,
+		"--out", outFile,
+	)
+	require.NotEqual(t, 0, r.exitCode, "the probe did not fail, so the topic may simply have been created and read\n%s", r.describe())
+
+	// Checked with an independent admin client, and by listing rather than by
+	// asking about the name: a topic-scoped metadata request is exactly the
+	// thing that can create a topic, so a verifier that asked that way could
+	// create the very topic it is checking for.
+	assert.False(t, topicExists(t, ghostTxnStateTopic),
+		"probing a nonexistent topic created it on a broker with auto-create enabled")
+}
+
+// requireBrokerAutoCreatesTopics proves the broker under test really does
+// create a topic in response to a topic-scoped metadata request, by doing
+// exactly that with a client that permits it.
+func requireBrokerAutoCreatesTopics(t *testing.T) {
+	t.Helper()
+
+	canary := fmt.Sprintf("%sautocreate-canary-%d", fixturePrefix, time.Now().UnixNano())
+	require.False(t, topicExists(t, canary), "the canary topic already exists")
+
+	cfg := baseConfig()
+	cfg.Metadata.AllowAutoTopicCreation = true
+	client, err := sarama.NewClient([]string{bootstrapAddr}, cfg)
+	require.NoError(t, err, "failed to create the auto-create canary client")
+	defer func() { _ = client.Close() }()
+
+	// A topic-scoped metadata request. The error is ignored: an unknown topic
+	// is reported as an error on the same response that causes the creation.
+	_ = client.RefreshMetadata(canary)
+
+	require.Eventually(t, func() bool { return topicExists(t, canary) }, 20*time.Second, 500*time.Millisecond,
+		"the broker did NOT auto-create a topic from a metadata request, so the no-auto-create scenario would be vacuous — check KAFKA_AUTO_CREATE_TOPICS_ENABLE in docker-compose.yml")
+}
 
 // TestSummaryCarriesNoTopicNames is R16's abuse case: the terminal reports
 // counts, never names.

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -1,0 +1,592 @@
+//go:build e2e_txndiscovery
+
+// Package txndiscovery_test exercises `kcp migration txn-discovery` against a
+// real single-node Kafka broker started by docker-compose.
+//
+// Per KTD5 the suite runs the BUILT BINARY as a subprocess and asserts on its
+// exit code, its stdout, and the files it wrote. Calling the discovery packages
+// directly — which the superseded branch's e2e did — would leave the command,
+// its flags, its preflight and its output formatting entirely unexercised, and
+// those are the deliverable.
+//
+// Fixtures are produced in-process by sarama transactional producers, so there
+// is no seed script to keep in step with the assertions.
+//
+// Every fixture name carries the `zzqx-` prefix. That is not decoration: three
+// abuse-case tests assert that no topic name and no transactional id reaches
+// stdout or kcp.log, and a prefix that cannot occur incidentally is what makes
+// those assertions meaningful rather than accidentally true.
+package txndiscovery_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// bootstrapAddr is the EXTERNAL listener the compose file advertises to the
+	// host. The broker reaches itself on the INTERNAL one.
+	bootstrapAddr = "localhost:29092"
+
+	// containerName must match docker-compose.yml; the broker-restart test
+	// drives it directly.
+	containerName = "kcp-test-txn-discovery-kafka"
+
+	// fixturePrefix is what the no-names assertions grep for.
+	fixturePrefix = "zzqx-"
+)
+
+// kafkaVersion is the broker's protocol version. cp-kafka 7.6.0 is Kafka 3.6.
+var kafkaVersion = sarama.V3_6_0_0
+
+// ---------------------------------------------------------------------------
+// Kafka fixture helpers
+// ---------------------------------------------------------------------------
+
+// baseConfig is the shared sarama configuration for every fixture client.
+func baseConfig() *sarama.Config {
+	cfg := sarama.NewConfig()
+	cfg.Version = kafkaVersion
+	cfg.ClientID = "kcp-txn-discovery-e2e"
+	cfg.Metadata.Retry.Max = 10
+	cfg.Metadata.Retry.Backoff = 500 * time.Millisecond
+	return cfg
+}
+
+// newAdmin returns a cluster admin against the broker.
+func newAdmin(t *testing.T) sarama.ClusterAdmin {
+	t.Helper()
+	admin, err := sarama.NewClusterAdmin([]string{bootstrapAddr}, baseConfig())
+	require.NoError(t, err, "failed to connect a cluster admin to %s — is the compose broker up?", bootstrapAddr)
+	t.Cleanup(func() { _ = admin.Close() })
+	return admin
+}
+
+// createTopics creates each topic with one partition, ignoring "already exists".
+//
+// One partition, deliberately: a transaction's Ongoing record is written as
+// partitions are added to it, so a multi-partition output topic can produce two
+// footprint records with a growing topic-partition set. TestAuditLogRecordsGrowthOnly
+// asserts an exact line count and would be at the mercy of that.
+func createTopics(t *testing.T, names ...string) {
+	t.Helper()
+	admin := newAdmin(t)
+	for _, name := range names {
+		err := admin.CreateTopic(name, &sarama.TopicDetail{NumPartitions: 1, ReplicationFactor: 1}, false)
+		if err != nil && !errors.Is(err, sarama.ErrTopicAlreadyExists) &&
+			!strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("failed to create topic: %v", err)
+		}
+	}
+}
+
+// txnFixture describes one transaction to produce.
+type txnFixture struct {
+	// TxnID is the transactional.id, which is what the transaction-state log
+	// records the footprint under.
+	TxnID string
+
+	// Produce are the topics the transaction writes to. They become the
+	// transaction's footprint and therefore its group.
+	Produce []string
+
+	// ConsumeTopic and Group, when set, make this a consume-transform-produce
+	// transaction: the offsets are committed INSIDE the transaction with
+	// AddOffsetsToTxn, so the resulting __consumer_offsets record is a
+	// transactional one carrying the producer id. That is the record
+	// producer-id correlation joins on.
+	ConsumeTopic string
+	Group        string
+
+	// Abort rolls the transaction back instead of committing it.
+	Abort bool
+}
+
+// produceTxn runs one transaction to completion against the broker.
+func produceTxn(t *testing.T, f txnFixture) {
+	t.Helper()
+
+	cfg := baseConfig()
+	cfg.Producer.Idempotent = true
+	cfg.Producer.RequiredAcks = sarama.WaitForAll
+	cfg.Producer.Return.Successes = true
+	cfg.Producer.Return.Errors = true
+	cfg.Net.MaxOpenRequests = 1
+	cfg.Producer.Transaction.ID = f.TxnID
+	cfg.Producer.Transaction.Timeout = 60 * time.Second
+
+	producer, err := sarama.NewSyncProducer([]string{bootstrapAddr}, cfg)
+	require.NoError(t, err, "failed to create a transactional producer")
+	defer func() { _ = producer.Close() }()
+
+	require.NoError(t, producer.BeginTxn(), "BeginTxn failed")
+
+	for _, topic := range f.Produce {
+		_, _, err := producer.SendMessage(&sarama.ProducerMessage{
+			Topic: topic,
+			Key:   sarama.StringEncoder("k"),
+			Value: sarama.StringEncoder("v"),
+		})
+		require.NoError(t, err, "failed to produce inside the transaction")
+	}
+
+	if f.ConsumeTopic != "" {
+		require.NotEmpty(t, f.Group, "a consumed topic needs the group that committed it")
+		err := producer.AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata{
+			f.ConsumeTopic: {{Partition: 0, Offset: 1}},
+		}, f.Group)
+		require.NoError(t, err, "AddOffsetsToTxn failed")
+	}
+
+	if f.Abort {
+		require.NoError(t, producer.AbortTxn(), "AbortTxn failed")
+		return
+	}
+	require.NoError(t, producer.CommitTxn(), "CommitTxn failed")
+}
+
+// commitGroupOffsets commits an offset for topic under group OUTSIDE any
+// transaction, which is how a plain consumer records what it consumes.
+//
+// Consumer-group enrichment reads exactly this — the topics a group has
+// committed offsets for — so it is what the Kafka Streams naming scenario needs
+// on the cluster. The commit is deliberately non-transactional: it must be the
+// NAMING convention that recovers the input, not producer-id correlation.
+func commitGroupOffsets(t *testing.T, group, topic string) {
+	t.Helper()
+
+	cfg := baseConfig()
+	cfg.Consumer.Offsets.AutoCommit.Enable = false
+	cfg.Consumer.Offsets.Initial = sarama.OffsetOldest
+
+	client, err := sarama.NewClient([]string{bootstrapAddr}, cfg)
+	require.NoError(t, err, "failed to create a client for the offset commit")
+	defer func() { _ = client.Close() }()
+
+	om, err := sarama.NewOffsetManagerFromClient(group, client)
+	require.NoError(t, err, "failed to create an offset manager")
+	defer func() { _ = om.Close() }()
+
+	pom, err := om.ManagePartition(topic, 0)
+	require.NoError(t, err, "failed to manage the partition's offsets")
+	pom.MarkOffset(1, "")
+	om.Commit()
+	require.NoError(t, pom.Close(), "failed to close the partition offset manager")
+}
+
+// topicExists reports whether the broker has topic, using a listing rather than
+// a topic-scoped metadata request.
+//
+// The distinction matters for TestNoTopicCreationOnProbe: a topic-scoped
+// metadata request is exactly what can create a topic on a broker with
+// auto-create on, so an independent verifier that asked that way could create
+// the very topic it is checking for and never notice.
+func topicExists(t *testing.T, topic string) bool {
+	t.Helper()
+	admin := newAdmin(t)
+	topics, err := admin.ListTopics()
+	require.NoError(t, err, "failed to list topics")
+	_, ok := topics[topic]
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// Running the binary under test
+// ---------------------------------------------------------------------------
+
+// repoRoot resolves the checkout root from this package's directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root, err := filepath.Abs(filepath.Join(wd, "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// kcpBinary returns the path to the binary the Makefile target built.
+func kcpBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "kcp")
+	_, err := os.Stat(path)
+	require.NoError(t, err, "the kcp binary is missing — run `make test-txn-discovery`, which builds it")
+	return path
+}
+
+// artifact filenames, fixed so every run's assertions look in the same place.
+const (
+	outFile   = "txn-discovery.yaml"
+	statsFile = "txn-discovery-stats.json"
+	auditFile = "txn-discovery-audit.jsonl"
+	logFile   = "kcp.log"
+)
+
+// kcpProc is a discovery run in flight.
+type kcpProc struct {
+	cmd    *exec.Cmd
+	dir    string
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+}
+
+// startKCP launches `kcp migration txn-discovery` in its own directory.
+//
+// The directory is per-run and is where the artifacts AND kcp.log land, since
+// the root command writes the log relative to the process working directory.
+// That isolation is what lets the kcp.log assertions be about one run.
+func startKCP(t *testing.T, args ...string) *kcpProc {
+	t.Helper()
+	dir := t.TempDir()
+
+	full := append([]string{"migration", "txn-discovery"}, args...)
+	cmd := exec.Command(kcpBinary(t), full...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Start(), "failed to start the kcp binary")
+
+	p := &kcpProc{cmd: cmd, dir: dir, stdout: &stdout, stderr: &stderr}
+	t.Cleanup(func() {
+		if p.cmd.ProcessState == nil && p.cmd.Process != nil {
+			_ = p.cmd.Process.Kill()
+			_ = p.cmd.Wait()
+		}
+	})
+	return p
+}
+
+// awaitObserving blocks until the run has begun reading the cluster.
+//
+// The consumer-offsets tail starts at LATEST, so a fixture produced before the
+// tail resolved its start offsets is invisible to producer-id correlation. The
+// run's own "starting transaction discovery" log line is the closest signal
+// available; the extra pause covers the partition discovery that follows it.
+func (p *kcpProc) awaitObserving(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(filepath.Join(p.dir, logFile))
+		if err == nil && strings.Contains(string(data), "starting transaction discovery") {
+			time.Sleep(5 * time.Second)
+			return
+		}
+		if p.cmd.ProcessState != nil {
+			t.Fatalf("the run exited before it began observing:\n%s\n%s", p.stdout.String(), p.stderr.String())
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("the run never reported that it had started observing:\n%s\n%s", p.stdout.String(), p.stderr.String())
+}
+
+// wait blocks for the run to finish and collects everything it produced.
+func (p *kcpProc) wait(t *testing.T) *runResult {
+	t.Helper()
+	err := p.cmd.Wait()
+	code := 0
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("failed to wait for the kcp binary: %v", err)
+	}
+	return collect(t, p.dir, code, p.stdout.String(), p.stderr.String())
+}
+
+// runKCP runs a discovery run to completion with no fixtures produced during it.
+func runKCP(t *testing.T, args ...string) *runResult {
+	t.Helper()
+	return startKCP(t, args...).wait(t)
+}
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+// discoveryDoc mirrors txn-discovery.yaml. It is redeclared here rather than
+// imported: the suite is a consumer of the on-disk format, and sharing the
+// producer's struct would let a field rename pass unnoticed.
+type discoveryDoc struct {
+	GeneratedBy          string           `yaml:"generated_by"`
+	GeneratedAt          string           `yaml:"generated_at"`
+	ObservationWindow    string           `yaml:"observation_window"`
+	Groups               []discoveryGroup `yaml:"groups"`
+	IndividualTopicCount int              `yaml:"individual_topic_count"`
+	IndividualTopics     []string         `yaml:"individual_topics"`
+}
+
+type discoveryGroup struct {
+	Name             string   `yaml:"name"`
+	ReadProcessWrite bool     `yaml:"read_process_write"`
+	Warning          string   `yaml:"warning"`
+	Topics           []string `yaml:"topics"`
+	TransactionalIDs []string `yaml:"transactional_ids"`
+}
+
+// auditLine mirrors one line of txn-discovery-audit.jsonl.
+type auditLine struct {
+	Timestamp time.Time `json:"timestamp"`
+	TxnID     string    `json:"transactional_id"`
+	Source    string    `json:"source"`
+	Added     []string  `json:"added"`
+	Topics    []string  `json:"topics"`
+}
+
+// runResult is everything one run left behind.
+type runResult struct {
+	dir      string
+	exitCode int
+	stdout   string
+	stderr   string
+
+	// doc is the parsed YAML, nil when the run wrote none.
+	doc *discoveryDoc
+	// audit is every parsed audit line, nil when no audit log was written.
+	audit []auditLine
+	// kcpLog is the run's log file, empty when it wrote none.
+	kcpLog string
+}
+
+// collect reads a finished run's directory.
+func collect(t *testing.T, dir string, code int, stdout, stderr string) *runResult {
+	t.Helper()
+	r := &runResult{dir: dir, exitCode: code, stdout: stdout, stderr: stderr}
+
+	if data, err := os.ReadFile(filepath.Join(dir, outFile)); err == nil {
+		var doc discoveryDoc
+		require.NoError(t, yaml.Unmarshal(data, &doc), "the discovery YAML did not parse:\n%s", data)
+		r.doc = &doc
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, auditFile)); err == nil {
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			var al auditLine
+			require.NoError(t, json.Unmarshal([]byte(line), &al), "an audit line did not parse: %s", line)
+			r.audit = append(r.audit, al)
+		}
+		require.NoError(t, scanner.Err(), "failed to read the audit log")
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, logFile)); err == nil {
+		r.kcpLog = string(data)
+	}
+	return r
+}
+
+// requireSucceeded fails the test unless the run exited cleanly and wrote a
+// document, quoting the run's own output when it did not.
+func (r *runResult) requireSucceeded(t *testing.T) {
+	t.Helper()
+	require.Equal(t, 0, r.exitCode, "the discovery run failed:\nSTDOUT\n%s\nSTDERR\n%s", r.stdout, r.stderr)
+	require.NotNil(t, r.doc, "the run wrote no %s:\nSTDOUT\n%s", outFile, r.stdout)
+}
+
+// groupWith returns the group containing topic, or nil.
+func (r *runResult) groupWith(topic string) *discoveryGroup {
+	for i := range r.doc.Groups {
+		for _, tp := range r.doc.Groups[i].Topics {
+			if tp == topic {
+				return &r.doc.Groups[i]
+			}
+		}
+	}
+	return nil
+}
+
+// isIndividual reports whether topic was reported as safe to migrate alone.
+func (r *runResult) isIndividual(topic string) bool {
+	for _, tp := range r.doc.IndividualTopics {
+		if tp == topic {
+			return true
+		}
+	}
+	return false
+}
+
+// observedTopics is every topic the document names, grouped or individual.
+func (r *runResult) observedTopics() []string {
+	var out []string
+	for _, g := range r.doc.Groups {
+		out = append(out, g.Topics...)
+	}
+	return append(out, r.doc.IndividualTopics...)
+}
+
+// auditFor returns every audit line naming topic in its resulting set.
+func (r *runResult) auditFor(topic string) []auditLine {
+	var out []auditLine
+	for _, l := range r.audit {
+		for _, tp := range l.Topics {
+			if tp == topic {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// auditForTxn returns every audit line for one transactional id.
+func (r *runResult) auditForTxn(txnID string) []auditLine {
+	var out []auditLine
+	for _, l := range r.audit {
+		if l.TxnID == txnID {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// describe renders the run for a failure message.
+func (r *runResult) describe() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit=%d\n--- STDOUT ---\n%s", r.exitCode, r.stdout)
+	if r.stderr != "" {
+		fmt.Fprintf(&b, "--- STDERR ---\n%s", r.stderr)
+	}
+	if r.doc != nil {
+		fmt.Fprintf(&b, "--- GROUPS ---\n")
+		for _, g := range r.doc.Groups {
+			fmt.Fprintf(&b, "  %s rpw=%v topics=%v txns=%v\n", g.Name, g.ReadProcessWrite, g.Topics, g.TransactionalIDs)
+		}
+		fmt.Fprintf(&b, "--- INDIVIDUAL ---\n  %v\n", r.doc.IndividualTopics)
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// The shared observation run
+// ---------------------------------------------------------------------------
+
+// Fixture names. Every one carries the fixturePrefix.
+const (
+	// warm-up: creates __transaction_state and __consumer_offsets so that a
+	// scenario whose own fixture is missing fails on its assertion rather than
+	// on a preflight that could not find the transaction-state log.
+	warmupTxn   = fixturePrefix + "warmup-txn"
+	warmupOut   = fixturePrefix + "warmup-out"
+	warmupIn    = fixturePrefix + "warmup-in"
+	warmupGroup = fixturePrefix + "warmup-cg"
+
+	// AE1 transitive union: two transactions overlapping on unionShared.
+	unionTxnA   = fixturePrefix + "union-txn-a"
+	unionTxnB   = fixturePrefix + "union-txn-b"
+	unionAlpha  = fixturePrefix + "union-alpha"
+	unionShared = fixturePrefix + "union-shared"
+	unionGamma  = fixturePrefix + "union-gamma"
+)
+
+// TestTransitiveUnion is AE1: coupling is transitive, so two transactions that
+// share a single topic collapse into ONE group of three rather than two groups
+// of two.
+func TestTransitiveUnion(t *testing.T) {
+	r := sharedRun(t)
+
+	g := r.groupWith(unionShared)
+	require.NotNil(t, g, "the topic shared by two transactions is in no group\n%s", r.describe())
+
+	assert.ElementsMatch(t, []string{unionAlpha, unionShared, unionGamma}, g.Topics,
+		"the two transactions sharing a topic did not collapse into one group of three\n%s", r.describe())
+	assert.ElementsMatch(t, []string{unionTxnA, unionTxnB}, g.TransactionalIDs,
+		"the group does not credit both transactions that formed it\n%s", r.describe())
+
+	// The two non-shared topics must be in the SAME group, not merely in some
+	// group each: two groups of two would satisfy a weaker assertion.
+	assert.Same(t, g, r.groupWith(unionAlpha), "the first transaction's topic landed in a different group")
+	assert.Same(t, g, r.groupWith(unionGamma), "the second transaction's topic landed in a different group")
+}
+
+var (
+	sharedOnce sync.Once
+	shared     *runResult
+)
+
+// sharedRun performs one observation window covering every scenario whose
+// fixtures can coexist, and returns its artifacts.
+//
+// One window rather than one per scenario, because each window costs its full
+// --duration. The fixtures are independent by construction: distinct topic and
+// transactional-id namespaces, so grouping cannot join them and each test's
+// assertion is about its own names only. The scenarios that cannot share a run
+// — a preflight that must fail, a broker that must restart — have their own.
+func sharedRun(t *testing.T) *runResult {
+	t.Helper()
+	sharedOnce.Do(func() { shared = doSharedRun(t) })
+	require.NotNil(t, shared, "the shared discovery run did not complete; see the first failing test in this package")
+	return shared
+}
+
+func doSharedRun(t *testing.T) *runResult {
+	t.Helper()
+
+	seedBeforeWindow(t)
+
+	proc := startKCP(t,
+		"--source-bootstrap", bootstrapAddr,
+		"--use-unauthenticated-plaintext",
+		"--duration", "45s",
+		"--interval", "5s",
+		"--out", outFile,
+		"--stats-out", statsFile,
+		"--audit-log-out", auditFile,
+	)
+	proc.awaitObserving(t)
+
+	// Produced in rounds rather than once. The consumer-offsets tail starts at
+	// latest and a single-node broker's first fetch after start can land either
+	// side of a one-shot fixture; repeating an identical transaction cannot
+	// create a second group, so the redundancy costs nothing.
+	for round := 0; round < 3; round++ {
+		seedDuringWindow(t)
+		time.Sleep(5 * time.Second)
+	}
+
+	res := proc.wait(t)
+	res.requireSucceeded(t)
+	return res
+}
+
+// seedBeforeWindow produces the fixtures the transaction-state log carries.
+//
+// They can precede the run because that log is read from the BEGINNING: a
+// transaction committed before the window opened is still discovered.
+func seedBeforeWindow(t *testing.T) {
+	t.Helper()
+
+	createTopics(t, warmupOut, warmupIn)
+	// A full consume-transform-produce cycle, so both internal topics exist
+	// before any run: without __transaction_state the preflight fails, and
+	// without __consumer_offsets the offsets tail reports itself unavailable.
+	produceTxn(t, txnFixture{TxnID: warmupTxn, Produce: []string{warmupOut}, ConsumeTopic: warmupIn, Group: warmupGroup})
+
+	// AE1. Two transactions overlapping on unionShared, which the union-find
+	// must collapse into one group of three.
+	createTopics(t, unionAlpha, unionShared, unionGamma)
+	produceTxn(t, txnFixture{TxnID: unionTxnA, Produce: []string{unionAlpha, unionShared}})
+	produceTxn(t, txnFixture{TxnID: unionTxnB, Produce: []string{unionShared, unionGamma}})
+}
+
+// seedDuringWindow produces the fixtures that must land inside the observation
+// window because the consumer-offsets tail starts at latest.
+func seedDuringWindow(t *testing.T) {
+	t.Helper()
+}

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -602,6 +602,13 @@ func (r *runResult) describe() string {
 	if r.stderr != "" {
 		fmt.Fprintf(&b, "--- STDERR ---\n%s", r.stderr)
 	}
+	if r.stats != nil {
+		// The tail counters are the only place a stalled reader shows up. Lag
+		// cannot reveal it — a partition that has never fetched successfully
+		// still holds a zero last-stable-offset, so its lag computes as zero —
+		// and a loop stuck retrying still counts as running.
+		fmt.Fprintf(&b, "--- TAIL ---\n  %+v\n", r.stats.Tail)
+	}
 	if r.doc != nil {
 		fmt.Fprintf(&b, "--- GROUPS ---\n")
 		for _, g := range r.doc.Groups {
@@ -755,7 +762,17 @@ func TestReaderResumesAcrossBrokerRestart(t *testing.T) {
 	// the post-restart ones are what separate a resumed reader from a dead one.
 	for _, f := range append(append([]txnFixture{}, pre...), post...) {
 		g := r.groupWith(f.Produce[0])
-		require.NotNil(t, g, "transaction %s is missing from the output entirely\n%s", f.TxnID, r.describe())
+		require.NotNil(t, g,
+			"transaction %s is missing from the output entirely.\n"+
+				"If the tail counters below show a large transport_errors with "+
+				"leadership_errors and offset_resets at zero, the partition loops are "+
+				"retrying a dead connection: a broken pipe is classified as a transport "+
+				"error, whose branch backs off without refreshing metadata, so the stale "+
+				"broker is never replaced. Note also that such a run still reports "+
+				"'100/100 partitions live, 0 records of lag' — a partition that never "+
+				"fetched successfully holds a zero last-stable-offset, so its lag "+
+				"computes as zero, and a loop stuck retrying still counts as running.\n%s",
+			f.TxnID, r.describe())
 		assert.ElementsMatch(t, f.Produce, g.Topics,
 			"transaction %s did not produce its own group of topics\n%s", f.TxnID, r.describe())
 		assert.Contains(t, g.TransactionalIDs, f.TxnID,

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -529,7 +529,45 @@ const (
 	ordersGroup = fixturePrefix + "quibble-consumer"
 	ordersIn    = fixturePrefix + "orders-in"
 	ordersOut   = fixturePrefix + "orders-out"
+
+	// AE5 internal-topic filtering: a second, entirely unrelated exactly-once
+	// workload that also commits its offsets transactionally.
+	billingTxn   = fixturePrefix + "billing-txn-88"
+	billingGroup = fixturePrefix + "wobble-consumer"
+	billingIn    = fixturePrefix + "billing-in"
+	billingOut   = fixturePrefix + "billing-out"
 )
+
+// TestUnrelatedExactlyOnceWorkloadsStaySeparate is AE5: two exactly-once
+// workloads that share nothing but __consumer_offsets must stay in separate
+// groups.
+//
+// Every exactly-once application on a cluster commits offsets to that one
+// internal topic, so it appears in every such transaction's footprint. Union it
+// like an ordinary topic and the transitive closure chains the entire estate
+// into a single group — a "result" that says migrate everything at once, which
+// is no result at all. Internal topics are therefore dropped BEFORE the union,
+// and this is the scenario that notices if that ordering is ever reversed.
+func TestUnrelatedExactlyOnceWorkloadsStaySeparate(t *testing.T) {
+	r := sharedRun(t)
+
+	orders := r.groupWith(ordersOut)
+	require.NotNil(t, orders, "the first workload's output topic is in no group\n%s", r.describe())
+	billing := r.groupWith(billingOut)
+	require.NotNil(t, billing, "the second workload's output topic is in no group\n%s", r.describe())
+
+	assert.NotEqual(t, orders.Name, billing.Name,
+		"two unrelated exactly-once workloads chained into one group through __consumer_offsets\n%s", r.describe())
+	assert.NotContains(t, orders.Topics, billingIn, "the second workload's input leaked into the first workload's group")
+	assert.NotContains(t, orders.Topics, billingOut, "the second workload's output leaked into the first workload's group")
+	assert.NotContains(t, billing.Topics, ordersIn, "the first workload's input leaked into the second workload's group")
+	assert.NotContains(t, billing.Topics, ordersOut, "the first workload's output leaked into the second workload's group")
+
+	// The internal topic every exactly-once app shares must not be reported as
+	// something to migrate at all.
+	assert.NotContains(t, r.observedTopics(), "__consumer_offsets",
+		"an internal topic was reported as migratable\n%s", r.describe())
+}
 
 // TestProducerIDRecoversConsumedInput is AE4: a non-Streams exactly-once
 // application whose group id bears no naming relationship to its transactional
@@ -690,10 +728,25 @@ func seedBeforeWindow(t *testing.T) {
 	createTopics(t, streamsIn, streamsOut)
 	commitGroupOffsets(t, streamsGroup, streamsIn)
 	produceTxn(t, txnFixture{TxnID: streamsTxn, Produce: []string{streamsOut}})
+
+	// The during-window fixtures' topics are created here so the observation
+	// window carries transactions rather than topic-creation churn. An unused
+	// topic is invisible to discovery, which reports only what it observed.
+	createTopics(t, ordersIn, ordersOut)
 }
 
 // seedDuringWindow produces the fixtures that must land inside the observation
 // window because the consumer-offsets tail starts at latest.
 func seedDuringWindow(t *testing.T) {
 	t.Helper()
+
+	// AE4. The offsets are committed INSIDE the transaction, so the resulting
+	// __consumer_offsets record is transactional and carries the producer id
+	// that ties it back to ordersTxn.
+	produceTxn(t, txnFixture{
+		TxnID:        ordersTxn,
+		Produce:      []string{ordersOut},
+		ConsumeTopic: ordersIn,
+		Group:        ordersGroup,
+	})
 }

--- a/integration-tests/txn-discovery/txn_discovery_e2e_test.go
+++ b/integration-tests/txn-discovery/txn_discovery_e2e_test.go
@@ -203,6 +203,48 @@ func commitGroupOffsets(t *testing.T, group, topic string) {
 	require.GreaterOrEqual(t, block.Offset, int64(0), "the offset commit did not land: the group's offset is unset")
 }
 
+// restartBroker stops and starts the broker container, then blocks until the
+// cluster can serve the transaction-state log again.
+//
+// `docker restart` rather than `docker compose up --force-recreate`: the
+// container keeps its filesystem, so the log the reader must resume within
+// survives. Recreating it would wipe the data and turn a resumption test into
+// a fresh-cluster test.
+func restartBroker(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("docker", "restart", containerName).CombinedOutput()
+	require.NoError(t, err, "failed to restart the broker: %s", out)
+	awaitBrokerReady(t)
+}
+
+// awaitBrokerReady blocks until the broker answers AND the transaction-state
+// log is loaded.
+//
+// Answering is not enough: the broker accepts API-version requests well before
+// the transaction coordinator has loaded its state, and a test that produced
+// into that gap would fail on the fixture rather than on the behaviour.
+func awaitBrokerReady(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		// A fresh admin per attempt: a client built before the restart holds
+		// stale metadata and a dead connection.
+		admin, err := sarama.NewClusterAdmin([]string{bootstrapAddr}, baseConfig())
+		if err != nil {
+			return false
+		}
+		defer func() { _ = admin.Close() }()
+		topics, err := admin.ListTopics()
+		if err != nil {
+			return false
+		}
+		_, ok := topics[txnStateTopic]
+		return ok
+	}, 120*time.Second, 2*time.Second, "the broker did not come back with a loaded transaction-state log")
+}
+
+// txnStateTopic is the internal topic the command reads by default.
+const txnStateTopic = "__transaction_state"
+
 // topicExists reports whether the broker has topic, using a listing rather than
 // a topic-scoped metadata request.
 //
@@ -352,6 +394,23 @@ type discoveryGroup struct {
 	TransactionalIDs []string `yaml:"transactional_ids"`
 }
 
+// statsDoc is the slice of txn-discovery-stats.json this suite reads: the
+// keep-up counters that say whether the reader stayed healthy and, for the
+// restart scenario, whether it was disrupted at all.
+type statsDoc struct {
+	Tail struct {
+		PartitionsAssigned int   `json:"partitions_assigned"`
+		PartitionsRunning  int   `json:"partitions_running"`
+		RecordsRead        int64 `json:"records_read"`
+		Lag                int64 `json:"lag"`
+		DecodeErrors       int64 `json:"decode_errors"`
+		LeadershipErrors   int64 `json:"leadership_errors"`
+		UnclassifiedErrors int64 `json:"unclassified_errors"`
+		OffsetResets       int64 `json:"offset_resets"`
+		TransportErrors    int64 `json:"transport_errors"`
+	} `json:"tail"`
+}
+
 // auditLine mirrors one line of txn-discovery-audit.jsonl.
 type auditLine struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -374,6 +433,8 @@ type runResult struct {
 	audit []auditLine
 	// kcpLog is the run's log file, empty when it wrote none.
 	kcpLog string
+	// stats is the parsed diagnostics document, nil when none was asked for.
+	stats *statsDoc
 
 	// files is every name the run left in its directory, and modes their
 	// permission bits.
@@ -419,6 +480,11 @@ func collect(t *testing.T, dir string, code int, stdout, stderr string) *runResu
 			r.audit = append(r.audit, al)
 		}
 		require.NoError(t, scanner.Err(), "failed to read the audit log")
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, statsFile)); err == nil {
+		var sd statsDoc
+		require.NoError(t, json.Unmarshal(data, &sd), "the stats JSON did not parse:\n%s", data)
+		r.stats = &sd
 	}
 	if data, err := os.ReadFile(filepath.Join(dir, logFile)); err == nil {
 		r.kcpLog = string(data)
@@ -577,7 +643,135 @@ const (
 	// AE6/AE7. A transaction-state topic name that does not exist and must not
 	// come to exist.
 	ghostTxnStateTopic = fixturePrefix + "ghost-txn-state"
+
+	// Broker restart. Transactions are produced in a phase before the restart
+	// and a phase after it, with deterministic ids so the run's output can be
+	// checked as a ledger.
+	restartPhaseTxns = 3
 )
+
+// TestReaderResumesAcrossBrokerRestart is R11's broker half: restarting the
+// broker mid-run leaves the reader re-resolving and resuming from its last
+// offset, with no gap and no duplicate group.
+//
+// The assertions are LEDGER-based, and deliberately so. The obvious ones are
+// all satisfied by a reader that simply died at the restart: the accumulator is
+// in-memory and append-only, so "nothing observed before the restart was lost"
+// holds trivially for a reader that never resumed, and "no duplicate group"
+// holds most easily of all for a reader that stopped. Only transactions
+// produced strictly AFTER the restart distinguish recovery from a silent stall,
+// so every phase is enumerated and every id must be present.
+func TestReaderResumesAcrossBrokerRestart(t *testing.T) {
+	awaitBrokerReady(t)
+
+	pre := restartFixtures(t, "pre")
+	post := restartFixtures(t, "post")
+	createTopics(t, append(topicsOf(pre), topicsOf(post)...)...)
+
+	proc := startKCP(t,
+		"--source-bootstrap", bootstrapAddr,
+		"--use-unauthenticated-plaintext",
+		"--duration", "150s",
+		"--interval", "5s",
+		"--out", outFile,
+		"--stats-out", statsFile,
+		"--audit-log-out", auditFile,
+	)
+	proc.awaitObserving(t)
+
+	for _, f := range pre {
+		produceTxn(t, f)
+	}
+	// Let the pre-restart phase be read before the broker goes away, so a
+	// failure afterwards is unambiguously about resumption.
+	time.Sleep(10 * time.Second)
+
+	restartBroker(t)
+
+	// The reader's backoff is capped at five seconds and a metadata refresh has
+	// to follow the restart, so give it room to re-resolve before judging it on
+	// records produced after.
+	time.Sleep(10 * time.Second)
+	for _, f := range post {
+		produceTxn(t, f)
+	}
+
+	r := proc.wait(t)
+	r.requireSucceeded(t)
+
+	// Non-vacuity, and the whole point of the scenario: the restart must
+	// actually have disrupted the reader. A run that sailed through without a
+	// single transport or leadership error did not exercise recovery, and the
+	// ledger below would then be proving nothing.
+	require.NotNil(t, r.stats, "the run wrote no stats document, so the disruption cannot be confirmed")
+	disruptions := r.stats.Tail.TransportErrors + r.stats.Tail.LeadershipErrors
+	require.Positive(t, disruptions,
+		"the broker restart caused no transport or leadership error, so the reader was never disrupted and this test proves nothing (tail=%+v)", r.stats.Tail)
+
+	// The ledger. Every transaction from both phases must be in the document —
+	// the post-restart ones are what separate a resumed reader from a dead one.
+	for _, f := range append(append([]txnFixture{}, pre...), post...) {
+		g := r.groupWith(f.Produce[0])
+		require.NotNil(t, g, "transaction %s is missing from the output entirely\n%s", f.TxnID, r.describe())
+		assert.ElementsMatch(t, f.Produce, g.Topics,
+			"transaction %s did not produce its own group of topics\n%s", f.TxnID, r.describe())
+		assert.Contains(t, g.TransactionalIDs, f.TxnID,
+			"the group is not credited to transaction %s\n%s", f.TxnID, r.describe())
+	}
+
+	// No duplicate group: a reconnect that re-read an offset range would show up
+	// as the same topic appearing in two groups, or as a repeated group name.
+	seenNames := map[string]int{}
+	for _, g := range r.doc.Groups {
+		seenNames[g.Name]++
+	}
+	for name, n := range seenNames {
+		assert.Equal(t, 1, n, "group name %s appears %d times", name, n)
+	}
+	for _, f := range append(append([]txnFixture{}, pre...), post...) {
+		var in []string
+		for _, g := range r.doc.Groups {
+			for _, tp := range g.Topics {
+				if tp == f.Produce[0] {
+					in = append(in, g.Name)
+				}
+			}
+		}
+		assert.Len(t, in, 1, "topic of %s appears in %v, so the reconnect duplicated it", f.TxnID, in)
+	}
+
+	// No gap: every partition assigned at startup must still be running at the
+	// end. A partition loop that gave up on the restart reads as zero lag and is
+	// otherwise indistinguishable from a healthy idle one.
+	assert.Equal(t, r.stats.Tail.PartitionsAssigned, r.stats.Tail.PartitionsRunning,
+		"%d of %d partitions stopped across the restart, so part of the window went unobserved",
+		r.stats.Tail.PartitionsAssigned-r.stats.Tail.PartitionsRunning, r.stats.Tail.PartitionsAssigned)
+	assert.Zero(t, r.stats.Tail.DecodeErrors, "records failed to decode across the restart")
+}
+
+// restartFixtures builds one phase's transactions, each writing its own pair of
+// topics so it forms its own group and can be found by name in the output.
+func restartFixtures(t *testing.T, phase string) []txnFixture {
+	t.Helper()
+	out := make([]txnFixture, 0, restartPhaseTxns)
+	for i := 0; i < restartPhaseTxns; i++ {
+		base := fmt.Sprintf("%srestart-%s-%d", fixturePrefix, phase, i)
+		out = append(out, txnFixture{
+			TxnID:   base + "-txn",
+			Produce: []string{base + "-a", base + "-b"},
+		})
+	}
+	return out
+}
+
+// topicsOf flattens the topics a set of fixtures produces to.
+func topicsOf(fs []txnFixture) []string {
+	var out []string
+	for _, f := range fs {
+		out = append(out, f.Produce...)
+	}
+	return out
+}
 
 // TestPreflightDeniesUnreadableTxnStateAndWritesNothing is AE6: when the
 // transaction-state log cannot be read the command fails fast, exits non-zero,

--- a/internal/client/kafka_admin.go
+++ b/internal/client/kafka_admin.go
@@ -242,6 +242,13 @@ func configureCommonSettings(config *sarama.Config, clientID string, kafkaVersio
 	// Request-specific timeout configurations
 	config.Metadata.Timeout = 15 * time.Second // Metadata request timeout
 
+	// kcp only ever reads from Kafka, but sarama defaults this to true: a metadata
+	// request naming a topic that does not exist makes a broker with
+	// auto.create.topics.enable=true create it. That turns a discovery command
+	// probing a mistyped or unknown topic name into one that mutates the cluster
+	// it is inspecting, so it stays off for every kcp client and admin.
+	config.Metadata.AllowAutoTopicCreation = false
+
 	// Retry configuration with backoff
 	config.Metadata.Retry.Max = 3
 	config.Metadata.Retry.Backoff = 250 * time.Millisecond

--- a/internal/client/kafka_admin_test.go
+++ b/internal/client/kafka_admin_test.go
@@ -332,6 +332,72 @@ func TestConfigureCommonSettings(t *testing.T) {
 	assert.Equal(t, 250*time.Millisecond, config.Metadata.Retry.Backoff)
 }
 
+// kcp is read-only against Kafka by intent, but sarama defaults
+// Metadata.AllowAutoTopicCreation to true, so a metadata request naming a topic
+// that does not exist can make a permissive broker create it. Assert the field
+// explicitly rather than trusting sarama's default to stay put across upgrades.
+func TestConfigureCommonSettings_DisablesAutoTopicCreation(t *testing.T) {
+	config := sarama.NewConfig()
+
+	configureCommonSettings(config, "test-client", sarama.V2_6_0_0)
+
+	assert.False(t, config.Metadata.AllowAutoTopicCreation,
+		"metadata requests must never create topics as a side effect")
+}
+
+// newAutoCreateProbeBroker stands up a sarama mock broker that answers just
+// enough (ApiVersions + Metadata) for NewKafkaClient/NewKafkaAdmin to connect,
+// so the construction paths can be exercised end to end without a real cluster.
+func newAutoCreateProbeBroker(t *testing.T) *sarama.MockBroker {
+	t.Helper()
+
+	mockBroker := sarama.NewMockBroker(t, 1)
+	t.Cleanup(mockBroker.Close)
+
+	mockBroker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mockBroker.Addr(), mockBroker.BrokerID()).
+			SetController(mockBroker.BrokerID()),
+	})
+
+	return mockBroker
+}
+
+// NewKafkaClient and NewKafkaAdmin build their sarama config independently of
+// one another, so each construction path is asserted separately — otherwise one
+// could regress to auto-creating topics while the other stayed safe.
+func TestNewKafkaClient_DisablesAutoTopicCreation(t *testing.T) {
+	mockBroker := newAutoCreateProbeBroker(t)
+
+	kafkaClient, err := NewKafkaClient([]string{mockBroker.Addr()}, "us-east-1", WithUnauthenticatedPlaintextAuth())
+	require.NoError(t, err)
+	defer func() { _ = kafkaClient.Close() }()
+
+	assert.False(t, kafkaClient.Config().Metadata.AllowAutoTopicCreation,
+		"NewKafkaClient must not let a metadata request create topics")
+}
+
+func TestNewKafkaAdmin_DisablesAutoTopicCreation(t *testing.T) {
+	mockBroker := newAutoCreateProbeBroker(t)
+
+	admin, err := NewKafkaAdmin(
+		[]string{mockBroker.Addr()},
+		kafkatypes.ClientBrokerPlaintext,
+		"us-east-1",
+		"2.6.0",
+		WithUnauthenticatedPlaintextAuth(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = admin.Close() }()
+
+	adminClient, ok := admin.(*KafkaAdminClient)
+	require.True(t, ok, "NewKafkaAdmin should return a *KafkaAdminClient")
+
+	assert.False(t, adminClient.saramaConfig.Metadata.AllowAutoTopicCreation,
+		"NewKafkaAdmin must not let a metadata request create topics")
+}
+
 func TestConfigureSASLTypeOAuthAuthentication(t *testing.T) {
 	config := sarama.NewConfig()
 	region := "us-west-2"

--- a/internal/services/txndiscovery/discovery/accumulator.go
+++ b/internal/services/txndiscovery/discovery/accumulator.go
@@ -1,0 +1,144 @@
+package discovery
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// TxnFootprint is the union of everything observed for one transactional id across the
+// whole run (all samples, all sources).
+type TxnFootprint struct {
+	TxnID            string
+	ProducerID       int64
+	Topics           []string // sorted union across sources; still includes internal topics
+	ReadProcessWrite bool
+	Sources          []string // sorted names of the phases that reported this transaction
+	FirstSeen        time.Time
+	LastSeen         time.Time
+	Samples          int
+}
+
+// Accumulator merges Observations from every source, keyed by transactional id. Safe
+// for concurrent use.
+type Accumulator struct {
+	mu    sync.Mutex
+	byTxn map[string]*txnState
+}
+
+type txnState struct {
+	producerID int64
+	// topics is the union across every source rather than a set per source. Nothing
+	// downstream reads a per-source topic set — only the set of source names — and the
+	// union is what "did this observation grow the transaction's topic set?" has to be
+	// answered against: a topic already reported by another source is not growth.
+	topics           map[string]struct{}
+	readProcessWrite bool
+	sources          map[string]struct{}
+	firstSeen        time.Time
+	lastSeen         time.Time
+	samples          int
+}
+
+// NewAccumulator returns an empty accumulator ready for concurrent use.
+func NewAccumulator() *Accumulator {
+	return &Accumulator{byTxn: make(map[string]*txnState)}
+}
+
+// Change reports what an Add did to a transaction's topic set.
+type Change struct {
+	// Added are the topics the observation introduced, sorted. Empty when the
+	// observation reported nothing the transaction had not already been seen touching.
+	Added []string
+
+	// Topics is the transaction's resulting full topic set, sorted.
+	Topics []string
+}
+
+// Grew reports whether the observation grew the transaction's topic set.
+func (c Change) Grew() bool { return len(c.Added) > 0 }
+
+// Add merges an observation into the footprint for its transactional id and reports
+// what that did to the transaction's topic set.
+func (a *Accumulator) Add(obs Observation) Change {
+	// An observation with no transactional id is dropped rather than pooled into a
+	// keyless bucket, which would chain unrelated topics into one group and attribute
+	// audit lines to a transaction that does not exist.
+	if obs.TxnID == "" {
+		return Change{}
+	}
+	// The whole merge runs under the lock: the check-and-insert that computes Added must
+	// be atomic, or two concurrent sources reporting the same topic both claim it (a
+	// duplicate audit line) or neither does (a coupling missing from the trace).
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	st := a.byTxn[obs.TxnID]
+	if st == nil {
+		st = &txnState{
+			topics:    make(map[string]struct{}),
+			sources:   make(map[string]struct{}),
+			firstSeen: obs.ObservedAt,
+		}
+		a.byTxn[obs.TxnID] = st
+	}
+	// Only a positive id is recorded. The naming-based enrichment phase reports 0 and a
+	// source with no producer may report Kafka's -1 sentinel; neither may displace a
+	// real id, which is the only key an offset commit can be correlated on.
+	if obs.ProducerID > 0 {
+		st.producerID = obs.ProducerID
+	}
+	st.sources[obs.Source] = struct{}{}
+	var added []string
+	for _, t := range obs.Topics {
+		if _, seen := st.topics[t]; seen {
+			continue
+		}
+		st.topics[t] = struct{}{}
+		added = append(added, t)
+	}
+	sort.Strings(added)
+
+	if obs.ReadProcessWrite {
+		st.readProcessWrite = true // sticky: once read-process-write, always
+	}
+	// Sources run concurrently, so a sighting can arrive out of order; only move the
+	// window forwards.
+	if obs.ObservedAt.After(st.lastSeen) {
+		st.lastSeen = obs.ObservedAt
+	}
+	st.samples++
+
+	return Change{Added: added, Topics: sortedKeys(st.topics)}
+}
+
+// Snapshot returns the accumulated footprints, sorted by transactional id.
+func (a *Accumulator) Snapshot() []TxnFootprint {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	out := make([]TxnFootprint, 0, len(a.byTxn))
+	for id, st := range a.byTxn {
+		out = append(out, TxnFootprint{
+			TxnID:            id,
+			ProducerID:       st.producerID,
+			Topics:           sortedKeys(st.topics),
+			ReadProcessWrite: st.readProcessWrite,
+			Sources:          sortedKeys(st.sources),
+			FirstSeen:        st.firstSeen,
+			LastSeen:         st.lastSeen,
+			Samples:          st.samples,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TxnID < out[j].TxnID })
+	return out
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/services/txndiscovery/discovery/accumulator_test.go
+++ b/internal/services/txndiscovery/discovery/accumulator_test.go
@@ -1,0 +1,235 @@
+package discovery
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccumulator_RepeatedObservationsUnionAndDeduplicateTopics(t *testing.T) {
+	// A transaction is observed many times across a run — the coordinator rewrites its
+	// state record on every status change — and each sighting reports the footprint as
+	// of that moment. The footprint that matters is the union of all of them, deduped.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "app-0", Topics: []string{"a", "b"}})
+	acc.Add(Observation{TxnID: "app-0", Topics: []string{"b", "c", "__consumer_offsets"}})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, "app-0", snap[0].TxnID)
+	assert.Equal(t, []string{"__consumer_offsets", "a", "b", "c"}, snap[0].Topics)
+	assert.Equal(t, 2, snap[0].Samples)
+}
+
+func TestAccumulator_SeparateTransactionsStaySeparate(t *testing.T) {
+	// Two unrelated transactions must not pool their topics: the whole grouping stage
+	// downstream reads a merge here as a coupling that the cluster never had.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "x", Topics: []string{"a"}})
+	acc.Add(Observation{TxnID: "y", Topics: []string{"b"}})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 2)
+	byID := map[string][]string{snap[0].TxnID: snap[0].Topics, snap[1].TxnID: snap[1].Topics}
+	assert.Equal(t, map[string][]string{"x": {"a"}, "y": {"b"}}, byID)
+}
+
+func TestAccumulator_SnapshotIsSortedByTransactionalID(t *testing.T) {
+	// The artifacts written from a snapshot must not churn between runs over identical
+	// observations. Go randomises map iteration per range, so the ordering is asserted
+	// across repeated snapshots rather than a single one.
+	acc := NewAccumulator()
+	for _, id := range []string{"tx-9", "tx-3", "tx-7", "tx-1", "tx-5", "tx-8", "tx-2", "tx-6", "tx-4"} {
+		acc.Add(Observation{TxnID: id, Topics: []string{"t"}})
+	}
+	want := []string{"tx-1", "tx-2", "tx-3", "tx-4", "tx-5", "tx-6", "tx-7", "tx-8", "tx-9"}
+
+	for range 20 {
+		var got []string
+		for _, fp := range acc.Snapshot() {
+			got = append(got, fp.TxnID)
+		}
+		require.Equal(t, want, got)
+	}
+}
+
+func TestAccumulator_ObservationsFromDifferentSourcesCreditTheSameTransaction(t *testing.T) {
+	// The pipeline contract that lets an enrichment phase fold a recovered consumed
+	// input into the write-side footprint: two sources reporting the same transactional
+	// id union into one footprint, with both sources credited.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "t", Topics: []string{"out"}, Source: SourceTxnStateLog})
+	acc.Add(Observation{TxnID: "t", Topics: []string{"in"}, Source: SourceConsumerGroups})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, []string{"in", "out"}, snap[0].Topics)
+	assert.Equal(t, []string{SourceConsumerGroups, SourceTxnStateLog}, snap[0].Sources)
+}
+
+func TestAccumulator_ZeroProducerIDDoesNotOverwriteARecordedOne(t *testing.T) {
+	// The naming-based enrichment phase emits observations carrying no producer id.
+	// Those must not erase the real id the __transaction_state reader recorded: it is
+	// the only key the __consumer_offsets phase can correlate an offset commit on, so
+	// clobbering it silently drops every exact recovery for that transaction.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "t", ProducerID: 42, Topics: []string{"out"}, Source: SourceTxnStateLog})
+	acc.Add(Observation{TxnID: "t", ProducerID: 0, Topics: []string{"in"}, Source: SourceConsumerGroups})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, int64(42), snap[0].ProducerID)
+}
+
+func TestAccumulator_OnlyAPositiveProducerIDIsRecorded(t *testing.T) {
+	// Abuse case: Kafka's no-producer sentinel is -1, not 0. Recording it would put a
+	// bogus id in the artifact and — worse — occupy the slot, so the real id decoded
+	// from a later record never lands.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "t", ProducerID: -1, Topics: []string{"a"}, Source: SourceConsumerOffsets})
+	acc.Add(Observation{TxnID: "t", ProducerID: 9, Topics: []string{"a"}, Source: SourceTxnStateLog})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, int64(9), snap[0].ProducerID)
+}
+
+func TestAccumulator_ReadProcessWriteIsStickyOnceSet(t *testing.T) {
+	// A transaction that once committed consumer offsets is a consume-transform-produce
+	// app for the rest of the run. Later sightings routinely omit the flag — a completed
+	// transaction's footprint is cleared by the coordinator, and enrichment observations
+	// carry only recovered inputs — and must not downgrade it. Losing the flag hides
+	// that the group's consumed inputs are absent from the footprint, which is exactly
+	// the case that breaks exactly-once delivery at cutover.
+	acc := NewAccumulator()
+
+	acc.Add(Observation{TxnID: "t", Topics: []string{"a"}, ReadProcessWrite: true, Source: SourceTxnStateLog})
+	acc.Add(Observation{TxnID: "t", Topics: []string{"b"}, ReadProcessWrite: false, Source: SourceTxnStateLog})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.True(t, snap[0].ReadProcessWrite)
+}
+
+func TestAccumulator_AddReportsExactlyTheTopicsItAdded(t *testing.T) {
+	// The audit trail exists so an operator can ask "why are these two topics in one
+	// group?" and get back the transaction and the phase that coupled them. Only the
+	// accumulator knows whether a sighting grew the set, so Add reports the delta —
+	// the topics this observation introduced — alongside the resulting full set.
+	acc := NewAccumulator()
+	acc.Add(Observation{TxnID: "t", Topics: []string{"a"}, Source: SourceTxnStateLog})
+
+	ch := acc.Add(Observation{TxnID: "t", Topics: []string{"c", "b", "a"}, Source: SourceTxnStateLog})
+
+	assert.True(t, ch.Grew())
+	assert.Equal(t, []string{"b", "c"}, ch.Added, "only the topics not already in the set, sorted")
+	assert.Equal(t, []string{"a", "b", "c"}, ch.Topics, "the resulting full set")
+}
+
+func TestAccumulator_AddReportsNoAdditionsWhenTheTopicsAreAlreadyPresent(t *testing.T) {
+	// A transaction is re-observed on every coordinator state change, so most sightings
+	// report a set already recorded. Those must report no growth, or the audit trail
+	// becomes one line per sighting and stops being a record of what coupled what.
+	// A topic another source already reported is not growth either: the set that
+	// matters is the union, which is what the grouping stage consumes.
+	acc := NewAccumulator()
+	acc.Add(Observation{TxnID: "t", Topics: []string{"a", "b"}, Source: SourceTxnStateLog})
+
+	repeat := acc.Add(Observation{TxnID: "t", Topics: []string{"b", "a"}, Source: SourceTxnStateLog})
+	otherSource := acc.Add(Observation{TxnID: "t", Topics: []string{"a"}, Source: SourceConsumerGroups})
+
+	assert.False(t, repeat.Grew())
+	assert.Empty(t, repeat.Added)
+	assert.Equal(t, []string{"a", "b"}, repeat.Topics, "the full set is still reported")
+
+	assert.False(t, otherSource.Grew(), "a topic another source already reported is not growth")
+	assert.Empty(t, otherSource.Added)
+}
+
+func TestAccumulator_ObservationWithAnEmptyTransactionalIDIsIgnored(t *testing.T) {
+	// Abuse case: a broker record that decodes to an empty transactional id — malformed,
+	// truncated, or a key shape the decoder does not model — must not open a keyless
+	// bucket. Every such record would pool into one synthetic transaction, chaining
+	// unrelated topics into a single group, and would emit audit lines attributing
+	// couplings to a transaction that does not exist.
+	acc := NewAccumulator()
+
+	ch := acc.Add(Observation{TxnID: "", Topics: []string{"a", "b"}, Source: SourceTxnStateLog})
+
+	assert.False(t, ch.Grew())
+	assert.Empty(t, ch.Added)
+	assert.Empty(t, ch.Topics)
+	assert.Empty(t, acc.Snapshot())
+}
+
+func TestAccumulator_TracksTheObservationWindowIgnoringOutOfOrderSightings(t *testing.T) {
+	// FirstSeen/LastSeen bound when a transaction was live during the run. The sources
+	// run concurrently and their observations interleave, so an Add can arrive carrying
+	// an earlier timestamp than one already merged; that must not drag LastSeen back.
+	acc := NewAccumulator()
+	t0 := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+
+	acc.Add(Observation{TxnID: "t", Topics: []string{"a"}, ObservedAt: t0.Add(1 * time.Minute)})
+	acc.Add(Observation{TxnID: "t", Topics: []string{"b"}, ObservedAt: t0.Add(5 * time.Minute)})
+	acc.Add(Observation{TxnID: "t", Topics: []string{"c"}, ObservedAt: t0.Add(2 * time.Minute)})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, t0.Add(1*time.Minute), snap[0].FirstSeen)
+	assert.Equal(t, t0.Add(5*time.Minute), snap[0].LastSeen)
+}
+
+func TestAccumulator_ConcurrentAddsReportEachTopicAsAddedExactlyOnce(t *testing.T) {
+	// Three observation sources feed one accumulator concurrently, and the audit line is
+	// written from the delta Add returns. If two concurrent Adds both claimed the same
+	// topic the trace would record a coupling twice; if the check-and-insert were not
+	// atomic, neither would claim it and the coupling would be missing from the trace
+	// altogether. Every goroutine reports the same topics so they contend on each one.
+	// Run under -race.
+	const goroutines, topicsEach = 8, 50
+	sources := []string{SourceTxnStateLog, SourceConsumerGroups, SourceConsumerOffsets}
+	acc := NewAccumulator()
+
+	var (
+		mu       sync.Mutex
+		reported []string
+		wg       sync.WaitGroup
+	)
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range topicsEach {
+				ch := acc.Add(Observation{
+					TxnID:      "t",
+					Topics:     []string{fmt.Sprintf("topic-%02d", i)},
+					Source:     sources[g%len(sources)],
+					ObservedAt: time.Now(),
+				})
+				mu.Lock()
+				reported = append(reported, ch.Added...)
+				mu.Unlock()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	require.Len(t, snap[0].Topics, topicsEach)
+	assert.Equal(t, goroutines*topicsEach, snap[0].Samples)
+
+	sort.Strings(reported)
+	assert.Equal(t, snap[0].Topics, reported,
+		"every topic in the final set must have been reported as added exactly once")
+}

--- a/internal/services/txndiscovery/discovery/catalog.go
+++ b/internal/services/txndiscovery/discovery/catalog.go
@@ -1,0 +1,66 @@
+package discovery
+
+import "sync"
+
+// TxnCatalog is the shared index the __transaction_state reader populates and the
+// enrichment phases read. Both facts the enrichment phases need to correlate on — the
+// set of live transactional ids, and each transaction's producer id — are present on
+// every state record the reader decodes, so the catalog lets those phases correlate
+// without calling the transaction admin APIs at all.
+//
+// Safe for concurrent use: the reader writes to it from its fetch loop while the
+// enrichment phases snapshot it on their refresh cadence.
+type TxnCatalog struct {
+	mu       sync.RWMutex
+	pidToTxn map[int64]string    // producer id -> transactional id (last writer wins)
+	txnIDs   map[string]struct{} // every transactional id ever observed
+}
+
+// NewTxnCatalog returns an empty catalog ready for concurrent use.
+func NewTxnCatalog() *TxnCatalog {
+	return &TxnCatalog{
+		pidToTxn: make(map[int64]string),
+		txnIDs:   make(map[string]struct{}),
+	}
+}
+
+// Observe records one sighting of a transactional id and, if present, its producer
+// id, as decoded from a __transaction_state record. A producerID of 0 or less is
+// ignored for the producer-id mapping — an early Empty record may carry no real id
+// yet — but the transactional id is always registered so the naming-based enrichment
+// phase can still correlate it.
+func (c *TxnCatalog) Observe(txnID string, producerID int64) {
+	if txnID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.txnIDs[txnID] = struct{}{}
+	if producerID > 0 {
+		c.pidToTxn[producerID] = txnID
+	}
+}
+
+// TxnIDs returns a snapshot of every transactional id observed so far.
+func (c *TxnCatalog) TxnIDs() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]string, 0, len(c.txnIDs))
+	for id := range c.txnIDs {
+		out = append(out, id)
+	}
+	return out
+}
+
+// ProducerIDToTxnID returns a snapshot of the producer-id -> transactional-id map.
+func (c *TxnCatalog) ProducerIDToTxnID() map[int64]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	// Defensive copy: callers hold this map across a resolve pass, so handing out the
+	// live one would let a reader's write race an enrichment phase's read.
+	out := make(map[int64]string, len(c.pidToTxn))
+	for pid, id := range c.pidToTxn {
+		out[pid] = id
+	}
+	return out
+}

--- a/internal/services/txndiscovery/discovery/catalog_test.go
+++ b/internal/services/txndiscovery/discovery/catalog_test.go
@@ -1,0 +1,93 @@
+package discovery
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxnCatalog_ZeroProducerIDRegistersTxnIDWithoutAProducerMapping(t *testing.T) {
+	// An early Empty __transaction_state record carries a transactional id but no real
+	// producer id yet. The id must still be registered so the naming-based enrichment
+	// phase can correlate it, but a 0 must never enter the producer-id map — every
+	// unmapped producer would otherwise resolve to whichever transaction registered
+	// first.
+	c := NewTxnCatalog()
+
+	c.Observe("tx-a", 0)
+
+	assert.Equal(t, []string{"tx-a"}, c.TxnIDs())
+	assert.Empty(t, c.ProducerIDToTxnID())
+}
+
+func TestTxnCatalog_PositiveProducerIDMapsToItsTransactionalID(t *testing.T) {
+	// The producer-id mapping is what lets the __consumer_offsets phase join a
+	// transactional offset commit back to its transaction without relying on a naming
+	// convention.
+	c := NewTxnCatalog()
+
+	c.Observe("tx-a", 0)   // early record, no real producer id yet
+	c.Observe("tx-a", 100) // later record carries it
+	c.Observe("tx-b", 200)
+
+	assert.ElementsMatch(t, []string{"tx-a", "tx-b"}, c.TxnIDs())
+	assert.Equal(t, map[int64]string{100: "tx-a", 200: "tx-b"}, c.ProducerIDToTxnID())
+}
+
+func TestTxnCatalog_EmptyTransactionalIDIsIgnoredEntirely(t *testing.T) {
+	// Abuse case: a malformed or non-transactional record decoding to an empty id must
+	// not register a keyless entry, and must not claim its producer id — a producer
+	// mapped to "" would later resolve an offset commit onto a nameless transaction.
+	c := NewTxnCatalog()
+
+	c.Observe("", 300)
+
+	assert.Empty(t, c.TxnIDs())
+	assert.Empty(t, c.ProducerIDToTxnID())
+}
+
+func TestTxnCatalog_ProducerIDSnapshotIsADefensiveCopy(t *testing.T) {
+	// The enrichment phases hold the returned map for the length of a resolve pass and
+	// are free to write to it. Handing out the live map would let one phase corrupt the
+	// index the reader is still populating — and with no lock held, race it.
+	c := NewTxnCatalog()
+	c.Observe("tx", 1)
+
+	snap := c.ProducerIDToTxnID()
+	snap[1] = "mutated"
+	snap[999] = "injected"
+
+	assert.Equal(t, map[int64]string{1: "tx"}, c.ProducerIDToTxnID())
+}
+
+func TestTxnCatalog_ObserveAndSnapshotAreSafeConcurrently(t *testing.T) {
+	// The __transaction_state reader writes to the catalog from its fetch loop while the
+	// enrichment phases snapshot it on their refresh cadence. Run under -race.
+	const writers, perWriter = 8, 200
+	c := NewTxnCatalog()
+
+	var wg sync.WaitGroup
+	for w := range writers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := range perWriter {
+				c.Observe(fmt.Sprintf("tx-%d", w), int64(w*perWriter+i+1))
+			}
+		}(w)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range writers * perWriter {
+			_ = c.TxnIDs()
+			_ = c.ProducerIDToTxnID()
+		}
+	}()
+	wg.Wait()
+
+	assert.Len(t, c.TxnIDs(), writers)
+	assert.Len(t, c.ProducerIDToTxnID(), writers*perWriter)
+}

--- a/internal/services/txndiscovery/discovery/consumergroups.go
+++ b/internal/services/txndiscovery/discovery/consumergroups.go
@@ -1,0 +1,187 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+)
+
+// ConsumerGroupAdmin is the slice of sarama.ClusterAdmin consumer-group enrichment
+// needs. It is declared here, narrowly, rather than reached through kcp's KafkaAdmin
+// interface: that interface exposes five unrelated methods and keeps its
+// sarama.ClusterAdmin unexported, so widening it would ripple through every existing
+// mock in the repo for the sake of two calls made by one command.
+//
+// *sarama.ClusterAdmin satisfies this as-is. The caller constructs one (over the same
+// sarama.Client the tail holds) and owns closing it; the enricher never does either.
+type ConsumerGroupAdmin interface {
+	// ListConsumerGroups returns group id -> protocol type for every group the
+	// credentials can describe.
+	ListConsumerGroups() (map[string]string, error)
+
+	// ListConsumerGroupOffsets returns a group's committed offsets. A nil
+	// topicPartitions asks for every topic the group has committed to.
+	ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*sarama.OffsetFetchResponse, error)
+}
+
+// ConsumerGroupEnricher recovers the CONSUMED (input) topics of read-process-write /
+// EOS apps, which are invisible in a transaction's footprint: __transaction_state
+// reports only the topics a transaction PRODUCED to (plus __consumer_offsets), never
+// the topics it consumed FROM. Without this, a consume-transform-produce app looks
+// like it touches only its output topics, so its inputs could be left behind on the
+// source cluster at cutover — breaking exactly-once.
+//
+// The topics a group has committed offsets for are exactly the topics it consumes, so
+// the recovery is a consumer-group listing joined to the transactional ids the
+// __transaction_state reader has already put in the shared TxnCatalog — no
+// ListTransactions call.
+//
+// The join is the Kafka Streams naming convention (see correlateByStreamsConvention),
+// which covers Kafka Streams apps — the dominant EOS workload. A plain
+// consumer+producer EOS app whose transactional.id bears no relation to its group.id
+// is handled instead by the __consumer_offsets phase's exact producer-id correlation.
+type ConsumerGroupEnricher struct {
+	Admin    ConsumerGroupAdmin
+	Catalog  *TxnCatalog
+	Interval time.Duration
+	Log      *slog.Logger
+}
+
+// Name returns the source name the observations this phase emits are tagged with.
+func (e *ConsumerGroupEnricher) Name() string { return SourceConsumerGroups }
+
+// Run enriches on entry and then on every Interval tick until ctx is done. The first
+// pass is immediate so an observation window shorter than the interval still enriches.
+func (e *ConsumerGroupEnricher) Run(ctx context.Context, out chan<- Observation) error {
+	e.enrichLogErr(ctx, out)
+	ticker := time.NewTicker(e.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			e.enrichLogErr(ctx, out)
+		}
+	}
+}
+
+// enrichLogErr runs one pass, logging rather than propagating its error so a single
+// failed pass — a coordinator move, a rebalance, a momentary ACL problem — never
+// aborts the observation window. The cancellation check keeps shutdown from being
+// reported as a failure.
+func (e *ConsumerGroupEnricher) enrichLogErr(ctx context.Context, out chan<- Observation) {
+	if err := e.enrich(ctx, out); err != nil && ctx.Err() == nil {
+		e.Log.Warn("❌ consumer-group enrichment pass failed", "source", e.Name(), "err", err)
+	}
+}
+
+// enrich runs one pass: list the groups, correlate each to the catalog, and emit the
+// consumed topics of every group that correlates.
+func (e *ConsumerGroupEnricher) enrich(ctx context.Context, out chan<- Observation) error {
+	// The transactional ids come from the __transaction_state reader via the shared
+	// catalog, not a ListTransactions call. Early in the run it may still be empty, and
+	// on an idle cluster it stays empty — with nothing to correlate against a pass can
+	// only produce nothing, so it costs the cluster no admin calls at all.
+	txnIDs := e.Catalog.TxnIDs()
+	if len(txnIDs) == 0 {
+		return nil
+	}
+
+	groups, err := e.Admin.ListConsumerGroups()
+	if err != nil {
+		return fmt.Errorf("list consumer groups: %w", err)
+	}
+
+	now := time.Now()
+	for group := range groups {
+		matches := correlateByStreamsConvention(group, txnIDs)
+		if len(matches) == 0 {
+			continue
+		}
+		resp, ferr := e.Admin.ListConsumerGroupOffsets(group, nil)
+		if ferr != nil {
+			// Skip this group, not the pass: a single application rebalancing must not
+			// decide whether every other application on the cluster gets enriched. The
+			// group id is deliberately absent from the line — it names a customer's
+			// application, and kcp.log is unconditionally Debug+.
+			e.Log.Warn("❌ failed to fetch consumer-group offsets", "source", e.Name(), "err", ferr)
+			continue
+		}
+		consumed := consumedTopics(resp)
+		if len(consumed) == 0 {
+			continue
+		}
+		for _, txnID := range matches {
+			obs := Observation{
+				TxnID: txnID,
+				// No ProducerID: this phase correlates on names, not producer ids. The
+				// accumulator only overwrites on a positive value, so leaving it zero
+				// cannot erase the real id the __transaction_state reader recorded.
+				Topics: consumed,
+				// A group correlated to a transaction is a consume-transform-produce app
+				// by construction, and these are its inputs.
+				ReadProcessWrite: true,
+				Source:           e.Name(),
+				ObservedAt:       now,
+			}
+			select {
+			case out <- obs:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// consumedTopics returns the topics a group has committed offsets for — i.e. the
+// topics it consumes — named once each, sorted.
+//
+// It takes sarama's response rather than a client-specific offset type so the helper
+// stays a pure function over the wire shape.
+func consumedTopics(resp *sarama.OffsetFetchResponse) []string {
+	set := make(map[string]struct{}, len(resp.Blocks))
+	for topic := range resp.Blocks {
+		// An EOS group commits its offsets through the transaction, so
+		// __consumer_offsets appears among its committed topics. Grouping drops internal
+		// topics too, but reporting one here would credit it as a recovered INPUT.
+		if grouping.IsInternalTopic(topic) {
+			continue
+		}
+		set[topic] = struct{}{}
+	}
+	return sortedKeys(set)
+}
+
+// correlateByStreamsConvention returns the transactional ids that belong to the
+// consumer group under the Kafka Streams naming rule: transactional.id is either
+// "<group>" or "<group>-<suffix>". Kafka Streams sets application.id == group.id and
+// derives transactional.id as "<application.id>-<processId|taskId>".
+//
+// The separator is part of the prefix on purpose. Matching on the bare group name
+// would correlate "payments-processor2" — a different application — to the
+// "payments-processor" group, folding one workload's input topics into another
+// workload's transaction.
+func correlateByStreamsConvention(group string, txnIDs []string) []string {
+	// An empty group id is reachable (pre-2.2 simple consumers committed under "") and
+	// degenerates the boundary prefix to "-", which matches every transactional id that
+	// merely starts with a hyphen. It carries no application name, so it correlates to
+	// nothing.
+	if group == "" {
+		return nil
+	}
+	prefix := group + "-"
+	var out []string
+	for _, id := range txnIDs {
+		if id == group || strings.HasPrefix(id, prefix) {
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/internal/services/txndiscovery/discovery/consumergroups.go
+++ b/internal/services/txndiscovery/discovery/consumergroups.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -50,6 +51,107 @@ type ConsumerGroupEnricher struct {
 	Catalog  *TxnCatalog
 	Interval time.Duration
 	Log      *slog.Logger
+
+	mu           sync.Mutex
+	passes       int
+	passFailures int
+	groupsListed int
+	// correlations holds the distinct "group\x00txnID" links made over the run. The
+	// listing repeats every pass, so a counter would report the same recovery once per
+	// pass; the set is what makes the number the run's total.
+	correlations map[string]struct{}
+}
+
+// EnricherStats is what this phase contributes to the run's report.
+type EnricherStats struct {
+	// Passes is how many enrichment passes completed.
+	//
+	// It is the cadence signal, and the reason this struct exists: this phase's admin
+	// calls are the run's slowest, so an --interval that should yield thirteen passes
+	// over a window can yield four, and nothing else in the report would say so.
+	//
+	// Every completed pass counts, including one that short-circuited on an empty
+	// catalog. The question is how many times the loop came round; a run against an
+	// idle cluster reporting zero passes would read as a phase that never started.
+	Passes int
+
+	// PassFailures is how many passes failed at the group listing.
+	//
+	// Kept apart from Passes because a phase whose every pass failed would otherwise
+	// report a full-cadence run — thirteen passes, no correlations — which is
+	// indistinguishable from a healthy run against a cluster with no exactly-once
+	// traffic. A single failed pass never aborts the window, so this count is the only
+	// artifact that says the phase was degraded.
+	PassFailures int
+
+	// GroupsListed is the most consumer groups any one pass listed.
+	//
+	// It separates "the naming convention matched nothing on this cluster" from "the
+	// credentials could not see a single group". Both recover no inputs, and Passes
+	// alone reports them identically.
+	//
+	// The most any pass saw rather than a running total, because the listing repeats
+	// every pass: a sum would multiply one cluster's group count by the cadence, and
+	// the last pass's figure would let a rebalance at the window's close understate the
+	// estate.
+	GroupsListed int
+
+	// Correlations is how many distinct consumer-group-to-transaction links this phase
+	// made over the run.
+	//
+	// Counted when the link is MADE, not when its observation is delivered, and the
+	// difference is the point: a correlation counted here that the report's naming
+	// attribution (Recovery.ByNamingTxns) does not credit was computed and then
+	// discarded at the send — R8's recovery silently not happening, which is what the
+	// final pass at the window's close exists to prevent.
+	Correlations int
+}
+
+// Stats returns a snapshot of what this phase has done so far.
+func (e *ConsumerGroupEnricher) Stats() EnricherStats {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return EnricherStats{
+		Passes:       e.passes,
+		PassFailures: e.passFailures,
+		GroupsListed: e.groupsListed,
+		Correlations: len(e.correlations),
+	}
+}
+
+// recordListing notes how many groups one pass saw, keeping the largest.
+func (e *ConsumerGroupEnricher) recordListing(n int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if n > e.groupsListed {
+		e.groupsListed = n
+	}
+}
+
+// recordCorrelation notes one group-to-transaction link, deduplicated across passes.
+func (e *ConsumerGroupEnricher) recordCorrelation(group, txnID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.correlations == nil {
+		e.correlations = make(map[string]struct{})
+	}
+	// NUL separator: it cannot occur in a group id or a transactional id, so two
+	// different links cannot collide into one key.
+	e.correlations[group+"\x00"+txnID] = struct{}{}
+}
+
+// countPass records that one pass finished its work.
+func (e *ConsumerGroupEnricher) countPass() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.passes++
+}
+
+// countPassFailure records that one pass did not get as far as finishing.
+func (e *ConsumerGroupEnricher) countPassFailure() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.passFailures++
 }
 
 // Name returns the source name the observations this phase emits are tagged with.
@@ -117,13 +219,16 @@ func (e *ConsumerGroupEnricher) enrich(ctx context.Context, out chan<- Observati
 	// only produce nothing, so it costs the cluster no admin calls at all.
 	txnIDs := e.Catalog.TxnIDs()
 	if len(txnIDs) == 0 {
+		e.countPass()
 		return nil
 	}
 
 	groups, err := e.Admin.ListConsumerGroups()
 	if err != nil {
+		e.countPassFailure()
 		return fmt.Errorf("list consumer groups: %w", err)
 	}
+	e.recordListing(len(groups))
 
 	now := time.Now()
 	for group := range groups {
@@ -145,6 +250,7 @@ func (e *ConsumerGroupEnricher) enrich(ctx context.Context, out chan<- Observati
 			continue
 		}
 		for _, txnID := range matches {
+			e.recordCorrelation(group, txnID)
 			obs := Observation{
 				TxnID: txnID,
 				// No ProducerID: this phase correlates on names, not producer ids. The
@@ -160,10 +266,13 @@ func (e *ConsumerGroupEnricher) enrich(ctx context.Context, out chan<- Observati
 			select {
 			case out <- obs:
 			case <-ctx.Done():
+				// Abandoned at shutdown rather than finished, so it is not counted:
+				// FinalEnrich's pass, on a fresh context, is the one that completes.
 				return nil
 			}
 		}
 	}
+	e.countPass()
 	return nil
 }
 

--- a/internal/services/txndiscovery/discovery/consumergroups.go
+++ b/internal/services/txndiscovery/discovery/consumergroups.go
@@ -52,6 +52,11 @@ type ConsumerGroupEnricher struct {
 	Interval time.Duration
 	Log      *slog.Logger
 
+	// FinalPassTimeout bounds how long FinalEnrich waits for the closing pass
+	// before abandoning it. Zero means finalFlushTimeout; the field exists so a
+	// test can assert the bound holds without waiting the production ten seconds.
+	FinalPassTimeout time.Duration
+
 	mu           sync.Mutex
 	passes       int
 	passFailures int
@@ -191,13 +196,61 @@ func (e *ConsumerGroupEnricher) Run(ctx context.Context, out chan<- Observation)
 // prevent.
 //
 // This mirrors ConsumerOffsetsTail.FinalFlush, which exists for the same reason on the
-// same catalog. The timeout is what keeps an unresponsive broker from wedging
-// shutdown, and it also bounds the send: by this point the accumulator is still
-// draining, but nothing may block the run from writing its artifacts indefinitely.
+// same catalog — but not the way it is bounded, and the difference is worth stating.
+// That flush is a pure in-memory map join, so a context is a genuine bound on it. This
+// pass talks to a broker through sarama's ClusterAdmin, whose ListConsumerGroups and
+// ListConsumerGroupOffsets take no context at all: a context can only be consulted
+// BETWEEN calls, never inside one. A pass makes 1+G of them in sequence, one per
+// naming-matched group, and with Net.ReadTimeout 30s, Admin.Retry.Max 5 and
+// Metadata.Retry.Max 3 x Metadata.Timeout 15s a single degraded call runs for minutes.
+// Nothing is written to disk until this returns, so an unbounded pass holds the entire
+// product of the window — hours of observation — behind a broker that has stopped
+// answering, leaving SIGKILL as the only way out and losing all three artifacts.
+//
+// The bound is therefore on the WAITING rather than on the calls: the pass runs on a
+// goroutine and this returns when it finishes or when the timeout fires, whichever
+// comes first, abandoning whatever call is in flight. The connection under it is closed
+// moments later by the runner's closers, which is what unblocks the abandoned call.
+//
+// The abandoned goroutine never gets the caller's channel. The runner closes the
+// observation channel as soon as the sources are done (close(obs) after srcWG.Wait()),
+// and a send on a closed channel panics unrecoverably — an abandoned pass sending on it
+// would kill a run that had already survived its window. So the pass sends on a private
+// relay this function owns and forwards from, and once the timeout fires it forwards no
+// more. The relay's only other reader is nobody, which is safe: enrich's send is
+// already a select on ctx.Done(), so the abandoned pass unwinds and returns the moment
+// its in-flight call comes back.
 func (e *ConsumerGroupEnricher) FinalEnrich(out chan<- Observation) {
-	ctx, cancel := context.WithTimeout(context.Background(), finalFlushTimeout)
+	timeout := e.FinalPassTimeout
+	if timeout <= 0 {
+		timeout = finalFlushTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	e.enrichLogErr(ctx, out)
+
+	relay := make(chan Observation)
+	go func() {
+		// Closed on the way out however the pass ends, which is what tells the
+		// loop below that the pass finished rather than timed out.
+		defer close(relay)
+		e.enrichLogErr(ctx, relay)
+	}()
+
+	for {
+		select {
+		case obs, ok := <-relay:
+			if !ok {
+				return
+			}
+			select {
+			case out <- obs:
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // enrichLogErr runs one pass, logging rather than propagating its error so a single
@@ -232,6 +285,14 @@ func (e *ConsumerGroupEnricher) enrich(ctx context.Context, out chan<- Observati
 
 	now := time.Now()
 	for group := range groups {
+		// Checked before the call, not only at the send below. Once the pass is
+		// cancelled every remaining group costs a round trip whose result the send
+		// will discard, and a group that correlates but has committed nothing
+		// outside the internal topics never reaches that send at all — so without
+		// this a cancelled pass runs to the end of the listing.
+		if ctx.Err() != nil {
+			return nil
+		}
 		matches := correlateByStreamsConvention(group, txnIDs)
 		if len(matches) == 0 {
 			continue

--- a/internal/services/txndiscovery/discovery/consumergroups.go
+++ b/internal/services/txndiscovery/discovery/consumergroups.go
@@ -55,8 +55,10 @@ type ConsumerGroupEnricher struct {
 // Name returns the source name the observations this phase emits are tagged with.
 func (e *ConsumerGroupEnricher) Name() string { return SourceConsumerGroups }
 
-// Run enriches on entry and then on every Interval tick until ctx is done. The first
-// pass is immediate so an observation window shorter than the interval still enriches.
+// Run enriches on entry, then on every Interval tick, and once more as the window
+// closes. The first pass is immediate so an observation window shorter than the
+// interval still enriches; the last one is FinalEnrich, for the ids that arrived too
+// late for any tick to act on.
 func (e *ConsumerGroupEnricher) Run(ctx context.Context, out chan<- Observation) error {
 	e.enrichLogErr(ctx, out)
 	ticker := time.NewTicker(e.Interval)
@@ -64,11 +66,36 @@ func (e *ConsumerGroupEnricher) Run(ctx context.Context, out chan<- Observation)
 	for {
 		select {
 		case <-ctx.Done():
+			e.FinalEnrich(out)
 			return nil
 		case <-ticker.C:
 			e.enrichLogErr(ctx, out)
 		}
 	}
+}
+
+// FinalEnrich runs one last pass as the window closes, on a fresh context.
+//
+// It exists because this phase's last pass is the one most likely to matter, and the
+// one least likely to survive. The transactional ids come from the catalog, which the
+// __transaction_state reader fills as it works from the beginning of a 50-partition
+// compacted log, so an id can arrive tens of seconds into the window — and this
+// phase's admin calls share one sarama Broker connection with that reader's fetches,
+// which makes a pass cost seconds rather than milliseconds. The deciding pass
+// therefore tends to straddle the end of the window, where the observation context is
+// already cancelled: it correlates the group correctly and then discards the result at
+// the send. Without this the recovery is computed and thrown away, and the app's input
+// topic is reported as individually migratable — the exactly-once break R8 exists to
+// prevent.
+//
+// This mirrors ConsumerOffsetsTail.FinalFlush, which exists for the same reason on the
+// same catalog. The timeout is what keeps an unresponsive broker from wedging
+// shutdown, and it also bounds the send: by this point the accumulator is still
+// draining, but nothing may block the run from writing its artifacts indefinitely.
+func (e *ConsumerGroupEnricher) FinalEnrich(out chan<- Observation) {
+	ctx, cancel := context.WithTimeout(context.Background(), finalFlushTimeout)
+	defer cancel()
+	e.enrichLogErr(ctx, out)
 }
 
 // enrichLogErr runs one pass, logging rather than propagating its error so a single

--- a/internal/services/txndiscovery/discovery/consumergroups_test.go
+++ b/internal/services/txndiscovery/discovery/consumergroups_test.go
@@ -326,6 +326,89 @@ func TestConsumerGroupEnricher_EmptyCatalogMakesNoAdminCall(t *testing.T) {
 	}
 }
 
+// A transactional id the catalog gains LATE in the window must still have its
+// consumed input recovered, so the window's end triggers one final pass.
+//
+// This is the pipeline's timing reality, not a hypothetical. The catalog is filled by
+// the __transaction_state reader, which works from the beginning of a 50-partition
+// compacted log, so a transaction's id routinely does not reach the catalog until tens
+// of seconds into the window — and the enricher's own admin calls share one sarama
+// Broker connection with that reader's fetches, so a pass takes seconds rather than
+// milliseconds. The deciding pass therefore straddles the end of the window: it
+// correlates the group correctly and then loses the race between its send and the
+// cancelled context, so the recovery is computed and thrown away. R8's recovery then
+// silently does not happen and the app's input topic is reported as individually
+// migratable — the exactly-once break the phase exists to prevent.
+//
+// The __consumer_offsets phase has the identical problem and solves it with a final
+// flush on a fresh context (see ConsumerOffsetsTail.FinalFlush, "most resolutions land
+// here"). This is that same contract for this phase.
+func TestConsumerGroupEnricher_FinalPassDeliversACorrelationTheCatalogGainedLate(t *testing.T) {
+	// Correlates to no group, so the first pass reaches the admin — which is the
+	// barrier that proves the late arrival really is late — and emits nothing.
+	catalog := NewTxnCatalog()
+	catalog.Observe("unrelated-workload-abc12", 3)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0, 1}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{}) // Interval is an hour: no tick will fire
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan Observation, 4)
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx, out) }()
+
+	// Wait for the immediate pass to have been and gone, so the transaction below
+	// cannot be picked up by it.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if listed, _ := admin.calls(); listed >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the immediate pass never reached the admin, so the late arrival below would not be late")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// The reader decodes the Streams transaction late in the window.
+	catalog.Observe("payments-processor-abc12", 7)
+
+	// The window closes.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v, want nil on cancellation", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+
+	close(out)
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	if len(got) != 1 {
+		t.Fatalf("delivered %d observations, want 1: the correlation the catalog gained late in the window was never emitted, so the consumed input is lost: %+v", len(got), got)
+	}
+	if got[0].TxnID != "payments-processor-abc12" {
+		t.Errorf("observation TxnID = %q, want the late-arriving correlated transactional id", got[0].TxnID)
+	}
+	if want := []string{"payments.requests"}; !reflect.DeepEqual(got[0].Topics, want) {
+		t.Errorf("observation Topics = %v, want %v", got[0].Topics, want)
+	}
+	if got[0].Source != SourceConsumerGroups {
+		t.Errorf("observation Source = %q, want %q", got[0].Source, SourceConsumerGroups)
+	}
+}
+
 // A coordinator moving, a rebalance, or a momentary ACL problem fails one pass. That
 // must not end enrichment for the rest of the window, and it must not vanish either:
 // the operator needs the failure in the log to know the phase was degraded.

--- a/internal/services/txndiscovery/discovery/consumergroups_test.go
+++ b/internal/services/txndiscovery/discovery/consumergroups_test.go
@@ -491,3 +491,56 @@ func TestConsumerGroupEnricher_GroupWithUnreadableOffsetsIsSkippedAndThePassCont
 		t.Errorf("skipped group was not logged; log was:\n%s", logs.String())
 	}
 }
+
+// kcp.log is unconditionally Debug+ and is the file operators attach to support
+// tickets, so a consumer group id, topic name, or transactional id in ANY log line
+// leaks customer business structure regardless of level — and under --verbose those
+// same lines reach the console. Both of this phase's log paths are driven here, with
+// distinctively-named fixtures, and neither may name anything.
+func TestConsumerGroupEnricher_LogLinesNameNoGroupTopicOrTransaction(t *testing.T) {
+	const (
+		groupID = "qxgroupqx"
+		txnID   = "qxgroupqx-abc12"
+		topic   = "qxtopicqx"
+	)
+
+	catalog := NewTxnCatalog()
+	catalog.Observe(txnID, 7)
+
+	admin := &fakeGroupAdmin{
+		groups:  map[string]string{groupID: "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{groupID: offsetFetch(map[string][]int32{topic: {0}})},
+		// First pass fails at the listing; every later pass reaches — and fails at —
+		// the per-group offsets call, so both log paths fire.
+		listErr:  []error{errors.New("listing blew up")},
+		fetchErr: map[string]error{groupID: errors.New("offsets blew up")},
+	}
+	logs := &syncBuffer{}
+	e := newTestEnricher(admin, catalog, logs)
+	e.Interval = 5 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan Observation, 16)
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx, out) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	got := logs.String()
+	// Both paths must actually have run, or the absence assertions below prove nothing.
+	for _, marker := range []string{"listing blew up", "offsets blew up"} {
+		if !strings.Contains(got, marker) {
+			t.Fatalf("log path %q never fired, so this test would pass vacuously; log was:\n%s", marker, got)
+		}
+	}
+	for name, kind := range map[string]string{
+		groupID: "consumer group id",
+		txnID:   "transactional id",
+		topic:   "topic name",
+	} {
+		if strings.Contains(got, name) {
+			t.Errorf("log leaked a %s (%q); log was:\n%s", kind, name, got)
+		}
+	}
+}

--- a/internal/services/txndiscovery/discovery/consumergroups_test.go
+++ b/internal/services/txndiscovery/discovery/consumergroups_test.go
@@ -110,6 +110,148 @@ func offsetFetch(topicPartitions map[string][]int32) *sarama.OffsetFetchResponse
 	return resp
 }
 
+// The pass count is the cadence signal: --interval 5s over a 60s window should
+// yield thirteen passes, and there is otherwise no way to see that a run achieved
+// four. Every completed pass counts, including one that short-circuited on an empty
+// catalog — the question this number answers is how many times the loop came round,
+// and a run against an idle cluster that reported zero passes would read as a phase
+// that never started.
+func TestConsumerGroupEnricher_StatsCountEveryCompletedPass(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 16)
+	for range 3 {
+		if err := e.enrich(context.Background(), out); err != nil {
+			t.Fatalf("enrich returned %v, want nil", err)
+		}
+	}
+
+	if got := e.Stats().Passes; got != 3 {
+		t.Errorf("Stats().Passes = %d, want 3", got)
+	}
+}
+
+// A failed pass is not a completed one. Folding the two together would let a phase
+// whose every pass failed report a full-cadence run: thirteen passes, no
+// correlations — indistinguishable from a healthy run against a cluster with no
+// exactly-once traffic.
+func TestConsumerGroupEnricher_StatsCountAFailedPassAsAFailureNotACompletion(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+		listErr: []error{errors.New("coordinator not available"), nil},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 16)
+	if err := e.enrich(context.Background(), out); err == nil {
+		t.Fatal("enrich returned nil on a failed listing, want an error")
+	}
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("second enrich returned %v, want nil", err)
+	}
+
+	got := e.Stats()
+	if got.PassFailures != 1 {
+		t.Errorf("Stats().PassFailures = %d, want 1", got.PassFailures)
+	}
+	if got.Passes != 1 {
+		t.Errorf("Stats().Passes = %d, want 1 — a failed pass must not count as completed", got.Passes)
+	}
+}
+
+// GroupsListed is what separates "the naming convention matched nothing" from "the
+// credentials could not see a single group". Both recover no inputs, and a pass count
+// alone reports them identically.
+//
+// It is the most any one pass saw rather than a running total, because the listing
+// repeats every pass: summing it would multiply one cluster's group count by the
+// cadence, and reporting the last pass's figure would let a rebalance at the window's
+// close understate the estate.
+func TestConsumerGroupEnricher_StatsReportTheLargestGroupListingAnyPassSaw(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{
+			"payments-processor": "consumer",
+			"analytics-reader":   "consumer",
+			"audit-sink":         "consumer",
+		},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 16)
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("enrich returned %v, want nil", err)
+	}
+	// A rebalance takes two groups away for the next pass. The larger figure survives.
+	admin.groups = map[string]string{"payments-processor": "consumer"}
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("second enrich returned %v, want nil", err)
+	}
+
+	if got := e.Stats().GroupsListed; got != 3 {
+		t.Errorf("Stats().GroupsListed = %d, want 3 (the most any single pass listed, not a sum and not the last)", got)
+	}
+}
+
+// Correlations is the number that says enrichment did its job: a run that listed four
+// hundred groups and correlated none has a naming convention that does not hold on that
+// cluster, which is invisible from any other count.
+//
+// It counts DISTINCT group-to-transaction links across the whole run, not per pass:
+// every pass re-correlates the same groups, so a per-pass sum would report the same
+// single recovery thirteen times.
+func TestConsumerGroupEnricher_StatsCountDistinctCorrelationsAcrossPasses(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+	catalog.Observe("payments-processor-def34", 8)
+	catalog.Observe("analytics-reader-0_0", 9)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{
+			"payments-processor": "consumer",
+			"analytics-reader":   "consumer",
+			"audit-sink":         "consumer", // correlates to nothing in the catalog
+		},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+			"analytics-reader":   offsetFetch(map[string][]int32{"analytics.raw": {0}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 64)
+	for range 3 {
+		if err := e.enrich(context.Background(), out); err != nil {
+			t.Fatalf("enrich returned %v, want nil", err)
+		}
+	}
+
+	// payments-processor -> two transactional ids, analytics-reader -> one.
+	if got := e.Stats().Correlations; got != 3 {
+		t.Errorf("Stats().Correlations = %d, want 3 distinct links (three passes must not report nine)", got)
+	}
+}
+
 func TestCorrelateByStreamsConvention_ExactNameMatches(t *testing.T) {
 	txnIDs := []string{"analytics-a", "payments-processor", "audit"}
 

--- a/internal/services/txndiscovery/discovery/consumergroups_test.go
+++ b/internal/services/txndiscovery/discovery/consumergroups_test.go
@@ -1,0 +1,493 @@
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+// The seam has to be satisfiable by the real thing: U11 injects a
+// sarama.NewClusterAdminFromClient over the same client the tail holds. This fails to
+// compile if either signature drifts from sarama's.
+var _ ConsumerGroupAdmin = (sarama.ClusterAdmin)(nil)
+
+// fakeGroupAdmin stands in for sarama's ClusterAdmin at the ConsumerGroupAdmin seam.
+type fakeGroupAdmin struct {
+	mu sync.Mutex
+
+	groups   map[string]string                      // group id -> protocol type
+	offsets  map[string]*sarama.OffsetFetchResponse // group id -> committed offsets
+	listErr  []error                                // consumed one per pass; nil means success
+	fetchErr map[string]error                       // group id -> error from the offsets call
+
+	listCalls  int
+	fetchCalls []string
+}
+
+func (f *fakeGroupAdmin) ListConsumerGroups() (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls++
+	if len(f.listErr) > 0 {
+		err := f.listErr[0]
+		f.listErr = f.listErr[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return f.groups, nil
+}
+
+func (f *fakeGroupAdmin) ListConsumerGroupOffsets(group string, _ map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchCalls = append(f.fetchCalls, group)
+	if err := f.fetchErr[group]; err != nil {
+		return nil, err
+	}
+	resp, ok := f.offsets[group]
+	if !ok {
+		return offsetFetch(nil), nil
+	}
+	return resp, nil
+}
+
+func (f *fakeGroupAdmin) calls() (list int, fetch []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listCalls, append([]string(nil), f.fetchCalls...)
+}
+
+// syncBuffer is a log sink safe to read from the test goroutine while Run's goroutine
+// writes to it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func newTestEnricher(admin ConsumerGroupAdmin, catalog *TxnCatalog, logTo *syncBuffer) *ConsumerGroupEnricher {
+	return &ConsumerGroupEnricher{
+		Admin:    admin,
+		Catalog:  catalog,
+		Interval: time.Hour,
+		Log:      slog.New(slog.NewTextHandler(logTo, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+}
+
+// offsetFetch builds the shape sarama's ClusterAdmin returns for a group's committed
+// offsets: one block per topic partition.
+func offsetFetch(topicPartitions map[string][]int32) *sarama.OffsetFetchResponse {
+	resp := &sarama.OffsetFetchResponse{
+		Blocks: make(map[string]map[int32]*sarama.OffsetFetchResponseBlock, len(topicPartitions)),
+	}
+	for topic, partitions := range topicPartitions {
+		blocks := make(map[int32]*sarama.OffsetFetchResponseBlock, len(partitions))
+		for _, p := range partitions {
+			blocks[p] = &sarama.OffsetFetchResponseBlock{Offset: 42}
+		}
+		resp.Blocks[topic] = blocks
+	}
+	return resp
+}
+
+func TestCorrelateByStreamsConvention_ExactNameMatches(t *testing.T) {
+	txnIDs := []string{"analytics-a", "payments-processor", "audit"}
+
+	got := correlateByStreamsConvention("payments-processor", txnIDs)
+
+	want := []string{"payments-processor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("correlateByStreamsConvention = %v, want %v", got, want)
+	}
+}
+
+// Kafka Streams derives transactional.id from application.id (== group.id) by
+// appending a taskId under EOS-v1 ("<app>-<taskId>") or a processId under EOS-v2
+// ("<app>-<processId>"). Both suffix forms must correlate back to the group.
+func TestCorrelateByStreamsConvention_EOSSuffixFormsMatch(t *testing.T) {
+	txnIDs := []string{
+		"payments-processor-0_0",   // EOS-v1 taskId suffix
+		"payments-processor-abc12", // EOS-v2 processId suffix
+		"analytics-a",
+	}
+
+	got := correlateByStreamsConvention("payments-processor", txnIDs)
+
+	want := []string{"payments-processor-0_0", "payments-processor-abc12"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("correlateByStreamsConvention = %v, want %v", got, want)
+	}
+}
+
+// A bare strings.HasPrefix(id, group) correlates "payments-processor2" — a
+// DIFFERENT application — to the "payments-processor" group, folding one app's
+// input topics into another app's transaction and coupling two unrelated
+// workloads into one migration group. The convention appends "-<suffix>", so the
+// separator is part of the prefix.
+func TestCorrelateByStreamsConvention_SharedPrefixWithoutHyphenBoundaryDoesNotMatch(t *testing.T) {
+	txnIDs := []string{
+		"payments-processor2",      // no "-" boundary: a different application
+		"payments-processorX-0_0",  // no "-" boundary before the suffix either
+		"payments-processor-abc12", // genuine EOS-v2 suffix
+	}
+
+	got := correlateByStreamsConvention("payments-processor", txnIDs)
+
+	want := []string{"payments-processor-abc12"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("correlateByStreamsConvention = %v, want %v", got, want)
+	}
+}
+
+// Abuse case. The group id comes from the broker, and an empty one is reachable:
+// pre-2.2 simple consumers committed offsets under group.id "". With group == ""
+// the boundary prefix degenerates to "-", which matches EVERY transactional id
+// beginning with a hyphen — ids that share not one character of application name
+// with the group. That group's committed topics would then be folded into
+// unrelated tenants' transactions. An empty group correlates to nothing.
+func TestCorrelateByStreamsConvention_EmptyGroupIDCorrelatesToNothing(t *testing.T) {
+	txnIDs := []string{"-payments-abc12", "-analytics", "payments-processor"}
+
+	got := correlateByStreamsConvention("", txnIDs)
+
+	if len(got) != 0 {
+		t.Errorf("empty group id correlated to %v, want no matches", got)
+	}
+}
+
+// The topics a group has committed offsets for are exactly the topics it consumes.
+// Each is named once regardless of how many partitions it committed, and the order
+// is stable — sarama hands back a map, whose iteration order is not.
+func TestConsumedTopics_NamesEachCommittedTopicOnceInSortedOrder(t *testing.T) {
+	resp := offsetFetch(map[string][]int32{
+		"payments.requests": {0, 1, 2},
+		"audit.events":      {0},
+	})
+
+	got := consumedTopics(resp)
+
+	want := []string{"audit.events", "payments.requests"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("consumedTopics = %v, want %v", got, want)
+	}
+}
+
+// An EOS group commits its offsets THROUGH the transaction, so __consumer_offsets
+// shows up among its committed topics. Reporting it as a consumed input would make
+// every EOS group on the cluster share a topic, chaining unrelated workloads into
+// one migration group.
+func TestConsumedTopics_DropsInternalTopics(t *testing.T) {
+	resp := offsetFetch(map[string][]int32{
+		"payments.requests":  {0, 1},
+		"__consumer_offsets": {12},
+	})
+
+	got := consumedTopics(resp)
+
+	want := []string{"payments.requests"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("consumedTopics = %v, want %v", got, want)
+	}
+}
+
+// One pass over the cluster: for every consumer group that correlates to a known
+// transactional id, the topics that group consumes become an observation against
+// that transaction. Groups that correlate to nothing cost no offsets call.
+func TestConsumerGroupEnricher_EmitsConsumedTopicsForEachCorrelatedTransaction(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+	catalog.Observe("analytics-aggregator-1", 9)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0, 1}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 4)
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("enrich returned %v, want nil", err)
+	}
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	if len(got) != 1 {
+		t.Fatalf("emitted %d observations, want 1: %+v", len(got), got)
+	}
+	if got[0].TxnID != "payments-processor-abc12" {
+		t.Errorf("observation TxnID = %q, want the correlated transactional id", got[0].TxnID)
+	}
+	if want := []string{"payments.requests"}; !reflect.DeepEqual(got[0].Topics, want) {
+		t.Errorf("observation Topics = %v, want %v", got[0].Topics, want)
+	}
+	if got[0].Source != SourceConsumerGroups {
+		t.Errorf("observation Source = %q, want %q", got[0].Source, SourceConsumerGroups)
+	}
+	if _, fetched := admin.calls(); !reflect.DeepEqual(fetched, []string{"payments-processor"}) {
+		t.Errorf("offsets fetched for %v, want only the correlated group", fetched)
+	}
+}
+
+// An observation window shorter than the enrichment interval must still enrich, so
+// the first pass runs on entry rather than on the first tick.
+func TestConsumerGroupEnricher_RunEnrichesImmediatelyNotOnTheFirstTick(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{}) // Interval is an hour
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan Observation, 4)
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx, out) }()
+
+	select {
+	case obs := <-out:
+		if obs.TxnID != "payments-processor-abc12" {
+			t.Errorf("observation TxnID = %q, want the correlated transactional id", obs.TxnID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no observation within 2s: the first pass waited for the interval")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v, want nil on cancellation", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+}
+
+// Abuse case. Until the __transaction_state reader has decoded something there is
+// nothing to correlate against, so a pass can only produce zero observations. Making
+// the admin calls anyway means every tick issues a ListGroups plus one OffsetFetch per
+// group against a production cluster for a run measured in hours — load with no
+// possible result. The catalog check comes before the first admin call.
+func TestConsumerGroupEnricher_EmptyCatalogMakesNoAdminCall(t *testing.T) {
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+	}
+	e := newTestEnricher(admin, NewTxnCatalog(), &syncBuffer{}) // catalog is empty
+	e.Interval = time.Millisecond                               // sweep hard
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan Observation, 64)
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx, out) }()
+
+	time.Sleep(50 * time.Millisecond) // many ticks
+	cancel()
+	<-done
+
+	listed, fetched := admin.calls()
+	if listed != 0 || len(fetched) != 0 {
+		t.Errorf("made %d ListConsumerGroups and %d offset calls against an empty catalog, want 0 and 0", listed, len(fetched))
+	}
+	if len(out) != 0 {
+		t.Errorf("emitted %d observations from an empty catalog, want 0", len(out))
+	}
+}
+
+// A coordinator moving, a rebalance, or a momentary ACL problem fails one pass. That
+// must not end enrichment for the rest of the window, and it must not vanish either:
+// the operator needs the failure in the log to know the phase was degraded.
+func TestConsumerGroupEnricher_FailedPassIsLoggedAndTheNextPassStillRuns(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}}),
+		},
+		listErr: []error{errors.New("coordinator not available")}, // first pass only
+	}
+	logs := &syncBuffer{}
+	e := newTestEnricher(admin, catalog, logs)
+	e.Interval = 5 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan Observation, 16)
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx, out) }()
+
+	select {
+	case obs := <-out:
+		if obs.TxnID != "payments-processor-abc12" {
+			t.Errorf("observation TxnID = %q, want the correlated transactional id", obs.TxnID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no observation after the failed pass: enrichment stopped instead of retrying")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Run returned %v, want nil — a failed pass must not propagate", err)
+	}
+
+	if listed, _ := admin.calls(); listed < 2 {
+		t.Errorf("made %d ListConsumerGroups calls, want at least 2 (the failure plus a retry)", listed)
+	}
+	if !strings.Contains(logs.String(), "coordinator not available") {
+		t.Errorf("failed pass was not logged; log was:\n%s", logs.String())
+	}
+}
+
+// The pipeline contract, against a real Accumulator rather than a mock. The
+// __transaction_state reader supplies the PRODUCED topics and the real producer id;
+// enrichment supplies the CONSUMED input under the same transactional id. They must
+// union into one footprint marked read-process-write — that flag is what tells the
+// report the group's inputs came from a recovery phase rather than the footprint.
+//
+// The producer id is the second half of the contract. Enrichment has no producer id,
+// so it emits 0; the accumulator's positive-only guard is what stops that 0 from
+// erasing the real id, which is the only key the __consumer_offsets phase can join a
+// transactional offset commit on. Losing it here would silently disable that phase.
+func TestConsumerGroupEnricher_RecoveredInputFoldsIntoTheProducedFootprint(t *testing.T) {
+	const (
+		txnID          = "payments-processor-abc12"
+		realProducerID = int64(5000)
+	)
+
+	catalog := NewTxnCatalog()
+	catalog.Observe(txnID, realProducerID)
+
+	acc := NewAccumulator()
+	acc.Add(Observation{
+		TxnID:            txnID,
+		ProducerID:       realProducerID,
+		Topics:           []string{"payments.approved", "payments.ledger", "__consumer_offsets"},
+		ReadProcessWrite: true,
+		Source:           SourceTxnStateLog,
+		ObservedAt:       time.Now(),
+	})
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"payments-processor": offsetFetch(map[string][]int32{
+				"payments.requests":  {0, 1},
+				"__consumer_offsets": {12},
+			}),
+		},
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	out := make(chan Observation, 4)
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("enrich returned %v, want nil", err)
+	}
+	close(out)
+	for obs := range out {
+		if !obs.ReadProcessWrite {
+			t.Error("enrichment observation is not marked read-process-write")
+		}
+		if obs.ProducerID != 0 {
+			t.Errorf("enrichment observation carries ProducerID %d, want 0 — it has no producer id to report", obs.ProducerID)
+		}
+		acc.Add(obs)
+	}
+
+	snap := acc.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("accumulated %d footprints, want 1", len(snap))
+	}
+	got := snap[0]
+	wantTopics := []string{
+		"__consumer_offsets",
+		"payments.approved",
+		"payments.ledger",
+		"payments.requests",
+	}
+	if !reflect.DeepEqual(got.Topics, wantTopics) {
+		t.Errorf("merged footprint = %v, want %v (the consumed input must union with the produced set)", got.Topics, wantTopics)
+	}
+	if !got.ReadProcessWrite {
+		t.Error("merged footprint is not read-process-write")
+	}
+	if got.ProducerID != realProducerID {
+		t.Errorf("footprint ProducerID = %d, want %d — enrichment's zero id clobbered the real one", got.ProducerID, realProducerID)
+	}
+	if want := []string{SourceConsumerGroups, SourceTxnStateLog}; !reflect.DeepEqual(got.Sources, want) {
+		t.Errorf("footprint Sources = %v, want %v", got.Sources, want)
+	}
+}
+
+// A group rebalancing mid-pass fails its own offsets call. Abandoning the whole pass
+// would make one busy application's rebalance rate decide whether every other
+// application on the cluster ever gets enriched.
+func TestConsumerGroupEnricher_GroupWithUnreadableOffsetsIsSkippedAndThePassContinues(t *testing.T) {
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+	catalog.Observe("analytics-aggregator-0_0", 8)
+
+	admin := &fakeGroupAdmin{
+		groups: map[string]string{
+			"payments-processor":   "consumer",
+			"analytics-aggregator": "consumer",
+		},
+		offsets: map[string]*sarama.OffsetFetchResponse{
+			"analytics-aggregator": offsetFetch(map[string][]int32{"analytics.raw": {0}}),
+		},
+		fetchErr: map[string]error{"payments-processor": errors.New("rebalance in progress")},
+	}
+	logs := &syncBuffer{}
+	e := newTestEnricher(admin, catalog, logs)
+
+	out := make(chan Observation, 8)
+	if err := e.enrich(context.Background(), out); err != nil {
+		t.Fatalf("enrich returned %v, want nil — one group's failure is not the pass's failure", err)
+	}
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	if len(got) != 1 {
+		t.Fatalf("emitted %d observations, want 1 (the group that could be read): %+v", len(got), got)
+	}
+	if got[0].TxnID != "analytics-aggregator-0_0" {
+		t.Errorf("observation TxnID = %q, want the readable group's transaction", got[0].TxnID)
+	}
+	if !strings.Contains(logs.String(), "rebalance in progress") {
+		t.Errorf("skipped group was not logged; log was:\n%s", logs.String())
+	}
+}

--- a/internal/services/txndiscovery/discovery/consumergroups_test.go
+++ b/internal/services/txndiscovery/discovery/consumergroups_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -28,32 +30,48 @@ type fakeGroupAdmin struct {
 	listErr  []error                                // consumed one per pass; nil means success
 	fetchErr map[string]error                       // group id -> error from the offsets call
 
+	// delay makes every call take this long before it answers, standing in for a
+	// degraded broker. sarama's ListConsumerGroups and ListConsumerGroupOffsets
+	// take no context at all, so this is the only shape a slow one has: a call
+	// that cannot be abandoned from the inside.
+	delay time.Duration
+
 	listCalls  int
 	fetchCalls []string
 }
 
 func (f *fakeGroupAdmin) ListConsumerGroups() (map[string]string, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.listCalls++
+	var err error
 	if len(f.listErr) > 0 {
-		err := f.listErr[0]
+		err = f.listErr[0]
 		f.listErr = f.listErr[1:]
-		if err != nil {
-			return nil, err
-		}
 	}
-	return f.groups, nil
+	groups, delay := f.groups, f.delay
+	f.mu.Unlock()
+
+	// Outside the lock, so a test can read the counters while a call is still in
+	// flight — which is the observation this fake exists to make.
+	time.Sleep(delay)
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
 }
 
 func (f *fakeGroupAdmin) ListConsumerGroupOffsets(group string, _ map[string][]int32) (*sarama.OffsetFetchResponse, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.fetchCalls = append(f.fetchCalls, group)
-	if err := f.fetchErr[group]; err != nil {
+	err := f.fetchErr[group]
+	resp, ok := f.offsets[group]
+	delay := f.delay
+	f.mu.Unlock()
+
+	time.Sleep(delay)
+	if err != nil {
 		return nil, err
 	}
-	resp, ok := f.offsets[group]
 	if !ok {
 		return offsetFetch(nil), nil
 	}
@@ -548,6 +566,152 @@ func TestConsumerGroupEnricher_FinalPassDeliversACorrelationTheCatalogGainedLate
 	}
 	if got[0].Source != SourceConsumerGroups {
 		t.Errorf("observation Source = %q, want %q", got[0].Source, SourceConsumerGroups)
+	}
+}
+
+// The final pass runs after the observation context is cancelled, which is the
+// operator's Ctrl-C: nothing is written to disk until it returns, so however long it
+// takes is how long the run holds the whole product of the window hostage.
+//
+// Its fresh context does NOT bound it. sarama's ClusterAdmin.ListConsumerGroups and
+// ListConsumerGroupOffsets take no context (admin.go), so a context can only ever be
+// consulted between calls, never inside one — and a pass makes 1+G of them in
+// sequence, one per naming-matched group. With Net.ReadTimeout 30s, Admin.Retry.Max 5
+// and Metadata.Retry.Max 3 x Metadata.Timeout 15s, ONE degraded call runs for minutes;
+// twenty Streams applications multiply that by twenty. The operator who pressed Ctrl-C
+// to bank a four-hour observation waits an hour, and SIGKILL is the only way out —
+// which loses all three artifacts.
+//
+// So the bound has to be on the WAITING, not on the calls: the pass must be abandoned
+// where it stands. The elapsed time is asserted against the timeout regardless of how
+// many groups match and how slow each call is.
+func TestConsumerGroupEnricher_FinalEnrichReturnsWithinItsTimeoutHoweverSlowTheBrokerIs(t *testing.T) {
+	// Per-call latency far above the bound: even the FIRST call, the group
+	// listing, outlasts the whole budget.
+	const perCall = 400 * time.Millisecond
+	const bound = 100 * time.Millisecond
+
+	for _, groupCount := range []int{1, 3, 10} {
+		t.Run(fmt.Sprintf("groups=%d", groupCount), func(t *testing.T) {
+			catalog := NewTxnCatalog()
+			admin := &fakeGroupAdmin{
+				groups:  map[string]string{},
+				offsets: map[string]*sarama.OffsetFetchResponse{},
+				delay:   perCall,
+			}
+			for i := range groupCount {
+				group := fmt.Sprintf("app%d", i)
+				catalog.Observe(group+"-abc12", int64(100+i))
+				admin.groups[group] = "consumer"
+				admin.offsets[group] = offsetFetch(map[string][]int32{group + ".in": {0}})
+			}
+			e := newTestEnricher(admin, catalog, &syncBuffer{})
+			e.FinalPassTimeout = bound
+
+			// Drained continuously, so a send can never be what holds the pass up.
+			out := make(chan Observation, 64)
+			drained := make(chan struct{})
+			go func() {
+				defer close(drained)
+				for range out { //nolint:revive // draining is the point
+				}
+			}()
+
+			started := time.Now()
+			e.FinalEnrich(out)
+			elapsed := time.Since(started)
+			close(out)
+			<-drained
+
+			// Generous slack for scheduling, still an order of magnitude below the
+			// 1+G sequential calls the unbounded pass makes.
+			if limit := bound + 200*time.Millisecond; elapsed > limit {
+				t.Errorf("FinalEnrich returned after %s with a %s timeout and %d matching groups, want under %s: shutdown is bounded by the broker, not by the timeout",
+					elapsed, bound, groupCount, limit)
+			}
+		})
+	}
+}
+
+// A pass whose context is already done must stop at the top of the group loop rather
+// than issue an offsets call per matching group.
+//
+// Without the check, cancelling the window commits the run to G more round trips: the
+// loop only ever consults the context at the SEND, which is reached after the call it
+// was meant to prevent. On a cancelled pass every one of those calls is work whose
+// result is thrown away at that same send.
+func TestConsumerGroupEnricher_CancelledPassMakesNoFurtherOffsetsCalls(t *testing.T) {
+	catalog := NewTxnCatalog()
+	admin := &fakeGroupAdmin{
+		groups:  map[string]string{},
+		offsets: map[string]*sarama.OffsetFetchResponse{},
+	}
+	for i := range 5 {
+		group := fmt.Sprintf("app%d", i)
+		catalog.Observe(group+"-abc12", int64(100+i))
+		admin.groups[group] = "consumer"
+		admin.offsets[group] = offsetFetch(map[string][]int32{group + ".in": {0}})
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out := make(chan Observation, 64)
+	if err := e.enrich(ctx, out); err != nil {
+		t.Fatalf("enrich returned %v, want nil on a cancelled pass", err)
+	}
+
+	listed, fetched := admin.calls()
+	if listed != 1 {
+		t.Errorf("made %d ListConsumerGroups calls, want 1 (the call already in flight when the window closed)", listed)
+	}
+	if len(fetched) != 0 {
+		t.Errorf("made %d ListConsumerGroupOffsets calls on a cancelled pass, want 0: %v", len(fetched), fetched)
+	}
+	if len(out) != 0 {
+		t.Errorf("emitted %d observations on a cancelled pass, want 0", len(out))
+	}
+}
+
+// The hazard the bound above introduces, guarded here rather than discovered in
+// production. Abandoning the pass leaves its goroutine mid-call, and the runner closes
+// the observation channel moments later (close(obs) after srcWG.Wait()). A send on a
+// closed channel panics, and a panic in an abandoned goroutine is unrecoverable — it
+// would take down a run that had already survived the window.
+//
+// The abandoned pass therefore never holds the caller's channel: FinalEnrich forwards
+// through a private relay and stops forwarding when the timeout fires, so the only
+// channel the goroutine can send on is one nobody else can close.
+func TestConsumerGroupEnricher_AbandonedFinalPassNeverTouchesTheCallersChannel(t *testing.T) {
+	const perCall = 300 * time.Millisecond
+
+	catalog := NewTxnCatalog()
+	catalog.Observe("payments-processor-abc12", 7)
+	admin := &fakeGroupAdmin{
+		groups:  map[string]string{"payments-processor": "consumer"},
+		offsets: map[string]*sarama.OffsetFetchResponse{"payments-processor": offsetFetch(map[string][]int32{"payments.requests": {0}})},
+		delay:   perCall,
+	}
+	e := newTestEnricher(admin, catalog, &syncBuffer{})
+	e.FinalPassTimeout = 20 * time.Millisecond
+
+	before := runtime.NumGoroutine()
+	out := make(chan Observation, 8)
+	e.FinalEnrich(out)
+
+	// Exactly what the runner does next.
+	close(out)
+
+	// Long enough for every abandoned call to have come back and the goroutine to
+	// have tried whatever it was going to try.
+	time.Sleep(4 * perCall)
+
+	for obs := range out {
+		t.Errorf("the abandoned pass delivered %+v on the caller's channel after it was closed", obs)
+	}
+	if after := runtime.NumGoroutine(); after > before+1 {
+		t.Errorf("goroutines went from %d to %d: the abandoned pass leaked rather than unwinding once its call returned", before, after)
 	}
 }
 

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -201,6 +201,39 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 	}
 }
 
+// Run consumes batches from in until the channel closes, buffering every
+// transactional offset commit and resolving the buffer against the catalog on
+// the configured interval. When the input ends it performs the final flush.
+//
+// This mirrors the __transaction_state reader's contract: the command wiring
+// owns the tail.Tail, reads its single batch channel, and copies each batch to
+// the reader whose topic it names. Run takes a receive-only channel rather than
+// a Tail precisely so one tail can be demultiplexed across both readers.
+//
+// out must be drained for the duration of the run. Run returns nil on both
+// ordinary endings — the counters on Stats report whether the read was clean.
+func (t *ConsumerOffsetsTail) Run(ctx context.Context, in <-chan tail.Batch, out chan<- Observation) error {
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case b, ok := <-in:
+			if !ok {
+				// The tail has stopped and the fan-out has closed our channel.
+				// The final flush runs on a fresh context because ctx is
+				// already cancelled by now and this is where most resolutions
+				// land.
+				t.FinalFlush(out)
+				return nil
+			}
+			t.HandleBatch(b)
+		case <-ticker.C:
+			t.resolveAndFlush(ctx, out)
+		}
+	}
+}
+
 // HandleBatch records the transactional offset commits carried by one batch.
 //
 // It is the demultiplexing entry point: one tail instance serves both this

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -99,6 +99,13 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		return
 	}
 	for _, r := range b.Records {
+		// A tombstone — a valid key with an empty value — is how the coordinator
+		// DELETES a commit on offset expiry or an admin DeleteOffsets. Its key
+		// still names a topic, so nothing downstream would notice; reading it as
+		// live would report an input the application no longer consumes.
+		if len(r.Value) == 0 {
+			continue
+		}
 		key, err := txnlog.DecodeOffsetKey(r.Key)
 		if err != nil {
 			continue

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
@@ -36,6 +37,8 @@ type ConsumerOffsetsTail struct {
 	catalog *TxnCatalog
 	topic   string
 
+	keyDecodeErrors atomic.Int64
+
 	mu sync.Mutex
 	// pending holds sightings not yet resolved to a transaction: producer id ->
 	// the set of consumed topics it committed offsets for. An entry is removed
@@ -63,6 +66,24 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 		catalog: catalog,
 		topic:   opts.Topic,
 		pending: make(map[int64]map[string]struct{}),
+	}
+}
+
+// ConsumerOffsetsStats is what this source contributes to the run's report.
+type ConsumerOffsetsStats struct {
+	// KeyDecodeErrors counts record keys this source could not parse. Record
+	// keys are a broker-internal format rather than part of the stable client
+	// protocol, so this is the format-drift alarm and is never swallowed.
+	KeyDecodeErrors int64
+}
+
+// Name reports this source's provenance label.
+func (t *ConsumerOffsetsTail) Name() string { return SourceConsumerOffsets }
+
+// Stats returns a snapshot of what this source recovered and how it coped.
+func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
+	return ConsumerOffsetsStats{
+		KeyDecodeErrors: t.keyDecodeErrors.Load(),
 	}
 }
 
@@ -108,6 +129,10 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		}
 		key, err := txnlog.DecodeOffsetKey(r.Key)
 		if err != nil {
+			// Counted, not fatal, and the rest of the batch is still read: the
+			// counter is this source's only format-drift alarm, and abandoning
+			// the batch would silently lose the recoveries after the bad key.
+			t.keyDecodeErrors.Add(1)
 			continue
 		}
 		// An empty topic is a group-metadata record (key version 2): consumer

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -102,6 +102,12 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		if err != nil {
 			continue
 		}
+		// An empty topic is a group-metadata record (key version 2): consumer
+		// group state, not an offset commit. It decodes cleanly, so only this
+		// check stops a nameless topic reaching a real transaction's group.
+		if key.Topic == "" {
+			continue
+		}
 		t.recordCommit(b.ProducerID, key.Topic)
 	}
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -11,11 +11,24 @@ import (
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/txnlog"
 )
 
-// DefaultConsumerOffsetsTopic is Kafka's internal consumer-offsets log.
-const DefaultConsumerOffsetsTopic = "__consumer_offsets"
-
 // finalFlushTimeout bounds the fresh context the final flush runs on.
 const finalFlushTimeout = 10 * time.Second
+
+// DefaultMaxPendingProducers caps how many unresolved producer ids the pending
+// buffer holds.
+//
+// The buffer only ever holds producers whose transaction has NOT been seen, and
+// on a large cluster that is most of them: their state records were compacted
+// before the window opened, or the transaction simply never recurs. Unbounded,
+// it therefore grows for the whole run, which on a multi-hour observation loses
+// the run rather than a request.
+//
+// Twenty thousand entries is roughly an order of magnitude above the producer
+// count of a large exactly-once estate, so a healthy cluster never reaches it
+// and the cap only engages on the pathological case it exists for. Each entry
+// is a map header plus the topic set one consumer group commits offsets for —
+// a few hundred bytes — so the cap bounds this buffer in the low tens of MiB.
+const DefaultMaxPendingProducers = 20000
 
 // ConsumerOffsetsTail recovers the CONSUMED (input) topics of exactly-once
 // applications by joining transactional offset commits to transactions on the
@@ -39,11 +52,36 @@ type ConsumerOffsetsTail struct {
 
 	keyDecodeErrors atomic.Int64
 
+	maxPending int
+
 	mu sync.Mutex
 	// pending holds sightings not yet resolved to a transaction: producer id ->
-	// the set of consumed topics it committed offsets for. An entry is removed
-	// once its producer id resolves and is emitted.
-	pending map[int64]map[string]struct{}
+	// the consumed topics it committed offsets for. An entry is removed once its
+	// producer id resolves and is emitted, or when it is evicted.
+	pending map[int64]*pendingCommits
+	// order lists pending entries oldest first, so eviction can drop the
+	// longest-waiting without scanning the map. It may hold references to
+	// entries that have since resolved or been replaced; seq disambiguates.
+	order []pendingRef
+	// seq numbers pending entries in creation order.
+	seq uint64
+	// evictedByCapacity counts entries dropped because the buffer was full.
+	evictedByCapacity int64
+}
+
+// pendingCommits is one producer's unresolved sighting.
+type pendingCommits struct {
+	topics map[string]struct{}
+	// seq is this entry's position in creation order. A producer that resolves
+	// and then commits again gets a new one, so a stale order entry naming the
+	// same producer id cannot evict the fresh sighting.
+	seq uint64
+}
+
+// pendingRef points at a pending entry as it was when it was created.
+type pendingRef struct {
+	pid int64
+	seq uint64
 }
 
 // ConsumerOffsetsOptions configures a ConsumerOffsetsTail. The zero value is
@@ -54,6 +92,11 @@ type ConsumerOffsetsOptions struct {
 	// the same place rather than hardcoded on both sides. Defaults to
 	// DefaultConsumerOffsetsTopic.
 	Topic string
+
+	// MaxPendingProducers caps how many unresolved producer ids stay buffered.
+	// Past it the longest-waiting entries are dropped and counted. Defaults to
+	// DefaultMaxPendingProducers.
+	MaxPendingProducers int
 }
 
 // NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
@@ -62,10 +105,14 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 	if opts.Topic == "" {
 		opts.Topic = DefaultConsumerOffsetsTopic
 	}
+	if opts.MaxPendingProducers <= 0 {
+		opts.MaxPendingProducers = DefaultMaxPendingProducers
+	}
 	return &ConsumerOffsetsTail{
-		catalog: catalog,
-		topic:   opts.Topic,
-		pending: make(map[int64]map[string]struct{}),
+		catalog:    catalog,
+		topic:      opts.Topic,
+		maxPending: opts.MaxPendingProducers,
+		pending:    make(map[int64]*pendingCommits),
 	}
 }
 
@@ -75,6 +122,16 @@ type ConsumerOffsetsStats struct {
 	// keys are a broker-internal format rather than part of the stable client
 	// protocol, so this is the format-drift alarm and is never swallowed.
 	KeyDecodeErrors int64
+
+	// PendingProducers is how many sightings are still waiting for their
+	// transaction to appear in the catalog.
+	PendingProducers int
+
+	// PendingEvicted counts sightings dropped from the pending buffer without
+	// ever resolving. It is reported because it is the only signal that a
+	// bounded buffer discarded recoveries: a run that evicted heavily observed
+	// far fewer consumed inputs than the cluster actually has.
+	PendingEvicted int64
 }
 
 // Name reports this source's provenance label.
@@ -82,8 +139,12 @@ func (t *ConsumerOffsetsTail) Name() string { return SourceConsumerOffsets }
 
 // Stats returns a snapshot of what this source recovered and how it coped.
 func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return ConsumerOffsetsStats{
-		KeyDecodeErrors: t.keyDecodeErrors.Load(),
+		KeyDecodeErrors:  t.keyDecodeErrors.Load(),
+		PendingProducers: len(t.pending),
+		PendingEvicted:   t.evictedByCapacity,
 	}
 }
 
@@ -158,12 +219,56 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 func (t *ConsumerOffsetsTail) recordCommit(pid int64, topic string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	set := t.pending[pid]
-	if set == nil {
-		set = make(map[string]struct{})
-		t.pending[pid] = set
+
+	e := t.pending[pid]
+	if e == nil {
+		// Only a NEW producer grows the buffer; another commit from one already
+		// buffered costs at most one more topic.
+		if len(t.pending) >= t.maxPending {
+			t.evictOldestLocked()
+		}
+		t.seq++
+		e = &pendingCommits{topics: make(map[string]struct{}), seq: t.seq}
+		t.pending[pid] = e
+		t.order = append(t.order, pendingRef{pid: pid, seq: e.seq})
+		t.compactOrderLocked()
 	}
-	set[topic] = struct{}{}
+	e.topics[topic] = struct{}{}
+}
+
+// evictOldestLocked drops the longest-waiting pending entry. A sighting that
+// has waited longest is the least likely ever to resolve, and dropping the
+// newest instead would discard the commits whose transactions the
+// __transaction_state reader is about to reach.
+func (t *ConsumerOffsetsTail) evictOldestLocked() {
+	for len(t.order) > 0 {
+		ref := t.order[0]
+		t.order = t.order[1:]
+		// Skip references to entries that have since resolved, or that were
+		// replaced by a later sighting from the same producer.
+		if e, ok := t.pending[ref.pid]; ok && e.seq == ref.seq {
+			delete(t.pending, ref.pid)
+			t.evictedByCapacity++
+			return
+		}
+	}
+}
+
+// compactOrderLocked drops stale references so the order list cannot outgrow
+// the buffer it indexes. Resolving an entry leaves its reference behind, so
+// over a long run the list would otherwise grow with total sightings rather
+// than with the bounded number outstanding.
+func (t *ConsumerOffsetsTail) compactOrderLocked() {
+	if len(t.order) <= 2*t.maxPending {
+		return
+	}
+	live := make([]pendingRef, 0, len(t.pending))
+	for _, ref := range t.order {
+		if e, ok := t.pending[ref.pid]; ok && e.seq == ref.seq {
+			live = append(live, ref)
+		}
+	}
+	t.order = live
 }
 
 // FinalFlush resolves everything still buffered, on a fresh context.
@@ -203,7 +308,7 @@ func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Ti
 	defer t.mu.Unlock()
 
 	var out []Observation
-	for pid, topics := range t.pending {
+	for pid, e := range t.pending {
 		txnID, ok := pidToTxn[pid]
 		if !ok {
 			// Its transaction has not been decoded yet — keep waiting. The two
@@ -215,7 +320,7 @@ func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Ti
 		out = append(out, Observation{
 			TxnID:      txnID,
 			ProducerID: pid,
-			Topics:     sortedKeys(topics),
+			Topics:     sortedKeys(e.topics),
 			// A recovered consumed input is by definition an input to a
 			// transaction that committed consumer offsets.
 			ReadProcessWrite: true,

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -56,6 +56,13 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 
 // HandleBatch records the transactional offset commits carried by one batch.
 func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
+	// Only a commit written inside a transaction correlates. A batch header
+	// carries a producer id for a plain idempotent producer too, so joining a
+	// non-transactional commit on it would attribute an unrelated consumer's
+	// topics to whichever transaction happened to share that id.
+	if !b.IsTransactional {
+		return
+	}
 	for _, r := range b.Records {
 		key, err := txnlog.DecodeOffsetKey(r.Key)
 		if err != nil {

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -33,6 +33,7 @@ const finalFlushTimeout = 10 * time.Second
 // than using sarama's consumer API, which discards the batch header.
 type ConsumerOffsetsTail struct {
 	catalog *TxnCatalog
+	topic   string
 
 	mu sync.Mutex
 	// pending holds sightings not yet resolved to a transaction: producer id ->
@@ -42,14 +43,24 @@ type ConsumerOffsetsTail struct {
 }
 
 // ConsumerOffsetsOptions configures a ConsumerOffsetsTail. The zero value is
-// usable.
-type ConsumerOffsetsOptions struct{}
+// usable: every field falls back to its package default.
+type ConsumerOffsetsOptions struct {
+	// Topic is the offsets log to demultiplex out of the shared tail channel.
+	// It must match the TopicSpec the tail was started with, so it is set from
+	// the same place rather than hardcoded on both sides. Defaults to
+	// DefaultConsumerOffsetsTopic.
+	Topic string
+}
 
 // NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
 // __transaction_state reader populates.
 func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *ConsumerOffsetsTail {
+	if opts.Topic == "" {
+		opts.Topic = DefaultConsumerOffsetsTopic
+	}
 	return &ConsumerOffsetsTail{
 		catalog: catalog,
+		topic:   opts.Topic,
 		pending: make(map[int64]map[string]struct{}),
 	}
 }
@@ -61,7 +72,7 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 // topics into a single channel, so batches for other topics are this
 // consumer's to ignore.
 func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
-	if b.Topic != DefaultConsumerOffsetsTopic {
+	if b.Topic != t.topic {
 		return
 	}
 	// Only a commit written inside a transaction correlates. A batch header

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -1,0 +1,138 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/txnlog"
+)
+
+// DefaultConsumerOffsetsTopic is Kafka's internal consumer-offsets log.
+const DefaultConsumerOffsetsTopic = "__consumer_offsets"
+
+// finalFlushTimeout bounds the fresh context the final flush runs on.
+const finalFlushTimeout = 10 * time.Second
+
+// ConsumerOffsetsTail recovers the CONSUMED (input) topics of exactly-once
+// applications by joining transactional offset commits to transactions on the
+// record-batch producer id.
+//
+// A transaction's footprint names only what it PRODUCED. When an exactly-once
+// app commits its consumer offsets inside the transaction
+// (sendOffsetsToTransaction), that commit is written to __consumer_offsets as a
+// TRANSACTIONAL record: the batch header carries the producer id, and the
+// record key carries the consumer group and the consumed topic. The
+// __transaction_state reader has already recorded which transactional id that
+// producer id belongs to, so joining the two on the producer id ties the
+// consumed topic to the exact transaction — with no assumption about how the
+// group id and the transactional id are named.
+//
+// That join is the entire reason this feature reads raw fetch responses rather
+// than using sarama's consumer API, which discards the batch header.
+type ConsumerOffsetsTail struct {
+	catalog *TxnCatalog
+
+	mu sync.Mutex
+	// pending holds sightings not yet resolved to a transaction: producer id ->
+	// the set of consumed topics it committed offsets for. An entry is removed
+	// once its producer id resolves and is emitted.
+	pending map[int64]map[string]struct{}
+}
+
+// ConsumerOffsetsOptions configures a ConsumerOffsetsTail. The zero value is
+// usable.
+type ConsumerOffsetsOptions struct{}
+
+// NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
+// __transaction_state reader populates.
+func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *ConsumerOffsetsTail {
+	return &ConsumerOffsetsTail{
+		catalog: catalog,
+		pending: make(map[int64]map[string]struct{}),
+	}
+}
+
+// HandleBatch records the transactional offset commits carried by one batch.
+func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
+	for _, r := range b.Records {
+		key, err := txnlog.DecodeOffsetKey(r.Key)
+		if err != nil {
+			continue
+		}
+		t.recordCommit(b.ProducerID, key.Topic)
+	}
+}
+
+// recordCommit buffers one sighting: producer id pid committed an offset for
+// consumed topic. It stays buffered until the producer id resolves to a
+// transaction.
+func (t *ConsumerOffsetsTail) recordCommit(pid int64, topic string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	set := t.pending[pid]
+	if set == nil {
+		set = make(map[string]struct{})
+		t.pending[pid] = set
+	}
+	set[topic] = struct{}{}
+}
+
+// FinalFlush resolves everything still buffered, on a fresh context.
+//
+// It exists because most resolutions land here: a short-lived transaction may
+// only reach the __transaction_state reader late in the window, long after its
+// offset commit was buffered. The observation context is already cancelled by
+// the time the run winds down, so a flush on it would send nothing.
+func (t *ConsumerOffsetsTail) FinalFlush(out chan<- Observation) {
+	ctx, cancel := context.WithTimeout(context.Background(), finalFlushTimeout)
+	defer cancel()
+	t.resolveAndFlush(ctx, out)
+}
+
+// resolveAndFlush reads the current producer-id -> transactional-id map from
+// the shared catalog and emits an observation for every pending sighting that
+// now resolves.
+func (t *ConsumerOffsetsTail) resolveAndFlush(ctx context.Context, out chan<- Observation) {
+	for _, obs := range t.resolveWith(t.catalog.ProducerIDToTxnID(), time.Now()) {
+		select {
+		case out <- obs:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// resolveWith is the pure join at the heart of this unit: every pending
+// sighting whose producer id appears in pidToTxn becomes an observation under
+// that transaction and leaves the buffer. It keys purely on the producer id, so
+// it correlates a consumer group to its transaction however their names relate.
+//
+// Observations are returned rather than sent so the caller can respect its
+// context without holding the lock.
+func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Time) []Observation {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var out []Observation
+	for pid, topics := range t.pending {
+		txnID, ok := pidToTxn[pid]
+		if !ok {
+			// Its transaction has not been decoded yet — keep waiting.
+			continue
+		}
+		out = append(out, Observation{
+			TxnID:      txnID,
+			ProducerID: pid,
+			Topics:     sortedKeys(topics),
+			// A recovered consumed input is by definition an input to a
+			// transaction that committed consumer offsets.
+			ReadProcessWrite: true,
+			Source:           SourceConsumerOffsets,
+			ObservedAt:       now,
+		})
+		delete(t.pending, pid)
+	}
+	return out
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -176,6 +176,10 @@ type ConsumerOffsetsOptions struct {
 // Reading __consumer_offsets is an optional grant: managed clusters hide the
 // topic and an operator's credentials may simply lack the ACL. The command
 // wiring supplies the probe so this package needs no admin client of its own.
+//
+// The returned error reaches both the console and kcp.log verbatim, so it must
+// name the failure — a missing topic and a missing ACL need different fixes —
+// without carrying a customer topic name, consumer group id or transactional id.
 type TopicProbe func(ctx context.Context) error
 
 // NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
@@ -408,7 +412,14 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 			// Counted, not fatal, and the rest of the batch is still read: the
 			// counter is this source's only format-drift alarm, and abandoning
 			// the batch would silently lose the recoveries after the bad key.
+			// The count is what the summary reports; the per-record detail stays
+			// at Debug so sustained drift cannot flood the console under
+			// --verbose. The offset is the diagnostic — the group and topic the
+			// key would have named are disclosure, and kcp.log is Debug+
+			// unconditionally and is attached to support tickets.
 			t.keyDecodeErrors.Add(1)
+			slog.Debug("⏭️ skipped a consumer-offsets record whose key would not decode",
+				"offset", r.Offset, "error", err)
 			continue
 		}
 		// An empty topic is a group-metadata record (key version 2): consumer

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -89,11 +90,22 @@ type ConsumerOffsetsTail struct {
 	// evicted counts sightings dropped without ever resolving — because the
 	// buffer was full, or because they aged out.
 	evicted int64
+
+	// Recovery attribution, cumulative across the run and counted only on
+	// delivery. The report credits each recovered input to the phase that found
+	// it, and it cannot infer that afterwards: both enrichment phases emit under
+	// the same transactional id and the accumulator unions them.
+	groupsLinked map[string]struct{}
+	correlations map[string]struct{} // "producerID\x00txnID"
+	recovered    map[string]struct{} // consumed topics this phase recovered
 }
 
 // pendingCommits is one producer's unresolved sighting.
 type pendingCommits struct {
 	topics map[string]struct{}
+	// group is the consumer group that committed, kept for the linked-group
+	// count only. It is never logged and never written to an artifact.
+	group string
 	// firstSeen is when this producer was first buffered. The TTL runs from
 	// here rather than from the last commit, because the question a sighting
 	// ages out on is "has its transaction shown up yet?", and a producer that
@@ -186,6 +198,20 @@ type ConsumerOffsetsStats struct {
 	// bounded buffer discarded recoveries: a run that evicted heavily observed
 	// far fewer consumed inputs than the cluster actually has.
 	PendingEvicted int64
+
+	// GroupsLinked is how many consumer groups were tied to a transaction by
+	// producer id.
+	GroupsLinked int
+
+	// Correlations is how many distinct producer-id to transactional-id links
+	// were resolved.
+	Correlations int
+
+	// RecoveredTopics are the consumed input topics THIS phase recovered,
+	// sorted. The report credits each input to the phase that found it, and
+	// cannot infer that afterwards: both enrichment phases emit under the same
+	// transactional id and the accumulator unions them.
+	RecoveredTopics []string
 }
 
 // Name reports this source's provenance label.
@@ -199,6 +225,9 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 		KeyDecodeErrors:  t.keyDecodeErrors.Load(),
 		PendingProducers: len(t.pending),
 		PendingEvicted:   t.evicted,
+		GroupsLinked:     len(t.groupsLinked),
+		Correlations:     len(t.correlations),
+		RecoveredTopics:  sortedKeys(t.recovered),
 	}
 }
 
@@ -296,14 +325,14 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		if grouping.IsInternalTopic(key.Topic) {
 			continue
 		}
-		t.recordCommit(b.ProducerID, key.Topic)
+		t.recordCommit(b.ProducerID, key.Group, key.Topic)
 	}
 }
 
 // recordCommit buffers one sighting: producer id pid committed an offset for
 // consumed topic. It stays buffered until the producer id resolves to a
 // transaction.
-func (t *ConsumerOffsetsTail) recordCommit(pid int64, topic string) {
+func (t *ConsumerOffsetsTail) recordCommit(pid int64, group, topic string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -325,6 +354,9 @@ func (t *ConsumerOffsetsTail) recordCommit(pid int64, topic string) {
 		t.compactOrderLocked()
 	}
 	e.topics[topic] = struct{}{}
+	if group != "" {
+		e.group = group
+	}
 }
 
 // evictOldestLocked drops the longest-waiting pending entry. A sighting that
@@ -389,7 +421,7 @@ func (t *ConsumerOffsetsTail) resolveAndFlush(ctx context.Context, out chan<- Ob
 			// time would mean a pass cancelled mid-send had both removed the
 			// sighting and failed to deliver it: the recovery gone, no counter
 			// moving, and the final flush finding nothing left to do.
-			t.forget(obs.ProducerID)
+			t.deliver(obs)
 		case <-ctx.Done():
 			// Abandoned. Everything not yet sent stays buffered for the final
 			// flush, which runs on a context that is not already cancelled.
@@ -404,14 +436,30 @@ func (t *ConsumerOffsetsTail) resolveAndFlush(ctx context.Context, out chan<- Ob
 	t.expire(now)
 }
 
-// forget removes a sighting that has been delivered.
+// deliver records what an observation recovered and drops its sighting from the
+// buffer. It runs only after the observation has been handed to the consumer,
+// so the recovery stats count inputs that actually reached the accumulator
+// rather than ones this source merely resolved.
 //
 // HandleBatch and the resolve passes are serialised by Run's select loop, so no
-// commit can land between an entry being resolved and being forgotten here.
-func (t *ConsumerOffsetsTail) forget(pid int64) {
+// commit can land between an entry being resolved and being delivered here.
+func (t *ConsumerOffsetsTail) deliver(obs Observation) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	delete(t.pending, pid)
+
+	if t.recovered == nil {
+		t.groupsLinked = make(map[string]struct{})
+		t.correlations = make(map[string]struct{})
+		t.recovered = make(map[string]struct{})
+	}
+	if e := t.pending[obs.ProducerID]; e != nil && e.group != "" {
+		t.groupsLinked[e.group] = struct{}{}
+	}
+	t.correlations[strconv.FormatInt(obs.ProducerID, 10)+"\x00"+obs.TxnID] = struct{}{}
+	for _, topic := range obs.Topics {
+		t.recovered[topic] = struct{}{}
+	}
+	delete(t.pending, obs.ProducerID)
 }
 
 // expire drops pending sightings that have gone unresolved for longer than the

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -69,6 +69,8 @@ type ConsumerOffsetsTail struct {
 	catalog *TxnCatalog
 	topic   string
 
+	recordsSeen     atomic.Int64
+	txnRecords      atomic.Int64
 	keyDecodeErrors atomic.Int64
 
 	maxPending int
@@ -184,6 +186,18 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 
 // ConsumerOffsetsStats is what this source contributes to the run's report.
 type ConsumerOffsetsStats struct {
+	// RecordsSeen counts every record delivered on this source's topic,
+	// transactional or not.
+	RecordsSeen int64
+
+	// TxnRecords counts the transactional offset commits that yielded a
+	// consumed topic — the records this source actually correlates on. Its
+	// ratio to RecordsSeen is the diagnostic: a run that read plenty and
+	// correlated none is a cluster with no exactly-once traffic, while a run
+	// that read nothing is a tail that never got going, and without both counts
+	// those look identical.
+	TxnRecords int64
+
 	// KeyDecodeErrors counts record keys this source could not parse. Record
 	// keys are a broker-internal format rather than part of the stable client
 	// protocol, so this is the format-drift alarm and is never swallowed.
@@ -222,6 +236,8 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return ConsumerOffsetsStats{
+		RecordsSeen:      t.recordsSeen.Load(),
+		TxnRecords:       t.txnRecords.Load(),
 		KeyDecodeErrors:  t.keyDecodeErrors.Load(),
 		PendingProducers: len(t.pending),
 		PendingEvicted:   t.evicted,
@@ -274,6 +290,12 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 	if b.Topic != t.topic {
 		return
 	}
+	// Counted before the filters below, so RecordsSeen reports what the tail
+	// delivered on this topic rather than what survived correlation. A run that
+	// read nothing and a run that read plenty and correlated none are different
+	// problems, and only this counter separates them.
+	t.recordsSeen.Add(int64(len(b.Records)))
+
 	// Only a commit written inside a transaction correlates. A batch header
 	// carries a producer id for a plain idempotent producer too, so joining a
 	// non-transactional commit on it would attribute an unrelated consumer's
@@ -325,6 +347,7 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		if grouping.IsInternalTopic(key.Topic) {
 			continue
 		}
+		t.txnRecords.Add(1)
 		t.recordCommit(b.ProducerID, key.Group, key.Topic)
 	}
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"strconv"
 	"sync"
@@ -76,7 +77,13 @@ type ConsumerOffsetsTail struct {
 	maxPending int
 	interval   time.Duration
 	pendingTTL time.Duration
+	probe      TopicProbe
 	now        func() time.Time
+
+	// probeOnce memoises the availability check: Run gates on it and the
+	// command wiring calls it too, but the cluster is asked once per run.
+	probeOnce sync.Once
+	available bool
 
 	mu sync.Mutex
 	// pending holds sightings not yet resolved to a transaction: producer id ->
@@ -92,6 +99,9 @@ type ConsumerOffsetsTail struct {
 	// evicted counts sightings dropped without ever resolving — because the
 	// buffer was full, or because they aged out.
 	evicted int64
+	// unavailableReason is why the probe found the topic unreadable, empty when
+	// it did not.
+	unavailableReason string
 
 	// Recovery attribution, cumulative across the run and counted only on
 	// delivery. The report credits each recovered input to the phase that found
@@ -150,10 +160,23 @@ type ConsumerOffsetsOptions struct {
 	// chances a sighting gets. Defaults to DefaultPendingTTLIntervals.
 	PendingTTLIntervals int
 
+	// Probe reports whether the offsets log can be read on this cluster,
+	// returning an error naming why when it cannot. Nil means "assume
+	// readable": the zero value has to stay usable, and treating a missing
+	// probe as unavailable would silently disable the phase.
+	Probe TopicProbe
+
 	// Now is the clock, injectable so the suite does not wait on real time.
 	// Defaults to time.Now.
 	Now func() time.Time
 }
+
+// TopicProbe reports whether an internal topic can be read on this cluster.
+//
+// Reading __consumer_offsets is an optional grant: managed clusters hide the
+// topic and an operator's credentials may simply lack the ACL. The command
+// wiring supplies the probe so this package needs no admin client of its own.
+type TopicProbe func(ctx context.Context) error
 
 // NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
 // __transaction_state reader populates.
@@ -179,6 +202,7 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 		maxPending: opts.MaxPendingProducers,
 		interval:   opts.Interval,
 		pendingTTL: time.Duration(opts.PendingTTLIntervals) * opts.Interval,
+		probe:      opts.Probe,
 		now:        opts.Now,
 		pending:    make(map[int64]*pendingCommits),
 	}
@@ -226,6 +250,21 @@ type ConsumerOffsetsStats struct {
 	// cannot infer that afterwards: both enrichment phases emit under the same
 	// transactional id and the accumulator unions them.
 	RecoveredTopics []string
+
+	// Unavailable is set when the availability probe found the offsets log
+	// unreadable, so this phase never ran and recovered nothing (R13).
+	//
+	// This is the flag the report gates crediting on. A phase that never ran and
+	// a phase that ran and found nothing both report zero recovered inputs, and
+	// only this distinguishes them — without it the summary would present an
+	// unreadable topic as evidence that the cluster has no read-process-write
+	// applications, which is the opposite of the truth it can support.
+	Unavailable bool
+
+	// UnavailableReason is why the probe failed, empty when it did not. The
+	// warning is unactionable without it: a missing topic and a missing ACL need
+	// different fixes.
+	UnavailableReason string
 }
 
 // Name reports this source's provenance label.
@@ -236,15 +275,44 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return ConsumerOffsetsStats{
-		RecordsSeen:      t.recordsSeen.Load(),
-		TxnRecords:       t.txnRecords.Load(),
-		KeyDecodeErrors:  t.keyDecodeErrors.Load(),
-		PendingProducers: len(t.pending),
-		PendingEvicted:   t.evicted,
-		GroupsLinked:     len(t.groupsLinked),
-		Correlations:     len(t.correlations),
-		RecoveredTopics:  sortedKeys(t.recovered),
+		RecordsSeen:       t.recordsSeen.Load(),
+		TxnRecords:        t.txnRecords.Load(),
+		KeyDecodeErrors:   t.keyDecodeErrors.Load(),
+		PendingProducers:  len(t.pending),
+		PendingEvicted:    t.evicted,
+		GroupsLinked:      len(t.groupsLinked),
+		Correlations:      len(t.correlations),
+		RecoveredTopics:   sortedKeys(t.recovered),
+		Unavailable:       t.unavailableReason != "",
+		UnavailableReason: t.unavailableReason,
 	}
+}
+
+// Available reports whether the offsets log can be read on this cluster,
+// probing once per run and caching the answer.
+//
+// R13: when it is false the command warns and continues with consumer-group
+// enrichment alone rather than failing. Reading __consumer_offsets is an
+// optional grant, and the __transaction_state footprints are still worth having
+// without it.
+func (t *ConsumerOffsetsTail) Available(ctx context.Context) bool {
+	t.probeOnce.Do(func() {
+		if t.probe == nil {
+			t.available = true
+			return
+		}
+		err := t.probe(ctx)
+		t.available = err == nil
+		if err != nil {
+			t.mu.Lock()
+			t.unavailableReason = err.Error()
+			t.mu.Unlock()
+			// The topic name is deliberately absent: kcp.log is unconditionally
+			// Debug+ and is what operators attach to support tickets.
+			slog.Warn("⚠️ the consumer-offsets log cannot be read; recovering exactly-once inputs by consumer-group naming alone", "error", err)
+		}
+	})
+	return t.available
 }
 
 // Run consumes batches from in until the channel closes, buffering every
@@ -259,6 +327,15 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 // out must be drained for the duration of the run. Run returns nil on both
 // ordinary endings — the counters on Stats report whether the read was clean.
 func (t *ConsumerOffsetsTail) Run(ctx context.Context, in <-chan tail.Batch, out chan<- Observation) error {
+	if !t.Available(ctx) {
+		// R13. The input is drained rather than abandoned: the caller fans one
+		// tail channel out to both readers, and walking away from ours would
+		// block that fan-out on an unread send.
+		for range in { //nolint:revive // draining, deliberately
+		}
+		return nil
+	}
+
 	ticker := time.NewTicker(t.interval)
 	defer ticker.Stop()
 

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -206,7 +206,10 @@ func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Ti
 	for pid, topics := range t.pending {
 		txnID, ok := pidToTxn[pid]
 		if !ok {
-			// Its transaction has not been decoded yet — keep waiting.
+			// Its transaction has not been decoded yet — keep waiting. The two
+			// readers race by design: this one starts at latest, the
+			// __transaction_state reader starts at earliest and takes the whole
+			// window to catch up, so a commit routinely arrives first.
 			continue
 		}
 		out = append(out, Observation{

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -63,6 +63,13 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 	if !b.IsTransactional {
 		return
 	}
+	// A control batch is the transaction marker itself, not application data.
+	// The tail component delivers control batches flagged rather than filtering
+	// them, so dropping them is this consumer's job — and a marker is
+	// transactional with a real producer id, so no other filter here stops it.
+	if b.Control {
+		return
+	}
 	for _, r := range b.Records {
 		key, err := txnlog.DecodeOffsetKey(r.Key)
 		if err != nil {

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -379,19 +380,38 @@ func (t *ConsumerOffsetsTail) FinalFlush(out chan<- Observation) {
 func (t *ConsumerOffsetsTail) resolveAndFlush(ctx context.Context, out chan<- Observation) {
 	now := t.now()
 	observations := t.resolveWith(t.catalog.ProducerIDToTxnID(), now)
+
+	for _, obs := range observations {
+		select {
+		case out <- obs:
+			// Only now, once the observation is actually in the consumer's
+			// hands, does the sighting leave the buffer. Dropping it at resolve
+			// time would mean a pass cancelled mid-send had both removed the
+			// sighting and failed to deliver it: the recovery gone, no counter
+			// moving, and the final flush finding nothing left to do.
+			t.forget(obs.ProducerID)
+		case <-ctx.Done():
+			// Abandoned. Everything not yet sent stays buffered for the final
+			// flush, which runs on a context that is not already cancelled.
+			return
+		}
+	}
+
 	// Expire AFTER resolving, never before. A sighting that has just reached its
 	// TTL may be exactly the one the __transaction_state reader has finally
 	// caught up to; expiring first would discard a recovery on the very pass
 	// that could have made it, visible only as an eviction count.
 	t.expire(now)
+}
 
-	for _, obs := range observations {
-		select {
-		case out <- obs:
-		case <-ctx.Done():
-			return
-		}
-	}
+// forget removes a sighting that has been delivered.
+//
+// HandleBatch and the resolve passes are serialised by Run's select loop, so no
+// commit can land between an entry being resolved and being forgotten here.
+func (t *ConsumerOffsetsTail) forget(pid int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.pending, pid)
 }
 
 // expire drops pending sightings that have gone unresolved for longer than the
@@ -418,11 +438,16 @@ func (t *ConsumerOffsetsTail) expire(now time.Time) {
 
 // resolveWith is the pure join at the heart of this unit: every pending
 // sighting whose producer id appears in pidToTxn becomes an observation under
-// that transaction and leaves the buffer. It keys purely on the producer id, so
-// it correlates a consumer group to its transaction however their names relate.
+// that transaction. It keys purely on the producer id, so it correlates a
+// consumer group to its transaction however their names relate.
 //
-// Observations are returned rather than sent so the caller can respect its
-// context without holding the lock.
+// It does NOT remove what it matched. Observations are returned for the caller
+// to send — so sending can respect a context without holding the lock — and the
+// caller calls forget once each one has actually been delivered. Removing here
+// instead would let a pass cancelled mid-send lose the recovery entirely.
+//
+// Sorted by transactional id so a pass over identical state emits in a stable
+// order, which the audit trail is diffed on.
 func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Time) []Observation {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -447,7 +472,7 @@ func (t *ConsumerOffsetsTail) resolveWith(pidToTxn map[int64]string, now time.Ti
 			Source:           SourceConsumerOffsets,
 			ObservedAt:       now,
 		})
-		delete(t.pending, pid)
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TxnID < out[j].TxnID })
 	return out
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -70,6 +70,14 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 	if b.Control {
 		return
 	}
+	// -1 is Kafka's "no producer id" sentinel and 0 is an absent field. Keying a
+	// pending entry on either would pool every producer without an id into one
+	// bucket, and the moment any transaction was catalogued under that sentinel
+	// the whole pool would be attributed to it. The catalog refuses to WRITE a
+	// non-positive id; refusing to READ one is this side's job.
+	if b.ProducerID <= 0 {
+		return
+	}
 	for _, r := range b.Records {
 		key, err := txnlog.DecodeOffsetKey(r.Key)
 		if err != nil {

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/txnlog"
 )
@@ -106,6 +107,13 @@ func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
 		// group state, not an offset commit. It decodes cleanly, so only this
 		// check stops a nameless topic reaching a real transaction's group.
 		if key.Topic == "" {
+			continue
+		}
+		// An exactly-once app routinely commits offsets for internal topics.
+		// Publishing one as a recovered input would give the grouping stage an
+		// edge through a topic every such app shares, and would report a topic
+		// no operator can migrate in the audit trail and the recovery stats.
+		if grouping.IsInternalTopic(key.Topic) {
 			continue
 		}
 		t.recordCommit(b.ProducerID, key.Topic)

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -30,6 +30,23 @@ const finalFlushTimeout = 10 * time.Second
 // a few hundred bytes — so the cap bounds this buffer in the low tens of MiB.
 const DefaultMaxPendingProducers = 20000
 
+// DefaultResolveInterval is how often buffered sightings are resolved against
+// the catalog. Resolution is a map lookup per pending entry, so the cadence is
+// set by how promptly a recovery should reach the audit trail rather than by
+// cost.
+const DefaultResolveInterval = 30 * time.Second
+
+// DefaultPendingTTLIntervals is how many resolve intervals a sighting may go
+// unresolved before it is dropped.
+//
+// The entry cap alone only engages once the buffer is full, which on a
+// moderately busy cluster may be never — so without a TTL a run keeps every
+// sighting from its first minute for hours. Ten intervals is deliberately
+// generous: the __transaction_state reader starts at the log's beginning and
+// can take many minutes to reach the present on a large partition, and every
+// sighting dropped before it gets there is a recovery lost.
+const DefaultPendingTTLIntervals = 10
+
 // ConsumerOffsetsTail recovers the CONSUMED (input) topics of exactly-once
 // applications by joining transactional offset commits to transactions on the
 // record-batch producer id.
@@ -53,6 +70,9 @@ type ConsumerOffsetsTail struct {
 	keyDecodeErrors atomic.Int64
 
 	maxPending int
+	interval   time.Duration
+	pendingTTL time.Duration
+	now        func() time.Time
 
 	mu sync.Mutex
 	// pending holds sightings not yet resolved to a transaction: producer id ->
@@ -65,13 +85,20 @@ type ConsumerOffsetsTail struct {
 	order []pendingRef
 	// seq numbers pending entries in creation order.
 	seq uint64
-	// evictedByCapacity counts entries dropped because the buffer was full.
-	evictedByCapacity int64
+	// evicted counts sightings dropped without ever resolving — because the
+	// buffer was full, or because they aged out.
+	evicted int64
 }
 
 // pendingCommits is one producer's unresolved sighting.
 type pendingCommits struct {
 	topics map[string]struct{}
+	// firstSeen is when this producer was first buffered. The TTL runs from
+	// here rather than from the last commit, because the question a sighting
+	// ages out on is "has its transaction shown up yet?", and a producer that
+	// keeps committing without ever being catalogued is exactly the case the
+	// buffer must not hold forever.
+	firstSeen time.Time
 	// seq is this entry's position in creation order. A producer that resolves
 	// and then commits again gets a new one, so a stale order entry naming the
 	// same producer id cannot evict the fresh sighting.
@@ -97,6 +124,20 @@ type ConsumerOffsetsOptions struct {
 	// Past it the longest-waiting entries are dropped and counted. Defaults to
 	// DefaultMaxPendingProducers.
 	MaxPendingProducers int
+
+	// Interval is the cadence at which buffered sightings are resolved against
+	// the catalog and flushed. Defaults to DefaultResolveInterval.
+	Interval time.Duration
+
+	// PendingTTLIntervals is how many resolve intervals a sighting may go
+	// unresolved before it is dropped. Expressed as a multiple of Interval
+	// rather than as a duration because the interval is what sets how many
+	// chances a sighting gets. Defaults to DefaultPendingTTLIntervals.
+	PendingTTLIntervals int
+
+	// Now is the clock, injectable so the suite does not wait on real time.
+	// Defaults to time.Now.
+	Now func() time.Time
 }
 
 // NewConsumerOffsetsTail builds a tail consumer over the shared catalog the
@@ -108,10 +149,22 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 	if opts.MaxPendingProducers <= 0 {
 		opts.MaxPendingProducers = DefaultMaxPendingProducers
 	}
+	if opts.Interval <= 0 {
+		opts.Interval = DefaultResolveInterval
+	}
+	if opts.PendingTTLIntervals <= 0 {
+		opts.PendingTTLIntervals = DefaultPendingTTLIntervals
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
 	return &ConsumerOffsetsTail{
 		catalog:    catalog,
 		topic:      opts.Topic,
 		maxPending: opts.MaxPendingProducers,
+		interval:   opts.Interval,
+		pendingTTL: time.Duration(opts.PendingTTLIntervals) * opts.Interval,
+		now:        opts.Now,
 		pending:    make(map[int64]*pendingCommits),
 	}
 }
@@ -144,7 +197,7 @@ func (t *ConsumerOffsetsTail) Stats() ConsumerOffsetsStats {
 	return ConsumerOffsetsStats{
 		KeyDecodeErrors:  t.keyDecodeErrors.Load(),
 		PendingProducers: len(t.pending),
-		PendingEvicted:   t.evictedByCapacity,
+		PendingEvicted:   t.evicted,
 	}
 }
 
@@ -228,7 +281,11 @@ func (t *ConsumerOffsetsTail) recordCommit(pid int64, topic string) {
 			t.evictOldestLocked()
 		}
 		t.seq++
-		e = &pendingCommits{topics: make(map[string]struct{}), seq: t.seq}
+		e = &pendingCommits{
+			topics:    make(map[string]struct{}),
+			firstSeen: t.now(),
+			seq:       t.seq,
+		}
 		t.pending[pid] = e
 		t.order = append(t.order, pendingRef{pid: pid, seq: e.seq})
 		t.compactOrderLocked()
@@ -248,7 +305,7 @@ func (t *ConsumerOffsetsTail) evictOldestLocked() {
 		// replaced by a later sighting from the same producer.
 		if e, ok := t.pending[ref.pid]; ok && e.seq == ref.seq {
 			delete(t.pending, ref.pid)
-			t.evictedByCapacity++
+			t.evicted++
 			return
 		}
 	}
@@ -287,12 +344,42 @@ func (t *ConsumerOffsetsTail) FinalFlush(out chan<- Observation) {
 // the shared catalog and emits an observation for every pending sighting that
 // now resolves.
 func (t *ConsumerOffsetsTail) resolveAndFlush(ctx context.Context, out chan<- Observation) {
-	for _, obs := range t.resolveWith(t.catalog.ProducerIDToTxnID(), time.Now()) {
+	now := t.now()
+	observations := t.resolveWith(t.catalog.ProducerIDToTxnID(), now)
+	// Expire AFTER resolving, never before. A sighting that has just reached its
+	// TTL may be exactly the one the __transaction_state reader has finally
+	// caught up to; expiring first would discard a recovery on the very pass
+	// that could have made it, visible only as an eviction count.
+	t.expire(now)
+
+	for _, obs := range observations {
 		select {
 		case out <- obs:
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// expire drops pending sightings that have gone unresolved for longer than the
+// TTL. Entries are held oldest-first, so the walk stops at the first survivor.
+func (t *ConsumerOffsetsTail) expire(now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for len(t.order) > 0 {
+		ref := t.order[0]
+		e, ok := t.pending[ref.pid]
+		if !ok || e.seq != ref.seq {
+			// A stale reference to an entry that resolved or was replaced.
+			t.order = t.order[1:]
+			continue
+		}
+		if now.Sub(e.firstSeen) <= t.pendingTTL {
+			return
+		}
+		t.order = t.order[1:]
+		delete(t.pending, ref.pid)
+		t.evicted++
 	}
 }
 

--- a/internal/services/txndiscovery/discovery/consumeroffsets.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets.go
@@ -55,7 +55,15 @@ func NewConsumerOffsetsTail(catalog *TxnCatalog, opts ConsumerOffsetsOptions) *C
 }
 
 // HandleBatch records the transactional offset commits carried by one batch.
+//
+// It is the demultiplexing entry point: one tail instance serves both this
+// consumer and the __transaction_state reader, fanning every partition of both
+// topics into a single channel, so batches for other topics are this
+// consumer's to ignore.
 func (t *ConsumerOffsetsTail) HandleBatch(b tail.Batch) {
+	if b.Topic != DefaultConsumerOffsetsTopic {
+		return
+	}
 	// Only a commit written inside a transaction correlates. A batch header
 	// carries a producer id for a plain idempotent producer too, so joining a
 	// non-transactional commit on it would attribute an unrelated consumer's

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -220,3 +220,28 @@ func TestAGroupMetadataKeyContributesNoConsumedTopic(t *testing.T) {
 
 	assert.Empty(t, flush(t, tl), "group metadata names no consumed topic")
 }
+
+func TestAnInternalConsumedTopicIsDropped(t *testing.T) {
+	// An exactly-once app can commit offsets for an internal topic — a Streams
+	// repartition or changelog topic is the routine case. Publishing one as a
+	// recovered input would hand the grouping stage an edge through a topic
+	// every such app shares, and the union-find would chain unrelated workloads
+	// into one group. Grouping filters internal topics itself, but this source
+	// also feeds the audit trail and the recovered-topics stat, both of which
+	// would otherwise report a topic no operator can migrate.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	tl.HandleBatch(commitBatch(4242,
+		commitKey("payments-group", "__consumer_offsets", 0),
+		commitKey("payments-group", "app-repartition-store-changelog", 0),
+		commitKey("payments-group", "orders.in", 0),
+	))
+
+	got := flush(t, tl)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, []string{"app-repartition-store-changelog", "orders.in"}, got[0].Topics,
+		"only __-prefixed topics are internal; a Streams changelog is a real topic")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -103,3 +103,19 @@ func TestATransactionalCommitWhoseProducerIDIsInTheCatalogResolvesToAnObservatio
 	assert.False(t, got[0].ObservedAt.IsZero())
 }
 
+func TestANonTransactionalBatchIsIgnored(t *testing.T) {
+	// The overwhelming majority of __consumer_offsets traffic is ordinary,
+	// non-transactional offset commits. A batch header carries a producer id for
+	// plain idempotent producers too, so correlating one would attribute an
+	// unrelated consumer's topics to whichever transaction happens to share that
+	// id. Only a commit written INSIDE a transaction says anything about one.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	b := commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	b.IsTransactional = false
+	tl.HandleBatch(b)
+
+	assert.Empty(t, flush(t, tl), "a non-transactional commit must not correlate")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -308,3 +308,31 @@ func TestAnUnresolvedProducerStaysBufferedAndThenEmitsExactlyOnce(t *testing.T) 
 
 	assert.Empty(t, flush(t, tl), "a resolved sighting must not be re-emitted")
 }
+
+func TestManyCommitsFromOneProducerMergeIntoASortedDeduplicatedTopicSet(t *testing.T) {
+	// One producer commits an offset per consumed topic-partition, on every
+	// transaction, for the whole window — so the same topic arrives hundreds of
+	// times across many batches. They must union into one set rather than a
+	// list with repeats, and the order must be stable: the YAML and the audit
+	// trail are diffed between runs, and Go randomises map iteration, so an
+	// unsorted set would churn the artifacts over identical observations.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	// Arriving out of order, across separate batches, with repeats.
+	tl.HandleBatch(commitBatch(4242,
+		commitKey("payments-group", "zeta.in", 0),
+		commitKey("payments-group", "orders.in", 0),
+	))
+	tl.HandleBatch(commitBatch(4242,
+		commitKey("payments-group", "orders.in", 1), // same topic, another partition
+		commitKey("payments-group", "alpha.in", 0),
+		commitKey("payments-group", "zeta.in", 3),
+	))
+
+	got := flush(t, tl)
+
+	require.Len(t, got, 1, "one producer yields one observation, not one per commit")
+	assert.Equal(t, []string{"alpha.in", "orders.in", "zeta.in"}, got[0].Topics)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"encoding/binary"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,4 +336,41 @@ func TestManyCommitsFromOneProducerMergeIntoASortedDeduplicatedTopicSet(t *testi
 
 	require.Len(t, got, 1, "one producer yields one observation, not one per commit")
 	assert.Equal(t, []string{"alpha.in", "orders.in", "zeta.in"}, got[0].Topics)
+}
+
+// streamsNamingCorrelates is the Kafka Streams naming convention the
+// consumer-group enrichment phase relies on: a Streams app sets group.id to its
+// application.id and derives transactional.id as "<application.id>-<taskId>"
+// (EOS v1) or "<application.id>-<processId>" (EOS v2). It is reproduced here so
+// the test below can assert what that heuristic CANNOT do, rather than merely
+// claiming it.
+func streamsNamingCorrelates(groupID, txnID string) bool {
+	return txnID == groupID || strings.HasPrefix(txnID, groupID+"-")
+}
+
+func TestCorrelationSucceedsWhereTheStreamsNamingHeuristicFails(t *testing.T) {
+	// This is the case the whole raw-fetch decision was made for. A plain
+	// consumer+producer exactly-once app — not Kafka Streams — picks its
+	// group.id and its transactional.id independently, so no naming rule can
+	// relate them. The enrichment phase is blind to it; the producer id in the
+	// batch header is not.
+	const groupID = "svc-ingest-consumer"
+	const txnID = "billing-writer-7"
+
+	require.False(t, streamsNamingCorrelates(groupID, txnID),
+		"fixture must be one the naming heuristic cannot correlate")
+	require.False(t, streamsNamingCorrelates(txnID, groupID),
+		"nor in the other direction")
+
+	cat := NewTxnCatalog()
+	cat.Observe(txnID, 990001)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	tl.HandleBatch(commitBatch(990001, commitKey(groupID, "raw.events", 0)))
+
+	got := flush(t, tl)
+
+	require.Len(t, got, 1, "the producer-id join must recover what naming cannot")
+	assert.Equal(t, txnID, got[0].TxnID)
+	assert.Equal(t, []string{"raw.events"}, got[0].Topics)
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -1,0 +1,105 @@
+package discovery
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fixture builders -------------------------------------------------------
+//
+// Keys are hand-assembled bytes against Kafka's OffsetCommitKey.json and
+// GroupMetadataKey.json schemas rather than produced by an encoder from the
+// package under test, so a decoder that agrees only with itself still fails.
+
+func be16(v int16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(v))
+	return b
+}
+
+func be32(v int32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(v))
+	return b
+}
+
+// kstr encodes a classic (non-flexible) string: int16 length then bytes.
+func kstr(s string) []byte {
+	return append(be16(int16(len(s))), []byte(s)...)
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// commitKey builds an OffsetCommitKey v1 — the key an EOS app's
+// sendOffsetsToTransaction writes for one consumed topic-partition.
+func commitKey(group, topic string, partition int32) []byte {
+	return concat(be16(1), kstr(group), kstr(topic), be32(partition))
+}
+
+// commitBatch builds the batch a transactional offset commit arrives in: the
+// header carries the producer id that ties it to its transaction.
+func commitBatch(producerID int64, keys ...[]byte) tail.Batch {
+	b := tail.Batch{
+		Topic:           DefaultConsumerOffsetsTopic,
+		ProducerID:      producerID,
+		IsTransactional: true,
+	}
+	for i, k := range keys {
+		b.Records = append(b.Records, tail.Record{
+			Offset: int64(i),
+			Key:    k,
+			Value:  []byte{0, 1}, // a non-empty value: a live commit, not a tombstone
+		})
+	}
+	return b
+}
+
+// flush runs the tail's final flush into a buffered channel and returns
+// everything it emitted.
+func flush(t *testing.T, tl *ConsumerOffsetsTail) []Observation {
+	t.Helper()
+	out := make(chan Observation, 256)
+	tl.FinalFlush(out)
+	close(out)
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	return got
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestATransactionalCommitWhoseProducerIDIsInTheCatalogResolvesToAnObservation(t *testing.T) {
+	// The exact join this whole unit exists for: __transaction_state recorded that
+	// producer 4242 is running transaction "payments-txn-0", and __consumer_offsets
+	// recorded that producer 4242 committed an offset for "orders.in". Neither
+	// record alone says the transaction consumes that topic; joining them on the
+	// producer id does, with no assumption about how the names relate.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+	tl.HandleBatch(commitBatch(4242, commitKey("payments-group", "orders.in", 0)))
+
+	got := flush(t, tl)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "payments-txn-0", got[0].TxnID)
+	assert.Equal(t, int64(4242), got[0].ProducerID)
+	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+	assert.True(t, got[0].ReadProcessWrite, "a recovered consumed input makes the transaction read-process-write")
+	assert.Equal(t, SourceConsumerOffsets, got[0].Source)
+	assert.False(t, got[0].ObservedAt.IsZero())
+}
+

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -597,3 +597,36 @@ func TestAnIntervalPassAbandonedMidSendDoesNotLoseWhatItResolved(t *testing.T) {
 	assert.Equal(t, "payments-txn-0", got[0].TxnID)
 	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
 }
+
+func TestTheStatsReportWhatThisPhaseItselfRecovered(t *testing.T) {
+	// The report credits each recovered input to the phase that actually found
+	// it — producer-id correlation or the naming heuristic — so this source has
+	// to say which topics IT recovered. Inferring it downstream is not possible:
+	// both phases emit observations under the same transactional id, and the
+	// accumulator unions them, so by the time the report sees a footprint the
+	// provenance of an individual topic is gone.
+	//
+	// Only DELIVERED recoveries count. A sighting resolved but not handed over
+	// has recovered nothing yet, and counting it would credit this phase for an
+	// input that never reached the accumulator.
+	cat := NewTxnCatalog()
+	cat.Observe("txn-a", 11)
+	cat.Observe("txn-b", 22)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	tl.HandleBatch(commitBatch(11,
+		commitKey("group-one", "zeta.in", 0),
+		commitKey("group-one", "alpha.in", 0),
+	))
+	tl.HandleBatch(commitBatch(22, commitKey("group-two", "alpha.in", 0)))
+	// A sighting whose transaction is never catalogued recovers nothing.
+	tl.HandleBatch(commitBatch(33, commitKey("group-three", "ghost.in", 0)))
+
+	require.Len(t, flush(t, tl), 2)
+
+	st := tl.Stats()
+	assert.Equal(t, []string{"alpha.in", "zeta.in"}, st.RecoveredTopics,
+		"deduplicated across producers and sorted; the unresolved one is absent")
+	assert.Equal(t, 2, st.GroupsLinked)
+	assert.Equal(t, 2, st.Correlations)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -162,3 +162,21 @@ func TestABatchWithANonPositiveProducerIDIsIgnored(t *testing.T) {
 	assert.Empty(t, tl.resolveWith(map[int64]string{-1: "some-txn", 0: "other-txn"}, time.Now()),
 		"nothing may be buffered under a sentinel producer id")
 }
+
+func TestABatchFromAnotherTopicOnTheSharedChannelIsIgnored(t *testing.T) {
+	// One tail instance serves both this consumer and the __transaction_state
+	// reader, fanning every partition of both topics into a single channel, so
+	// each consumer must demultiplex on the batch's topic. The batch here is
+	// transactional with a real producer id, so every other filter waves it
+	// through — only the topic check stops a __transaction_state record's key
+	// from being decoded as an OffsetCommitKey and published as a consumed topic.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	b := commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	b.Topic = "__transaction_state"
+	tl.HandleBatch(b)
+
+	assert.Empty(t, flush(t, tl), "a batch from another topic must not correlate")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -119,3 +119,22 @@ func TestANonTransactionalBatchIsIgnored(t *testing.T) {
 
 	assert.Empty(t, flush(t, tl), "a non-transactional commit must not correlate")
 }
+
+func TestAControlBatchIsIgnored(t *testing.T) {
+	// A control batch is the transaction marker itself — the COMMIT or ABORT the
+	// coordinator writes — not application data. The tail component delivers
+	// control batches flagged rather than filtering them, so dropping them is
+	// this consumer's job. A marker is transactional and carries a real producer
+	// id, so every other filter here waves it through; only the flag stops it.
+	// Its record key is not an OffsetCommitKey at all, so treating it as one
+	// would decode a marker as a consumed topic.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	b := commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	b.Control = true
+	tl.HandleBatch(b)
+
+	assert.Empty(t, flush(t, tl), "a control batch must not correlate")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -661,4 +662,64 @@ func TestTheStatsSeparateRecordsSeenFromTransactionalCommits(t *testing.T) {
 	st := tl.Stats()
 	assert.Equal(t, int64(4), st.RecordsSeen, "every record on OUR topic, transactional or not")
 	assert.Equal(t, int64(2), st.TxnRecords, "only the transactional commits that yielded a consumed topic")
+}
+
+func TestWhenTheOffsetsTopicIsUnreadableTheProbeShortCircuitsTheTail(t *testing.T) {
+	// R13. Reading __consumer_offsets is an optional grant: managed clusters
+	// hide the topic and an operator's credentials may simply lack the ACL.
+	// That must degrade to the naming heuristic alone, not fail the run — the
+	// __transaction_state footprints are still worth having.
+	//
+	// The flag matters as much as the short-circuit. A phase that never ran and
+	// a phase that ran and found nothing both report zero recovered inputs, and
+	// the report must not credit the first as evidence the cluster has no
+	// read-process-write applications.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+
+	var probes int
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{
+		Probe: func(context.Context) error {
+			probes++
+			return errors.New("topic authorization failed")
+		},
+	})
+
+	require.False(t, tl.Available(context.Background()))
+
+	in := make(chan tail.Batch, 1)
+	in <- commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	close(in)
+	out := make(chan Observation, 4)
+	require.NoError(t, tl.Run(context.Background(), in, out))
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	assert.Empty(t, got, "an unreadable topic correlates nothing")
+
+	st := tl.Stats()
+	assert.True(t, st.Unavailable, "the report must not read this as a cluster with no EOS inputs")
+	assert.Contains(t, st.UnavailableReason, "topic authorization failed",
+		"and the reason has to reach the operator, or the warning is unactionable")
+	assert.Zero(t, st.RecordsSeen, "no batch is decoded after a failed probe")
+	assert.Equal(t, 1, probes, "probed once for the run, not once per caller")
+}
+
+func TestWithNoProbeConfiguredTheTailRunsNormally(t *testing.T) {
+	// The probe is injected by the command wiring; the zero value must stay
+	// usable, and "no probe" must not read as "unavailable" — that would silently
+	// disable the phase for every caller that did not supply one.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	require.True(t, tl.Available(context.Background()))
+
+	tl.HandleBatch(commitBatch(4242, commitKey("payments-group", "orders.in", 0)))
+
+	require.Len(t, flush(t, tl), 1)
+	assert.False(t, tl.Stats().Unavailable)
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -448,4 +449,80 @@ func TestASustainedStreamOfUnresolvableCommitsDoesNotGrowThePendingBufferWithout
 	}
 	sort.Strings(survived)
 	assert.Equal(t, []string{"topic-07", "topic-08", "topic-09", "topic-10"}, survived)
+}
+
+func TestAnUnresolvedSightingAgesOutAfterAMultipleOfTheInterval(t *testing.T) {
+	// The entry cap alone only engages once the buffer is full, which on a
+	// moderately busy cluster may be never — so a run can still carry thousands
+	// of sightings from the first minute for hours, none of which will ever
+	// resolve. Ageing them out keeps the buffer proportional to what is
+	// plausibly still in flight rather than to the length of the run.
+	//
+	// The TTL is a multiple of the resolve interval, not an absolute duration,
+	// because the interval is what sets how many chances a sighting gets.
+	const interval = time.Second
+	start := time.Now()
+	now := start
+
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{
+		Interval:            interval,
+		PendingTTLIntervals: 3,
+		Now:                 func() time.Time { return now },
+	})
+
+	tl.HandleBatch(commitBatch(1, commitKey("g", "old.in", 0)))
+	now = start.Add(2 * interval)
+	tl.HandleBatch(commitBatch(2, commitKey("g", "new.in", 0)))
+
+	// A pass three and a half intervals after the first sighting: it is past its
+	// three-interval TTL, the second — two intervals younger — is not.
+	now = start.Add(3*interval + interval/2)
+	out := make(chan Observation, 8)
+	tl.resolveAndFlush(context.Background(), out)
+
+	st := tl.Stats()
+	assert.Equal(t, 1, st.PendingProducers)
+	assert.Equal(t, int64(1), st.PendingEvicted, "an aged-out sighting is counted, not silently lost")
+
+	// The survivor is the younger one, not an arbitrary one.
+	got := tl.resolveWith(map[int64]string{1: "txn-1", 2: "txn-2"}, now)
+	require.Len(t, got, 1)
+	assert.Equal(t, "txn-2", got[0].TxnID)
+	assert.Equal(t, []string{"new.in"}, got[0].Topics)
+}
+
+func TestAResolvePassResolvesBeforeItExpires(t *testing.T) {
+	// Ordering inside one pass is load-bearing. A sighting that has just reached
+	// its TTL may be exactly the one the __transaction_state reader has finally
+	// caught up to — expiring first would discard a recovery on the very pass
+	// that could have made it, and the loss would be invisible except as an
+	// eviction count.
+	const interval = time.Second
+	start := time.Now()
+	now := start
+
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{
+		Interval:            interval,
+		PendingTTLIntervals: 2,
+		Now:                 func() time.Time { return now },
+	})
+	tl.HandleBatch(commitBatch(7, commitKey("g", "late.in", 0)))
+
+	// The catalog catches up only now, well past the sighting's TTL.
+	cat.Observe("late-txn", 7)
+	now = start.Add(10 * interval)
+
+	out := make(chan Observation, 8)
+	tl.resolveAndFlush(context.Background(), out)
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	require.Len(t, got, 1, "a resolvable sighting must not be expired out from under the join")
+	assert.Equal(t, "late-txn", got[0].TxnID)
+	assert.Zero(t, tl.Stats().PendingEvicted)
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/IBM/sarama"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
@@ -722,4 +724,138 @@ func TestWithNoProbeConfiguredTheTailRunsNormally(t *testing.T) {
 
 	require.Len(t, flush(t, tl), 1)
 	assert.False(t, tl.Stats().Unavailable)
+}
+
+// --- integration with the tail's abort filter --------------------------------
+
+// offsetsFakeClient is a tail.Client that serves one canned fetch response and
+// then nothing. It exists so this suite can drive a REAL tail.Tail: the abort
+// filter is the tail's, and the guarantee this unit depends on only holds across
+// the two of them.
+type offsetsFakeClient struct {
+	topic string
+	mu    sync.Mutex
+	calls int
+	first *sarama.FetchResponse
+}
+
+func (f *offsetsFakeClient) Partitions(string) ([]int32, error) { return []int32{0}, nil }
+
+func (f *offsetsFakeClient) Offset(string, int32, tail.StartPosition) (int64, error) { return 0, nil }
+
+func (f *offsetsFakeClient) Leader(string, int32) (tail.Leader, error) {
+	return tail.Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11}, nil
+}
+
+func (f *offsetsFakeClient) RefreshMetadata(...string) error { return nil }
+
+func (f *offsetsFakeClient) Fetch(_ tail.Leader, spec tail.FetchSpec) (*sarama.FetchResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if spec.Offset == 0 && f.calls == 1 {
+		return f.first, nil
+	}
+	empty := &sarama.FetchResponse{Version: 11}
+	empty.AddError(f.topic, 0, sarama.ErrNoError)
+	empty.SetLastStableOffset(f.topic, 0, 2)
+	return empty, nil
+}
+
+func TestAnOffsetCommitBelongingToAnAbortedTransactionProducesNoObservation(t *testing.T) {
+	// Zombie fencing and rebalance-driven aborts are routine on an exactly-once
+	// cluster, so rolled-back offset commits are not an edge case — and
+	// ReadCommitted does NOT remove them at the wire level. Crediting one would
+	// report an input the application never actually consumed in that
+	// transaction, and the operator would migrate a topic into a group on the
+	// strength of work that was undone.
+	//
+	// The filter itself lives in the tail component, so this drives a real
+	// tail.Tail rather than calling HandleBatch: the guarantee only holds across
+	// the two together, and that seam is exactly what a unit test of either half
+	// alone would miss.
+	const topic = DefaultConsumerOffsetsTopic
+	const abortedPID, committedPID int64 = 4242, 5555
+
+	resp := &sarama.FetchResponse{Version: 11}
+	resp.AddError(topic, 0, sarama.ErrNoError)
+	resp.SetLastStableOffset(topic, 0, 2)
+	blk := resp.GetBlock(topic, 0)
+	blk.HighWaterMarkOffset = 2
+	blk.AbortedTransactions = []*sarama.AbortedTransaction{
+		{ProducerID: abortedPID, FirstOffset: 0},
+	}
+	addOffsetsBatch(resp, topic, offsetsBatch(0, abortedPID, commitKey("aborted-group", "rolled.back.in", 0)))
+	addOffsetsBatch(resp, topic, offsetsBatch(1, committedPID, commitKey("ok-group", "committed.in", 0)))
+
+	cat := NewTxnCatalog()
+	cat.Observe("txn-aborted", abortedPID)
+	cat.Observe("txn-committed", committedPID)
+
+	fake := &offsetsFakeClient{topic: topic, first: resp}
+	tl := tail.New(fake, tail.Options{
+		Sleep: func(context.Context, time.Duration) { time.Sleep(time.Millisecond) },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	batches, err := tl.Start(ctx, []tail.TopicSpec{{Topic: topic, Start: tail.StartLatest}})
+	require.NoError(t, err)
+
+	co := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{Interval: time.Hour})
+	out := make(chan Observation, 16)
+	done := make(chan error, 1)
+	go func() { done <- co.Run(ctx, batches, out) }()
+
+	// Wait for the committed batch to arrive, then end the window.
+	require.Eventually(t, func() bool { return co.Stats().RecordsSeen >= 1 },
+		5*time.Second, 5*time.Millisecond, "the tail never delivered the committed batch")
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the tail closed its channel")
+	}
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+
+	// The abort filter really engaged — without this the test would also pass if
+	// the tail had simply never served the aborted batch.
+	require.Equal(t, int64(1), tl.Stats().AbortedBatches, "the aborted batch must have been filtered, not merely absent")
+
+	require.Len(t, got, 1, "only the committed transaction's input is recovered")
+	assert.Equal(t, "txn-committed", got[0].TxnID)
+	assert.Equal(t, []string{"committed.in"}, got[0].Topics)
+	assert.NotContains(t, co.Stats().RecoveredTopics, "rolled.back.in")
+}
+
+// offsetsBatch builds a transactional record batch carrying one offset-commit
+// record per key.
+func offsetsBatch(firstOffset int64, producerID int64, keys ...[]byte) *sarama.RecordBatch {
+	rb := &sarama.RecordBatch{
+		Version:         2,
+		FirstOffset:     firstOffset,
+		LastOffsetDelta: int32(len(keys) - 1),
+		ProducerID:      producerID,
+		ProducerEpoch:   1,
+		IsTransactional: true,
+	}
+	for i, k := range keys {
+		rb.Records = append(rb.Records, &sarama.Record{
+			OffsetDelta: int64(i),
+			Key:         k,
+			Value:       []byte{0, 1},
+		})
+	}
+	return rb
+}
+
+func addOffsetsBatch(r *sarama.FetchResponse, topic string, rb *sarama.RecordBatch) {
+	blk := r.GetBlock(topic, 0)
+	blk.RecordsSet = append(blk.RecordsSet, &sarama.Records{RecordBatch: rb})
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -286,3 +286,25 @@ func TestAKeyThatFailsToDecodeIsCountedAndDoesNotStopTheTail(t *testing.T) {
 	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
 	assert.Equal(t, int64(2), tl.Stats().KeyDecodeErrors)
 }
+
+func TestAnUnresolvedProducerStaysBufferedAndThenEmitsExactlyOnce(t *testing.T) {
+	// The two readers race by design: this one starts at LATEST so it sees live
+	// commits, while the __transaction_state reader starts at EARLIEST and takes
+	// the whole window to catch up. A commit therefore routinely arrives before
+	// its transaction is catalogued, so an unresolved sighting must be kept
+	// rather than dropped. Once it resolves it must leave the buffer, or every
+	// later pass re-emits it — inflating the sample count and writing a
+	// duplicate audit line for a coupling that happened once.
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+	tl.HandleBatch(commitBatch(4242, commitKey("payments-group", "orders.in", 0)))
+
+	assert.Empty(t, flush(t, tl), "nothing resolves while the catalog is empty")
+
+	cat.Observe("payments-txn-0", 4242)
+	got := flush(t, tl)
+	require.Len(t, got, 1, "the buffered sighting resolves once the catalog catches up")
+	assert.Equal(t, "payments-txn-0", got[0].TxnID)
+
+	assert.Empty(t, flush(t, tl), "a resolved sighting must not be re-emitted")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -526,3 +526,47 @@ func TestAResolvePassResolvesBeforeItExpires(t *testing.T) {
 	assert.Equal(t, "late-txn", got[0].TxnID)
 	assert.Zero(t, tl.Stats().PendingEvicted)
 }
+
+func TestRunFinalFlushesOnAFreshContextAfterTheWindowIsCancelled(t *testing.T) {
+	// Most resolutions land in the final flush. This reader starts at LATEST so
+	// it sees commits immediately, while the __transaction_state reader starts
+	// at EARLIEST and is still catching up — so a transaction routinely becomes
+	// known only as the window closes. By then the observation context is
+	// already cancelled, so flushing on it would resolve every buffered sighting
+	// (removing it from the buffer) and then send none of them. The whole point
+	// of the phase would be lost at the last step, silently.
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{
+		Interval: time.Hour, // long enough that no interval pass fires
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan tail.Batch)
+	out := make(chan Observation, 8)
+
+	done := make(chan error, 1)
+	go func() { done <- tl.Run(ctx, in, out) }()
+
+	in <- commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+
+	// The window ends. Only now does the state reader reach this transaction.
+	cat.Observe("payments-txn-0", 4242)
+	cancel()
+	close(in)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after its input closed")
+	}
+
+	close(out)
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	require.Len(t, got, 1, "the final flush must still deliver on a cancelled context")
+	assert.Equal(t, "payments-txn-0", got[0].TxnID)
+	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -180,3 +180,22 @@ func TestABatchFromAnotherTopicOnTheSharedChannelIsIgnored(t *testing.T) {
 
 	assert.Empty(t, flush(t, tl), "a batch from another topic must not correlate")
 }
+
+func TestTheDemultiplexedTopicFollowsTheConfiguredTopic(t *testing.T) {
+	// The demux compares against a configured name, not a hardcoded one. U11
+	// builds the tail's TopicSpec and this consumer from the same setting, so a
+	// hardcode here would silently drop every batch on a cluster whose offsets
+	// topic is named otherwise — a consumer that reads nothing looks exactly
+	// like a cluster with no exactly-once traffic.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{Topic: "__custom_offsets"})
+
+	b := commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	b.Topic = "__custom_offsets"
+	tl.HandleBatch(b)
+
+	got := flush(t, tl)
+	require.Len(t, got, 1)
+	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -245,3 +245,20 @@ func TestAnInternalConsumedTopicIsDropped(t *testing.T) {
 	assert.Equal(t, []string{"app-repartition-store-changelog", "orders.in"}, got[0].Topics,
 		"only __-prefixed topics are internal; a Streams changelog is a real topic")
 }
+
+func TestATombstonedCommitIsNotALiveConsumedInput(t *testing.T) {
+	// A tombstone — a valid key with an empty value — is how the coordinator
+	// DELETES an offset commit on expiry or an admin DeleteOffsets. Its key
+	// still names a topic, so every decode-side check passes it; reading it as
+	// a live commit would report an input the application no longer consumes,
+	// and the operator would migrate a topic into a group that does not need it.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	b := commitBatch(4242, commitKey("payments-group", "orders.in", 0))
+	b.Records[0].Value = nil
+	tl.HandleBatch(b)
+
+	assert.Empty(t, flush(t, tl), "a tombstone is a deleted commit, not a live one")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -1,9 +1,11 @@
 package discovery
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -724,6 +726,49 @@ func TestWithNoProbeConfiguredTheTailRunsNormally(t *testing.T) {
 
 	require.Len(t, flush(t, tl), 1)
 	assert.False(t, tl.Stats().Unavailable)
+}
+
+func TestNoCustomerIdentifierReachesTheLogAtAnyLevel(t *testing.T) {
+	// kcp.log is Debug+ unconditionally, has no level control, and is the file
+	// operators attach to support tickets — so it is a fourth artifact, not a
+	// scratch pad. A topic name, consumer group id or transactional id on any
+	// slog call defeats the counts-only terminal entirely, and under --verbose
+	// those same lines reach the console.
+	//
+	// Every identifier this source handles is distinctive here, and the whole
+	// run is exercised: a clean decode, a decode failure (Debug), and a failed
+	// availability probe (Warn).
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	const (
+		topicName = "zzdistinctivetopiczz"
+		groupID   = "zzdistinctivegroupzz"
+		txnID     = "zzdistinctivetxnzz"
+	)
+
+	cat := NewTxnCatalog()
+	cat.Observe(txnID, 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{
+		Probe: func(context.Context) error { return errors.New("cluster denied the read") },
+	})
+
+	tl.Available(context.Background())
+	tl.HandleBatch(commitBatch(4242,
+		commitKey(groupID, topicName, 0),
+		be16(99), // an undecodable key, so the Debug path runs too
+	))
+	flush(t, tl)
+
+	logged := buf.String()
+	require.NotEmpty(t, logged, "the fixture must actually produce log lines, or this asserts nothing")
+	for _, secret := range []string{topicName, groupID, txnID} {
+		assert.NotContains(t, logged, secret)
+	}
+	// The producer id identifies a specific application instance too.
+	assert.NotContains(t, logged, "4242")
 }
 
 // --- integration with the tail's abort filter --------------------------------

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -1,7 +1,8 @@
 package discovery
 
 import (
-	"encoding/binary"
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -18,30 +19,8 @@ import (
 // GroupMetadataKey.json schemas rather than produced by an encoder from the
 // package under test, so a decoder that agrees only with itself still fails.
 
-func be16(v int16) []byte {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(v))
-	return b
-}
-
-func be32(v int32) []byte {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b, uint32(v))
-	return b
-}
-
-// kstr encodes a classic (non-flexible) string: int16 length then bytes.
-func kstr(s string) []byte {
-	return append(be16(int16(len(s))), []byte(s)...)
-}
-
-func concat(parts ...[]byte) []byte {
-	var out []byte
-	for _, p := range parts {
-		out = append(out, p...)
-	}
-	return out
-}
+// be16, be32, kstr and concat are the byte builders this suite shares with the
+// __transaction_state reader's (txnstate_test.go), same package.
 
 // commitKey builds an OffsetCommitKey v1 — the key an EOS app's
 // sendOffsetsToTransaction writes for one consumed topic-partition.
@@ -432,4 +411,41 @@ func TestARecoveredInputFoldsIntoTheProducedGroupWithItsProducerIDIntact(t *test
 	require.Len(t, res.Groups, 1, "the recovered input must not be a separate group")
 	assert.Equal(t, []string{"billing.out", "raw.events"}, res.Groups[0].Topics)
 	assert.True(t, res.Groups[0].ReadProcessWrite)
+}
+
+func TestASustainedStreamOfUnresolvableCommitsDoesNotGrowThePendingBufferWithoutBound(t *testing.T) {
+	// On a large cluster most commits come from producers whose transactions
+	// this run never observes — they were compacted away before the window, or
+	// belong to an app that never commits again. Those sightings never resolve,
+	// so an unbounded buffer grows for the whole run: a multi-hour observation
+	// on a busy cluster is exactly the situation a slow memory leak is worst in,
+	// because the operator loses the run rather than a request.
+	//
+	// The oldest go first: a sighting that has waited longest is the least
+	// likely to ever resolve, and dropping the newest would discard the commits
+	// whose transactions the __transaction_state reader is about to reach.
+	const maxPending = 4
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{MaxPendingProducers: maxPending})
+
+	for pid := int64(1); pid <= 10; pid++ {
+		tl.HandleBatch(commitBatch(pid, commitKey("g", fmt.Sprintf("topic-%02d", pid), 0)))
+	}
+
+	st := tl.Stats()
+	assert.Equal(t, maxPending, st.PendingProducers, "the buffer is capped")
+	assert.Equal(t, int64(6), st.PendingEvicted, "and what it dropped is counted, not silent")
+
+	// Prove it kept the NEWEST four rather than an arbitrary four: a catalog
+	// that resolves all ten may only yield the survivors.
+	all := map[int64]string{}
+	for pid := int64(1); pid <= 10; pid++ {
+		all[pid] = fmt.Sprintf("txn-%02d", pid)
+	}
+	var survived []string
+	for _, obs := range tl.resolveWith(all, time.Now()) {
+		survived = append(survived, obs.Topics[0])
+	}
+	sort.Strings(survived)
+	assert.Equal(t, []string{"topic-07", "topic-08", "topic-09", "topic-10"}, survived)
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -630,3 +630,35 @@ func TestTheStatsReportWhatThisPhaseItselfRecovered(t *testing.T) {
 	assert.Equal(t, 2, st.GroupsLinked)
 	assert.Equal(t, 2, st.Correlations)
 }
+
+func TestTheStatsSeparateRecordsSeenFromTransactionalCommits(t *testing.T) {
+	// The keep-up signal needs both numbers, and their RATIO is the diagnostic.
+	// The overwhelming majority of __consumer_offsets traffic is ordinary
+	// commits and group metadata, so a healthy run on an exactly-once cluster
+	// reads a great many records and correlates a small fraction of them. A run
+	// reporting zero records read means the tail never got going; a run reading
+	// plenty but correlating none means the cluster has no exactly-once traffic
+	// — and without both counts those two look identical in the summary.
+	cat := NewTxnCatalog()
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	// Two ordinary commits: seen, not correlatable.
+	plain := commitBatch(4242, commitKey("plain-group", "orders.in", 0), commitKey("plain-group", "orders.in", 1))
+	plain.IsTransactional = false
+	tl.HandleBatch(plain)
+
+	// One transactional commit carrying two consumed topic-partitions.
+	tl.HandleBatch(commitBatch(4242,
+		commitKey("eos-group", "orders.in", 0),
+		commitKey("eos-group", "payments.in", 0),
+	))
+
+	// A batch on the other topic is not this source's traffic at all.
+	other := commitBatch(4242, commitKey("eos-group", "orders.in", 0))
+	other.Topic = DefaultTxnStateTopic
+	tl.HandleBatch(other)
+
+	st := tl.Stats()
+	assert.Equal(t, int64(4), st.RecordsSeen, "every record on OUR topic, transactional or not")
+	assert.Equal(t, int64(2), st.TxnRecords, "only the transactional commits that yielded a consumed topic")
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -262,3 +262,27 @@ func TestATombstonedCommitIsNotALiveConsumedInput(t *testing.T) {
 
 	assert.Empty(t, flush(t, tl), "a tombstone is a deleted commit, not a live one")
 }
+
+func TestAKeyThatFailsToDecodeIsCountedAndDoesNotStopTheTail(t *testing.T) {
+	// Record keys are a broker-internal binary format, not part of the stable
+	// client protocol, so a broker upgrade can change them under us. A decode
+	// failure must neither panic nor abandon the rest of the batch — dropping
+	// the remaining records would silently lose recoveries — and it must be
+	// counted, because the counter is the only format-drift alarm this source
+	// has. A run that decoded nothing otherwise looks like an idle cluster.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	tl.HandleBatch(commitBatch(4242,
+		be16(99),  // an unsupported key version
+		[]byte{0}, // shorter than the version prefix itself
+		commitKey("payments-group", "orders.in", 0),
+	))
+
+	got := flush(t, tl)
+
+	require.Len(t, got, 1, "the records after a bad key are still processed")
+	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+	assert.Equal(t, int64(2), tl.Stats().KeyDecodeErrors)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
@@ -137,4 +138,27 @@ func TestAControlBatchIsIgnored(t *testing.T) {
 	tl.HandleBatch(b)
 
 	assert.Empty(t, flush(t, tl), "a control batch must not correlate")
+}
+
+func TestABatchWithANonPositiveProducerIDIsIgnored(t *testing.T) {
+	// -1 is Kafka's "no producer id" sentinel and 0 is the zero value of an
+	// absent field. Buffering either would key a pending entry on a sentinel, so
+	// every unrelated producer lacking an id would pool its consumed topics into
+	// one bucket — and the moment any transaction happened to be catalogued
+	// under that sentinel, the whole pool would be attributed to it. The
+	// catalog's own guard only refuses to WRITE a non-positive id; refusing to
+	// READ one is this side's job.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	for _, pid := range []int64{-1, 0} {
+		tl.HandleBatch(commitBatch(pid, commitKey("payments-group", "orders.in", 0)))
+	}
+
+	assert.Empty(t, flush(t, tl), "a sentinel producer id must not correlate")
+	// And it is not merely unresolved — nothing was buffered under the sentinel
+	// key at all, so a later catalog entry cannot resurrect it.
+	assert.Empty(t, tl.resolveWith(map[int64]string{-1: "some-txn", 0: "other-txn"}, time.Now()),
+		"nothing may be buffered under a sentinel producer id")
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -47,6 +47,12 @@ func commitKey(group, topic string, partition int32) []byte {
 	return concat(be16(1), kstr(group), kstr(topic), be32(partition))
 }
 
+// groupMetadataKey builds a GroupMetadataKey v2 — consumer-group state, which
+// shares the __consumer_offsets topic with offset commits but names no topic.
+func groupMetadataKey(group string) []byte {
+	return concat(be16(2), kstr(group))
+}
+
 // commitBatch builds the batch a transactional offset commit arrives in: the
 // header carries the producer id that ties it to its transaction.
 func commitBatch(producerID int64, keys ...[]byte) tail.Batch {
@@ -198,4 +204,19 @@ func TestTheDemultiplexedTopicFollowsTheConfiguredTopic(t *testing.T) {
 	got := flush(t, tl)
 	require.Len(t, got, 1)
 	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+}
+
+func TestAGroupMetadataKeyContributesNoConsumedTopic(t *testing.T) {
+	// Key version 2 is GroupMetadataKey: consumer-group state sharing the
+	// __consumer_offsets topic, naming no topic at all. It decodes successfully,
+	// so nothing upstream rejects it — and its empty Topic field would otherwise
+	// be buffered as a consumed topic named "", which reaches the YAML as a
+	// nameless member of a real transaction's group.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+
+	tl.HandleBatch(commitBatch(4242, groupMetadataKey("payments-group")))
+
+	assert.Empty(t, flush(t, tl), "group metadata names no consumed topic")
 }

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -570,3 +570,30 @@ func TestRunFinalFlushesOnAFreshContextAfterTheWindowIsCancelled(t *testing.T) {
 	assert.Equal(t, "payments-txn-0", got[0].TxnID)
 	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
 }
+
+func TestAnIntervalPassAbandonedMidSendDoesNotLoseWhatItResolved(t *testing.T) {
+	// An interval pass races the end of the window: the context can be cancelled
+	// between resolving a sighting and sending its observation. A pass that
+	// dropped the entry when it resolved it would then have removed the sighting
+	// from the buffer AND failed to deliver it — the recovery is gone, with no
+	// counter moving and the final flush finding nothing left to do. Nothing
+	// downstream can tell that apart from a transaction that had no inputs.
+	//
+	// So a sighting leaves the buffer only once its observation has actually
+	// been handed over.
+	cat := NewTxnCatalog()
+	cat.Observe("payments-txn-0", 4242)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+	tl.HandleBatch(commitBatch(4242, commitKey("payments-group", "orders.in", 0)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tl.resolveAndFlush(ctx, make(chan Observation)) // nobody reads; the send is abandoned
+
+	require.Equal(t, 1, tl.Stats().PendingProducers, "an undelivered sighting stays buffered")
+
+	got := flush(t, tl)
+	require.Len(t, got, 1, "and the final flush still delivers it")
+	assert.Equal(t, "payments-txn-0", got[0].TxnID)
+	assert.Equal(t, []string{"orders.in"}, got[0].Topics)
+}

--- a/internal/services/txndiscovery/discovery/consumeroffsets_test.go
+++ b/internal/services/txndiscovery/discovery/consumeroffsets_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -373,4 +374,62 @@ func TestCorrelationSucceedsWhereTheStreamsNamingHeuristicFails(t *testing.T) {
 	require.Len(t, got, 1, "the producer-id join must recover what naming cannot")
 	assert.Equal(t, txnID, got[0].TxnID)
 	assert.Equal(t, []string{"raw.events"}, got[0].Topics)
+}
+
+func TestARecoveredInputFoldsIntoTheProducedGroupWithItsProducerIDIntact(t *testing.T) {
+	// End of the pipeline this source feeds. A transaction's own footprint names
+	// only what it PRODUCED, so "billing.out" alone looks like a topic that can
+	// migrate on its own — when moving it without "raw.events" breaks
+	// exactly-once at cutover. The recovered input has to reach the same group.
+	//
+	// The producer id is the load-bearing detail. The __transaction_state
+	// reader's first sighting of a transaction is routinely an Empty record with
+	// no usable producer id, and the naming-based enrichment phase never has
+	// one, so this source is often the ONLY observation carrying a real id. The
+	// accumulator refuses to let a zero overwrite a positive one; this asserts
+	// that this source supplies the positive one in the first place.
+	const txnID = "billing-writer-7"
+	const pid int64 = 990001
+
+	cat := NewTxnCatalog()
+	cat.Observe(txnID, pid)
+	tl := NewConsumerOffsetsTail(cat, ConsumerOffsetsOptions{})
+	tl.HandleBatch(commitBatch(pid, commitKey("svc-ingest-consumer", "raw.events", 0)))
+
+	acc := NewAccumulator()
+	acc.Add(Observation{
+		TxnID:            txnID,
+		ProducerID:       0, // an early Empty state record carries no real id yet
+		Topics:           []string{"billing.out", "__consumer_offsets"},
+		ReadProcessWrite: true,
+		Source:           SourceTxnStateLog,
+		ObservedAt:       time.Now(),
+	})
+	for _, obs := range flush(t, tl) {
+		acc.Add(obs)
+	}
+	acc.Add(Observation{
+		TxnID:      txnID,
+		ProducerID: 0, // the naming-based phase never has one
+		Topics:     []string{"raw.events"},
+		Source:     SourceConsumerGroups,
+		ObservedAt: time.Now(),
+	})
+
+	snap := acc.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, pid, snap[0].ProducerID,
+		"the only real producer id came from this source and must survive the zero-id guard")
+	assert.Equal(t, []string{"__consumer_offsets", "billing.out", "raw.events"}, snap[0].Topics)
+	assert.True(t, snap[0].ReadProcessWrite)
+
+	res := grouping.Build([]grouping.Transaction{{
+		ID:               snap[0].TxnID,
+		Topics:           snap[0].Topics,
+		ReadProcessWrite: snap[0].ReadProcessWrite,
+	}}, grouping.Options{})
+
+	require.Len(t, res.Groups, 1, "the recovered input must not be a separate group")
+	assert.Equal(t, []string{"billing.out", "raw.events"}, res.Groups[0].Topics)
+	assert.True(t, res.Groups[0].ReadProcessWrite)
 }

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -104,6 +104,14 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 	}
 	val, err := txnlog.DecodeValue(rec.Value)
 	if err != nil {
+		// The format-drift alarm. If a broker upgrade changes the TransactionLogValue
+		// schema the reader stops understanding footprints, and without this counter the
+		// run would finish "successfully" having found nothing — reporting an
+		// exactly-once cluster as having no transactional coupling at all. Counted
+		// separately from the key errors so the summary can name which half drifted.
+		r.valueDecodeErrors.Add(1)
+		slog.Debug("⏭️ skipped a transaction-state record whose value would not decode",
+			"offset", rec.Offset, "error", err)
 		return true
 	}
 

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -16,6 +16,9 @@ const DefaultTxnStateTopic = "__transaction_state"
 type TxnStateStats struct {
 	RecordsSeen int64
 	Footprints  int64
+	Empty       int64
+	Committed   int64
+	Aborted     int64
 }
 
 // TxnStateReader decodes __transaction_state records into Observations.
@@ -25,6 +28,9 @@ type TxnStateReader struct {
 
 	recordsSeen atomic.Int64
 	footprints  atomic.Int64
+	empty       atomic.Int64
+	committed   atomic.Int64
+	aborted     atomic.Int64
 }
 
 // NewTxnStateReader builds a reader over the named transaction-state topic.
@@ -37,6 +43,9 @@ func (r *TxnStateReader) Stats() TxnStateStats {
 	return TxnStateStats{
 		RecordsSeen: r.recordsSeen.Load(),
 		Footprints:  r.footprints.Load(),
+		Empty:       r.empty.Load(),
+		Committed:   r.committed.Load(),
+		Aborted:     r.aborted.Load(),
 	}
 }
 
@@ -63,6 +72,29 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 	}
 	val, err := txnlog.DecodeValue(rec.Value)
 	if err != nil {
+		return true
+	}
+
+	// Register with the shared catalog before anything else. Even a Complete* record,
+	// which carries no footprint, still carries the transactional id and producer id
+	// the enrichment phases correlate on — so registration is unconditional on status.
+	r.catalog.Observe(key.TransactionalID, val.ProducerID)
+
+	// Count the terminal states so the run can report how many transactions committed
+	// versus aborted in the window. Reading from earliest, this counts the completions
+	// the compacted log still retains plus those occurring inside the window, not a
+	// guaranteed lifetime total.
+	switch val.Status {
+	case txnlog.StatusCompleteCommit:
+		r.committed.Add(1)
+	case txnlog.StatusCompleteAbort:
+		r.aborted.Add(1)
+	}
+
+	if !val.Status.HasFootprint() {
+		// Empty / Complete* / Dead: the coordinator has already cleared the partition
+		// set, so there is no footprint to report — only the catalog entry above.
+		r.empty.Add(1)
 		return true
 	}
 

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -158,6 +158,8 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 		Source:           SourceTxnStateLog,
 		ObservedAt:       time.Now(),
 	}
+	// A consumer that has stopped draining must not pin the reader open, or shutdown
+	// deadlocks behind an unread send and the command never writes its artifacts.
 	select {
 	case out <- obs:
 		return true

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -19,6 +19,9 @@ type TxnStateStats struct {
 	Empty       int64
 	Committed   int64
 	Aborted     int64
+	Tombstones  int64
+
+	ValueDecodeErrors int64
 }
 
 // TxnStateReader decodes __transaction_state records into Observations.
@@ -31,6 +34,7 @@ type TxnStateReader struct {
 	empty       atomic.Int64
 	committed   atomic.Int64
 	aborted     atomic.Int64
+	tombstones  atomic.Int64
 }
 
 // NewTxnStateReader builds a reader over the named transaction-state topic.
@@ -46,6 +50,7 @@ func (r *TxnStateReader) Stats() TxnStateStats {
 		Empty:       r.empty.Load(),
 		Committed:   r.committed.Load(),
 		Aborted:     r.aborted.Load(),
+		Tombstones:  r.tombstones.Load(),
 	}
 }
 
@@ -65,6 +70,14 @@ func (r *TxnStateReader) Run(ctx context.Context, in <-chan tail.Batch, out chan
 // when ctx ended while sending, signalling the caller to stop.
 func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<- Observation) bool {
 	r.recordsSeen.Add(1)
+
+	// A null value is compaction retiring a transactional id, not corruption. It is
+	// checked before the decoder so a routine tombstone cannot register as a value
+	// decode error and fire the format-drift alarm.
+	if len(rec.Value) == 0 {
+		r.tombstones.Add(1)
+		return true
+	}
 
 	key, err := txnlog.DecodeKey(rec.Key)
 	if err != nil {

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -1,0 +1,83 @@
+package discovery
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/txnlog"
+)
+
+// DefaultTxnStateTopic is Kafka's internal transaction-coordinator log.
+const DefaultTxnStateTopic = "__transaction_state"
+
+// TxnStateStats is a snapshot of what the transaction-state reader decoded.
+type TxnStateStats struct {
+	RecordsSeen int64
+	Footprints  int64
+}
+
+// TxnStateReader decodes __transaction_state records into Observations.
+type TxnStateReader struct {
+	topic   string
+	catalog *TxnCatalog
+
+	recordsSeen atomic.Int64
+	footprints  atomic.Int64
+}
+
+// NewTxnStateReader builds a reader over the named transaction-state topic.
+func NewTxnStateReader(topic string, catalog *TxnCatalog) *TxnStateReader {
+	return &TxnStateReader{topic: topic, catalog: catalog}
+}
+
+// Stats returns a snapshot of the reader's counters.
+func (r *TxnStateReader) Stats() TxnStateStats {
+	return TxnStateStats{
+		RecordsSeen: r.recordsSeen.Load(),
+		Footprints:  r.footprints.Load(),
+	}
+}
+
+// Run drains the batch channel, emitting observations onto out.
+func (r *TxnStateReader) Run(ctx context.Context, in <-chan tail.Batch, out chan<- Observation) error {
+	for b := range in {
+		for _, rec := range b.Records {
+			if !r.handle(ctx, rec, out) {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// handle decodes one record and emits an Observation for it. It reports false only
+// when ctx ended while sending, signalling the caller to stop.
+func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<- Observation) bool {
+	r.recordsSeen.Add(1)
+
+	key, err := txnlog.DecodeKey(rec.Key)
+	if err != nil {
+		return true
+	}
+	val, err := txnlog.DecodeValue(rec.Value)
+	if err != nil {
+		return true
+	}
+
+	r.footprints.Add(1)
+	obs := Observation{
+		TxnID:      key.TransactionalID,
+		ProducerID: val.ProducerID,
+		Topics:     val.Topics(),
+		Source:     SourceTxnStateLog,
+		ObservedAt: time.Now(),
+	}
+	select {
+	case out <- obs:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,7 @@ type TxnStateStats struct {
 	Aborted     int64
 	Tombstones  int64
 
+	KeyDecodeErrors   int64
 	ValueDecodeErrors int64
 }
 
@@ -39,6 +41,9 @@ type TxnStateReader struct {
 	committed   atomic.Int64
 	aborted     atomic.Int64
 	tombstones  atomic.Int64
+
+	keyDecodeErrors   atomic.Int64
+	valueDecodeErrors atomic.Int64
 }
 
 // NewTxnStateReader builds a reader over the named transaction-state topic.
@@ -55,6 +60,9 @@ func (r *TxnStateReader) Stats() TxnStateStats {
 		Committed:   r.committed.Load(),
 		Aborted:     r.aborted.Load(),
 		Tombstones:  r.tombstones.Load(),
+
+		KeyDecodeErrors:   r.keyDecodeErrors.Load(),
+		ValueDecodeErrors: r.valueDecodeErrors.Load(),
 	}
 }
 
@@ -85,6 +93,13 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 
 	key, err := txnlog.DecodeKey(rec.Key)
 	if err != nil {
+		// Counted, not fatal. One unreadable record must not end the observation
+		// window — the run would then report what it had read so far as the whole
+		// truth. The count is what the summary reports; the per-record detail stays at
+		// Debug so sustained drift cannot flood the console under --verbose.
+		r.keyDecodeErrors.Add(1)
+		slog.Debug("⏭️ skipped a transaction-state record whose key would not decode",
+			"offset", rec.Offset, "error", err)
 		return true
 	}
 	val, err := txnlog.DecodeValue(rec.Value)

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -17,20 +17,54 @@ const DefaultTxnStateTopic = "__transaction_state"
 // enrolling it is how a transaction declares itself read-process-write.
 const DefaultConsumerOffsetsTopic = "__consumer_offsets"
 
-// TxnStateStats is a snapshot of what the transaction-state reader decoded.
+// TxnStateStats is a snapshot of what the transaction-state reader decoded. It is
+// what the run summary reports for this phase.
+//
+// Reader lag is deliberately absent: the tail component owns offset tracking and
+// reports lag against the last stable offset, so duplicating a records-behind figure
+// here would give the summary two disagreeing answers to the same question.
 type TxnStateStats struct {
+	// RecordsSeen counts every record this reader was handed, including tombstones
+	// and records it could not decode.
 	RecordsSeen int64
-	Footprints  int64
-	Empty       int64
-	Committed   int64
-	Aborted     int64
-	Tombstones  int64
+	// Footprints counts records that carried a topic-partition set and so produced an
+	// Observation.
+	Footprints int64
+	// Empty counts records whose status carries no footprint because the coordinator
+	// had already cleared the partition set.
+	Empty int64
+	// Committed and Aborted count the terminal CompleteCommit / CompleteAbort records
+	// seen. Reading from earliest, this is the completions the compacted log still
+	// retains plus those occurring inside the window — not a lifetime total, since
+	// compaction may already have collapsed an old transaction down to one record.
+	Committed int64
+	Aborted   int64
+	// Tombstones counts null-valued records, which is compaction retiring a
+	// transactional id rather than anything malformed.
+	Tombstones int64
 
+	// KeyDecodeErrors and ValueDecodeErrors count broker-supplied records this reader
+	// could not parse. They are the format-drift alarm — a non-zero count means the
+	// run may have missed footprints — and are kept apart so the summary can name
+	// which half of the record drifted.
 	KeyDecodeErrors   int64
 	ValueDecodeErrors int64
 }
 
-// TxnStateReader decodes __transaction_state records into Observations.
+// TxnStateReader decodes __transaction_state records — the transaction coordinator's
+// own log — into Observations, reconstructing each transaction's topic footprint
+// straight from the records the coordinator wrote.
+//
+// It does not own its Kafka connection. It consumes tail.Batch values from a channel
+// so that ONE tail instance can serve both this reader and the __consumer_offsets
+// one; batches are demultiplexed on topic. The caller starts that tail at the
+// EARLIEST offset, so the run also recovers footprints the log retained from before
+// it started, and keeps it in a continuous fetch loop rather than a periodic poll —
+// a short transaction's record can be compacted away between polls.
+//
+// As it decodes it registers every transactional id and producer id in the shared
+// TxnCatalog, which the enrichment phases read instead of calling the transaction
+// admin APIs.
 type TxnStateReader struct {
 	topic   string
 	catalog *TxnCatalog
@@ -46,12 +80,15 @@ type TxnStateReader struct {
 	valueDecodeErrors atomic.Int64
 }
 
-// NewTxnStateReader builds a reader over the named transaction-state topic.
+// NewTxnStateReader builds a reader over the named transaction-state topic, which is
+// DefaultTxnStateTopic unless the operator overrode it. Only batches carrying that
+// topic are decoded. Every decoded record is registered in catalog.
 func NewTxnStateReader(topic string, catalog *TxnCatalog) *TxnStateReader {
 	return &TxnStateReader{topic: topic, catalog: catalog}
 }
 
-// Stats returns a snapshot of the reader's counters.
+// Stats returns a snapshot of the reader's counters. Safe to call while Run is in
+// flight, which is what the periodic keep-up signal does.
 func (r *TxnStateReader) Stats() TxnStateStats {
 	return TxnStateStats{
 		RecordsSeen: r.recordsSeen.Load(),
@@ -66,7 +103,17 @@ func (r *TxnStateReader) Stats() TxnStateStats {
 	}
 }
 
-// Run drains the batch channel, emitting observations onto out.
+// Run consumes batches from in until the channel closes or ctx ends, emitting an
+// Observation onto out for every footprint-bearing record.
+//
+// This is the contract the command wiring implements: it owns the tail.Tail, reads
+// its single batch channel, and hands each batch to the reader whose topic it names.
+// Run takes a receive-only channel rather than a Tail precisely so one tail can be
+// demultiplexed across this reader and the __consumer_offsets one.
+//
+// out must be drained for the duration of the run. Run returns nil on both ordinary
+// endings — input exhausted, or context cancelled — because neither is a failure of
+// the run; the counters on Stats are what report whether the read was clean.
 func (r *TxnStateReader) Run(ctx context.Context, in <-chan tail.Batch, out chan<- Observation) error {
 	for b := range in {
 		// Demultiplex. One Tail serves this reader and the __consumer_offsets one over a
@@ -118,6 +165,9 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 		// separately from the key errors so the summary can name which half drifted.
 		r.valueDecodeErrors.Add(1)
 		slog.Debug("⏭️ skipped a transaction-state record whose value would not decode",
+			// Deliberately NOT key.TransactionalID, which is in scope here and which the
+			// ported source logged: kcp.log is Debug+ unconditionally and is attached to
+			// support tickets, so the offset is the diagnostic and the id is disclosure.
 			"offset", rec.Offset, "error", err)
 		return true
 	}

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -69,6 +69,13 @@ func (r *TxnStateReader) Stats() TxnStateStats {
 // Run drains the batch channel, emitting observations onto out.
 func (r *TxnStateReader) Run(ctx context.Context, in <-chan tail.Batch, out chan<- Observation) error {
 	for b := range in {
+		// Demultiplex. One Tail serves this reader and the __consumer_offsets one over a
+		// single channel, so a batch that is not ours is skipped rather than decoded:
+		// feeding an offset-commit record to the TransactionLogValue decoder would fire
+		// the format-drift alarm on a cluster whose format never drifted.
+		if b.Topic != r.topic {
+			continue
+		}
 		for _, rec := range b.Records {
 			if !r.handle(ctx, rec, out) {
 				return nil

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -12,6 +12,10 @@ import (
 // DefaultTxnStateTopic is Kafka's internal transaction-coordinator log.
 const DefaultTxnStateTopic = "__transaction_state"
 
+// DefaultConsumerOffsetsTopic is Kafka's internal consumer-offsets log. A footprint
+// enrolling it is how a transaction declares itself read-process-write.
+const DefaultConsumerOffsetsTopic = "__consumer_offsets"
+
 // TxnStateStats is a snapshot of what the transaction-state reader decoded.
 type TxnStateStats struct {
 	RecordsSeen int64
@@ -112,12 +116,17 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 	}
 
 	r.footprints.Add(1)
+	topics := val.Topics()
 	obs := Observation{
 		TxnID:      key.TransactionalID,
 		ProducerID: val.ProducerID,
-		Topics:     val.Topics(),
-		Source:     SourceTxnStateLog,
-		ObservedAt: time.Now(),
+		// The RAW footprint, internal topics included. Filtering belongs to the grouping
+		// stage; dropping __consumer_offsets here would erase the evidence for the flag
+		// below from the audit trail.
+		Topics:           topics,
+		ReadProcessWrite: containsTopic(topics, DefaultConsumerOffsetsTopic),
+		Source:           SourceTxnStateLog,
+		ObservedAt:       time.Now(),
 	}
 	select {
 	case out <- obs:
@@ -125,4 +134,14 @@ func (r *TxnStateReader) handle(ctx context.Context, rec tail.Record, out chan<-
 	case <-ctx.Done():
 		return false
 	}
+}
+
+// containsTopic reports whether want is in topics.
+func containsTopic(topics []string, want string) bool {
+	for _, t := range topics {
+		if t == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/services/txndiscovery/discovery/txnstate.go
+++ b/internal/services/txndiscovery/discovery/txnstate.go
@@ -123,6 +123,17 @@ func (r *TxnStateReader) Run(ctx context.Context, in <-chan tail.Batch, out chan
 		if b.Topic != r.topic {
 			continue
 		}
+		// A control batch is the transaction marker itself, not application data. The
+		// tail component delivers control batches flagged rather than filtering them, so
+		// dropping them is this consumer's job, exactly as it is ConsumerOffsetsTail's.
+		// A marker's key and value are a completely different schema — four and six
+		// bytes — so feeding them to the TransactionLog decoders ticks the decode-error
+		// counters, and those counters are the format-drift alarm: firing them on a
+		// cluster whose format never drifted discredits the one signal that tells an
+		// operator a broker upgrade has moved the schema out from under the run.
+		if b.Control {
+			continue
+		}
 		for _, rec := range b.Records {
 			if !r.handle(ctx, rec, out) {
 				return nil

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -320,4 +321,33 @@ func TestTxnStateReader_IgnoresBatchesFromAnotherTopic(t *testing.T) {
 	assert.Equal(t, int64(1), st.RecordsSeen, "a foreign topic's records are not this reader's to count")
 	assert.Equal(t, int64(0), st.KeyDecodeErrors)
 	assert.Equal(t, int64(0), st.ValueDecodeErrors, "a foreign record must not fire the format-drift alarm")
+}
+
+func TestTxnStateReader_CancelledContextStopsTheReaderRatherThanBlockingOnAnUnreadSend(t *testing.T) {
+	// At shutdown the orchestrator stops draining observations before every source has
+	// finished. A reader that blocked on the send would pin the whole run open and the
+	// command would hang instead of writing its artifacts. The send must lose to
+	// cancellation.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	in := make(chan tail.Batch, 1)
+	in <- stateBatch(tail.Record{Key: txnKey("app"), Value: txnValue(1, 1, "a")})
+	// Deliberately NOT closed: Run must return because the context ended, not because
+	// its input ran out.
+
+	// Unbuffered and never read, so the send can only complete via cancellation.
+	out := make(chan Observation)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx, in, out) }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "cancellation is an ordinary shutdown, not a run failure")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run blocked on an unread send after its context was cancelled")
+	}
 }

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -265,3 +265,33 @@ func TestTxnStateReader_UndecodableKeyIsCountedAndDoesNotStopTheReader(t *testin
 	assert.Equal(t, int64(0), st.ValueDecodeErrors)
 	assert.Equal(t, int64(1), st.Footprints)
 }
+
+func TestTxnStateReader_UndecodableValueIncrementsItsOwnCounterAndDoesNotStopTheReader(t *testing.T) {
+	// Value decode failures are the format-drift alarm. If a broker upgrade changes the
+	// TransactionLogValue schema the reader stops understanding footprints, and the run
+	// would otherwise finish "successfully" having found nothing — reporting an EOS
+	// cluster as having no transactional coupling at all. The counter is tracked apart
+	// from the key counter so the summary can name which half of the record drifted.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r, stateBatch(
+		// Value version 99 — the decoder rejects an unknown schema rather than guessing.
+		tail.Record{Key: txnKey("drift-app"), Value: concat(be16(99), be64(1))},
+		// Truncated mid-record: the header is present but the body is cut short.
+		tail.Record{Key: txnKey("cut-app"), Value: concat(be16(0), be64(2), be16(1))},
+		tail.Record{Key: txnKey("healthy-app"), Value: txnValue(3, 1, "c")},
+	))
+
+	require.Len(t, got, 1, "the reader must survive the bad values and still emit the good record")
+	assert.Equal(t, "healthy-app", got[0].TxnID)
+
+	st := r.Stats()
+	assert.Equal(t, int64(3), st.RecordsSeen)
+	assert.Equal(t, int64(2), st.ValueDecodeErrors)
+	// The keys decoded fine, so this must stay clean or the summary blames the wrong half.
+	assert.Equal(t, int64(0), st.KeyDecodeErrors)
+	// A record whose value would not decode is NOT a tombstone: conflating the two would
+	// silence the alarm behind a routine compaction count.
+	assert.Equal(t, int64(0), st.Tombstones)
+	assert.Equal(t, int64(1), st.Footprints)
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -1,0 +1,125 @@
+package discovery
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+)
+
+// --- literal-byte fixtures ---
+//
+// The __transaction_state key and value bytes are hand-assembled rather than built
+// with an encoder, for the same reason the txnlog decoder's own tests are: a fixture
+// produced by the code under test would only prove the reader agrees with itself.
+
+func be16(v int16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(v))
+	return b
+}
+
+func be32(v int32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(v))
+	return b
+}
+
+func be64(v int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+// kstr encodes a classic (non-flexible) string: int16 length, then the bytes.
+func kstr(s string) []byte { return append(be16(int16(len(s))), s...) }
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// txnKey encodes a __transaction_state record key at schema v0.
+func txnKey(txnID string) []byte {
+	return concat(be16(0), kstr(txnID))
+}
+
+// txnValue encodes a __transaction_state record value at schema v0 (the classic,
+// non-flexible encoding), with one partition per named topic.
+func txnValue(producerID int64, status int8, topics ...string) []byte {
+	parts := [][]byte{
+		be16(0),          // version = 0
+		be64(producerID), // producerId
+		be16(1),          // producerEpoch
+		be32(60000),      // timeoutMs
+		{byte(status)},   // transactionStatus
+		be32(int32(len(topics))),
+	}
+	for _, tp := range topics {
+		parts = append(parts,
+			kstr(tp),
+			be32(1), // one partition
+			be32(0), // partition 0
+		)
+	}
+	parts = append(parts, be64(1000), be64(900)) // lastUpdateMs, startMs
+	return concat(parts...)
+}
+
+// stateBatch wraps records into the batch shape the tail delivers for the
+// transaction-state topic.
+func stateBatch(records ...tail.Record) tail.Batch {
+	return tail.Batch{Topic: DefaultTxnStateTopic, Partition: 3, Records: records}
+}
+
+// runReader feeds the reader one closed channel of batches and returns everything it
+// emitted. Feeding a closed channel keeps the test synchronous: Run returns when the
+// input is drained, so there is no goroutine to join and no timeout to tune.
+func runReader(t *testing.T, r *TxnStateReader, batches ...tail.Batch) []Observation {
+	t.Helper()
+	in := make(chan tail.Batch, len(batches))
+	for _, b := range batches {
+		in <- b
+	}
+	close(in)
+
+	// Buffered past any plausible emission count so Run never blocks on the send.
+	out := make(chan Observation, 64)
+	require.NoError(t, r.Run(context.Background(), in, out))
+	close(out)
+
+	var got []Observation
+	for obs := range out {
+		got = append(got, obs)
+	}
+	return got
+}
+
+func TestTxnStateReader_FootprintBearingRecordProducesAnObservationCarryingItsTopics(t *testing.T) {
+	// An Ongoing record is the coordinator's own statement of which topics the
+	// transaction has enrolled. That footprint is the entire point of reading this
+	// log, so it must reach the accumulator with its topics intact.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r, stateBatch(tail.Record{
+		Offset: 7,
+		Key:    txnKey("payments-app-0"),
+		Value:  txnValue(42, 1, "payments.approved", "payments.ledger"), // 1 = Ongoing
+	}))
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "payments-app-0", got[0].TxnID)
+	assert.Equal(t, int64(42), got[0].ProducerID)
+	assert.Equal(t, []string{"payments.approved", "payments.ledger"}, got[0].Topics)
+	assert.Equal(t, SourceTxnStateLog, got[0].Source)
+	assert.False(t, got[0].ObservedAt.IsZero())
+	assert.Equal(t, int64(1), r.Stats().Footprints)
+	assert.Equal(t, int64(1), r.Stats().RecordsSeen)
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -150,3 +150,25 @@ func TestTxnStateReader_CompletedTransactionRegistersInTheCatalogButProducesNoOb
 	assert.Equal(t, int64(1), st.Committed)
 	assert.Equal(t, int64(1), st.Empty)
 }
+
+func TestTxnStateReader_TombstoneIsCountedAndProducesNoObservation(t *testing.T) {
+	// Compaction writes a null value to retire a transactional id. There is nothing to
+	// decode, so it must be counted as a tombstone and skipped — NOT routed into the
+	// value decoder, which would report a truncated record and fire the format-drift
+	// alarm on a completely routine event.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r, stateBatch(tail.Record{
+		Offset: 19,
+		Key:    txnKey("payments-app-0"),
+		Value:  nil,
+	}))
+
+	assert.Empty(t, got)
+
+	st := r.Stats()
+	assert.Equal(t, int64(1), st.RecordsSeen)
+	assert.Equal(t, int64(1), st.Tombstones)
+	assert.Equal(t, int64(0), st.ValueDecodeErrors)
+	assert.Equal(t, int64(0), st.Footprints)
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -382,3 +382,57 @@ func TestTxnStateReader_NoTopicNameOrTransactionalIDReachesTheLog(t *testing.T) 
 	assert.NotContains(t, logged.String(), "secret-txnid", "a transactional id reached kcp.log")
 	assert.NotContains(t, logged.String(), "secret-topic", "a topic name reached kcp.log")
 }
+
+// controlBatch wraps a transaction marker in the batch shape the tail delivers for one:
+// flagged as a control batch, transactional, and carrying a real producer id, because a
+// marker genuinely is all three.
+func controlBatch(records ...tail.Record) tail.Batch {
+	b := stateBatch(records...)
+	b.IsTransactional = true
+	b.Control = true
+	b.ProducerID = 42
+	return b
+}
+
+// markerKey encodes a control record's key: version int16, then the marker type
+// (0 = ABORT, 1 = COMMIT). Four bytes, and nothing else.
+func markerKey(markerType int16) []byte { return concat(be16(0), be16(markerType)) }
+
+// markerValue encodes a control record's value: version int16, then coordinatorEpoch
+// int32. Six bytes, and nothing else.
+func markerValue(coordinatorEpoch int32) []byte { return concat(be16(0), be32(coordinatorEpoch)) }
+
+func TestTxnStateReader_ControlBatchIsSkippedRatherThanDecodedAsATransactionRecord(t *testing.T) {
+	// tail.consumeBlock deliberately EMITS control batches and documents that dropping
+	// them is the consumer's job. ConsumerOffsetsTail.HandleBatch does so; this reader
+	// did not, so a marker reaching the transaction-state topic was fed to decoders
+	// written for a completely different schema.
+	//
+	// Neither marker survives that. A commit marker's 4-byte key decodes as key-version 0
+	// and then reads the marker TYPE as a string length, which runs off the end of the
+	// key; an abort marker's key decodes to an empty transactional id and its 6-byte
+	// value then dies in the value decoder. Either way a counter ticks — and these two
+	// counters are the format-drift alarm, the thing that tells an operator a broker
+	// upgrade has moved the internal schema out from under the run. Firing it on a
+	// cluster whose format never drifted is a false alarm on the one signal that has to
+	// stay trustworthy.
+	for name, markerType := range map[string]int16{"abort marker": 0, "commit marker": 1} {
+		t.Run(name, func(t *testing.T) {
+			cat := NewTxnCatalog()
+			r := NewTxnStateReader(DefaultTxnStateTopic, cat)
+
+			got := runReader(t, r, controlBatch(tail.Record{
+				Offset: 5,
+				Key:    markerKey(markerType),
+				Value:  markerValue(7),
+			}))
+
+			assert.Empty(t, got, "a marker is not application data and carries no footprint")
+			assert.Empty(t, cat.TxnIDs(), "a marker carries no transactional id to register")
+
+			st := r.Stats()
+			assert.Equal(t, int64(0), st.KeyDecodeErrors, "a marker key fired the format-drift alarm")
+			assert.Equal(t, int64(0), st.ValueDecodeErrors, "a marker value fired the format-drift alarm")
+		})
+	}
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -1,9 +1,11 @@
 package discovery
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"sort"
 	"testing"
 	"time"
@@ -350,4 +352,33 @@ func TestTxnStateReader_CancelledContextStopsTheReaderRatherThanBlockingOnAnUnre
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run blocked on an unread send after its context was cancelled")
 	}
+}
+
+func TestTxnStateReader_NoTopicNameOrTransactionalIDReachesTheLog(t *testing.T) {
+	// kcp.log is written at Debug+ unconditionally and is the file operators attach to
+	// support tickets, so a name on ANY slog call defeats the counts-only terminal
+	// entirely — and under --verbose those same lines reach the console. The value
+	// decode path is the trap: the key decoded fine there, so the transactional id IS
+	// in scope and the POC this was ported from logs it.
+	var logged bytes.Buffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	runReader(t, r, stateBatch(
+		// Key decodes, value does not: the transactional id is available to be leaked.
+		tail.Record{Key: txnKey("secret-txnid"), Value: concat(be16(99), be64(1))},
+		// Neither decodes.
+		tail.Record{Key: concat(be16(9), kstr("secret-txnid")), Value: []byte("junk")},
+		// A clean record whose topic names must not be narrated either.
+		tail.Record{Key: txnKey("secret-txnid"), Value: txnValue(1, 1, "secret-topic")},
+	))
+
+	require.Equal(t, int64(1), r.Stats().KeyDecodeErrors)
+	require.Equal(t, int64(1), r.Stats().ValueDecodeErrors)
+
+	assert.NotContains(t, logged.String(), "secret-txnid", "a transactional id reached kcp.log")
+	assert.NotContains(t, logged.String(), "secret-topic", "a topic name reached kcp.log")
 }

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -197,4 +199,41 @@ func TestTxnStateReader_FootprintContainingConsumerOffsetsIsReadProcessWrite(t *
 	// grouping stage's job, and dropping it here would make the observation unauditable.
 	assert.Equal(t, []string{"orders.enriched", DefaultConsumerOffsetsTopic}, got[0].Topics)
 	assert.False(t, got[1].ReadProcessWrite, "a produce-only footprint is not read-process-write")
+}
+
+func TestTxnStateReader_EveryStatusRegistersItsTxnIDAndProducerIDInTheCatalog(t *testing.T) {
+	// The catalog is what the enrichment phases correlate on instead of calling the
+	// transaction admin APIs, and both facts they need — the transactional id and the
+	// producer id — are on EVERY state record whatever its status. Registering only
+	// footprint-bearing records would hide every transaction that had already finished
+	// when the run started, which on a compacted log is most of them.
+	cat := NewTxnCatalog()
+	r := NewTxnStateReader(DefaultTxnStateTopic, cat)
+
+	// One record per status, none of which is Ongoing/PrepareCommit/PrepareAbort except
+	// where noted, and all with their partition set cleared as the coordinator leaves it.
+	var records []tail.Record
+	for i, status := range []int8{0, 4, 5, 6, 7} { // Empty, CompleteCommit, CompleteAbort, Dead, PrepareEpochFence
+		records = append(records, tail.Record{
+			Key:   txnKey(fmt.Sprintf("app-%d", i)),
+			Value: txnValue(int64(100+i), status),
+		})
+	}
+
+	got := runReader(t, r, stateBatch(records...))
+
+	assert.Empty(t, got, "no status in this set carries a footprint")
+
+	ids := cat.TxnIDs()
+	sort.Strings(ids)
+	assert.Equal(t, []string{"app-0", "app-1", "app-2", "app-3", "app-4"}, ids)
+	assert.Equal(t, map[int64]string{
+		100: "app-0", 101: "app-1", 102: "app-2", 103: "app-3", 104: "app-4",
+	}, cat.ProducerIDToTxnID())
+
+	st := r.Stats()
+	assert.Equal(t, int64(5), st.RecordsSeen)
+	assert.Equal(t, int64(5), st.Empty)
+	assert.Equal(t, int64(1), st.Committed)
+	assert.Equal(t, int64(1), st.Aborted)
 }

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -295,3 +295,29 @@ func TestTxnStateReader_UndecodableValueIncrementsItsOwnCounterAndDoesNotStopThe
 	assert.Equal(t, int64(0), st.Tombstones)
 	assert.Equal(t, int64(1), st.Footprints)
 }
+
+func TestTxnStateReader_IgnoresBatchesFromAnotherTopic(t *testing.T) {
+	// One Tail instance serves both this reader and the __consumer_offsets one, and a
+	// single channel carries both topics, so every consumer must demultiplex on the
+	// batch's topic. Without this filter a __consumer_offsets commit record would be
+	// fed to the TransactionLogValue decoder, which cannot read it — turning a
+	// correctly wired run into a flood of value decode errors and firing the
+	// format-drift alarm on a cluster whose format never drifted.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r,
+		tail.Batch{
+			Topic:   DefaultConsumerOffsetsTopic,
+			Records: []tail.Record{{Key: []byte("an offset commit key"), Value: []byte("not a txn state value")}},
+		},
+		stateBatch(tail.Record{Key: txnKey("mine"), Value: txnValue(1, 1, "a")}),
+	)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "mine", got[0].TxnID)
+
+	st := r.Stats()
+	assert.Equal(t, int64(1), st.RecordsSeen, "a foreign topic's records are not this reader's to count")
+	assert.Equal(t, int64(0), st.KeyDecodeErrors)
+	assert.Equal(t, int64(0), st.ValueDecodeErrors, "a foreign record must not fire the format-drift alarm")
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -237,3 +237,31 @@ func TestTxnStateReader_EveryStatusRegistersItsTxnIDAndProducerIDInTheCatalog(t 
 	assert.Equal(t, int64(1), st.Committed)
 	assert.Equal(t, int64(1), st.Aborted)
 }
+
+func TestTxnStateReader_UndecodableKeyIsCountedAndDoesNotStopTheReader(t *testing.T) {
+	// The broker is untrusted input here: these are internal record schemas outside the
+	// stable client protocol. One unreadable key must not take the reader down with it,
+	// or a single malformed record ends the observation window and the run silently
+	// reports whatever it had managed to read so far as the whole truth.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r, stateBatch(
+		// Key version 9 — not a version that exists, so the decoder rejects it rather
+		// than guessing at the layout.
+		tail.Record{Key: concat(be16(9), kstr("evil-app")), Value: txnValue(1, 1, "a")},
+		// Truncated: the length prefix claims more bytes than the buffer holds.
+		tail.Record{Key: concat(be16(0), be16(64), []byte("short")), Value: txnValue(2, 1, "b")},
+		// A good record after the bad ones proves the loop kept going.
+		tail.Record{Key: txnKey("healthy-app"), Value: txnValue(3, 1, "c")},
+	))
+
+	require.Len(t, got, 1, "the reader must survive the bad keys and still emit the good record")
+	assert.Equal(t, "healthy-app", got[0].TxnID)
+
+	st := r.Stats()
+	assert.Equal(t, int64(3), st.RecordsSeen)
+	assert.Equal(t, int64(2), st.KeyDecodeErrors)
+	// A bad key must not be miscounted as the format-drift alarm for values.
+	assert.Equal(t, int64(0), st.ValueDecodeErrors)
+	assert.Equal(t, int64(1), st.Footprints)
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -123,3 +123,30 @@ func TestTxnStateReader_FootprintBearingRecordProducesAnObservationCarryingItsTo
 	assert.Equal(t, int64(1), r.Stats().Footprints)
 	assert.Equal(t, int64(1), r.Stats().RecordsSeen)
 }
+
+func TestTxnStateReader_CompletedTransactionRegistersInTheCatalogButProducesNoObservation(t *testing.T) {
+	// Once a transaction completes, the coordinator rewrites its state record with the
+	// partition set CLEARED. Emitting an observation from it would report an empty
+	// footprint as if it were the truth and, worse, credit the transaction with having
+	// touched nothing. The transactional id and producer id are still on the record,
+	// though, and the enrichment phases correlate on exactly those — so the catalog
+	// registration must happen regardless of status.
+	cat := NewTxnCatalog()
+	r := NewTxnStateReader(DefaultTxnStateTopic, cat)
+
+	got := runReader(t, r, stateBatch(tail.Record{
+		Offset: 11,
+		Key:    txnKey("payments-app-0"),
+		Value:  txnValue(42, 4), // 4 = CompleteCommit, no partitions
+	}))
+
+	assert.Empty(t, got)
+	assert.Equal(t, []string{"payments-app-0"}, cat.TxnIDs())
+	assert.Equal(t, map[int64]string{42: "payments-app-0"}, cat.ProducerIDToTxnID())
+
+	st := r.Stats()
+	assert.Equal(t, int64(1), st.RecordsSeen)
+	assert.Equal(t, int64(0), st.Footprints)
+	assert.Equal(t, int64(1), st.Committed)
+	assert.Equal(t, int64(1), st.Empty)
+}

--- a/internal/services/txndiscovery/discovery/txnstate_test.go
+++ b/internal/services/txndiscovery/discovery/txnstate_test.go
@@ -172,3 +172,29 @@ func TestTxnStateReader_TombstoneIsCountedAndProducesNoObservation(t *testing.T)
 	assert.Equal(t, int64(0), st.ValueDecodeErrors)
 	assert.Equal(t, int64(0), st.Footprints)
 }
+
+func TestTxnStateReader_FootprintContainingConsumerOffsetsIsReadProcessWrite(t *testing.T) {
+	// A transaction that enrolled __consumer_offsets committed consumer offsets inside
+	// itself, which makes it a consume-transform-produce app. Its CONSUMED input topics
+	// are not in this footprint — only its outputs are — so the flag is what tells the
+	// downstream enrichment phases there are inputs still to recover.
+	r := NewTxnStateReader(DefaultTxnStateTopic, NewTxnCatalog())
+
+	got := runReader(t, r,
+		stateBatch(tail.Record{
+			Key:   txnKey("streams-app-0"),
+			Value: txnValue(7, 1, "orders.enriched", DefaultConsumerOffsetsTopic),
+		}),
+		stateBatch(tail.Record{
+			Key:   txnKey("produce-only-0"),
+			Value: txnValue(8, 1, "audit.events"),
+		}),
+	)
+
+	require.Len(t, got, 2)
+	assert.True(t, got[0].ReadProcessWrite, "a footprint enrolling __consumer_offsets is read-process-write")
+	// The raw footprint is passed through INCLUDING the internal topic: filtering is the
+	// grouping stage's job, and dropping it here would make the observation unauditable.
+	assert.Equal(t, []string{"orders.enriched", DefaultConsumerOffsetsTopic}, got[0].Topics)
+	assert.False(t, got[1].ReadProcessWrite, "a produce-only footprint is not read-process-write")
+}

--- a/internal/services/txndiscovery/discovery/types.go
+++ b/internal/services/txndiscovery/discovery/types.go
@@ -1,0 +1,44 @@
+// Package discovery observes transactions on a running cluster and accumulates the
+// set of topics each transaction touches.
+//
+// The design separates observation (sources, which emit raw Observations) from
+// accumulation (Accumulator) from grouping (the grouping package). Each source is
+// independent, so adding one needs no change to the accumulator or the grouping stage.
+package discovery
+
+import "time"
+
+// Source name constants, used for provenance in Observations and in the audit trail.
+const (
+	SourceTxnStateLog     = "transaction-state-log"
+	SourceConsumerGroups  = "consumer-groups"
+	SourceConsumerOffsets = "consumer-offsets-log"
+)
+
+// Observation is a single sighting of one transaction's topic footprint.
+type Observation struct {
+	TxnID string
+
+	// ProducerID is the producer id the source saw for this transaction, or 0 when the
+	// source has none — the naming-based enrichment phase never has one.
+	ProducerID int64
+
+	// Topics is the raw footprint reported by the source, INCLUDING Kafka-internal
+	// topics such as __consumer_offsets. Filtering is deferred to the grouping stage so
+	// that sources stay simple and their output stays auditable.
+	Topics []string
+
+	// ReadProcessWrite is set when the raw footprint included __consumer_offsets, i.e.
+	// the transaction committed consumer offsets (a consume-transform-produce app).
+	// Such an app's CONSUMED input topics are NOT in the transaction footprint; the
+	// enrichment phases recover them and set this flag on the observations they emit.
+	ReadProcessWrite bool
+
+	// Source names the phase that made the sighting — one of the Source* constants.
+	// It is the provenance an audit line records, so an operator reading the trace can
+	// tell which phase coupled two topics.
+	Source string
+
+	// ObservedAt is when the source made the sighting.
+	ObservedAt time.Time
+}

--- a/internal/services/txndiscovery/grouping/grouping.go
+++ b/internal/services/txndiscovery/grouping/grouping.go
@@ -1,0 +1,174 @@
+// Package grouping derives transactional topic groups from observed transactions.
+//
+// Rule: if two or more topics appear within the same transaction, they belong in the
+// same group. Coupling is transitive — two transactions that share even a single
+// topic merge into one group — so the result is the connected components of the
+// topic co-occurrence graph.
+package grouping
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Transaction is the grouping input: one transactional id and the topics it touched.
+type Transaction struct {
+	ID               string
+	Topics           []string
+	ReadProcessWrite bool
+}
+
+// Options tunes grouping behaviour.
+type Options struct {
+	// IncludeInternalTopics keeps __-prefixed topics in the grouping. Default false:
+	// internal topics — above all __consumer_offsets, which every exactly-once
+	// application shares — are dropped BEFORE grouping. Leaving them in would
+	// transitively chain every unrelated workload into one giant group.
+	IncludeInternalTopics bool
+}
+
+// Group is a set of topics that must migrate together (atomically).
+type Group struct {
+	Name             string
+	Topics           []string
+	TxnIDs           []string
+	ReadProcessWrite bool
+}
+
+// Result is the full output of grouping.
+type Result struct {
+	Groups []Group
+
+	// IndividualTopics were only ever seen alone in a transaction (or in no
+	// multi-topic transaction) and can migrate one at a time.
+	IndividualTopics []string
+
+	// ReadProcessWriteTopics are topics PRODUCED inside a consume-transform-produce
+	// (exactly-once) transaction. Surfaced separately — and independently of whether
+	// they landed in a group or as an individual topic — because their CONSUMED input
+	// topics are invisible in the transaction footprint. A read-process-write app that
+	// produces to a single topic otherwise looks like a safe "move individually" topic
+	// when it is not: moving it without its (unknown) input topics breaks exactly-once
+	// delivery at cutover.
+	ReadProcessWriteTopics []string
+}
+
+// IsInternalTopic reports whether t is a Kafka-internal topic (e.g.
+// __consumer_offsets, __transaction_state) that must be excluded from grouping.
+func IsInternalTopic(t string) bool {
+	return strings.HasPrefix(t, "__")
+}
+
+type component struct {
+	topics           map[string]struct{}
+	txns             map[string]struct{}
+	readProcessWrite bool
+}
+
+// Build computes the transactional topic groups from txns.
+func Build(txns []Transaction, opts Options) Result {
+	uf := newUnionFind()
+	txnTopics := make(map[string][]string, len(txns))
+	rpwTxns := make(map[string]bool)
+
+	for _, txn := range txns {
+		var topics []string
+		for _, t := range txn.Topics {
+			// Filtered here, before uf.add and before the union below. Removing internal
+			// topics from the finished components instead would keep the transitive
+			// closure that already ran through them, chaining every unrelated
+			// exactly-once workload on the cluster into one group.
+			if !opts.IncludeInternalTopics && IsInternalTopic(t) {
+				continue
+			}
+			topics = append(topics, t)
+			uf.add(t)
+		}
+		txnTopics[txn.ID] = topics
+		if txn.ReadProcessWrite {
+			rpwTxns[txn.ID] = true
+		}
+		// Union every topic in this transaction together (via the first one).
+		for i := 1; i < len(topics); i++ {
+			uf.union(topics[0], topics[i])
+		}
+	}
+
+	// Bucket topics into their connected components.
+	comps := map[string]*component{}
+	for topic := range uf.parent {
+		root := uf.find(topic)
+		c := comps[root]
+		if c == nil {
+			c = &component{topics: map[string]struct{}{}, txns: map[string]struct{}{}}
+			comps[root] = c
+		}
+		c.topics[topic] = struct{}{}
+	}
+
+	// Attribute each transaction (and its read-process-write flag) to the component of
+	// its topics.
+	for id, topics := range txnTopics {
+		for _, t := range topics {
+			c := comps[uf.find(t)]
+			c.txns[id] = struct{}{}
+			if rpwTxns[id] {
+				c.readProcessWrite = true
+			}
+		}
+	}
+
+	var (
+		groups     []Group
+		individual []string
+		rpwTopics  []string
+	)
+	for _, c := range comps {
+		topics := keys(c.topics)
+		if c.readProcessWrite {
+			rpwTopics = append(rpwTopics, topics...)
+		}
+		if len(topics) < 2 {
+			individual = append(individual, topics...)
+			continue
+		}
+		groups = append(groups, Group{
+			Topics:           topics,
+			TxnIDs:           keys(c.txns),
+			ReadProcessWrite: c.readProcessWrite,
+		})
+	}
+
+	// Deterministic ordering: largest groups first, then alphabetical. Components are
+	// disjoint, so comparing the first topic is a total order and the result does not
+	// depend on the map iteration order above.
+	sort.Slice(groups, func(i, j int) bool {
+		if len(groups[i].Topics) != len(groups[j].Topics) {
+			return len(groups[i].Topics) > len(groups[j].Topics)
+		}
+		// Components are disjoint, so no two groups share a first topic: this makes the
+		// comparator a total order and the sort independent of map iteration order.
+		return groups[i].Topics[0] < groups[j].Topics[0]
+	})
+	for i := range groups {
+		groups[i].Name = fmt.Sprintf("group-%d", i+1)
+	}
+	sort.Strings(individual)
+	sort.Strings(rpwTopics)
+
+	return Result{
+		Groups:                 groups,
+		IndividualTopics:       individual,
+		ReadProcessWriteTopics: rpwTopics,
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/services/txndiscovery/grouping/grouping_test.go
+++ b/internal/services/txndiscovery/grouping/grouping_test.go
@@ -1,0 +1,141 @@
+package grouping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild_CouplingIsTransitiveAcrossTransactions(t *testing.T) {
+	// Topics coupled by a transaction must migrate together, and the coupling is
+	// transitive: two transactions sharing a single topic put every topic either of
+	// them touched into the same group. a-b, b-c and c-d chain into one group of four.
+	res := Build([]Transaction{
+		{ID: "1", Topics: []string{"a", "b"}},
+		{ID: "2", Topics: []string{"b", "c"}},
+		{ID: "3", Topics: []string{"c", "d"}},
+	}, Options{})
+
+	require.Len(t, res.Groups, 1)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, res.Groups[0].Topics)
+	assert.Equal(t, []string{"1", "2", "3"}, res.Groups[0].TxnIDs)
+}
+
+func TestBuild_UnrelatedWorkloadsStaySeparateAndAreOrderedLargestFirst(t *testing.T) {
+	// Client A touches t1,t2,t3; client B touches t2,t4; client C touches t5,t6.
+	// A and B share t2 so they merge; C shares nothing so it stays its own group.
+	// Groups are presented largest first, because group size is what an operator
+	// planning migration batches reads off the summary.
+	res := Build([]Transaction{
+		{ID: "A", Topics: []string{"t1", "t2", "t3"}},
+		{ID: "B", Topics: []string{"t2", "t4"}},
+		{ID: "C", Topics: []string{"t5", "t6"}},
+	}, Options{})
+
+	require.Len(t, res.Groups, 2)
+	assert.Equal(t, "group-1", res.Groups[0].Name)
+	assert.Equal(t, []string{"t1", "t2", "t3", "t4"}, res.Groups[0].Topics)
+	assert.Equal(t, "group-2", res.Groups[1].Name)
+	assert.Equal(t, []string{"t5", "t6"}, res.Groups[1].Topics)
+	assert.Empty(t, res.IndividualTopics)
+}
+
+func TestIsInternalTopic(t *testing.T) {
+	// Kafka's own internal topics use a double underscore. A single underscore is a
+	// naming convention some deployments use for their own topics (_schemas is
+	// Schema Registry's, not Kafka's) and must not be swept up.
+	cases := map[string]bool{
+		"__consumer_offsets":  true,
+		"__transaction_state": true,
+		"orders":              false,
+		"_schemas":            false,
+		"":                    false,
+	}
+
+	for topic, want := range cases {
+		assert.Equal(t, want, IsInternalTopic(topic), "IsInternalTopic(%q)", topic)
+	}
+}
+
+func TestBuild_InternalTopicsAreFilteredBeforeTheUnion(t *testing.T) {
+	// Every exactly-once application commits its consumer offsets inside the
+	// transaction, so __consumer_offsets is in the footprint of all of them. It has to
+	// be dropped BEFORE the union: filtering it out of the finished components instead
+	// would leave the transitive closure already computed through it, chaining every
+	// unrelated workload on the cluster into one meaningless group.
+	res := Build([]Transaction{
+		{ID: "app1", Topics: []string{"orders", "__consumer_offsets"}},
+		{ID: "app2", Topics: []string{"payments", "shipments", "__consumer_offsets"}},
+	}, Options{})
+
+	require.Len(t, res.Groups, 1, "the two workloads must not chain into one group")
+	assert.Equal(t, []string{"payments", "shipments"}, res.Groups[0].Topics)
+	assert.Equal(t, []string{"app2"}, res.Groups[0].TxnIDs)
+	assert.Equal(t, []string{"orders"}, res.IndividualTopics)
+}
+
+func TestBuild_IncludingInternalTopicsChainsEverythingIntoOneGroup(t *testing.T) {
+	// The guard rail for the test above: it proves the chaining is real rather than
+	// hypothetical, so if someone "simplifies" the filter away the previous test's
+	// failure has an explanation sitting next to it. Two workloads with nothing in
+	// common fuse into one group the moment the shared internal topic is kept.
+	res := Build([]Transaction{
+		{ID: "app1", Topics: []string{"orders", "__consumer_offsets"}},
+		{ID: "app2", Topics: []string{"payments", "__consumer_offsets"}},
+	}, Options{IncludeInternalTopics: true})
+
+	require.Len(t, res.Groups, 1)
+	assert.Equal(t, []string{"__consumer_offsets", "orders", "payments"}, res.Groups[0].Topics)
+	assert.Empty(t, res.IndividualTopics)
+}
+
+func TestBuild_ReadProcessWriteTopicsAreFlaggedEvenWhenUngrouped(t *testing.T) {
+	// A consume-transform-produce transaction's CONSUMED topics are invisible in its
+	// footprint, so a read-process-write app producing to one topic looks like a safe
+	// "move it on its own" topic when it is not. The flag has to survive landing in
+	// IndividualTopics, which is exactly the case that would otherwise read as safe.
+	res := Build([]Transaction{
+		{ID: "app1", Topics: []string{"orders", "__consumer_offsets"}, ReadProcessWrite: true},
+		{ID: "app2", Topics: []string{"payments", "shipments", "__consumer_offsets"}, ReadProcessWrite: true},
+		{ID: "app3", Topics: []string{"x", "y"}},
+	}, Options{})
+
+	require.Len(t, res.Groups, 2)
+	assert.Equal(t, []string{"payments", "shipments"}, res.Groups[0].Topics)
+	assert.True(t, res.Groups[0].ReadProcessWrite)
+	assert.Equal(t, []string{"x", "y"}, res.Groups[1].Topics)
+	assert.False(t, res.Groups[1].ReadProcessWrite, "a plain produce-only transaction is not read-process-write")
+
+	assert.Equal(t, []string{"orders"}, res.IndividualTopics)
+	assert.Equal(t, []string{"orders", "payments", "shipments"}, res.ReadProcessWriteTopics,
+		"the lone produced topic must stay flagged despite grouping alone")
+	assert.NotContains(t, res.ReadProcessWriteTopics, "__consumer_offsets",
+		"the filtered internal topic must not reappear here")
+}
+
+func TestBuild_OutputIsDeterministicAcrossRuns(t *testing.T) {
+	// Components are bucketed through Go maps, whose iteration order is randomised on
+	// every range. Two runs over the same observations must still produce identical
+	// group names, identical membership order within each group, and identical ordering
+	// between groups — otherwise a re-run of the command produces a diff that looks
+	// like the cluster changed. Every group here is the same size, so the size
+	// comparison alone cannot order them and the tiebreak has to carry it.
+	txns := []Transaction{
+		{ID: "t-zulu", Topics: []string{"zulu", "yankee"}},
+		{ID: "t-alpha", Topics: []string{"alpha", "bravo"}, ReadProcessWrite: true},
+		{ID: "t-mike", Topics: []string{"mike", "november"}},
+		{ID: "t-delta", Topics: []string{"delta", "echo"}},
+		{ID: "t-papa", Topics: []string{"papa", "quebec"}},
+		{ID: "t-sierra", Topics: []string{"sierra", "tango"}},
+		{ID: "t-solo", Topics: []string{"solo", "__consumer_offsets"}, ReadProcessWrite: true},
+		{ID: "t-lone", Topics: []string{"lone"}},
+	}
+
+	first := Build(txns, Options{})
+	require.Len(t, first.Groups, 6, "fixture must produce several equal-sized groups")
+
+	for run := 1; run < 200; run++ {
+		assert.Equal(t, first, Build(txns, Options{}), "run %d differed from run 0", run)
+	}
+}

--- a/internal/services/txndiscovery/grouping/unionfind.go
+++ b/internal/services/txndiscovery/grouping/unionfind.go
@@ -1,0 +1,40 @@
+package grouping
+
+// unionFind is a disjoint-set structure over topic names, used to compute the
+// connected components of the "co-occurs in a transaction" relation.
+type unionFind struct {
+	parent map[string]string
+	rank   map[string]int
+}
+
+func newUnionFind() *unionFind {
+	return &unionFind{parent: map[string]string{}, rank: map[string]int{}}
+}
+
+func (u *unionFind) add(x string) {
+	if _, ok := u.parent[x]; !ok {
+		u.parent[x] = x
+	}
+}
+
+func (u *unionFind) find(x string) string {
+	for u.parent[x] != x {
+		u.parent[x] = u.parent[u.parent[x]] // path halving
+		x = u.parent[x]
+	}
+	return x
+}
+
+func (u *unionFind) union(a, b string) {
+	ra, rb := u.find(a), u.find(b)
+	if ra == rb {
+		return
+	}
+	if u.rank[ra] < u.rank[rb] {
+		ra, rb = rb, ra
+	}
+	u.parent[rb] = ra
+	if u.rank[ra] == u.rank[rb] {
+		u.rank[ra]++
+	}
+}

--- a/internal/services/txndiscovery/report/auditlog.go
+++ b/internal/services/txndiscovery/report/auditlog.go
@@ -121,14 +121,17 @@ func openAuditFile(path string) (*os.File, error) {
 		_ = f.Close()
 		return nil, fmt.Errorf("refusing to write the audit log: %s is %s, not a regular file; remove it or choose another path with --audit-log-out", path, describeFileType(fi.Mode()))
 	}
-	// auditFileMode is only applied when the open creates the file. An existing file
-	// keeps whatever mode it already had, so the mode has to be verified rather than
-	// assumed — the audit log carries topic names and transactional ids.
-	if perm := fi.Mode().Perm(); perm&^auditFileMode != 0 {
+	if err := checkAuditFilePerm(path, fi.Mode()); err != nil {
 		_ = f.Close()
-		return nil, fmt.Errorf("refusing to write the audit log: %s has mode %#o, wider than %#o, and the audit log carries topic names and transactional ids; remove it or choose another path with --audit-log-out", path, perm, auditFileMode)
+		return nil, err
 	}
 	return f, nil
+}
+
+// errAuditFileTooWide is the refusal for an audit log whose mode is wider than
+// auditFileMode.
+func errAuditFileTooWide(path string, perm fs.FileMode) error {
+	return fmt.Errorf("refusing to write the audit log: %s has mode %#o, wider than %#o, and the audit log carries topic names and transactional ids; remove it or choose another path with --audit-log-out", path, perm, auditFileMode)
 }
 
 // rotateExisting moves any file already at path aside to <path>.<timestamp>.

--- a/internal/services/txndiscovery/report/auditlog.go
+++ b/internal/services/txndiscovery/report/auditlog.go
@@ -1,0 +1,314 @@
+// Package report renders the artifacts a transaction-discovery run produces.
+//
+// # Encoding of hostile topic names
+//
+// Topic names reach the audit log as attacker-influenceable data: whoever can create a
+// topic on the observed cluster chooses the bytes, and the names additionally arrive via
+// decoders for broker-internal binary formats that are not part of the stable client
+// protocol. Records are therefore always produced with encoding/json, never with string
+// formatting, so quotes, backslashes, control characters and — critically — newlines are
+// escaped. An unescaped newline would terminate the record early and let the remainder of
+// a name be read as a second, forged audit record.
+//
+// One case is deliberately lossy. encoding/json substitutes U+FFFD for invalid UTF-8
+// rather than returning an error, so a topic name containing invalid UTF-8 is recorded
+// with those bytes replaced. That is accepted here:
+//
+//   - The alternative is dropping the line, and a missing line reads downstream as "no
+//     transaction coupled these topics" — indistinguishable from a clean run, and the
+//     single worst failure mode for this artifact.
+//   - The coupling itself, which is what the file exists to record, survives intact; only
+//     the rendering of the name is lossy.
+//   - Kafka constrains topic names to [a-zA-Z0-9._-], so invalid UTF-8 cannot come from a
+//     legitimate topic. Its presence means a decode went wrong upstream, which the decode
+//     error counters report separately.
+//
+// The consequence to be aware of: grepping the audit log for the original raw bytes will
+// not match such a name. Grep for the U+FFFD-substituted form, or for the transactional
+// id instead.
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+)
+
+// auditFileMode is the mode the audit log is created with. The file carries topic
+// names and transactional ids — customer business structure — so it matches the 0600
+// used for kcp-state.json rather than the 0644 used for reports.
+const auditFileMode os.FileMode = 0600
+
+// AuditLine is the on-disk shape of one audit record: a single JSON object on a
+// single line.
+type AuditLine struct {
+	Timestamp time.Time `json:"timestamp"`
+	TxnID     string    `json:"transactional_id"`
+	Source    string    `json:"source"`
+	Added     []string  `json:"added"`
+	Topics    []string  `json:"topics"`
+}
+
+// AuditWriter appends a JSONL line to the audit log each time a transaction's topic
+// set grows.
+type AuditWriter struct {
+	path string
+	f    *os.File
+
+	// mu serialises the write and the error counter. Without it a concurrent source
+	// silently loses increments, so the summary under-reports how much of the trace is
+	// missing — the one number that distinguishes a truncated run from a clean one.
+	mu sync.Mutex
+
+	// sink is where lines are written. It is always f in production; the indirection
+	// exists so tests can drive the failure paths a full disk would produce.
+	sink io.Writer
+
+	// errs counts lines that were meant to reach disk and did not, plus a failed
+	// close. A truncated audit log reads downstream as "no transaction coupled these
+	// topics" — indistinguishable from a clean run — so the count is the only thing
+	// that lets the summary and the exit code tell the two apart.
+	errs int
+
+	// warned records that the first failure has already been logged, so a full disk
+	// produces one warning rather than one per dropped line.
+	warned bool
+}
+
+// NewAuditWriter opens the audit log at path, rotating any file already there.
+func NewAuditWriter(path string) (*AuditWriter, error) {
+	if err := rotateExisting(path); err != nil {
+		return nil, err
+	}
+	f, err := openAuditFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// sink is the *os.File itself, deliberately unbuffered: the audit log is a live
+	// trace an operator tails during a run measured in hours, and a run killed by
+	// SIGKILL must still leave everything observed up to that point on disk.
+	return &AuditWriter{path: path, f: f, sink: f}, nil
+}
+
+// openAuditFile opens the audit log for appending.
+//
+// rotateExisting has already established that nothing unsuitable sits at path, but it
+// checked the path and this opens the path, so the two are separated by a window an
+// attacker with write access to the directory can use. Everything here re-establishes
+// the invariant against the opened handle rather than trusting that pre-check.
+func openAuditFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY|openNoFollow, auditFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audit log %s: %w", path, err)
+	}
+	// Stat the handle, not the path: statting the path would re-open the same TOCTOU
+	// window this check exists to close. os.File.Stat is fstat(2) on the descriptor
+	// already opened, so what it reports is what will actually be written to.
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("failed to stat opened audit log %s: %w", path, err)
+	}
+	if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, fmt.Errorf("refusing to write the audit log: %s is %s, not a regular file; remove it or choose another path with --audit-log-out", path, describeFileType(fi.Mode()))
+	}
+	// auditFileMode is only applied when the open creates the file. An existing file
+	// keeps whatever mode it already had, so the mode has to be verified rather than
+	// assumed — the audit log carries topic names and transactional ids.
+	if perm := fi.Mode().Perm(); perm&^auditFileMode != 0 {
+		_ = f.Close()
+		return nil, fmt.Errorf("refusing to write the audit log: %s has mode %#o, wider than %#o, and the audit log carries topic names and transactional ids; remove it or choose another path with --audit-log-out", path, perm, auditFileMode)
+	}
+	return f, nil
+}
+
+// rotateExisting moves any file already at path aside to <path>.<timestamp>.
+//
+// Appending instead would be wrong twice over. Functionally, the file exists so an
+// operator can trace how one union was built; concatenating two runs' traces makes
+// that read ambiguous. Security-wise, O_APPEND|O_CREATE applies its mode only on
+// creation, so appending to a file left at 0644 silently keeps it world-readable.
+func rotateExisting(path string) error {
+	// Lstat, not Stat: a symlink at the audit path must be seen as a symlink rather
+	// than resolved to whatever it targets.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil // nothing to rotate
+		}
+		return fmt.Errorf("failed to inspect existing audit log %s: %w", path, err)
+	}
+	// Only a regular file is a plausible previous run's audit log, and only a regular
+	// file is safe to rotate. Anything else is rejected and left in place rather than
+	// renamed aside: a symlink or fifo at the audit path is a signal that something is
+	// wrong, and quietly rotating it away hides the evidence from the operator.
+	if !fi.Mode().IsRegular() {
+		return errNotRegularFile(path, fi.Mode())
+	}
+	dst, err := freeRotationName(path)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(path, dst); err != nil {
+		return fmt.Errorf("failed to rotate existing audit log %s to %s: %w", path, dst, err)
+	}
+	return nil
+}
+
+// errNotRegularFile is the refusal both the pre-check and the post-open check return, so
+// the operator sees the same wording whichever of the two caught it.
+func errNotRegularFile(path string, m fs.FileMode) error {
+	return fmt.Errorf("refusing to write the audit log: %s is %s, not a regular file; remove it or choose another path with --audit-log-out", path, describeFileType(m))
+}
+
+// describeFileType renders a file mode's type in words. fs.FileMode.String() encodes
+// the type as a single letter, which is not something to put in front of an operator.
+func describeFileType(m fs.FileMode) string {
+	switch {
+	case m&fs.ModeSymlink != 0:
+		return "a symbolic link"
+	case m.IsDir():
+		return "a directory"
+	case m&fs.ModeNamedPipe != 0:
+		return "a named pipe"
+	case m&fs.ModeSocket != 0:
+		return "a socket"
+	case m&fs.ModeDevice != 0:
+		return "a device"
+	default:
+		return "an irregular file"
+	}
+}
+
+// maxRotationAttempts bounds the same-second collision search so a directory that
+// somehow already holds every candidate name fails loudly instead of spinning.
+const maxRotationAttempts = 100
+
+// freeRotationName returns an unused <path>.<timestamp> name, adding a counter suffix
+// when two runs rotate within the same second. Without the counter the second rotation
+// renames over the first, destroying exactly the trace rotation exists to preserve.
+func freeRotationName(path string) (string, error) {
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	for i := 0; i < maxRotationAttempts; i++ {
+		candidate := path + "." + ts
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.%s-%d", path, ts, i)
+		}
+		if _, err := os.Lstat(candidate); errors.Is(err, fs.ErrNotExist) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find a free rotation name for audit log %s after %d attempts", path, maxRotationAttempts)
+}
+
+// Record appends one audit line describing what obs did to its transaction's topic set.
+func (w *AuditWriter) Record(obs discovery.Observation, ch discovery.Change) {
+	// A nil writer is --no-audit-log (R18). Tolerating it here means the caller wires
+	// one branch instead of a nil check at every call site, where a forgotten one would
+	// panic partway through a run measured in hours.
+	if w == nil {
+		return
+	}
+	// R19: the audit trail records couplings, so an observation that re-reports a
+	// footprint already seen is not an event. Logging it would bury the growth events
+	// the file exists to make findable.
+	if !ch.Grew() {
+		return
+	}
+	line := AuditLine{
+		Timestamp: obs.ObservedAt,
+		TxnID:     obs.TxnID,
+		Source:    obs.Source,
+		Added:     ch.Added,
+		Topics:    ch.Topics,
+	}
+	// encoding/json, never hand-rolled formatting. A topic name is attacker-influenced:
+	// whoever can create a topic chooses the bytes that land here, and an unescaped
+	// newline would end the record early and let the rest of the name be read as a
+	// second, forged audit record.
+	data, err := json.Marshal(line)
+
+	// Marshalling is done above, outside the lock; only the write and the counter need
+	// serialising. KTD7 puts this write under the accumulator's decision, but
+	// Accumulator.Add releases its own lock before returning the Change, so by the time
+	// Record is called the three sources are once again running concurrently.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if err != nil {
+		w.errs++
+		w.warnOnce(err)
+		return
+	}
+	// One Write for the record and its newline together. Splitting them would let a
+	// crash land between the two and leave a line with no terminator, which merges two
+	// records into one unparseable line instead of losing only the trailing one.
+	if _, err := w.sink.Write(append(data, '\n')); err != nil {
+		w.errs++
+		w.warnOnce(err)
+	}
+}
+
+// warnOnce logs the first failure and stays quiet thereafter. Callers hold w.mu.
+//
+// Once, because the realistic cause is a full disk or an unmounted volume, which fails
+// every subsequent write too — thousands of identical lines would bury the rest of the
+// run. The running total is Errors(), which the summary reports at the end.
+//
+// The line carries the path and the cause and nothing else. kcp.log's file leg is
+// unconditionally Debug+ and is what operators attach to support tickets, so no topic
+// name or transactional id may appear in it at any level — the audit file itself is the
+// artifact that carries those.
+func (w *AuditWriter) warnOnce(cause error) {
+	if w.warned {
+		return
+	}
+	w.warned = true
+	slog.Warn("❌ failed to write to the transaction discovery audit log, the trace will be incomplete", "path", w.path, "error", cause)
+}
+
+// Errors returns the number of audit lines that failed to reach disk, plus a failed
+// close. A non-zero count means the trace is incomplete and must be surfaced as a
+// warning and a non-zero exit code rather than passing as a clean run.
+func (w *AuditWriter) Errors() int {
+	if w == nil {
+		return 0
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.errs
+}
+
+// Path returns the path the audit log is being written to, or "" when the audit log is
+// disabled.
+func (w *AuditWriter) Path() string {
+	if w == nil {
+		return ""
+	}
+	return w.path
+}
+
+// Close closes the audit log, counting a failure the same way a failed write is
+// counted: on buffered and network filesystems the deferred write error surfaces here
+// rather than at the write, so a failed close also means lines are missing.
+func (w *AuditWriter) Close() error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.f.Close(); err != nil {
+		w.errs++
+		return fmt.Errorf("failed to close audit log %s: %w", w.path, err)
+	}
+	return nil
+}

--- a/internal/services/txndiscovery/report/auditlog_nofollow_other.go
+++ b/internal/services/txndiscovery/report/auditlog_nofollow_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package report
+
+// openNoFollow is a no-op flag on platforms whose syscall package does not define
+// O_NOFOLLOW — notably Windows, which kcp ships a binary for. Referencing
+// syscall.O_NOFOLLOW unconditionally would not compile there.
+//
+// The symlink defence on those platforms is rotateExisting's Lstat classification,
+// which rejects anything that is not a regular file, plus openAuditFile's Fstat of the
+// opened handle. Only the narrow race between those two is uncovered.
+const openNoFollow = 0

--- a/internal/services/txndiscovery/report/auditlog_nofollow_unix.go
+++ b/internal/services/txndiscovery/report/auditlog_nofollow_unix.go
@@ -1,0 +1,10 @@
+//go:build unix
+
+package report
+
+import "syscall"
+
+// openNoFollow makes an open fail with ELOOP rather than follow a symbolic link at the
+// final path component, closing the window between rotateExisting's check of the path
+// and openAuditFile's open of it.
+const openNoFollow = syscall.O_NOFOLLOW

--- a/internal/services/txndiscovery/report/auditlog_perm_other.go
+++ b/internal/services/txndiscovery/report/auditlog_perm_other.go
@@ -1,0 +1,25 @@
+//go:build !unix
+
+package report
+
+import "io/fs"
+
+// checkAuditFilePerm is a no-op on platforms that do not carry a unix permission triple
+// — notably Windows, which kcp ships a binary for.
+//
+// Go does not read a real mode there. It synthesises one from a single attribute bit
+// (os/types_windows.go): every writable file reports 0666 and every read-only one 0444.
+// os.OpenFile(..., 0600) does not set FILE_ATTRIBUTE_READONLY, so the file the audit
+// writer JUST CREATED ITSELF stats back as 0666, and applying the unix assertion to that
+// (0666 &^ 0600 = 0066) refused on the first run of every Windows invocation — telling
+// the operator their brand-new file was "wider than 0600" and failing a command whose
+// audit log is on by default.
+//
+// Widening this to "accept 0666 too" would be worse than a no-op: it would silently
+// accept a genuinely world-writable file anywhere the split is later reused. Perm()
+// simply carries no information on these platforms, so there is nothing to assert.
+//
+// What still holds everywhere is the IsRegular() check in openAuditFile, which stays
+// outside this split, plus rotateExisting's Lstat classification. The confidentiality of
+// the file on Windows rests on the directory's ACL, which is the platform's own model.
+func checkAuditFilePerm(string, fs.FileMode) error { return nil }

--- a/internal/services/txndiscovery/report/auditlog_perm_other_test.go
+++ b/internal/services/txndiscovery/report/auditlog_perm_other_test.go
@@ -1,0 +1,31 @@
+//go:build !unix
+
+package report
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// The build tag is the same !unix one the production split uses, so this runs on the
+// platforms the assertion is about. Windows itself cannot be executed here; GOOS=js
+// GOARCH=wasm is a !unix platform that can, and the decision under test is a pure
+// function of the mode, so running it there exercises the same branch Windows takes.
+
+func TestCheckAuditFilePermAcceptsTheModeWindowsSynthesisesForAWritableFile(t *testing.T) {
+	// Go does not read a real permission triple on Windows. It synthesises the mode from
+	// a single attribute bit (os/types_windows.go): every writable file reports 0666 and
+	// every read-only one 0444. os.OpenFile(..., 0600) does not set FILE_ATTRIBUTE_READONLY,
+	// so the file the audit writer JUST CREATED ITSELF stats back as 0666.
+	//
+	// Applying the unix 0600 assertion to that turns 0666 &^ 0600 = 0066 into a refusal on
+	// the FIRST run of every Windows invocation — kcp ships a Windows binary and the audit
+	// log is on by default, so the command fails outright while telling the operator their
+	// brand-new file is "wider than 0600". The mode is not expressible on this platform, so
+	// Perm() carries no information to assert on and the check has to be a no-op.
+	for _, mode := range []fs.FileMode{0666, 0444} {
+		if err := checkAuditFilePerm("audit.log", mode); err != nil {
+			t.Errorf("mode %#o: %v", mode, err)
+		}
+	}
+}

--- a/internal/services/txndiscovery/report/auditlog_perm_unix.go
+++ b/internal/services/txndiscovery/report/auditlog_perm_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package report
+
+import "io/fs"
+
+// checkAuditFilePerm rejects an audit log whose mode is wider than auditFileMode.
+//
+// auditFileMode is only applied when the open CREATES the file. An existing file keeps
+// whatever mode it already had, so the mode has to be verified rather than assumed —
+// the audit log carries topic names and transactional ids.
+func checkAuditFilePerm(path string, mode fs.FileMode) error {
+	if perm := mode.Perm(); perm&^auditFileMode != 0 {
+		return errAuditFileTooWide(path, perm)
+	}
+	return nil
+}

--- a/internal/services/txndiscovery/report/auditlog_test.go
+++ b/internal/services/txndiscovery/report/auditlog_test.go
@@ -1,0 +1,735 @@
+package report
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+)
+
+// readLines returns the raw newline-delimited records currently on disk at path.
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open audit log: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		out = append(out, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan audit log: %v", err)
+	}
+	return out
+}
+
+// decodeLines parses every line on disk into an AuditLine, failing the test if any
+// line is not independently valid JSON.
+func decodeLines(t *testing.T, path string) []AuditLine {
+	t.Helper()
+	raw := readLines(t, path)
+	out := make([]AuditLine, 0, len(raw))
+	for i, line := range raw {
+		var al AuditLine
+		if err := json.Unmarshal([]byte(line), &al); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v\nline: %q", i, err, line)
+		}
+		out = append(out, al)
+	}
+	return out
+}
+
+func TestRecordWritesOneLineNamingTheAddedTopicsAndTheResultingSet(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	obs := discovery.Observation{
+		TxnID:      "orders-tx-0",
+		ProducerID: 42,
+		Topics:     []string{"orders", "payments"},
+		Source:     discovery.SourceTxnStateLog,
+		ObservedAt: time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+	}
+	ch := discovery.Change{
+		Added:  []string{"orders", "payments"},
+		Topics: []string{"orders", "payments"},
+	}
+	w.Record(obs, ch)
+
+	lines := decodeLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("want 1 audit line, got %d", len(lines))
+	}
+	got := lines[0]
+	if got.TxnID != "orders-tx-0" {
+		t.Errorf("transactional_id: want %q, got %q", "orders-tx-0", got.TxnID)
+	}
+	if want := []string{"orders", "payments"}; !equal(got.Added, want) {
+		t.Errorf("added: want %v, got %v", want, got.Added)
+	}
+	if want := []string{"orders", "payments"}; !equal(got.Topics, want) {
+		t.Errorf("topics: want %v, got %v", want, got.Topics)
+	}
+	if !got.Timestamp.Equal(obs.ObservedAt) {
+		t.Errorf("timestamp: want %v, got %v", obs.ObservedAt, got.Timestamp)
+	}
+}
+
+func TestRecordWritesNoLineWhenTheObservationAddedNothing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	obs := discovery.Observation{
+		TxnID:      "orders-tx-0",
+		Topics:     []string{"orders", "payments"},
+		Source:     discovery.SourceTxnStateLog,
+		ObservedAt: time.Date(2026, 7, 27, 10, 0, 1, 0, time.UTC),
+	}
+	// The transaction was already seen touching both topics, so nothing was added.
+	ch := discovery.Change{Added: nil, Topics: []string{"orders", "payments"}}
+	w.Record(obs, ch)
+
+	if lines := readLines(t, path); len(lines) != 0 {
+		t.Fatalf("want no audit lines for a non-growing observation, got %d: %q", len(lines), lines)
+	}
+}
+
+// feed mirrors the wiring U11 uses: every observation goes through the accumulator,
+// and the change it reports drives the audit line.
+func feed(w *AuditWriter, acc *discovery.Accumulator, obs discovery.Observation) {
+	w.Record(obs, acc.Add(obs))
+}
+
+func TestRecordWritesOnlyTheNewlyAddedTopicAcrossASequence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	acc := discovery.NewAccumulator()
+	base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+
+	// 1. Introduces two topics.
+	feed(w, acc, discovery.Observation{
+		TxnID: "orders-tx-0", Topics: []string{"orders", "payments"},
+		Source: discovery.SourceTxnStateLog, ObservedAt: base,
+	})
+	// 2. Re-reports the same footprint: no growth, no line.
+	feed(w, acc, discovery.Observation{
+		TxnID: "orders-tx-0", Topics: []string{"payments", "orders"},
+		Source: discovery.SourceTxnStateLog, ObservedAt: base.Add(time.Second),
+	})
+	// 3. Introduces one more.
+	feed(w, acc, discovery.Observation{
+		TxnID: "orders-tx-0", Topics: []string{"orders", "payments", "shipments"},
+		Source: discovery.SourceTxnStateLog, ObservedAt: base.Add(2 * time.Second),
+	})
+
+	lines := decodeLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("want 2 audit lines across the sequence, got %d", len(lines))
+	}
+	if want := []string{"orders", "payments"}; !equal(lines[0].Added, want) {
+		t.Errorf("line 0 added: want %v, got %v", want, lines[0].Added)
+	}
+	if want := []string{"shipments"}; !equal(lines[1].Added, want) {
+		t.Errorf("line 1 added: want %v, got %v", want, lines[1].Added)
+	}
+	if want := []string{"orders", "payments", "shipments"}; !equal(lines[1].Topics, want) {
+		t.Errorf("line 1 topics: want %v, got %v", want, lines[1].Topics)
+	}
+}
+
+// failingWriter stands in for a full disk or an unmounted volume: the descriptor is
+// open, but every write fails.
+type failingWriter struct {
+	err   error
+	calls int
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.calls++
+	return 0, f.err
+}
+
+func TestRecordCountsWriteFailuresRatherThanDroppingThemSilently(t *testing.T) {
+	captureLogs(t) // the writer warns on the first failure; keep it out of the test output
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if got := w.Errors(); got != 0 {
+		t.Fatalf("want 0 errors on a fresh writer, got %d", got)
+	}
+
+	// The volume goes away mid-run.
+	w.sink = &failingWriter{err: errors.New("no space left on device")}
+
+	for i := range 3 {
+		w.Record(discovery.Observation{
+			TxnID:      "orders-tx-0",
+			Source:     discovery.SourceTxnStateLog,
+			ObservedAt: time.Date(2026, 7, 27, 10, 0, i, 0, time.UTC),
+		}, discovery.Change{Added: []string{"t"}, Topics: []string{"t"}})
+	}
+
+	// A dropped line reads downstream as "no transaction coupled these topics", which
+	// is indistinguishable from a clean run. The count is what makes it distinguishable.
+	if got := w.Errors(); got != 3 {
+		t.Fatalf("want 3 counted write failures, got %d", got)
+	}
+}
+
+func TestCloseCountsAndReturnsAFailedClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+
+	// Pull the descriptor out from under the writer. On buffered and network
+	// filesystems the deferred write error surfaces at close, not at write, so a close
+	// that fails means lines are missing just as surely as a failed write does.
+	if err := w.f.Close(); err != nil {
+		t.Fatalf("pre-close: %v", err)
+	}
+
+	if err := w.Close(); err == nil {
+		t.Errorf("want Close to return the failure, got nil")
+	}
+	if got := w.Errors(); got != 1 {
+		t.Fatalf("want the failed close counted, got %d errors", got)
+	}
+}
+
+// countingWriter records how many Write calls each line takes.
+type countingWriter struct {
+	writes int
+	buf    bytes.Buffer
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.writes++
+	return c.buf.Write(p)
+}
+
+func TestEachLineIsEmittedWithASingleWriteCall(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	cw := &countingWriter{}
+	w.sink = cw
+
+	const records = 3
+	for i := range records {
+		w.Record(discovery.Observation{
+			TxnID:      "orders-tx-0",
+			Source:     discovery.SourceTxnStateLog,
+			ObservedAt: time.Date(2026, 7, 27, 10, 0, i, 0, time.UTC),
+		}, discovery.Change{Added: []string{"t"}, Topics: []string{"t"}})
+	}
+
+	// The record and its newline go out together. If they were separate writes a crash
+	// could land between them, leaving a line with no terminator — which glues two
+	// records into one unparseable line rather than losing only the trailing one.
+	if cw.writes != records {
+		t.Fatalf("want %d writes for %d records, got %d", records, records, cw.writes)
+	}
+}
+
+func TestLinesAreOnDiskBeforeTheWriterIsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	w.Record(discovery.Observation{
+		TxnID: "orders-tx-0", Source: discovery.SourceTxnStateLog,
+		ObservedAt: time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+	}, discovery.Change{Added: []string{"orders"}, Topics: []string{"orders"}})
+
+	// Read through a separate handle, with the writer still open. The audit log is a
+	// live trace: an operator tails it during a run that lasts hours, and a run killed
+	// by SIGKILL must still leave everything observed up to that point on disk.
+	// Buffering would make both false.
+	lines := decodeLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("want the line readable before Close, got %d lines — output is buffered", len(lines))
+	}
+	if lines[0].TxnID != "orders-tx-0" {
+		t.Errorf("transactional_id: want %q, got %q", "orders-tx-0", lines[0].TxnID)
+	}
+}
+
+// recoverLines re-reads the audit log the way a consumer of a crashed run's file must:
+// every line that parses is kept, and a damaged one is skipped rather than aborting the
+// read. It returns the recovered records and the number of unparseable lines.
+func recoverLines(t *testing.T, path string) ([]AuditLine, int) {
+	t.Helper()
+	var out []AuditLine
+	damaged := 0
+	for _, line := range readLines(t, path) {
+		var al AuditLine
+		if err := json.Unmarshal([]byte(line), &al); err != nil {
+			damaged++
+			continue
+		}
+		out = append(out, al)
+	}
+	return out, damaged
+}
+
+func TestATruncatedTrailingLineDoesNotInvalidateThePrecedingLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	acc := discovery.NewAccumulator()
+	base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	for i, topic := range []string{"orders", "payments", "shipments"} {
+		feed(w, acc, discovery.Observation{
+			TxnID: "orders-tx-0", Topics: []string{topic},
+			Source: discovery.SourceTxnStateLog, ObservedAt: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Chop the file ten bytes into the third record, as a SIGKILL or a full disk during
+	// the third write would.
+	full, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	thirdRecordStart := 0
+	seen := 0
+	for i, b := range full {
+		if b == '\n' {
+			seen++
+			if seen == 2 {
+				thirdRecordStart = i + 1
+				break
+			}
+		}
+	}
+	cut := thirdRecordStart + 10
+	if cut >= len(full) {
+		t.Fatalf("test setup: cut %d is not inside the third record (file is %d bytes)", cut, len(full))
+	}
+	if err := os.Truncate(path, int64(cut)); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	recovered, damaged := recoverLines(t, path)
+	if damaged != 1 {
+		t.Errorf("want exactly the trailing record damaged, got %d damaged lines", damaged)
+	}
+	if len(recovered) != 2 {
+		t.Fatalf("want the 2 complete records still readable after truncation, got %d", len(recovered))
+	}
+	if want := []string{"orders"}; !equal(recovered[0].Added, want) {
+		t.Errorf("record 0 added: want %v, got %v", want, recovered[0].Added)
+	}
+	if want := []string{"payments"}; !equal(recovered[1].Added, want) {
+		t.Errorf("record 1 added: want %v, got %v", want, recovered[1].Added)
+	}
+}
+
+func TestTheSourceFieldDistinguishesWhichPhaseProducedTheEdge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	acc := discovery.NewAccumulator()
+	base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+
+	// The transaction log sees only what the transaction produced to.
+	feed(w, acc, discovery.Observation{
+		TxnID: "orders-tx-0", Topics: []string{"orders-out"},
+		Source: discovery.SourceTxnStateLog, ObservedAt: base,
+	})
+	// The consumer-group enrichment phase recovers the input it consumed from. That is
+	// a weaker inference than the log, so an operator questioning why these two topics
+	// were coupled has to be able to tell which phase asserted the edge.
+	feed(w, acc, discovery.Observation{
+		TxnID: "orders-tx-0", Topics: []string{"orders-in"}, ReadProcessWrite: true,
+		Source: discovery.SourceConsumerGroups, ObservedAt: base.Add(time.Second),
+	})
+
+	lines := decodeLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("want 2 audit lines, got %d", len(lines))
+	}
+	if lines[0].Source != discovery.SourceTxnStateLog {
+		t.Errorf("line 0 source: want %q, got %q", discovery.SourceTxnStateLog, lines[0].Source)
+	}
+	if lines[1].Source != discovery.SourceConsumerGroups {
+		t.Errorf("line 1 source: want %q, got %q", discovery.SourceConsumerGroups, lines[1].Source)
+	}
+}
+
+// TestHostileTopicNamesStayOnOneParseableLine is the audit-log-injection case. A topic
+// name is attacker-influenced data as far as this file is concerned: whoever can create
+// a topic on the cluster chooses the bytes that end up in it.
+//
+// The critical property is that one record occupies exactly one physical line. A raw
+// newline inside a name would end the record early and let the remainder of the name be
+// read as a second, forged audit record — a way to plant a coupling that was never
+// observed, or to hide a real one by making the surrounding lines unparseable.
+func TestHostileTopicNamesStayOnOneParseableLine(t *testing.T) {
+	// A name carrying a complete, well-formed audit record after a newline: if
+	// newlines were not escaped, this single topic would forge a second record.
+	const forgery = "orders\n" +
+		`{"timestamp":"2000-01-01T00:00:00Z","transactional_id":"forged","source":"transaction-state-log","added":["never-observed"],"topics":["never-observed"]}`
+
+	tests := []struct {
+		name  string
+		topic string
+		want  string // what must come back out; differs from topic only for lossy input
+	}{
+		{"double quote", `orders"; DROP`, `orders"; DROP`},
+		{"backslash", `orders\payments`, `orders\payments`},
+		{"newline forging a second record", forgery, forgery},
+		{"carriage return", "orders\rpayments", "orders\rpayments"},
+		{"nul byte", "orders\x00payments", "orders\x00payments"},
+		// encoding/json substitutes U+FFFD for invalid UTF-8 rather than failing. See
+		// the package comment on why that is the right trade for this artifact.
+		{"invalid utf-8", "orders\xff\xfepayments", "orders��payments"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+			w, err := NewAuditWriter(path)
+			if err != nil {
+				t.Fatalf("NewAuditWriter: %v", err)
+			}
+			defer func() { _ = w.Close() }()
+
+			w.Record(discovery.Observation{
+				TxnID:      "orders-tx-0",
+				Source:     discovery.SourceTxnStateLog,
+				ObservedAt: time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+			}, discovery.Change{Added: []string{tc.topic}, Topics: []string{tc.topic}})
+
+			if got := w.Errors(); got != 0 {
+				t.Fatalf("the line must be written, not dropped; got %d errors", got)
+			}
+
+			// Exactly one physical line: no forged second record, no split.
+			raw := readLines(t, path)
+			if len(raw) != 1 {
+				t.Fatalf("want 1 physical line, got %d — a name broke out of its record: %q", len(raw), raw)
+			}
+
+			lines := decodeLines(t, path)
+			if got := lines[0].Added[0]; got != tc.want {
+				t.Errorf("added[0]: want %q, got %q", tc.want, got)
+			}
+			if lines[0].TxnID != "orders-tx-0" {
+				t.Errorf("transactional_id was displaced by the payload: got %q", lines[0].TxnID)
+			}
+		})
+	}
+}
+
+// alwaysFailWriter fails every write and holds no state of its own, so it adds no race
+// of its own to the one under test.
+type alwaysFailWriter struct{}
+
+func (alwaysFailWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("no space left on device")
+}
+
+// The three observation sources run concurrently, and Accumulator.Add releases its lock
+// before returning the Change, so Record is genuinely called from several goroutines at
+// once. These two run under -race.
+
+func TestConcurrentRecordsEachProduceOneIntactLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	const sources, perSource = 8, 60
+	var wg sync.WaitGroup
+	for s := range sources {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range perSource {
+				w.Record(discovery.Observation{
+					TxnID:      fmt.Sprintf("txn-%d", s),
+					Source:     discovery.SourceTxnStateLog,
+					ObservedAt: time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+				}, discovery.Change{
+					Added:  []string{fmt.Sprintf("topic-%d-%d", s, i)},
+					Topics: []string{fmt.Sprintf("topic-%d-%d", s, i)},
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	// decodeLines fails the test on any line that is not independently valid JSON, so
+	// an interleaved or torn write shows up here.
+	lines := decodeLines(t, path)
+	if want := sources * perSource; len(lines) != want {
+		t.Fatalf("want %d intact lines, got %d", want, len(lines))
+	}
+}
+
+func TestConcurrentWriteFailuresAreAllCounted(t *testing.T) {
+	captureLogs(t) // the writer warns on the first failure; keep it out of the test output
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	w.sink = alwaysFailWriter{}
+
+	const sources, perSource = 8, 60
+	var wg sync.WaitGroup
+	for s := range sources {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range perSource {
+				w.Record(discovery.Observation{
+					TxnID:      fmt.Sprintf("txn-%d", s),
+					Source:     discovery.SourceTxnStateLog,
+					ObservedAt: time.Date(2026, 7, 27, 10, 0, i%60, 0, time.UTC),
+				}, discovery.Change{Added: []string{"t"}, Topics: []string{"t"}})
+			}
+		}()
+	}
+	wg.Wait()
+
+	// A lost increment here means the summary under-reports how much of the trace is
+	// missing, which is the failure this count exists to prevent.
+	if want, got := sources*perSource, w.Errors(); got != want {
+		t.Fatalf("want %d counted failures, got %d", want, got)
+	}
+}
+
+// R18: --no-audit-log is expressed as the absence of a writer. Every method tolerating
+// a nil receiver means the caller wires one branch, not a nil check at each call site
+// where a forgotten one would panic mid-run.
+func TestANilWriterIsASafeNoOp(t *testing.T) {
+	var w *AuditWriter
+
+	w.Record(discovery.Observation{
+		TxnID: "orders-tx-0", Source: discovery.SourceTxnStateLog,
+		ObservedAt: time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+	}, discovery.Change{Added: []string{"orders"}, Topics: []string{"orders"}})
+
+	if got := w.Errors(); got != 0 {
+		t.Errorf("Errors on a disabled writer: want 0, got %d", got)
+	}
+	if got := w.Path(); got != "" {
+		t.Errorf("Path on a disabled writer: want %q, got %q", "", got)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("Close on a disabled writer: want nil, got %v", err)
+	}
+}
+
+// captureLogs redirects the default slog logger at Debug+ for the duration of the test
+// and returns the accumulated output. Debug+ because kcp.log's file leg has no level
+// control: every level lands in the file operators attach to support tickets.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+func TestAWriteFailureIsWarnedAboutWithoutLeakingNamesIntoTheLog(t *testing.T) {
+	const (
+		secretTopic = "acme-super-secret-ledger"
+		secretTxnID = "acme-payments-tx-7"
+	)
+	buf := captureLogs(t)
+
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	w.sink = alwaysFailWriter{}
+	for i := range 3 {
+		w.Record(discovery.Observation{
+			TxnID:      secretTxnID,
+			Source:     discovery.SourceTxnStateLog,
+			ObservedAt: time.Date(2026, 7, 27, 10, 0, i, 0, time.UTC),
+		}, discovery.Change{Added: []string{secretTopic}, Topics: []string{secretTopic}})
+	}
+
+	out := buf.String()
+	if out == "" {
+		t.Fatalf("a failed audit write must reach kcp.log; nothing was logged")
+	}
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("the failure must be logged at Warn so it reaches the console too; got:\n%s", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("the warning should name the path so it is actionable; got:\n%s", out)
+	}
+	// The audit file carries names by design. kcp.log must not: it is unconditionally
+	// Debug+ and is what operators attach to support tickets.
+	if strings.Contains(out, secretTopic) {
+		t.Errorf("topic name leaked into the log:\n%s", out)
+	}
+	if strings.Contains(out, secretTxnID) {
+		t.Errorf("transactional id leaked into the log:\n%s", out)
+	}
+
+	// Warn once, not once per line: a full disk fails every write, and thousands of
+	// identical warnings would bury the rest of the run's log.
+	if got := strings.Count(out, "WARN"); got != 1 {
+		t.Errorf("want exactly 1 warning across 3 failures, got %d:\n%s", got, out)
+	}
+}
+
+// TestFilteringTheAuditLogToATopicYieldsTheTransactionThatCoupledIt is the unit's
+// acceptance case: the whole point of the file is that, months later, an operator who
+// asks "why is this topic in that migration batch?" can answer it from the trace.
+func TestFilteringTheAuditLogToATopicYieldsTheTransactionThatCoupledIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+
+	acc := discovery.NewAccumulator()
+	base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	at := func(n int) time.Time { return base.Add(time.Duration(n) * time.Second) }
+
+	// A realistic run: three transactions, several sources, repeated sightings.
+	feed(w, acc, discovery.Observation{TxnID: "orders-tx", ProducerID: 1001,
+		Topics: []string{"orders-out"}, Source: discovery.SourceTxnStateLog, ObservedAt: at(0)})
+	feed(w, acc, discovery.Observation{TxnID: "billing-tx", ProducerID: 1002,
+		Topics: []string{"ledger", "__consumer_offsets"}, ReadProcessWrite: true,
+		Source: discovery.SourceTxnStateLog, ObservedAt: at(1)})
+	// Repeated sighting: no growth, no line.
+	feed(w, acc, discovery.Observation{TxnID: "billing-tx", ProducerID: 1002,
+		Topics: []string{"ledger"}, Source: discovery.SourceTxnStateLog, ObservedAt: at(2)})
+	// The enrichment phase recovers what billing-tx consumed — this is the edge that
+	// pulls "invoices" into the same migration batch as "ledger".
+	feed(w, acc, discovery.Observation{TxnID: "billing-tx",
+		Topics: []string{"invoices"}, ReadProcessWrite: true,
+		Source: discovery.SourceConsumerGroups, ObservedAt: at(3)})
+	feed(w, acc, discovery.Observation{TxnID: "audit-tx", ProducerID: 1003,
+		Topics: []string{"audit-events"}, Source: discovery.SourceTxnStateLog, ObservedAt: at(4)})
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := w.Errors(); got != 0 {
+		t.Fatalf("want a clean run, got %d errors", got)
+	}
+
+	// The operator's question: "why is `invoices` grouped with `ledger`?"
+	// The filter: every line whose topic set mentions `invoices`.
+	const query = "invoices"
+	var hits []AuditLine
+	for _, al := range decodeLines(t, path) {
+		for _, topic := range al.Topics {
+			if topic == query {
+				hits = append(hits, al)
+				break
+			}
+		}
+	}
+
+	if len(hits) != 1 {
+		t.Fatalf("want exactly 1 audit line mentioning %q, got %d", query, len(hits))
+	}
+	hit := hits[0]
+	if hit.TxnID != "billing-tx" {
+		t.Errorf("the coupling transaction: want %q, got %q", "billing-tx", hit.TxnID)
+	}
+	// The line names the phase that asserted the edge...
+	if hit.Source != discovery.SourceConsumerGroups {
+		t.Errorf("coupling source: want %q, got %q", discovery.SourceConsumerGroups, hit.Source)
+	}
+	// ...what that phase contributed...
+	if want := []string{"invoices"}; !equal(hit.Added, want) {
+		t.Errorf("added: want %v, got %v", want, hit.Added)
+	}
+	// ...and the resulting union, which is the group `invoices` landed in.
+	if want := []string{"__consumer_offsets", "invoices", "ledger"}; !equal(hit.Topics, want) {
+		t.Errorf("resulting set: want %v, got %v", want, hit.Topics)
+	}
+	// The unrelated transactions are not implicated.
+	if hit.TxnID == "orders-tx" || hit.TxnID == "audit-tx" {
+		t.Errorf("filter matched an unrelated transaction: %q", hit.TxnID)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/services/txndiscovery/report/auditlog_unix_test.go
+++ b/internal/services/txndiscovery/report/auditlog_unix_test.go
@@ -1,0 +1,251 @@
+//go:build unix
+
+// Mode bits, symlink semantics and directory-permission enforcement are unix concepts.
+// Windows' os.Chmod only toggles the read-only bit, so these assertions are meaningless
+// there — and a runtime GOOS skip cannot save a package that will not compile, hence a
+// build tag rather than t.Skip.
+package report
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewAuditWriterCreatesTheFile0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "txn-discovery-audit.jsonl")
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat audit log: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Fatalf("audit log mode: want 0600, got %#o — the file carries topic names and transactional ids", got)
+	}
+}
+
+func TestNewAuditWriterRotatesAnExistingWorldReadableAuditFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+
+	// A previous run (or a planted file) left a world-readable audit log behind.
+	// O_APPEND|O_CREATE applies its mode only on creation, so appending here would
+	// both keep 0644 and concatenate two runs' traces.
+	const stale = `{"timestamp":"2020-01-01T00:00:00Z","transactional_id":"stale","source":"x","added":["old"],"topics":["old"]}` + "\n"
+	if err := os.WriteFile(path, []byte(stale), 0644); err != nil {
+		t.Fatalf("plant stale audit log: %v", err)
+	}
+
+	w, err := NewAuditWriter(path)
+	if err != nil {
+		t.Fatalf("NewAuditWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// The live audit log is a fresh, empty, 0600 file.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if strings.Contains(string(body), "stale") {
+		t.Errorf("audit log was appended to rather than rotated; it still carries the previous run's trace")
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat audit log: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("audit log mode after rotation: want 0600, got %#o", got)
+	}
+
+	// The previous run's trace is preserved alongside, not destroyed.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var rotated string
+	for _, e := range entries {
+		if n := e.Name(); n != "txn-discovery-audit.jsonl" && strings.HasPrefix(n, "txn-discovery-audit.jsonl.") {
+			rotated = filepath.Join(dir, n)
+		}
+	}
+	if rotated == "" {
+		t.Fatalf("no rotated file found in %v; the previous run's trace was destroyed", entries)
+	}
+	kept, err := os.ReadFile(rotated)
+	if err != nil {
+		t.Fatalf("read rotated file: %v", err)
+	}
+	if string(kept) != stale {
+		t.Errorf("rotated file content: want %q, got %q", stale, string(kept))
+	}
+}
+
+func TestRotationInTheSameSecondDoesNotDestroyTheEarlierTrace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+
+	// Two runs started back to back land on the same second-precision timestamp. The
+	// rotated name must still be unique, or the second rotation silently overwrites
+	// the first run's trace.
+	for _, body := range []string{"first-run\n", "second-run\n"} {
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatalf("plant %q: %v", body, err)
+		}
+		w, err := NewAuditWriter(path)
+		if err != nil {
+			t.Fatalf("NewAuditWriter for %q: %v", body, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	found := map[string]bool{}
+	for _, e := range entries {
+		if e.Name() == "txn-discovery-audit.jsonl" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		found[strings.TrimSpace(string(b))] = true
+	}
+	if !found["first-run"] || !found["second-run"] {
+		t.Fatalf("both rotated traces should survive; found %v across %d rotated files", found, len(found))
+	}
+}
+
+func TestNewAuditWriterRejectsASymlinkAtTheAuditPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+	target := filepath.Join(dir, "victim")
+
+	if err := os.WriteFile(target, []byte("untouched\n"), 0600); err != nil {
+		t.Fatalf("create victim: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	w, err := NewAuditWriter(path)
+	if err == nil {
+		_ = w.Close()
+		t.Fatalf("want an error for a symlink at the audit path, got nil")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Errorf("error should name the symlink so an operator can act on it; got: %v", err)
+	}
+
+	// The symlink's target must be neither appended to nor truncated...
+	body, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(body) != "untouched\n" {
+		t.Errorf("symlink was followed; victim content is now %q", string(body))
+	}
+	// ...and the planted link is left in place rather than quietly rotated away, so
+	// the operator sees what the command refused to write through.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat audit path: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("the planted symlink should be left untouched for inspection, got mode %v", fi.Mode())
+	}
+}
+
+// The rotate step checks the path and the open step opens the path, so an attacker with
+// write access to the directory can act in between. These two exercise openAuditFile
+// directly — i.e. the state as it would be after that pre-check has already passed.
+
+func TestOpenAuditFileRejectsASymlinkPlantedAfterThePreCheck(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+	target := filepath.Join(dir, "victim")
+
+	if err := os.WriteFile(target, []byte("untouched\n"), 0600); err != nil {
+		t.Fatalf("create victim: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	f, err := openAuditFile(path)
+	if err == nil {
+		_ = f.Close()
+		t.Fatalf("want an error, got nil — the open followed a symlink planted in the race window")
+	}
+
+	body, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("read victim: %v", readErr)
+	}
+	if string(body) != "untouched\n" {
+		t.Errorf("symlink was followed; victim content is now %q", string(body))
+	}
+}
+
+func TestOpenAuditFileRejectsAWiderThan0600FilePlantedAfterThePreCheck(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+
+	// O_APPEND|O_CREATE applies auditFileMode only when it creates the file, so a
+	// group/world-readable file planted here would be appended to at its own mode.
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatalf("plant 0644 file: %v", err)
+	}
+
+	f, err := openAuditFile(path)
+	if err == nil {
+		_ = f.Close()
+		t.Fatalf("want an error, got nil — opened a 0644 file that would carry topic names")
+	}
+	if !strings.Contains(err.Error(), "0644") {
+		t.Errorf("error should name the offending mode; got: %v", err)
+	}
+}
+
+func TestNewAuditWriterFailsUpFrontOnAnUnwritableDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory permissions are not enforced")
+	}
+	dir := filepath.Join(t.TempDir(), "readonly")
+	if err := os.Mkdir(dir, 0500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "txn-discovery-audit.jsonl")
+
+	// The failure must land here, at construction, so the preflight can abort before
+	// the run starts. Discovering it on the first Record means the run has already
+	// spent its observation window producing a trace that was never written.
+	w, err := NewAuditWriter(path)
+	if err == nil {
+		_ = w.Close()
+		t.Fatalf("want an error for an unwritable directory, got nil")
+	}
+	if w != nil {
+		t.Errorf("want a nil writer alongside the error, got %#v", w)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("the underlying cause must survive wrapping so callers can classify it; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error should name the path the operator has to fix; got: %v", err)
+	}
+}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -51,14 +51,14 @@ type Run struct {
 	// input topics that phase recovered and whether it ran at all (R13).
 	Offsets discovery.ConsumerOffsetsStats
 
+	// Enrichment is consumer-group enrichment's counters: how many passes it
+	// completed against the cadence --interval asked for, how many failed, and
+	// what they correlated.
+	Enrichment discovery.EnricherStats
+
 	// AuditErrors is AuditWriter.Errors(): audit lines that were meant to reach disk
 	// and did not. Zero when the audit log was disabled.
 	AuditErrors int
-
-	// EnrichmentActive reports whether consumer-group enrichment ran. The offsets
-	// phase carries its own Unavailable flag; enrichment has no counters of its
-	// own, so whether it ran has to be told to the report.
-	EnrichmentActive bool
 }
 
 // Summary is the derived, render-ready view of a run.
@@ -157,7 +157,7 @@ func recoveryOf(r Run) Recovery {
 	rec := Recovery{
 		ByOffsetsTopics:          r.Offsets.RecoveredTopics,
 		OffsetsActive:            slices.Contains(r.ActiveSources, discovery.SourceConsumerOffsets) && !r.Offsets.Unavailable,
-		EnrichmentActive:         r.EnrichmentActive,
+		EnrichmentActive:         slices.Contains(r.ActiveSources, discovery.SourceConsumerGroups),
 		OffsetsUnavailableReason: r.Offsets.UnavailableReason,
 		byTxn:                    make(map[string]mechanisms, len(r.Footprints)),
 	}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -433,8 +433,28 @@ type discoveryDoc struct {
 type discoveryGroup struct {
 	Name             string   `yaml:"name"`
 	ReadProcessWrite bool     `yaml:"read_process_write"`
+	Warning          string   `yaml:"warning,omitempty"`
 	Topics           []string `yaml:"topics"`
 	TransactionalIDs []string `yaml:"transactional_ids"`
+}
+
+// groupWarning explains what a read-process-write group's consumed inputs depend on,
+// naming the mechanism that recovered THIS group's inputs rather than whichever phase
+// happened to be enabled. A group with no read-process-write transaction has nothing to
+// warn about and gets no warning.
+func groupWarning(g grouping.Group, s Summary) string {
+	if !g.ReadProcessWrite {
+		return ""
+	}
+	m := s.Recovery.forGroup(g)
+	if !m.any() {
+		return "read-process-write group: consumed input topics are not captured; review before cutover."
+	}
+	warning := "read-process-write group: consumed input topics recovered and included via " + m.describe() + "."
+	if !s.Recovery.OffsetsActive {
+		warning += " Producer-id correlation did not run, so verify coverage for non-Streams exactly-once apps."
+	}
+	return warning
 }
 
 // WriteYAML writes the discovered groups to path.
@@ -450,6 +470,7 @@ func WriteYAML(path string, s Summary) error {
 		doc.Groups = append(doc.Groups, discoveryGroup{
 			Name:             g.Name,
 			ReadProcessWrite: g.ReadProcessWrite,
+			Warning:          groupWarning(g, s),
 			Topics:           g.Topics,
 			TransactionalIDs: g.TxnIDs,
 		})

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -2,8 +2,10 @@ package report
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -498,7 +500,14 @@ const artifactFileMode os.FileMode = 0600
 // os.CreateTemp already creates at 0600, and the mode is pinned again explicitly so an
 // unusual umask cannot widen it even briefly.
 func writeSensitiveFile(path string, data []byte) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	dir := filepath.Dir(path)
+	// Checked up front and named separately, because the raw failure is "open
+	// <dir>/.<name>.tmp-1837027495: no such file or directory" — a temp name the
+	// operator never chose, and no statement of which part of their path is wrong.
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot write %s: the directory %s does not exist; create it or choose another output path", filepath.Base(path), dir)
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return fmt.Errorf("failed to create a temporary file next to %s: %w", path, err)
 	}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -197,7 +197,7 @@ func (rc Recovery) forGroup(g grouping.Group) mechanisms {
 	return out
 }
 
-// Health is the three things that together say whether the window was actually
+// Health is the set of indicators that together say whether the window was actually
 // observed. Any one of them alone can read clean on a run that missed data: a stalled
 // partition reports zero lag, and a reader that decoded nothing reports no lag either.
 type Health struct {
@@ -205,6 +205,16 @@ type Health struct {
 	// snapshot was taken, which must be before shutdown.
 	PartitionsAssigned int
 	PartitionsRunning  int
+
+	// PartitionsStalled is how many live loops were retrying a failed fetch rather
+	// than reading when the snapshot was taken.
+	//
+	// It closes the hole the other two numbers leave: a loop stuck retrying still
+	// counts as running, and a partition that never fetched successfully holds a
+	// zero last stable offset, so its lag computes as zero. Zero lag therefore does
+	// not mean "caught up" — it can mean "never read anything" — and this is what
+	// tells the two apart.
+	PartitionsStalled int
 
 	// Lag is the aggregate last-stable-offset lag (KTD9), not the high-watermark
 	// gap: under ReadCommitted the broker serves nothing past the last stable
@@ -214,6 +224,18 @@ type Health struct {
 	// DecodeErrors is every broker-supplied structure any source failed to parse.
 	// It is the format-drift alarm.
 	DecodeErrors int64
+
+	// FetchErrors is every fetch the reader had to retry: transport, leadership and
+	// unclassified together.
+	//
+	// It is reported but does not by itself spoil the line, and the asymmetry is
+	// deliberate. Surviving a leader election or a broker restart is the
+	// requirement, not a fault, so a reader that recovered and caught up must still
+	// read as OK or operators learn to ignore the one line that says the window was
+	// observed. What the number does is separate a run that recovered from three
+	// thousand failures from one that never faltered, which is otherwise invisible
+	// outside --stats-out.
+	FetchErrors int64
 }
 
 // healthOf collects the keep-up indicators from every source that produces them.
@@ -221,10 +243,12 @@ func healthOf(r Run) Health {
 	return Health{
 		PartitionsAssigned: r.Tail.PartitionsAssigned,
 		PartitionsRunning:  r.Tail.PartitionsRunning,
+		PartitionsStalled:  r.Tail.PartitionsStalled,
 		Lag:                r.Tail.Lag,
 		DecodeErrors: r.Tail.DecodeErrors +
 			r.TxnState.KeyDecodeErrors + r.TxnState.ValueDecodeErrors +
 			r.Offsets.KeyDecodeErrors,
+		FetchErrors: r.Tail.TransportErrors + r.Tail.LeadershipErrors + r.Tail.UnclassifiedErrors,
 	}
 }
 
@@ -362,11 +386,12 @@ func (h Health) Line() string {
 	if len(h.concerns()) > 0 {
 		status = "WARNING"
 	}
-	return fmt.Sprintf("%s — %d/%d %s live, %d %s of lag, %d decode %s",
+	return fmt.Sprintf("%s — %d/%d %s live, %d %s of lag, %d decode %s, %d fetch %s",
 		status,
 		h.PartitionsRunning, h.PartitionsAssigned, plural(h.PartitionsAssigned, "partition", "partitions"),
 		h.Lag, plural64(h.Lag, "record", "records"),
-		h.DecodeErrors, plural64(h.DecodeErrors, "failure", "failures"))
+		h.DecodeErrors, plural64(h.DecodeErrors, "failure", "failures"),
+		h.FetchErrors, plural64(h.FetchErrors, "failure", "failures"))
 }
 
 // concerns lists what is wrong with the run, empty when nothing is.
@@ -378,6 +403,16 @@ func (h Health) concerns() []string {
 	if dead := h.PartitionsAssigned - h.PartitionsRunning; dead > 0 {
 		out = append(out, fmt.Sprintf("%d %s stopped early, so part of the window went unobserved",
 			dead, plural(dead, "partition", "partitions")))
+	}
+	// The same hole one step further in, and the worse half of it: a loop that never
+	// exits is counted as live, so on its own the line above reads perfectly while
+	// the reader fetches nothing at all. Naming the zero-lag trap here is the point
+	// — an operator who reads "0 records of lag" next to this must not take it as
+	// evidence of catching up.
+	if h.PartitionsStalled > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d %s retrying a failed fetch rather than reading, so the zero lag above means nothing was read, not that the reader caught up",
+			h.PartitionsStalled, plural(h.PartitionsStalled, "partition is", "partitions are")))
 	}
 	if h.Lag > 0 {
 		out = append(out, "the reader did not catch up to the last stable offset, so the window was not fully observed")

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/goccy/go-yaml"
 )
 
 // Run is the raw material of a completed discovery run: what the sources
@@ -406,6 +408,58 @@ func printGroupTable(w io.Writer, groups []grouping.Group) {
 			len(g.TxnIDs), plural(len(g.TxnIDs), "id", "ids"),
 			tag)
 	}
+}
+
+// --- txn-discovery.yaml ---
+
+// discoveryDoc is the on-disk shape of txn-discovery.yaml.
+//
+// This is the artifact that carries the names: the terminal deliberately reports counts
+// only, so everything an operator needs to act on is here.
+type discoveryDoc struct {
+	GeneratedBy       string `yaml:"generated_by"`
+	GeneratedAt       string `yaml:"generated_at"`
+	ObservationWindow string `yaml:"observation_window"`
+
+	Groups []discoveryGroup `yaml:"groups"`
+
+	IndividualTopicCount int `yaml:"individual_topic_count"`
+	// IndividualTopics were only ever seen alone in a transaction, so they can
+	// migrate one at a time. Listed rather than merely counted so the document holds
+	// the complete set of observed topics.
+	IndividualTopics []string `yaml:"individual_topics"`
+}
+
+type discoveryGroup struct {
+	Name             string   `yaml:"name"`
+	ReadProcessWrite bool     `yaml:"read_process_write"`
+	Topics           []string `yaml:"topics"`
+	TransactionalIDs []string `yaml:"transactional_ids"`
+}
+
+// WriteYAML writes the discovered groups to path.
+func WriteYAML(path string, s Summary) error {
+	doc := discoveryDoc{
+		GeneratedBy:          "kcp migration txn-discovery",
+		GeneratedAt:          time.Now().UTC().Format(time.RFC3339),
+		ObservationWindow:    s.Duration.String(),
+		IndividualTopicCount: len(s.Result.IndividualTopics),
+		IndividualTopics:     s.Result.IndividualTopics,
+	}
+	for _, g := range s.Result.Groups {
+		doc.Groups = append(doc.Groups, discoveryGroup{
+			Name:             g.Name,
+			ReadProcessWrite: g.ReadProcessWrite,
+			Topics:           g.Topics,
+			TransactionalIDs: g.TxnIDs,
+		})
+	}
+
+	body, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal the transaction discovery document: %w", err)
+	}
+	return os.WriteFile(path, body, 0644)
 }
 
 func plural(n int, one, many string) string {

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 )
 
 // Run is the raw material of a completed discovery run: what the sources
@@ -30,6 +31,12 @@ type Run struct {
 
 	// Result is the grouping computed from those footprints.
 	Result grouping.Result
+
+	// Tail is the fetch component's snapshot. It must be taken BEFORE the run's
+	// context is cancelled: every partition loop clears its running flag as it
+	// exits, so a snapshot taken after shutdown reports zero partitions live and
+	// the health line would condemn a perfectly healthy run.
+	Tail tail.Stats
 
 	// TxnState is the __transaction_state reader's counters.
 	TxnState discovery.TxnStateStats
@@ -59,6 +66,41 @@ type Summary struct {
 	TxnAborted     int64
 
 	Result grouping.Result
+
+	// Health is the one keep-up indicator the summary carries; the full per-source
+	// and per-partition detail lives in the stats document (KTD4).
+	Health Health
+}
+
+// Health is the three things that together say whether the window was actually
+// observed. Any one of them alone can read clean on a run that missed data: a stalled
+// partition reports zero lag, and a reader that decoded nothing reports no lag either.
+type Health struct {
+	// PartitionsAssigned and PartitionsRunning are counted at the moment the tail
+	// snapshot was taken, which must be before shutdown.
+	PartitionsAssigned int
+	PartitionsRunning  int
+
+	// Lag is the aggregate last-stable-offset lag (KTD9), not the high-watermark
+	// gap: under ReadCommitted the broker serves nothing past the last stable
+	// offset, so an open transaction is not something the reader can catch up on.
+	Lag int64
+
+	// DecodeErrors is every broker-supplied structure any source failed to parse.
+	// It is the format-drift alarm.
+	DecodeErrors int64
+}
+
+// healthOf collects the keep-up indicators from every source that produces them.
+func healthOf(r Run) Health {
+	return Health{
+		PartitionsAssigned: r.Tail.PartitionsAssigned,
+		PartitionsRunning:  r.Tail.PartitionsRunning,
+		Lag:                r.Tail.Lag,
+		DecodeErrors: r.Tail.DecodeErrors +
+			r.TxnState.KeyDecodeErrors + r.TxnState.ValueDecodeErrors +
+			r.Offsets.KeyDecodeErrors,
+	}
 }
 
 // Summarize derives the render-ready summary from a completed run.
@@ -74,6 +116,7 @@ func Summarize(r Run) Summary {
 		TxnCommitted:   r.TxnState.Committed,
 		TxnAborted:     r.TxnState.Aborted,
 		Result:         result,
+		Health:         healthOf(r),
 	}
 }
 
@@ -121,7 +164,17 @@ func PrintTerminal(w io.Writer, s Summary) {
 	_, _ = fmt.Fprintf(w, "  read-process-write     : %d %s; %d consumed input topic(s) recovered\n",
 		rpwGroups, plural(rpwGroups, "group", "groups"), 0)
 
+	_, _ = fmt.Fprintf(w, "  keep-up                : %s\n", s.Health.Line())
+
 	printGroupTable(w, groups)
+}
+
+// Line renders the single health indicator the summary carries.
+func (h Health) Line() string {
+	return fmt.Sprintf("OK — %d/%d %s live, %d %s of lag, %d decode %s",
+		h.PartitionsRunning, h.PartitionsAssigned, plural(h.PartitionsAssigned, "partition", "partitions"),
+		h.Lag, plural64(h.Lag, "record", "records"),
+		h.DecodeErrors, plural64(h.DecodeErrors, "failure", "failures"))
 }
 
 // printGroupTable writes one row per group.
@@ -152,6 +205,13 @@ func printGroupTable(w io.Writer, groups []grouping.Group) {
 }
 
 func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+func plural64(n int64, one, many string) string {
 	if n == 1 {
 		return one
 	}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -293,6 +293,9 @@ func PrintTerminal(w io.Writer, s Summary) {
 		s.Recovery.Txns, plural(s.Recovery.Txns, "transaction", "transactions"))
 
 	_, _ = fmt.Fprintf(w, "  keep-up                : %s\n", s.Health.Line())
+	for _, reason := range s.Health.concerns() {
+		_, _ = fmt.Fprintf(w, "                           - %s\n", reason)
+	}
 
 	// A truncated audit log is silent by nature: the missing lines read downstream as
 	// "no transaction coupled these topics", which is exactly what a clean run looks
@@ -350,22 +353,20 @@ func printRecovery(w io.Writer, s Summary) {
 	}
 }
 
-// Line renders the single health indicator the summary carries: the status, the three
-// numbers it is derived from, and — when it is not OK — why.
+// Line renders the single health indicator the summary carries: the status and the
+// three numbers it is derived from. Why it is not OK is in concerns, on its own lines —
+// three concurrent problems concatenated onto this one would run past 300 characters
+// and wrap into unreadability exactly when an operator most needs to read it.
 func (h Health) Line() string {
-	status, reasons := "OK", h.concerns()
-	if len(reasons) > 0 {
+	status := "OK"
+	if len(h.concerns()) > 0 {
 		status = "WARNING"
 	}
-	line := fmt.Sprintf("%s — %d/%d %s live, %d %s of lag, %d decode %s",
+	return fmt.Sprintf("%s — %d/%d %s live, %d %s of lag, %d decode %s",
 		status,
 		h.PartitionsRunning, h.PartitionsAssigned, plural(h.PartitionsAssigned, "partition", "partitions"),
 		h.Lag, plural64(h.Lag, "record", "records"),
 		h.DecodeErrors, plural64(h.DecodeErrors, "failure", "failures"))
-	if len(reasons) > 0 {
-		line += "; " + strings.Join(reasons, "; ")
-	}
-	return line
 }
 
 // concerns lists what is wrong with the run, empty when nothing is.

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -169,12 +169,31 @@ func PrintTerminal(w io.Writer, s Summary) {
 	printGroupTable(w, groups)
 }
 
-// Line renders the single health indicator the summary carries.
+// Line renders the single health indicator the summary carries: the status, the three
+// numbers it is derived from, and — when it is not OK — why.
 func (h Health) Line() string {
-	return fmt.Sprintf("OK — %d/%d %s live, %d %s of lag, %d decode %s",
+	status, reasons := "OK", h.concerns()
+	if len(reasons) > 0 {
+		status = "WARNING"
+	}
+	line := fmt.Sprintf("%s — %d/%d %s live, %d %s of lag, %d decode %s",
+		status,
 		h.PartitionsRunning, h.PartitionsAssigned, plural(h.PartitionsAssigned, "partition", "partitions"),
 		h.Lag, plural64(h.Lag, "record", "records"),
 		h.DecodeErrors, plural64(h.DecodeErrors, "failure", "failures"))
+	if len(reasons) > 0 {
+		line += "; " + strings.Join(reasons, "; ")
+	}
+	return line
+}
+
+// concerns lists what is wrong with the run, empty when nothing is.
+func (h Health) concerns() []string {
+	var out []string
+	if h.DecodeErrors > 0 {
+		out = append(out, "the internal record format may have drifted, so footprints may be missing")
+	}
+	return out
 }
 
 // printGroupTable writes one row per group.

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -197,6 +197,9 @@ func (h Health) concerns() []string {
 		out = append(out, fmt.Sprintf("%d %s stopped early, so part of the window went unobserved",
 			dead, plural(dead, "partition", "partitions")))
 	}
+	if h.Lag > 0 {
+		out = append(out, "the reader did not catch up to the last stable offset, so the window was not fully observed")
+	}
 	if h.DecodeErrors > 0 {
 		out = append(out, "the internal record format may have drifted, so footprints may be missing")
 	}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -430,15 +431,55 @@ type discoveryDoc struct {
 	// IndividualTopics were only ever seen alone in a transaction, so they can
 	// migrate one at a time. Listed rather than merely counted so the document holds
 	// the complete set of observed topics.
-	IndividualTopics []string `yaml:"individual_topics"`
+	IndividualTopics []yamlName `yaml:"individual_topics"`
 }
 
 type discoveryGroup struct {
-	Name             string   `yaml:"name"`
-	ReadProcessWrite bool     `yaml:"read_process_write"`
-	Warning          string   `yaml:"warning,omitempty"`
-	Topics           []string `yaml:"topics"`
-	TransactionalIDs []string `yaml:"transactional_ids"`
+	Name             string     `yaml:"name"`
+	ReadProcessWrite bool       `yaml:"read_process_write"`
+	Warning          string     `yaml:"warning,omitempty"`
+	Topics           []yamlName `yaml:"topics"`
+	TransactionalIDs []yamlName `yaml:"transactional_ids"`
+}
+
+// yamlName is a topic name or transactional id on its way into the document: a string
+// whose bytes are chosen by whoever can create a topic or configure a producer, and
+// which additionally arrives through decoders for broker-internal binary formats that
+// are not part of the stable client protocol.
+//
+// It exists because github.com/goccy/go-yaml's encoder emits a string containing a TAB
+// as a PLAIN (unquoted) scalar, and the parser then discards the tab — "a\tb" is written
+// as "a<TAB>b" and reads back as "ab". Transactional ids are free-form strings an
+// application chooses, so this is reachable, and a silently altered name in this
+// document points an operator at a topic that does not exist or, worse, at a different
+// one that does. Emitting an explicitly double-quoted scalar sidesteps the encoder's
+// style choice entirely and is also what makes a name containing a newline unable to
+// forge a second group entry.
+//
+// One case stays lossy, deliberately and for the same reason the audit writer accepts
+// it: invalid UTF-8 is escaped byte-wise, so \xff reads back as U+00FF rather than as
+// the original byte. The document stays well-formed and the coupling it records stays
+// correct; only the rendering of the name changes. Kafka constrains topic names to
+// [a-zA-Z0-9._-], so invalid UTF-8 cannot come from a legitimate topic — its presence
+// means an upstream decode went wrong, which the decode-error counters report.
+type yamlName string
+
+// MarshalYAML emits the name as a double-quoted scalar. strconv.Quote's escapes (\t,
+// \n, \\, \", \xNN, \uNNNN) are all valid inside a YAML double-quoted scalar.
+func (n yamlName) MarshalYAML() ([]byte, error) {
+	return []byte(strconv.Quote(string(n))), nil
+}
+
+// yamlNames converts a list of names for the document.
+func yamlNames(in []string) []yamlName {
+	if in == nil {
+		return nil
+	}
+	out := make([]yamlName, len(in))
+	for i, v := range in {
+		out[i] = yamlName(v)
+	}
+	return out
 }
 
 // groupWarning explains what a read-process-write group's consumed inputs depend on,
@@ -467,15 +508,15 @@ func WriteYAML(path string, s Summary) error {
 		GeneratedAt:          time.Now().UTC().Format(time.RFC3339),
 		ObservationWindow:    s.Duration.String(),
 		IndividualTopicCount: len(s.Result.IndividualTopics),
-		IndividualTopics:     s.Result.IndividualTopics,
+		IndividualTopics:     yamlNames(s.Result.IndividualTopics),
 	}
 	for _, g := range s.Result.Groups {
 		doc.Groups = append(doc.Groups, discoveryGroup{
 			Name:             g.Name,
 			ReadProcessWrite: g.ReadProcessWrite,
 			Warning:          groupWarning(g, s),
-			Topics:           g.Topics,
-			TransactionalIDs: g.TxnIDs,
+			Topics:           yamlNames(g.Topics),
+			TransactionalIDs: yamlNames(g.TxnIDs),
 		})
 	}
 

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -190,6 +190,13 @@ func (h Health) Line() string {
 // concerns lists what is wrong with the run, empty when nothing is.
 func (h Health) concerns() []string {
 	var out []string
+	// Liveness first, because it is the concern that hides behind a clean-looking
+	// line: a stopped partition contributes no lag and no decode errors, so without
+	// this branch the worst outcome renders identically to the best one.
+	if dead := h.PartitionsAssigned - h.PartitionsRunning; dead > 0 {
+		out = append(out, fmt.Sprintf("%d %s stopped early, so part of the window went unobserved",
+			dead, plural(dead, "partition", "partitions")))
+	}
 	if h.DecodeErrors > 0 {
 		out = append(out, "the internal record format may have drifted, so footprints may be missing")
 	}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -77,6 +77,118 @@ type Summary struct {
 
 	// AuditErrors is how many audit lines never reached disk.
 	AuditErrors int
+
+	// Recovery attributes recovered consumed inputs to the phase that found them.
+	Recovery Recovery
+}
+
+// Recovery records which enrichment phase actually recovered each read-process-write
+// transaction's consumed inputs.
+//
+// Attribution matters because the two phases have very different coverage: the Kafka
+// Streams naming convention only correlates applications that follow it, while
+// producer-id correlation works for any exactly-once application. Crediting a phase
+// that merely ran would tell an operator their non-Streams applications were covered
+// when nothing looked at them.
+//
+// The two phases are attributed at different granularities, and deliberately so. The
+// __consumer_offsets tail records the exact set of input topics it recovered, so it is
+// credited per topic. Consumer-group enrichment keeps no such record: the accumulator
+// unions every source's topics into one set, so once an enrichment observation has
+// merged there is no way to tell which topics it contributed. What survives is the
+// per-transaction source list, so naming is credited per transaction. Inventing a topic
+// count for it would mean guessing.
+type Recovery struct {
+	// ByOffsetsTopics are the consumed input topics producer-id correlation
+	// recovered, exactly.
+	ByOffsetsTopics []string
+
+	// ByOffsetsTxns and ByNamingTxns count the transactions each phase enriched.
+	// A transaction enriched by both is counted in each.
+	ByOffsetsTxns int
+	ByNamingTxns  int
+
+	// Txns is how many distinct transactions had inputs recovered by either phase.
+	Txns int
+
+	// OffsetsActive and EnrichmentActive report whether each phase ran, so a phase
+	// that was never enabled is not presented as having found nothing.
+	OffsetsActive    bool
+	EnrichmentActive bool
+
+	// OffsetsUnavailableReason is why the offsets tail could not run (R13).
+	OffsetsUnavailableReason string
+
+	// byTxn maps a transactional id to the phases that enriched it, which is what
+	// lets a group's warning name the mechanism that recovered ITS inputs.
+	byTxn map[string]mechanisms
+}
+
+// mechanisms is the set of enrichment phases that reported one transaction.
+type mechanisms struct {
+	byOffsets bool
+	byNaming  bool
+}
+
+func (m mechanisms) any() bool { return m.byOffsets || m.byNaming }
+
+// describe names the phases in m, or the empty string when none apply.
+func (m mechanisms) describe() string {
+	switch {
+	case m.byOffsets && m.byNaming:
+		return "exact producer-id correlation via __consumer_offsets and the Kafka Streams naming convention"
+	case m.byOffsets:
+		return "exact producer-id correlation via __consumer_offsets"
+	case m.byNaming:
+		return "the Kafka Streams transactional.id<->group.id naming convention"
+	default:
+		return ""
+	}
+}
+
+// recoveryOf derives the attribution from the per-transaction source lists.
+func recoveryOf(r Run) Recovery {
+	rec := Recovery{
+		ByOffsetsTopics:          r.Offsets.RecoveredTopics,
+		OffsetsActive:            slices.Contains(r.ActiveSources, discovery.SourceConsumerOffsets) && !r.Offsets.Unavailable,
+		EnrichmentActive:         r.EnrichmentActive,
+		OffsetsUnavailableReason: r.Offsets.UnavailableReason,
+		byTxn:                    make(map[string]mechanisms, len(r.Footprints)),
+	}
+	for _, fp := range r.Footprints {
+		var m mechanisms
+		for _, src := range fp.Sources {
+			switch src {
+			case discovery.SourceConsumerOffsets:
+				m.byOffsets = true
+			case discovery.SourceConsumerGroups:
+				m.byNaming = true
+			}
+		}
+		if !m.any() {
+			continue
+		}
+		rec.byTxn[fp.TxnID] = m
+		rec.Txns++
+		if m.byOffsets {
+			rec.ByOffsetsTxns++
+		}
+		if m.byNaming {
+			rec.ByNamingTxns++
+		}
+	}
+	return rec
+}
+
+// forGroup collapses the mechanisms that enriched any of a group's transactions.
+func (rc Recovery) forGroup(g grouping.Group) mechanisms {
+	var out mechanisms
+	for _, id := range g.TxnIDs {
+		m := rc.byTxn[id]
+		out.byOffsets = out.byOffsets || m.byOffsets
+		out.byNaming = out.byNaming || m.byNaming
+	}
+	return out
 }
 
 // Health is the three things that together say whether the window was actually
@@ -125,6 +237,7 @@ func Summarize(r Run) Summary {
 		Result:         result,
 		Health:         healthOf(r),
 		AuditErrors:    r.AuditErrors,
+		Recovery:       recoveryOf(r),
 	}
 }
 
@@ -169,8 +282,9 @@ func PrintTerminal(w io.Writer, s Summary) {
 	_, _ = fmt.Fprintf(w, "  transactions           : %d committed, %d aborted\n", s.TxnCommitted, s.TxnAborted)
 	_, _ = fmt.Fprintf(w, "  topics                 : %d total — %d in %d %s, %d individual\n",
 		groupedTopics+len(individual), groupedTopics, len(groups), plural(len(groups), "group", "groups"), len(individual))
-	_, _ = fmt.Fprintf(w, "  read-process-write     : %d %s; %d consumed input topic(s) recovered\n",
-		rpwGroups, plural(rpwGroups, "group", "groups"), 0)
+	_, _ = fmt.Fprintf(w, "  read-process-write     : %d %s; consumed inputs recovered for %d %s\n",
+		rpwGroups, plural(rpwGroups, "group", "groups"),
+		s.Recovery.Txns, plural(s.Recovery.Txns, "transaction", "transactions"))
 
 	_, _ = fmt.Fprintf(w, "  keep-up                : %s\n", s.Health.Line())
 
@@ -184,6 +298,50 @@ func PrintTerminal(w io.Writer, s Summary) {
 	}
 
 	printGroupTable(w, groups)
+
+	if len(s.Result.ReadProcessWriteTopics) > 0 {
+		printRecovery(w, s)
+	}
+}
+
+// printRecovery explains what happened to the consumed inputs of the exactly-once
+// applications observed, naming only the phases that actually recovered something.
+func printRecovery(w io.Writer, s Summary) {
+	rc := s.Recovery
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Read-process-write (exactly-once consume-transform-produce) apps detected.")
+	_, _ = fmt.Fprintf(w, "  %d %s are coupled by consume-transform-produce transactions.\n",
+		len(s.Result.ReadProcessWriteTopics), plural(len(s.Result.ReadProcessWriteTopics), "topic", "topics"))
+
+	switch {
+	case rc.Txns > 0:
+		_, _ = fmt.Fprintln(w, "  Consumed input topics were recovered and folded into their groups by:")
+		if rc.ByOffsetsTxns > 0 || len(rc.ByOffsetsTopics) > 0 {
+			_, _ = fmt.Fprintf(w, "    - exact producer-id correlation via __consumer_offsets: %d %s, %d input %s\n",
+				rc.ByOffsetsTxns, plural(rc.ByOffsetsTxns, "transaction", "transactions"),
+				len(rc.ByOffsetsTopics), plural(len(rc.ByOffsetsTopics), "topic", "topics"))
+		}
+		if rc.ByNamingTxns > 0 {
+			// No topic count: the accumulator unions every source's topics, so which
+			// of a transaction's topics enrichment contributed is not recoverable.
+			_, _ = fmt.Fprintf(w, "    - the Kafka Streams transactional.id<->group.id naming convention: %d %s\n",
+				rc.ByNamingTxns, plural(rc.ByNamingTxns, "transaction", "transactions"))
+		}
+		if !rc.OffsetsActive {
+			_, _ = fmt.Fprintln(w, "  NOTE: producer-id correlation did not run, so non-Streams exactly-once")
+			_, _ = fmt.Fprintln(w, "        applications may have unrecovered inputs — verify coverage before cutover.")
+		}
+	case rc.EnrichmentActive || rc.OffsetsActive:
+		_, _ = fmt.Fprintln(w, "  No consumed input topics were recovered: no correlatable exactly-once consumer")
+		_, _ = fmt.Fprintln(w, "  group was observed in the window. Verify inputs before cutover.")
+	default:
+		_, _ = fmt.Fprintln(w, "  Their consumed input topics are not visible through the transaction footprint")
+		_, _ = fmt.Fprintln(w, "  and may need to migrate with them. Verify inputs before cutover.")
+	}
+
+	if rc.OffsetsUnavailableReason != "" {
+		_, _ = fmt.Fprintf(w, "  NOTE: the __consumer_offsets tail could not run (%s).\n", rc.OffsetsUnavailableReason)
+	}
 }
 
 // Line renders the single health indicator the summary carries: the status, the three

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -1,0 +1,100 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+)
+
+// Run is the raw material of a completed discovery run: what the sources
+// accumulated plus the parameters they ran under. It is the single input the
+// command hands to this package, so the derivation of every artifact lives here
+// rather than being duplicated at the call site.
+type Run struct {
+	// Duration is the observation window and Interval the enrichment period.
+	Duration time.Duration
+	Interval time.Duration
+
+	// ActiveSources names the phases that ran, in the order they are reported.
+	ActiveSources []string
+
+	// Footprints is the accumulator's snapshot: one entry per transactional id
+	// observed, carrying the phases that reported it.
+	Footprints []discovery.TxnFootprint
+
+	// Result is the grouping computed from those footprints.
+	Result grouping.Result
+
+	// TxnState is the __transaction_state reader's counters.
+	TxnState discovery.TxnStateStats
+}
+
+// Summary is the derived, render-ready view of a run.
+type Summary struct {
+	Duration time.Duration
+	Interval time.Duration
+
+	ActiveSources []string
+
+	// TxnRecordsRead is how many __transaction_state records were read and
+	// TxnCount how many distinct transactional ids those yielded.
+	TxnRecordsRead int64
+	TxnCount       int
+	TxnCommitted   int64
+	TxnAborted     int64
+
+	Result grouping.Result
+}
+
+// Summarize derives the render-ready summary from a completed run.
+func Summarize(r Run) Summary {
+	return Summary{
+		Duration:       r.Duration,
+		Interval:       r.Interval,
+		ActiveSources:  r.ActiveSources,
+		TxnRecordsRead: r.TxnState.RecordsSeen,
+		TxnCount:       len(r.Footprints),
+		TxnCommitted:   r.TxnState.Committed,
+		TxnAborted:     r.TxnState.Aborted,
+		Result:         r.Result,
+	}
+}
+
+// PrintTerminal writes the operator-facing summary.
+func PrintTerminal(w io.Writer, s Summary) {
+	groups := s.Result.Groups
+	individual := s.Result.IndividualTopics
+
+	groupedTopics, rpwGroups := 0, 0
+	for _, g := range groups {
+		groupedTopics += len(g.Topics)
+		if g.ReadProcessWrite {
+			rpwGroups++
+		}
+	}
+
+	const rule = "============================================================"
+	_, _ = fmt.Fprintln(w, rule)
+	_, _ = fmt.Fprintln(w, " Transaction discovery summary")
+	_, _ = fmt.Fprintln(w, rule)
+	_, _ = fmt.Fprintf(w, "  window                 : %s (enrichment interval %s)\n", s.Duration, s.Interval)
+	_, _ = fmt.Fprintf(w, "  sources                : %s\n", strings.Join(s.ActiveSources, ", "))
+	_, _ = fmt.Fprintf(w, "  transactions read      : %d record(s) on the transaction-state log, %d transactional id(s) observed\n",
+		s.TxnRecordsRead, s.TxnCount)
+	_, _ = fmt.Fprintf(w, "  transactions           : %d committed, %d aborted\n", s.TxnCommitted, s.TxnAborted)
+	_, _ = fmt.Fprintf(w, "  topics                 : %d total — %d in %d %s, %d individual\n",
+		groupedTopics+len(individual), groupedTopics, len(groups), plural(len(groups), "group", "groups"), len(individual))
+	_, _ = fmt.Fprintf(w, "  read-process-write     : %d %s; %d consumed input topic(s) recovered\n",
+		rpwGroups, plural(rpwGroups, "group", "groups"), 0)
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -33,6 +33,15 @@ type Run struct {
 
 	// TxnState is the __transaction_state reader's counters.
 	TxnState discovery.TxnStateStats
+
+	// Offsets is the __consumer_offsets tail's counters, including the consumed
+	// input topics that phase recovered and whether it ran at all (R13).
+	Offsets discovery.ConsumerOffsetsStats
+
+	// EnrichmentActive reports whether consumer-group enrichment ran. The offsets
+	// phase carries its own Unavailable flag; enrichment has no counters of its
+	// own, so whether it ran has to be told to the report.
+	EnrichmentActive bool
 }
 
 // Summary is the derived, render-ready view of a run.

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -1,8 +1,10 @@
 package report
 
 import (
+	"cmp"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
@@ -52,6 +54,8 @@ type Summary struct {
 
 // Summarize derives the render-ready summary from a completed run.
 func Summarize(r Run) Summary {
+	result := r.Result
+	result.Groups = orderGroups(r.Result.Groups)
 	return Summary{
 		Duration:       r.Duration,
 		Interval:       r.Interval,
@@ -60,8 +64,25 @@ func Summarize(r Run) Summary {
 		TxnCount:       len(r.Footprints),
 		TxnCommitted:   r.TxnState.Committed,
 		TxnAborted:     r.TxnState.Aborted,
-		Result:         r.Result,
+		Result:         result,
 	}
+}
+
+// orderGroups returns a copy of groups ordered largest first, ties broken by name.
+//
+// grouping.Build already emits this order, but the ordering is re-imposed here rather
+// than assumed: it is what makes the artifacts diffable between runs, and inheriting it
+// from an upstream package's incidental behaviour would let a change there silently
+// reorder every report. The input slice is copied because it belongs to the caller.
+func orderGroups(groups []grouping.Group) []grouping.Group {
+	out := slices.Clone(groups)
+	slices.SortStableFunc(out, func(a, b grouping.Group) int {
+		if n := cmp.Compare(len(b.Topics), len(a.Topics)); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return out
 }
 
 // PrintTerminal writes the operator-facing summary.
@@ -90,6 +111,29 @@ func PrintTerminal(w io.Writer, s Summary) {
 		groupedTopics+len(individual), groupedTopics, len(groups), plural(len(groups), "group", "groups"), len(individual))
 	_, _ = fmt.Fprintf(w, "  read-process-write     : %d %s; %d consumed input topic(s) recovered\n",
 		rpwGroups, plural(rpwGroups, "group", "groups"), 0)
+
+	printGroupTable(w, groups)
+}
+
+// printGroupTable writes one row per group.
+//
+// Counts only: no topic name and no transactional id reaches the terminal. Group names
+// are synthetic ordinals produced by grouping.Build, so they carry no customer
+// information; the names themselves live in the YAML.
+func printGroupTable(w io.Writer, groups []grouping.Group) {
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Transaction groups (topics coupled by a shared transaction — migrate each group atomically):")
+	for _, g := range groups {
+		tag := ""
+		if g.ReadProcessWrite {
+			tag = "  [read-process-write]"
+		}
+		_, _ = fmt.Fprintf(w, "  %s: %d %s, %d transactional %s%s\n",
+			g.Name,
+			len(g.Topics), plural(len(g.Topics), "topic", "topics"),
+			len(g.TxnIDs), plural(len(g.TxnIDs), "id", "ids"),
+			tag)
+	}
 }
 
 func plural(n int, one, many string) string {

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -480,7 +481,49 @@ func WriteYAML(path string, s Summary) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal the transaction discovery document: %w", err)
 	}
-	return os.WriteFile(path, body, 0644)
+	return writeSensitiveFile(path, body)
+}
+
+// artifactFileMode is the mode every artifact this package writes ends up at. The YAML
+// and the stats document both carry topic names and transactional ids — customer
+// business structure — so they match kcp-state.json's 0600 rather than the 0644 a
+// report would use.
+const artifactFileMode os.FileMode = 0600
+
+// writeSensitiveFile writes data to path at 0600, atomically.
+//
+// The write goes to a uniquely-named temp file in the same directory which is then
+// renamed onto the target, so an interrupted run leaves either the previous artifact or
+// nothing — never a half-written document that parses as a shorter list of groups.
+// os.CreateTemp already creates at 0600, and the mode is pinned again explicitly so an
+// unusual umask cannot widen it even briefly.
+func writeSensitiveFile(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create a temporary file next to %s: %w", path, err)
+	}
+	name := tmp.Name()
+	cleanup := func() { _ = os.Remove(name) }
+
+	if err := tmp.Chmod(artifactFileMode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("failed to set permissions on %s: %w", name, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close %s: %w", name, err)
+	}
+	if err := os.Rename(name, path); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to move %s into place at %s: %w", name, path, err)
+	}
+	return nil
 }
 
 func plural(n int, one, many string) string {

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -45,6 +45,10 @@ type Run struct {
 	// input topics that phase recovered and whether it ran at all (R13).
 	Offsets discovery.ConsumerOffsetsStats
 
+	// AuditErrors is AuditWriter.Errors(): audit lines that were meant to reach disk
+	// and did not. Zero when the audit log was disabled.
+	AuditErrors int
+
 	// EnrichmentActive reports whether consumer-group enrichment ran. The offsets
 	// phase carries its own Unavailable flag; enrichment has no counters of its
 	// own, so whether it ran has to be told to the report.
@@ -70,6 +74,9 @@ type Summary struct {
 	// Health is the one keep-up indicator the summary carries; the full per-source
 	// and per-partition detail lives in the stats document (KTD4).
 	Health Health
+
+	// AuditErrors is how many audit lines never reached disk.
+	AuditErrors int
 }
 
 // Health is the three things that together say whether the window was actually
@@ -117,6 +124,7 @@ func Summarize(r Run) Summary {
 		TxnAborted:     r.TxnState.Aborted,
 		Result:         result,
 		Health:         healthOf(r),
+		AuditErrors:    r.AuditErrors,
 	}
 }
 
@@ -165,6 +173,15 @@ func PrintTerminal(w io.Writer, s Summary) {
 		rpwGroups, plural(rpwGroups, "group", "groups"), 0)
 
 	_, _ = fmt.Fprintf(w, "  keep-up                : %s\n", s.Health.Line())
+
+	// A truncated audit log is silent by nature: the missing lines read downstream as
+	// "no transaction coupled these topics", which is exactly what a clean run looks
+	// like. The count is the only thing that tells the two apart, so it is surfaced
+	// next to the other keep-up signal rather than left to the exit code alone.
+	if s.AuditErrors > 0 {
+		_, _ = fmt.Fprintf(w, "  WARNING: %d audit log %s failed to reach disk, so the trace is incomplete — a coupling it should record may be missing.\n",
+			s.AuditErrors, plural(s.AuditErrors, "line", "lines"))
+	}
 
 	printGroupTable(w, groups)
 }

--- a/internal/services/txndiscovery/report/report.go
+++ b/internal/services/txndiscovery/report/report.go
@@ -131,6 +131,12 @@ func PrintTerminal(w io.Writer, s Summary) {
 // information; the names themselves live in the YAML.
 func printGroupTable(w io.Writer, groups []grouping.Group) {
 	_, _ = fmt.Fprintln(w)
+	// A table header with nothing under it reads as "the report broke". Naming the
+	// zero state says the run worked and found no coupling, which is a result.
+	if len(groups) == 0 {
+		_, _ = fmt.Fprintln(w, "Transaction groups: none — every observed topic can migrate individually.")
+		return
+	}
 	_, _ = fmt.Fprintln(w, "Transaction groups (topics coupled by a shared transaction — migrate each group atomically):")
 	for _, g := range groups {
 		tag := ""

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -140,6 +140,21 @@ func TestSummaryLeaksNoTopicNameOrTransactionalID(t *testing.T) {
 	}
 }
 
+func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {
+	out := render(t, Run{
+		Duration:      time.Minute,
+		Interval:      10 * time.Second,
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		TxnState:      discovery.TxnStateStats{RecordsSeen: 4},
+		Result:        grouping.Result{IndividualTopics: []string{"solo"}},
+	})
+
+	requireContains(t, out, "Transaction groups: none — every observed topic can migrate individually.")
+	if strings.Contains(out, "migrate each group atomically") {
+		t.Errorf("a run with no groups rendered the group table header\n--- summary ---\n%s", out)
+	}
+}
+
 // groupLines returns the rendered group rows in the order they appear, so ordering can
 // be asserted without pinning the surrounding prose.
 func groupLines(out string) []string {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -93,7 +93,6 @@ func distinctiveRun() Run {
 			Correlations:    1,
 			RecoveredTopics: []string{"zqx-topic-orders-in"},
 		},
-		EnrichmentActive: true,
 		Result: grouping.Result{
 			Groups: []grouping.Group{
 				{
@@ -291,7 +290,6 @@ func rpwRun() Run {
 			{TxnID: "unenriched", ReadProcessWrite: true, Topics: []string{"out-c"},
 				Sources: []string{discovery.SourceTxnStateLog}},
 		},
-		EnrichmentActive: true,
 		Offsets:          discovery.ConsumerOffsetsStats{RecoveredTopics: []string{"in-a"}},
 		Result: grouping.Result{
 			Groups: []grouping.Group{
@@ -324,6 +322,43 @@ func TestSummaryDoesNotCreditAnEnrichmentPhaseThatRecoveredNothing(t *testing.T)
 	if strings.Contains(out, "exact producer-id correlation via __consumer_offsets:") {
 		t.Errorf("credited the producer-id correlation phase, which recovered nothing\n--- summary ---\n%s", out)
 	}
+}
+
+// Whether enrichment ran is derived from the sources the run declares, exactly as the
+// offsets phase's activity already is — not taken on a caller's word.
+//
+// Run.EnrichmentActive was a stopgap for a phase with no counters of its own. It now has
+// them, so the field is a second, independent source of truth for a fact ActiveSources
+// already states, and the two can disagree: a caller that passes --enrich-consumer-groups
+// and whose enrichment never starts would have the report announce a phase that did not
+// run, which is precisely what R13's Unavailable flag exists to prevent for the other
+// phase.
+func TestSummaryDerivesEnrichmentActivityFromTheRunsDeclaredSources(t *testing.T) {
+	// A read-process-write transaction nothing enriched: the summary's wording turns on
+	// whether an enrichment phase was active at all.
+	base := Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Footprints: []discovery.TxnFootprint{
+			{TxnID: "eos", ReadProcessWrite: true, Topics: []string{"out"},
+				Sources: []string{discovery.SourceTxnStateLog}},
+		},
+		Result: grouping.Result{
+			Groups:                 []grouping.Group{{Name: "group-1", Topics: []string{"out"}, TxnIDs: []string{"eos"}, ReadProcessWrite: true}},
+			ReadProcessWriteTopics: []string{"out"},
+		},
+	}
+
+	withEnrichment := base
+	withEnrichment.ActiveSources = []string{discovery.SourceTxnStateLog, discovery.SourceConsumerGroups}
+	if got := Summarize(withEnrichment).Recovery.EnrichmentActive; !got {
+		t.Error("a run naming consumer-group enrichment among its sources is not reported as having enriched")
+	}
+	requireContains(t, render(t, withEnrichment), "no correlatable exactly-once consumer")
+
+	if got := Summarize(base).Recovery.EnrichmentActive; got {
+		t.Error("a run that did not name consumer-group enrichment is reported as having enriched")
+	}
+	requireContains(t, render(t, base), "not visible through the transaction footprint")
 }
 
 func TestSummaryWarnsWhenAuditLinesFailedToReachDisk(t *testing.T) {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -449,6 +450,34 @@ func TestYAMLWarningNamesTheMechanismThatRecoveredThatGroupsInputs(t *testing.T)
 		if g.Name == "group-2" && strings.Contains(g.Warning, "producer-id correlation") {
 			t.Errorf("group-2 credited producer-id correlation, which recovered nothing for it: %q", g.Warning)
 		}
+	}
+}
+
+func TestWriteYAMLFailsActionablyWhenTheOutputDirectoryDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "no-such-dir")
+	path := filepath.Join(missing, "txn-discovery.yaml")
+
+	err := WriteYAML(path, Summarize(distinctiveRun()))
+	if err == nil {
+		t.Fatal("writing into a nonexistent directory succeeded")
+	}
+	for _, want := range []string{missing, "does not exist"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	// A partial artifact is worse than none: a truncated document parses as a shorter
+	// list of groups, which reads as "these topics are not coupled".
+	if _, statErr := os.Stat(missing); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("the missing directory was created: %v", statErr)
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read temp dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("failed write left %d entries behind: %v", len(entries), entries)
 	}
 }
 

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -51,3 +51,48 @@ func TestSummaryRendersTheRunCounts(t *testing.T) {
 	requireContains(t, out, "topics                 : 6 total — 5 in 2 groups, 1 individual")
 	requireContains(t, out, "read-process-write     : 0 groups; 0 consumed input topic(s) recovered")
 }
+
+// groupLines returns the rendered group rows in the order they appear, so ordering can
+// be asserted without pinning the surrounding prose.
+func groupLines(out string) []string {
+	var rows []string
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "group-") {
+			rows = append(rows, trimmed)
+		}
+	}
+	return rows
+}
+
+func TestGroupTableListsLargestGroupsFirstWithStableOrdering(t *testing.T) {
+	// Deliberately supplied smallest-first and with the two three-topic groups in
+	// reverse name order: the table must impose its own ordering rather than echoing
+	// whatever order it was handed.
+	out := render(t, Run{
+		Result: grouping.Result{
+			Groups: []grouping.Group{
+				{Name: "group-3", Topics: []string{"m", "n"}, TxnIDs: []string{"t3"}},
+				{Name: "group-2", Topics: []string{"d", "e", "f"}, TxnIDs: []string{"t2a", "t2b"}},
+				{Name: "group-1", Topics: []string{"a", "b", "c"}, TxnIDs: []string{"t1"}},
+				{Name: "group-0", Topics: []string{"p", "q", "r", "s"}, TxnIDs: []string{"t0"}},
+			},
+		},
+	})
+
+	want := []string{
+		"group-0: 4 topics, 1 transactional id",
+		"group-1: 3 topics, 1 transactional id",
+		"group-2: 3 topics, 2 transactional ids",
+		"group-3: 2 topics, 1 transactional id",
+	}
+	got := groupLines(out)
+	if len(got) != len(want) {
+		t.Fatalf("expected %d group rows, got %d\n--- summary ---\n%s", len(want), len(got), out)
+	}
+	for i := range want {
+		if !strings.HasPrefix(got[i], want[i]) {
+			t.Errorf("group row %d = %q, want prefix %q\n--- summary ---\n%s", i, got[i], want[i], out)
+		}
+	}
+}

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -481,6 +481,79 @@ func TestWriteYAMLFailsActionablyWhenTheOutputDirectoryDoesNotExist(t *testing.T
 	}
 }
 
+// hostileNames are topic names chosen to break a document assembled by string
+// formatting rather than by an encoder. Whoever can create a topic on the observed
+// cluster chooses these bytes, and they additionally arrive through decoders for
+// broker-internal binary formats that are not part of the stable client protocol.
+var hostileNames = []string{
+	"-leading-dash",
+	"key: value",
+	"trailing-hash # comment",
+	"!!str tagged",
+	"yes",
+	"no",
+	"on",
+	"true",
+	"null",
+	"~",
+	"1.0",
+	"\"double-quoted\"",
+	"'single-quoted'",
+	"&anchor",
+	"*alias",
+	"{inline: map}",
+	"[inline, seq]",
+	"---",
+	"...",
+	"\ttab-indented",
+	" leading-space",
+	"trailing-space ",
+	"line-one\nline-two",
+	// The forgery probe: if the document were assembled with string formatting, this
+	// name would close its own list item and open a second, complete group.
+	"forge\n  - name: forged-group\n    read_process_write: false\n    topics:\n      - pwned\n    transactional_ids: []",
+}
+
+func TestYAMLRoundTripsTopicNamesContainingYAMLMetacharacters(t *testing.T) {
+	r := Run{
+		Duration: time.Minute,
+		Result: grouping.Result{
+			Groups: []grouping.Group{{
+				Name:   "group-1",
+				Topics: hostileNames,
+				TxnIDs: hostileNames,
+			}},
+			IndividualTopics: hostileNames,
+		},
+	}
+
+	_, body := writeYAML(t, r)
+	doc := parseYAML(t, body)
+
+	// Exactly one group: a name that forged a second list item would show up here.
+	if len(doc.Groups) != 1 {
+		t.Fatalf("expected 1 group after round-trip, got %d\n--- yaml ---\n%s", len(doc.Groups), body)
+	}
+	for _, tc := range []struct {
+		what string
+		got  []string
+	}{
+		{"topics", doc.Groups[0].Topics},
+		{"transactional_ids", doc.Groups[0].TransactionalIDs},
+		{"individual_topics", doc.IndividualTopics},
+	} {
+		if len(tc.got) != len(hostileNames) {
+			t.Errorf("%s round-tripped to %d entries, want %d\n--- yaml ---\n%s", tc.what, len(tc.got), len(hostileNames), body)
+			continue
+		}
+		for i, want := range hostileNames {
+			if tc.got[i] != want {
+				t.Errorf("%s[%d] round-tripped to %q, want %q", tc.what, i, tc.got[i], want)
+			}
+		}
+	}
+}
+
 // groupLines returns the rendered group rows in the order they appear, so ordering can
 // be asserted without pinning the surrounding prose.
 func groupLines(out string) []string {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+	"github.com/goccy/go-yaml"
 )
 
 // render runs the terminal summary for r and returns what an operator would see.
@@ -371,6 +372,82 @@ func TestYAMLClaimsNeitherPOCStatusNorThatItDrivesMigration(t *testing.T) {
 	} {
 		if strings.Contains(body, banned) {
 			t.Errorf("yaml contains %q\n--- yaml ---\n%s", banned, body)
+		}
+	}
+}
+
+// yamlDoc mirrors the on-disk document by its YAML keys rather than by reusing the
+// production struct, so a renamed key is a test failure instead of an invisible change.
+type yamlDoc struct {
+	GeneratedBy       string `yaml:"generated_by"`
+	ObservationWindow string `yaml:"observation_window"`
+	Groups            []struct {
+		Name             string   `yaml:"name"`
+		ReadProcessWrite bool     `yaml:"read_process_write"`
+		Warning          string   `yaml:"warning"`
+		Topics           []string `yaml:"topics"`
+		TransactionalIDs []string `yaml:"transactional_ids"`
+	} `yaml:"groups"`
+	IndividualTopicCount int      `yaml:"individual_topic_count"`
+	IndividualTopics     []string `yaml:"individual_topics"`
+}
+
+func parseYAML(t *testing.T, body string) yamlDoc {
+	t.Helper()
+	var doc yamlDoc
+	if err := yaml.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("yaml did not parse: %v\n--- yaml ---\n%s", err, body)
+	}
+	return doc
+}
+
+func TestYAMLWarningNamesTheMechanismThatRecoveredThatGroupsInputs(t *testing.T) {
+	r := rpwRun()
+	// A third group that is read-process-write but had nothing recovered, so a
+	// warning that merely names whichever phase ran is distinguishable from one that
+	// names the phase that found THIS group's inputs.
+	r.Result.Groups = append(r.Result.Groups, grouping.Group{
+		Name: "group-3", Topics: []string{"out-d", "out-e"}, TxnIDs: []string{"unenriched"}, ReadProcessWrite: true,
+	})
+	r.Result.Groups = append(r.Result.Groups, grouping.Group{
+		Name: "group-4", Topics: []string{"plain-1", "plain-2"}, TxnIDs: []string{"plain"},
+	})
+
+	_, body := writeYAML(t, r)
+	doc := parseYAML(t, body)
+
+	want := map[string]string{
+		"group-1": "exact producer-id correlation via __consumer_offsets",
+		"group-2": "the Kafka Streams transactional.id<->group.id naming convention",
+		"group-3": "consumed input topics are not captured",
+		"group-4": "",
+	}
+	if len(doc.Groups) != len(want) {
+		t.Fatalf("expected %d groups on disk, got %d\n--- yaml ---\n%s", len(want), len(doc.Groups), body)
+	}
+	for _, g := range doc.Groups {
+		w, ok := want[g.Name]
+		if !ok {
+			t.Fatalf("unexpected group %q on disk", g.Name)
+		}
+		if w == "" {
+			if g.Warning != "" {
+				t.Errorf("group %q is not read-process-write but carries warning %q", g.Name, g.Warning)
+			}
+			continue
+		}
+		if !strings.Contains(g.Warning, w) {
+			t.Errorf("group %q warning = %q, want it to name %q", g.Name, g.Warning, w)
+		}
+	}
+	// group-1's inputs came from producer-id correlation alone, so naming must not be
+	// credited for it, and vice versa.
+	for _, g := range doc.Groups {
+		if g.Name == "group-1" && strings.Contains(g.Warning, "Kafka Streams") {
+			t.Errorf("group-1 credited the naming convention, which recovered nothing for it: %q", g.Warning)
+		}
+		if g.Name == "group-2" && strings.Contains(g.Warning, "producer-id correlation") {
+			t.Errorf("group-2 credited producer-id correlation, which recovered nothing for it: %q", g.Warning)
 		}
 	}
 }

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -290,7 +290,7 @@ func rpwRun() Run {
 			{TxnID: "unenriched", ReadProcessWrite: true, Topics: []string{"out-c"},
 				Sources: []string{discovery.SourceTxnStateLog}},
 		},
-		Offsets:          discovery.ConsumerOffsetsStats{RecoveredTopics: []string{"in-a"}},
+		Offsets: discovery.ConsumerOffsetsStats{RecoveredTopics: []string{"in-a"}},
 		Result: grouping.Result{
 			Groups: []grouping.Group{
 				{Name: "group-1", Topics: []string{"in-a", "out-a"}, TxnIDs: []string{"by-offsets"}, ReadProcessWrite: true},

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -310,6 +311,47 @@ func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {
 	requireContains(t, out, "Transaction groups: none — every observed topic can migrate individually.")
 	if strings.Contains(out, "migrate each group atomically") {
 		t.Errorf("a run with no groups rendered the group table header\n--- summary ---\n%s", out)
+	}
+}
+
+// resultIdentifiers are every topic name and transactional id the grouping result
+// carries — the set the YAML exists to record.
+func resultIdentifiers(res grouping.Result) []string {
+	var out []string
+	for _, g := range res.Groups {
+		out = append(out, g.Topics...)
+		out = append(out, g.TxnIDs...)
+	}
+	out = append(out, res.IndividualTopics...)
+	return out
+}
+
+// writeYAML writes the YAML for r into a fresh temp dir and returns its path and body.
+func writeYAML(t *testing.T, r Run) (string, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "txn-discovery.yaml")
+	if err := WriteYAML(path, Summarize(r)); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read yaml: %v", err)
+	}
+	return path, string(body)
+}
+
+func TestYAMLCarriesEveryTopicNameAndTransactionalID(t *testing.T) {
+	r := distinctiveRun()
+	_, body := writeYAML(t, r)
+
+	ids := resultIdentifiers(r.Result)
+	if len(ids) == 0 {
+		t.Fatal("fixture carries no identifiers, so this test would pass vacuously")
+	}
+	for _, id := range ids {
+		if !strings.Contains(body, id) {
+			t.Errorf("yaml is missing %q\n--- yaml ---\n%s", id, body)
+		}
 	}
 }
 

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -158,6 +158,24 @@ func TestHealthLineIsOKWhenCaughtUpCleanAndEveryPartitionLive(t *testing.T) {
 	requireContains(t, out, "keep-up                : OK — 3/3 partitions live, 0 records of lag, 0 decode failures")
 }
 
+func TestHealthLineWarnsWhenAnySourceFailedToDecode(t *testing.T) {
+	// One failure from each source that counts them, so the aggregate cannot pass by
+	// watching only the tail.
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 2,
+			PartitionsRunning:  2,
+			DecodeErrors:       1,
+		},
+		TxnState: discovery.TxnStateStats{KeyDecodeErrors: 2, ValueDecodeErrors: 3},
+		Offsets:  discovery.ConsumerOffsetsStats{KeyDecodeErrors: 4},
+	})
+
+	requireContains(t, out, "keep-up                : WARNING — 2/2 partitions live, 0 records of lag, 10 decode failures")
+	requireContains(t, out, "the internal record format may have drifted, so footprints may be missing")
+}
+
 func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {
 	out := render(t, Run{
 		Duration:      time.Minute,

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -355,6 +355,26 @@ func TestYAMLCarriesEveryTopicNameAndTransactionalID(t *testing.T) {
 	}
 }
 
+func TestYAMLClaimsNeitherPOCStatusNorThatItDrivesMigration(t *testing.T) {
+	_, body := writeYAML(t, distinctiveRun())
+
+	// Nothing in kcp reads this document; presenting it as an input to an automated
+	// migration, or leaving a field for the operator to complete before migrating,
+	// promises a workflow that does not exist.
+	for _, banned := range []string{
+		"POC",
+		"bootstrap_url",
+		"before migrating",
+		"drive an automated migration",
+		"provisional",
+		"roadmap",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("yaml contains %q\n--- yaml ---\n%s", banned, body)
+		}
+	}
+}
+
 // groupLines returns the rendered group rows in the order they appear, so ordering can
 // be asserted without pinning the surrounding prose.
 func groupLines(out string) []string {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -3,6 +3,7 @@ package report
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"os"
@@ -16,6 +17,9 @@ import (
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 	"github.com/goccy/go-yaml"
 )
+
+// updateGolden rewrites the golden summary instead of comparing against it.
+var updateGolden = flag.Bool("update-golden", false, "rewrite the golden summary fixture")
 
 // render runs the terminal summary for r and returns what an operator would see.
 func render(t *testing.T, r Run) string {
@@ -552,6 +556,58 @@ func TestYAMLRoundTripsTopicNamesContainingYAMLMetacharacters(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestSummaryMatchesGolden pins the whole rendered summary, not just the lines other
+// tests assert on. Its job is to make an accidental addition visible in review: a stray
+// topic name added to a line nobody asserts on is exactly the change that would slip
+// through a suite of substring checks.
+//
+// Regenerate with: go test ./internal/services/txndiscovery/report -update-golden
+func TestSummaryMatchesGolden(t *testing.T) {
+	got := render(t, goldenRun())
+	golden := filepath.Join("testdata", "summary.golden")
+
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0755); err != nil {
+			t.Fatalf("create testdata: %v", err)
+		}
+		if err := os.WriteFile(golden, []byte(got), 0644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Log("golden updated")
+		return
+	}
+
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("read golden (regenerate with -update-golden): %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("summary does not match %s\n--- want ---\n%s\n--- got ---\n%s", golden, want, got)
+	}
+}
+
+// goldenRun is the distinctive-name run with the keep-up numbers and the audit failure
+// filled in, so the golden covers every section the summary can render.
+func goldenRun() Run {
+	r := distinctiveRun()
+	r.Tail = tail.Stats{
+		PartitionsAssigned: 4,
+		PartitionsRunning:  3,
+		RecordsRead:        1400,
+		Lag:                12,
+		OpenTxnBacklog:     300,
+		DecodeErrors:       1,
+	}
+	r.TxnState.KeyDecodeErrors = 2
+	r.AuditErrors = 5
+	r.Result.Groups = append(r.Result.Groups, grouping.Group{
+		Name:   "group-2",
+		Topics: []string{"zqx-topic-billing", "zqx-topic-invoices"},
+		TxnIDs: []string{"zqx-txnid-billing-3"},
+	})
+	return r
 }
 
 // groupLines returns the rendered group rows in the order they appear, so ordering can

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -193,6 +193,26 @@ func TestHealthLineIsNotOKWhenAPartitionStoppedEvenWithZeroLag(t *testing.T) {
 	requireContains(t, out, "1 partition stopped early, so part of the window went unobserved")
 }
 
+func TestHealthLineWarnsOnLastStableOffsetLagButNotOnOpenTransactionBacklog(t *testing.T) {
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 2,
+			PartitionsRunning:  2,
+			Lag:                750,
+			OpenTxnBacklog:     9000,
+		},
+	})
+
+	requireContains(t, out, "keep-up                : WARNING — 2/2 partitions live, 750 records of lag, 0 decode failures")
+	requireContains(t, out, "the reader did not catch up to the last stable offset, so the window was not fully observed")
+	// KTD9: the high-watermark-to-LSO gap is not something the reader can catch up
+	// on, so it must not appear as lag on the health line.
+	if strings.Contains(out, "9000") {
+		t.Errorf("open-transaction backlog was reported as reader lag\n--- summary ---\n%s", out)
+	}
+}
+
 func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {
 	out := render(t, Run{
 		Duration:      time.Minute,

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -53,7 +53,7 @@ func TestSummaryRendersTheRunCounts(t *testing.T) {
 	requireContains(t, out, "transactions read      : 12 record(s) on the transaction-state log, 4 transactional id(s) observed")
 	requireContains(t, out, "transactions           : 3 committed, 1 aborted")
 	requireContains(t, out, "topics                 : 6 total — 5 in 2 groups, 1 individual")
-	requireContains(t, out, "read-process-write     : 0 groups; 0 consumed input topic(s) recovered")
+	requireContains(t, out, "read-process-write     : 0 groups; consumed inputs recovered for 0 transactions")
 }
 
 // distinctiveRun is a run whose every topic name and transactional id is a token that
@@ -213,6 +213,55 @@ func TestHealthLineWarnsOnLastStableOffsetLagButNotOnOpenTransactionBacklog(t *t
 	// on, so it must not appear as lag on the health line.
 	if strings.Contains(out, "9000") {
 		t.Errorf("open-transaction backlog was reported as reader lag\n--- summary ---\n%s", out)
+	}
+}
+
+// rpwRun is a read-process-write run in which each enrichment phase recovered the
+// inputs of exactly one transaction, so an attribution that credits whichever phase
+// merely ran is distinguishable from one that credits the phase that found the input.
+func rpwRun() Run {
+	return Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog, discovery.SourceConsumerGroups, discovery.SourceConsumerOffsets},
+		Footprints: []discovery.TxnFootprint{
+			{TxnID: "by-offsets", ReadProcessWrite: true, Topics: []string{"out-a", "in-a"},
+				Sources: []string{discovery.SourceTxnStateLog, discovery.SourceConsumerOffsets}},
+			{TxnID: "by-naming", ReadProcessWrite: true, Topics: []string{"out-b", "in-b"},
+				Sources: []string{discovery.SourceConsumerGroups, discovery.SourceTxnStateLog}},
+			{TxnID: "unenriched", ReadProcessWrite: true, Topics: []string{"out-c"},
+				Sources: []string{discovery.SourceTxnStateLog}},
+		},
+		EnrichmentActive: true,
+		Offsets:          discovery.ConsumerOffsetsStats{RecoveredTopics: []string{"in-a"}},
+		Result: grouping.Result{
+			Groups: []grouping.Group{
+				{Name: "group-1", Topics: []string{"in-a", "out-a"}, TxnIDs: []string{"by-offsets"}, ReadProcessWrite: true},
+				{Name: "group-2", Topics: []string{"in-b", "out-b"}, TxnIDs: []string{"by-naming"}, ReadProcessWrite: true},
+			},
+			IndividualTopics:       []string{"out-c"},
+			ReadProcessWriteTopics: []string{"in-a", "in-b", "out-a", "out-b", "out-c"},
+		},
+	}
+}
+
+func TestSummaryCreditsOnlyThePhaseThatActuallyRecoveredEachInput(t *testing.T) {
+	out := render(t, rpwRun())
+
+	requireContains(t, out, "read-process-write     : 2 groups; consumed inputs recovered for 2 transactions")
+	requireContains(t, out, "exact producer-id correlation via __consumer_offsets: 1 transaction, 1 input topic")
+	requireContains(t, out, "the Kafka Streams transactional.id<->group.id naming convention: 1 transaction")
+}
+
+func TestSummaryDoesNotCreditAnEnrichmentPhaseThatRecoveredNothing(t *testing.T) {
+	r := rpwRun()
+	// The offsets tail ran but correlated nothing: every recovery came from naming.
+	r.Footprints[0].Sources = []string{discovery.SourceTxnStateLog}
+	r.Offsets.RecoveredTopics = nil
+
+	out := render(t, r)
+
+	requireContains(t, out, "the Kafka Streams transactional.id<->group.id naming convention: 1 transaction")
+	if strings.Contains(out, "exact producer-id correlation via __consumer_offsets:") {
+		t.Errorf("credited the producer-id correlation phase, which recovered nothing\n--- summary ---\n%s", out)
 	}
 }
 

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 )
 
 // render runs the terminal summary for r and returns what an operator would see.
@@ -138,6 +139,23 @@ func TestSummaryLeaksNoTopicNameOrTransactionalID(t *testing.T) {
 			t.Errorf("summary leaked the customer identifier %q\n--- summary ---\n%s", id, out)
 		}
 	}
+}
+
+func TestHealthLineIsOKWhenCaughtUpCleanAndEveryPartitionLive(t *testing.T) {
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 3,
+			PartitionsRunning:  3,
+			RecordsRead:        500,
+			// An open transaction holding the high watermark above the last stable
+			// offset is the normal state on an internal topic and is not reader lag
+			// (KTD9), so it must not spoil the health line.
+			OpenTxnBacklog: 42,
+		},
+	})
+
+	requireContains(t, out, "keep-up                : OK — 3/3 partitions live, 0 records of lag, 0 decode failures")
 }
 
 func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -52,6 +52,94 @@ func TestSummaryRendersTheRunCounts(t *testing.T) {
 	requireContains(t, out, "read-process-write     : 0 groups; 0 consumed input topic(s) recovered")
 }
 
+// distinctiveRun is a run whose every topic name and transactional id is a token that
+// cannot occur in the summary's prose by accident, so a leak is unambiguous.
+func distinctiveRun() Run {
+	return Run{
+		Duration:      90 * time.Second,
+		Interval:      15 * time.Second,
+		ActiveSources: []string{discovery.SourceTxnStateLog, discovery.SourceConsumerGroups, discovery.SourceConsumerOffsets},
+		Footprints: []discovery.TxnFootprint{
+			{
+				TxnID:            "zqx-txnid-ledger-77",
+				ProducerID:       4001,
+				Topics:           []string{"zqx-topic-payments", "zqx-topic-ledger"},
+				ReadProcessWrite: true,
+				Sources:          []string{discovery.SourceTxnStateLog, discovery.SourceConsumerOffsets},
+			},
+			{
+				TxnID:      "zqx-txnid-audit-12",
+				ProducerID: 4002,
+				Topics:     []string{"zqx-topic-audit"},
+				Sources:    []string{discovery.SourceTxnStateLog},
+			},
+		},
+		TxnState: discovery.TxnStateStats{RecordsSeen: 40, Committed: 9, Aborted: 2},
+		Offsets: discovery.ConsumerOffsetsStats{
+			RecordsSeen:     120,
+			TxnRecords:      6,
+			GroupsLinked:    1,
+			Correlations:    1,
+			RecoveredTopics: []string{"zqx-topic-orders-in"},
+		},
+		EnrichmentActive: true,
+		Result: grouping.Result{
+			Groups: []grouping.Group{
+				{
+					Name:             "group-1",
+					Topics:           []string{"zqx-topic-ledger", "zqx-topic-orders-in", "zqx-topic-payments"},
+					TxnIDs:           []string{"zqx-txnid-ledger-77"},
+					ReadProcessWrite: true,
+				},
+			},
+			IndividualTopics:       []string{"zqx-topic-audit"},
+			ReadProcessWriteTopics: []string{"zqx-topic-ledger", "zqx-topic-payments"},
+		},
+	}
+}
+
+// customerIdentifiers are every topic name and transactional id distinctiveRun carries.
+func customerIdentifiers(r Run) []string {
+	seen := map[string]struct{}{}
+	add := func(vs ...string) {
+		for _, v := range vs {
+			seen[v] = struct{}{}
+		}
+	}
+	for _, fp := range r.Footprints {
+		add(fp.TxnID)
+		add(fp.Topics...)
+	}
+	for _, g := range r.Result.Groups {
+		add(g.Topics...)
+		add(g.TxnIDs...)
+	}
+	add(r.Result.IndividualTopics...)
+	add(r.Result.ReadProcessWriteTopics...)
+	add(r.Offsets.RecoveredTopics...)
+
+	out := make([]string, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestSummaryLeaksNoTopicNameOrTransactionalID(t *testing.T) {
+	r := distinctiveRun()
+	out := render(t, r)
+
+	ids := customerIdentifiers(r)
+	if len(ids) == 0 {
+		t.Fatal("fixture carries no identifiers, so this test would pass vacuously")
+	}
+	for _, id := range ids {
+		if strings.Contains(out, id) {
+			t.Errorf("summary leaked the customer identifier %q\n--- summary ---\n%s", id, out)
+		}
+	}
+}
+
 // groupLines returns the rendered group rows in the order they appear, so ordering can
 // be asserted without pinning the surrounding prose.
 func groupLines(out string) []string {

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -2,6 +2,9 @@ package report
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -210,6 +213,39 @@ func TestHealthLineWarnsOnLastStableOffsetLagButNotOnOpenTransactionBacklog(t *t
 	// on, so it must not appear as lag on the health line.
 	if strings.Contains(out, "9000") {
 		t.Errorf("open-transaction backlog was reported as reader lag\n--- summary ---\n%s", out)
+	}
+}
+
+func TestSummaryWarnsWhenAuditLinesFailedToReachDisk(t *testing.T) {
+	// Driven from a real AuditWriter rather than a hand-set number, because the
+	// contract being proved is that the writer's error count reaches the summary at
+	// all: a truncated trace reads downstream as "no transaction coupled these
+	// topics", which is indistinguishable from a clean run.
+	w, err := NewAuditWriter(filepath.Join(t.TempDir(), "audit.jsonl"))
+	if err != nil {
+		t.Fatalf("open audit log: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	w.sink = &failingWriter{err: errors.New("no space left on device")}
+	for i := 0; i < 3; i++ {
+		w.Record(
+			discovery.Observation{TxnID: fmt.Sprintf("t-%d", i), Source: discovery.SourceTxnStateLog},
+			discovery.Change{Added: []string{fmt.Sprintf("topic-%d", i)}},
+		)
+	}
+	if w.Errors() != 3 {
+		t.Fatalf("fixture did not produce audit errors: got %d", w.Errors())
+	}
+
+	out := render(t, Run{ActiveSources: []string{discovery.SourceTxnStateLog}, AuditErrors: w.Errors()})
+	requireContains(t, out, "WARNING: 3 audit log lines failed to reach disk")
+	requireContains(t, out, "the trace is incomplete")
+}
+
+func TestSummaryDoesNotWarnAboutTheAuditLogWhenEveryLineReachedDisk(t *testing.T) {
+	out := render(t, Run{ActiveSources: []string{discovery.SourceTxnStateLog}, AuditErrors: 0})
+	if strings.Contains(out, "audit log") {
+		t.Errorf("a clean run warned about the audit log\n--- summary ---\n%s", out)
 	}
 }
 

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -176,6 +176,23 @@ func TestHealthLineWarnsWhenAnySourceFailedToDecode(t *testing.T) {
 	requireContains(t, out, "the internal record format may have drifted, so footprints may be missing")
 }
 
+func TestHealthLineIsNotOKWhenAPartitionStoppedEvenWithZeroLag(t *testing.T) {
+	// The stall failure mode: a partition loop that exited reports zero lag and no
+	// decode errors, so liveness is the only thing that distinguishes it from a
+	// caught-up run.
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 4,
+			PartitionsRunning:  3,
+			RecordsRead:        900,
+		},
+	})
+
+	requireContains(t, out, "keep-up                : WARNING — 3/4 partitions live, 0 records of lag, 0 decode failures")
+	requireContains(t, out, "1 partition stopped early, so part of the window went unobserved")
+}
+
 func TestSummaryRendersAZeroStateWhenNoGroupsWereFound(t *testing.T) {
 	out := render(t, Run{
 		Duration:      time.Minute,

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -203,6 +203,60 @@ func TestHealthLineIsNotOKWhenAPartitionStoppedEvenWithZeroLag(t *testing.T) {
 	requireContains(t, out, "1 partition stopped early, so part of the window went unobserved")
 }
 
+func TestHealthLineIsNotOKWhenPartitionsAreStuckRetryingEvenWithZeroLag(t *testing.T) {
+	// The run this test exists for, reproduced from the integration suite's own
+	// numbers: a broker restarted mid-run, every partition loop is retrying a
+	// dead connection, 98 of 100 read nothing at all — and the summary said
+	// "OK — 100/100 partitions live, 0 records of lag". Every existing signal
+	// was clean. The loops never exited, so the liveness count was full; no
+	// partition ever fetched successfully, so each held a zero last stable
+	// offset and its lag computed as zero; and nothing decoded, so there were no
+	// decode errors either.
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 100,
+			PartitionsRunning:  100,
+			PartitionsStalled:  98,
+			RecordsRead:        16,
+			TransportErrors:    3200,
+		},
+	})
+
+	if strings.Contains(out, "keep-up                : OK") {
+		t.Errorf("the health line reported OK while 98 partitions were retrying a dead connection\n--- summary ---\n%s", out)
+	}
+	requireContains(t, out, "keep-up                : WARNING — 100/100 partitions live, 0 records of lag, 0 decode failures, 3200 fetch failures")
+	requireContains(t, out, "98 partitions are retrying a failed fetch rather than reading")
+}
+
+func TestHealthLineStaysOKWhenAFetchFailureWasRecoveredFromButShowsTheCount(t *testing.T) {
+	// The other side of the same rule, and the reason it keys on partitions that
+	// are still stuck rather than on the error counters. Surviving a leader
+	// election or a broker restart IS the requirement, and a reader that
+	// recovered and caught up did its job: condemning it would train operators
+	// to ignore the one line that says the window was observed. The counts are
+	// rendered anyway, because a run that recovered from three thousand failures
+	// is not the same run as one that never faltered.
+	out := render(t, Run{
+		ActiveSources: []string{discovery.SourceTxnStateLog},
+		Tail: tail.Stats{
+			PartitionsAssigned: 50,
+			PartitionsRunning:  50,
+			PartitionsStalled:  0,
+			RecordsRead:        900,
+			LeadershipErrors:   12,
+			TransportErrors:    30,
+			UnclassifiedErrors: 1,
+		},
+	})
+
+	requireContains(t, out, "keep-up                : OK — 50/50 partitions live, 0 records of lag, 0 decode failures, 43 fetch failures")
+	if strings.Contains(out, "retrying a failed fetch") {
+		t.Errorf("a recovered disruption was reported as an ongoing stall\n--- summary ---\n%s", out)
+	}
+}
+
 func TestHealthLineWarnsOnLastStableOffsetLagButNotOnOpenTransactionBacklog(t *testing.T) {
 	out := render(t, Run{
 		ActiveSources: []string{discovery.SourceTxnStateLog},
@@ -595,10 +649,16 @@ func goldenRun() Run {
 	r.Tail = tail.Stats{
 		PartitionsAssigned: 4,
 		PartitionsRunning:  3,
-		RecordsRead:        1400,
-		Lag:                12,
-		OpenTxnBacklog:     300,
-		DecodeErrors:       1,
+		// One of the three live partitions is retrying a failed fetch, so the golden
+		// carries the stall concern as well as the stopped-early one: they are
+		// different failures and the summary has to be able to say both at once.
+		PartitionsStalled: 1,
+		RecordsRead:       1400,
+		Lag:               12,
+		OpenTxnBacklog:    300,
+		DecodeErrors:      1,
+		TransportErrors:   6,
+		LeadershipErrors:  1,
 	}
 	r.TxnState.KeyDecodeErrors = 2
 	r.AuditErrors = 5

--- a/internal/services/txndiscovery/report/report_test.go
+++ b/internal/services/txndiscovery/report/report_test.go
@@ -1,0 +1,53 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/grouping"
+)
+
+// render runs the terminal summary for r and returns what an operator would see.
+func render(t *testing.T, r Run) string {
+	t.Helper()
+	var buf bytes.Buffer
+	PrintTerminal(&buf, Summarize(r))
+	return buf.String()
+}
+
+// requireContains fails with the whole rendered summary attached, because a missing
+// line is only diagnosable next to the output that was produced instead.
+func requireContains(t *testing.T, out, want string) {
+	t.Helper()
+	if !strings.Contains(out, want) {
+		t.Errorf("summary is missing %q\n--- summary ---\n%s", want, out)
+	}
+}
+
+func TestSummaryRendersTheRunCounts(t *testing.T) {
+	out := render(t, Run{
+		Duration:      30 * time.Second,
+		Interval:      10 * time.Second,
+		ActiveSources: []string{discovery.SourceTxnStateLog, discovery.SourceConsumerGroups},
+		Footprints: []discovery.TxnFootprint{
+			{TxnID: "txn-a"}, {TxnID: "txn-b"}, {TxnID: "txn-c"}, {TxnID: "txn-d"},
+		},
+		TxnState: discovery.TxnStateStats{RecordsSeen: 12, Committed: 3, Aborted: 1},
+		Result: grouping.Result{
+			Groups: []grouping.Group{
+				{Name: "group-1", Topics: []string{"alpha", "beta", "gamma"}, TxnIDs: []string{"txn-a", "txn-b"}},
+				{Name: "group-2", Topics: []string{"delta", "epsilon"}, TxnIDs: []string{"txn-c"}},
+			},
+			IndividualTopics: []string{"zeta"},
+		},
+	})
+
+	requireContains(t, out, "window                 : 30s (enrichment interval 10s)")
+	requireContains(t, out, "transactions read      : 12 record(s) on the transaction-state log, 4 transactional id(s) observed")
+	requireContains(t, out, "transactions           : 3 committed, 1 aborted")
+	requireContains(t, out, "topics                 : 6 total — 5 in 2 groups, 1 individual")
+	requireContains(t, out, "read-process-write     : 0 groups; 0 consumed input topic(s) recovered")
+}

--- a/internal/services/txndiscovery/report/report_unix_test.go
+++ b/internal/services/txndiscovery/report/report_unix_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+// Mode bits are a unix concept. Windows' os.Chmod only toggles the read-only bit, so
+// these assertions are meaningless there — and a runtime GOOS skip cannot save a package
+// that will not compile, hence a build tag rather than t.Skip.
+package report
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// withPermissiveUmask clears the process umask for the duration of a test, so a mode
+// assertion proves the writer asked for 0600 rather than proving the ambient umask
+// happened to strip the wider bits. Tests using it must not run in parallel: the umask
+// is process-wide.
+func withPermissiveUmask(t *testing.T) {
+	t.Helper()
+	old := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+// requireMode0600 fails unless path is on disk at exactly mode 0600.
+func requireMode0600(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("%s has mode %#o, want %#o", path, got, 0600)
+	}
+}
+
+func TestYAMLIsWritten0600(t *testing.T) {
+	withPermissiveUmask(t)
+
+	// The document carries every topic name and transactional id the run observed —
+	// customer business structure — so it matches kcp-state.json's 0600 rather than
+	// the 0644 a report would use.
+	path := filepath.Join(t.TempDir(), "txn-discovery.yaml")
+	if err := WriteYAML(path, Summarize(distinctiveRun())); err != nil {
+		t.Fatalf("WriteYAML: %v", err)
+	}
+	requireMode0600(t, path)
+}

--- a/internal/services/txndiscovery/report/report_unix_test.go
+++ b/internal/services/txndiscovery/report/report_unix_test.go
@@ -34,6 +34,18 @@ func requireMode0600(t *testing.T, path string) {
 	}
 }
 
+func TestStatsJSONIsWritten0600(t *testing.T) {
+	withPermissiveUmask(t)
+
+	// The stats document is NOT a counts-only file: it carries every observed
+	// transaction's id and topic set, so the POC's 0644 must not port across.
+	path := filepath.Join(t.TempDir(), "txn-discovery-stats.json")
+	if err := WriteStatsJSON(path, distinctiveRun()); err != nil {
+		t.Fatalf("WriteStatsJSON: %v", err)
+	}
+	requireMode0600(t, path)
+}
+
 func TestYAMLIsWritten0600(t *testing.T) {
 	withPermissiveUmask(t)
 

--- a/internal/services/txndiscovery/report/stats.go
+++ b/internal/services/txndiscovery/report/stats.go
@@ -3,6 +3,7 @@ package report
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
@@ -114,6 +115,70 @@ type statsTxn struct {
 	FirstSeen        time.Time `json:"first_seen"`
 	LastSeen         time.Time `json:"last_seen"`
 	Samples          int       `json:"samples"`
+}
+
+// PrintKeepUp writes the detailed keep-up breakdown.
+//
+// Per KTD4 this does NOT belong in the default summary, which carries one health line:
+// three overlapping views of the same numbers is what the output tidy-up removed. The
+// command calls this only under --verbose, for the operator who has seen the health line
+// warn and needs to know which partition or which source is responsible.
+//
+// It names only the two internal topics the tail is assigned, never a customer topic.
+func PrintKeepUp(w io.Writer, r Run) {
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Keep-up detail:")
+
+	t := r.Tail
+	_, _ = fmt.Fprintf(w, "  fetch: %d/%d %s live, %d %s read, lag %d, open-txn backlog %d\n",
+		t.PartitionsRunning, t.PartitionsAssigned, plural(t.PartitionsAssigned, "partition", "partitions"),
+		t.RecordsRead, plural64(t.RecordsRead, "record", "records"), t.Lag, t.OpenTxnBacklog)
+	// The taxonomy the health line collapses into one number. A run that recovered
+	// from fifty leader changes and one that never saw a broker hiccup produce the
+	// same health line, and this is where they differ.
+	_, _ = fmt.Fprintf(w, "    errors: %d decode, %d leadership, %d unclassified, %d offset reset, %d transport\n",
+		t.DecodeErrors, t.LeadershipErrors, t.UnclassifiedErrors, t.OffsetResets, t.TransportErrors)
+
+	for _, p := range t.Partitions {
+		state := "live"
+		if !p.Running {
+			state = "STOPPED"
+		}
+		_, _ = fmt.Fprintf(w, "    %s[%d]: next %d, LSO %d, HWM %d, lag %d, backlog %d, %d %s, %s\n",
+			p.Topic, p.Partition, p.NextOffset, p.LastStableOffset, p.HighWaterMark,
+			p.Lag, p.OpenTxnBacklog, p.RecordsRead, plural64(p.RecordsRead, "record", "records"), state)
+		if p.LastError != "" {
+			_, _ = fmt.Fprintf(w, "      last error: %s\n", p.LastError)
+		}
+	}
+
+	ts := r.TxnState
+	_, _ = fmt.Fprintf(w, "  transaction-state reader: %d %s, %d %s, %d committed / %d aborted, %d %s\n",
+		ts.RecordsSeen, plural64(ts.RecordsSeen, "record", "records"),
+		ts.Footprints, plural64(ts.Footprints, "footprint", "footprints"),
+		ts.Committed, ts.Aborted,
+		ts.Tombstones, plural64(ts.Tombstones, "tombstone", "tombstones"))
+	if ts.KeyDecodeErrors > 0 || ts.ValueDecodeErrors > 0 {
+		_, _ = fmt.Fprintf(w, "    decode failures: %d key, %d value — the __transaction_state record format may have drifted\n",
+			ts.KeyDecodeErrors, ts.ValueDecodeErrors)
+	}
+
+	o := r.Offsets
+	if o.Unavailable {
+		_, _ = fmt.Fprintf(w, "  consumer-offsets tail: did not run (%s)\n", o.UnavailableReason)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "  consumer-offsets tail: %d %s, %d txn %s, %d %s linked, %d input %s recovered\n",
+		o.RecordsSeen, plural64(o.RecordsSeen, "record", "records"),
+		o.TxnRecords, plural64(o.TxnRecords, "offset-commit", "offset-commits"),
+		o.GroupsLinked, plural(o.GroupsLinked, "group", "groups"),
+		len(o.RecoveredTopics), plural(len(o.RecoveredTopics), "topic", "topics"))
+	// Evictions are the only signal that the bounded pending buffer discarded
+	// recoveries, so a run that evicted heavily observed fewer inputs than exist.
+	_, _ = fmt.Fprintf(w, "    %d pending, %d pending %s, %d key decode %s\n",
+		o.PendingProducers,
+		o.PendingEvicted, plural64(o.PendingEvicted, "eviction", "evictions"),
+		o.KeyDecodeErrors, plural64(o.KeyDecodeErrors, "failure", "failures"))
 }
 
 // WriteStatsJSON writes the diagnostics document for r to path.

--- a/internal/services/txndiscovery/report/stats.go
+++ b/internal/services/txndiscovery/report/stats.go
@@ -1,0 +1,230 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+)
+
+// statsDoc is the on-disk shape of the --stats-out document: the diagnostics view of a
+// run, carrying the keep-up signal in full (R21) plus the per-transaction footprints
+// the summary reduces to counts.
+//
+// It is a sensitive artifact, not a counts-only file: the footprints carry transactional
+// ids and topic names, which is why it is written at the same 0600 as txn-discovery.yaml
+// rather than the 0644 a report would use.
+type statsDoc struct {
+	GeneratedAt        string   `json:"generated_at"`
+	ObservationWindow  string   `json:"observation_window"`
+	EnrichmentInterval string   `json:"enrichment_interval"`
+	ActiveSources      []string `json:"active_sources"`
+
+	ObservedTransactionalIDs int `json:"observed_transactional_ids"`
+
+	Tail                tailDoc        `json:"tail"`
+	TransactionStateLog txnStateDoc    `json:"transaction_state_log"`
+	ConsumerOffsetsLog  offsetsTailDoc `json:"consumer_offsets_log"`
+
+	// AuditLogWriteErrors is the count the summary warns on, recorded here too so a
+	// captured run's diagnostics say whether its audit trace is complete.
+	AuditLogWriteErrors int `json:"audit_log_write_errors"`
+
+	Transactions []statsTxn `json:"transactions"`
+}
+
+// tailDoc is the fetch component's keep-up view: aggregate first, then per partition.
+// Both are needed — the aggregate says whether the run kept up, the per-partition
+// breakdown says which partition did not.
+type tailDoc struct {
+	PartitionsAssigned int   `json:"partitions_assigned"`
+	PartitionsRunning  int   `json:"partitions_running"`
+	RecordsRead        int64 `json:"records_read"`
+	// Lag is measured to the last stable offset (KTD9); OpenTxnBacklog is the
+	// high-watermark gap, which is not something the reader can catch up on.
+	Lag                int64          `json:"lag"`
+	OpenTxnBacklog     int64          `json:"open_txn_backlog"`
+	AbortedBatches     int64          `json:"aborted_batches"`
+	DecodeErrors       int64          `json:"decode_errors"`
+	LeadershipErrors   int64          `json:"leadership_errors"`
+	UnclassifiedErrors int64          `json:"unclassified_errors"`
+	OffsetResets       int64          `json:"offset_resets"`
+	TransportErrors    int64          `json:"transport_errors"`
+	Partitions         []partitionDoc `json:"partitions"`
+}
+
+type partitionDoc struct {
+	Topic            string `json:"topic"`
+	Partition        int32  `json:"partition"`
+	NextOffset       int64  `json:"next_offset"`
+	LastStableOffset int64  `json:"last_stable_offset"`
+	HighWaterMark    int64  `json:"high_water_mark"`
+	Lag              int64  `json:"lag"`
+	OpenTxnBacklog   int64  `json:"open_txn_backlog"`
+	// Running and LastAdvance together separate a stalled partition from an idle
+	// one: both report zero lag, and only these say which happened.
+	Running     bool       `json:"running"`
+	LastAdvance *time.Time `json:"last_advance"`
+
+	RecordsRead        int64  `json:"records_read"`
+	AbortedBatches     int64  `json:"aborted_batches"`
+	DecodeErrors       int64  `json:"decode_errors"`
+	LeadershipErrors   int64  `json:"leadership_errors"`
+	UnclassifiedErrors int64  `json:"unclassified_errors"`
+	OffsetResets       int64  `json:"offset_resets"`
+	TransportErrors    int64  `json:"transport_errors"`
+	LastError          string `json:"last_error"`
+}
+
+type txnStateDoc struct {
+	RecordsSeen int64 `json:"records_seen"`
+	Footprints  int64 `json:"footprints"`
+	Empty       int64 `json:"empty"`
+	Committed   int64 `json:"committed_completions"`
+	Aborted     int64 `json:"aborted_completions"`
+	Tombstones  int64 `json:"tombstones"`
+	// Key and value decode errors are kept apart so the alarm says which half of the
+	// record drifted.
+	KeyDecodeErrors   int64 `json:"key_decode_errors"`
+	ValueDecodeErrors int64 `json:"value_decode_errors"`
+}
+
+type offsetsTailDoc struct {
+	RecordsSeen      int64    `json:"records_seen"`
+	TxnRecords       int64    `json:"txn_offset_commits"`
+	KeyDecodeErrors  int64    `json:"key_decode_errors"`
+	PendingProducers int      `json:"pending_producers"`
+	PendingEvicted   int64    `json:"pending_evicted"`
+	GroupsLinked     int      `json:"groups_linked"`
+	Correlations     int      `json:"correlations"`
+	RecoveredTopics  []string `json:"recovered_topics"`
+	// Unavailable distinguishes a phase that never ran from one that ran and found
+	// nothing; both otherwise report zero recoveries (R13).
+	Unavailable       bool   `json:"unavailable"`
+	UnavailableReason string `json:"unavailable_reason"`
+}
+
+type statsTxn struct {
+	TransactionalID  string    `json:"transactional_id"`
+	ProducerID       int64     `json:"producer_id"`
+	Topics           []string  `json:"topics"`
+	ReadProcessWrite bool      `json:"read_process_write"`
+	Sources          []string  `json:"sources"`
+	FirstSeen        time.Time `json:"first_seen"`
+	LastSeen         time.Time `json:"last_seen"`
+	Samples          int       `json:"samples"`
+}
+
+// WriteStatsJSON writes the diagnostics document for r to path.
+func WriteStatsJSON(path string, r Run) error {
+	doc := statsDoc{
+		GeneratedAt:              time.Now().UTC().Format(time.RFC3339),
+		ObservationWindow:        r.Duration.String(),
+		EnrichmentInterval:       r.Interval.String(),
+		ActiveSources:            emptyIfNil(r.ActiveSources),
+		ObservedTransactionalIDs: len(r.Footprints),
+		Tail:                     tailDocOf(r.Tail),
+		TransactionStateLog: txnStateDoc{
+			RecordsSeen:       r.TxnState.RecordsSeen,
+			Footprints:        r.TxnState.Footprints,
+			Empty:             r.TxnState.Empty,
+			Committed:         r.TxnState.Committed,
+			Aborted:           r.TxnState.Aborted,
+			Tombstones:        r.TxnState.Tombstones,
+			KeyDecodeErrors:   r.TxnState.KeyDecodeErrors,
+			ValueDecodeErrors: r.TxnState.ValueDecodeErrors,
+		},
+		ConsumerOffsetsLog: offsetsTailDoc{
+			RecordsSeen:       r.Offsets.RecordsSeen,
+			TxnRecords:        r.Offsets.TxnRecords,
+			KeyDecodeErrors:   r.Offsets.KeyDecodeErrors,
+			PendingProducers:  r.Offsets.PendingProducers,
+			PendingEvicted:    r.Offsets.PendingEvicted,
+			GroupsLinked:      r.Offsets.GroupsLinked,
+			Correlations:      r.Offsets.Correlations,
+			RecoveredTopics:   emptyIfNil(r.Offsets.RecoveredTopics),
+			Unavailable:       r.Offsets.Unavailable,
+			UnavailableReason: r.Offsets.UnavailableReason,
+		},
+		AuditLogWriteErrors: r.AuditErrors,
+		Transactions:        make([]statsTxn, 0, len(r.Footprints)),
+	}
+	for _, fp := range r.Footprints {
+		doc.Transactions = append(doc.Transactions, statsTxn{
+			TransactionalID:  fp.TxnID,
+			ProducerID:       fp.ProducerID,
+			Topics:           emptyIfNil(fp.Topics),
+			ReadProcessWrite: fp.ReadProcessWrite,
+			Sources:          emptyIfNil(fp.Sources),
+			FirstSeen:        fp.FirstSeen,
+			LastSeen:         fp.LastSeen,
+			Samples:          fp.Samples,
+		})
+	}
+
+	// encoding/json, never string formatting: topic names and transactional ids are
+	// chosen by whoever can create a topic or configure a producer, and an unescaped
+	// newline in one would let the rest of a name be read as a forged field.
+	body, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal the transaction discovery stats document: %w", err)
+	}
+	return writeSensitiveFile(path, append(body, '\n'))
+}
+
+// tailDocOf converts the fetch component's snapshot, aggregate and per partition.
+func tailDocOf(s tail.Stats) tailDoc {
+	out := tailDoc{
+		PartitionsAssigned: s.PartitionsAssigned,
+		PartitionsRunning:  s.PartitionsRunning,
+		RecordsRead:        s.RecordsRead,
+		Lag:                s.Lag,
+		OpenTxnBacklog:     s.OpenTxnBacklog,
+		AbortedBatches:     s.AbortedBatches,
+		DecodeErrors:       s.DecodeErrors,
+		LeadershipErrors:   s.LeadershipErrors,
+		UnclassifiedErrors: s.UnclassifiedErrors,
+		OffsetResets:       s.OffsetResets,
+		TransportErrors:    s.TransportErrors,
+		Partitions:         make([]partitionDoc, 0, len(s.Partitions)),
+	}
+	for _, p := range s.Partitions {
+		pd := partitionDoc{
+			Topic:              p.Topic,
+			Partition:          p.Partition,
+			NextOffset:         p.NextOffset,
+			LastStableOffset:   p.LastStableOffset,
+			HighWaterMark:      p.HighWaterMark,
+			Lag:                p.Lag,
+			OpenTxnBacklog:     p.OpenTxnBacklog,
+			Running:            p.Running,
+			RecordsRead:        p.RecordsRead,
+			AbortedBatches:     p.AbortedBatches,
+			DecodeErrors:       p.DecodeErrors,
+			LeadershipErrors:   p.LeadershipErrors,
+			UnclassifiedErrors: p.UnclassifiedErrors,
+			OffsetResets:       p.OffsetResets,
+			TransportErrors:    p.TransportErrors,
+			LastError:          p.LastError,
+		}
+		// A partition that never advanced has a zero time. Rendering that as
+		// "0001-01-01T00:00:00Z" reads as a real timestamp from an absurd clock;
+		// null says plainly that it never moved.
+		if !p.LastAdvance.IsZero() {
+			t := p.LastAdvance.UTC()
+			pd.LastAdvance = &t
+		}
+		out.Partitions = append(out.Partitions, pd)
+	}
+	return out
+}
+
+// emptyIfNil renders an absent list as [] rather than null, so a consumer can iterate
+// it without a nil check.
+func emptyIfNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/services/txndiscovery/report/stats.go
+++ b/internal/services/txndiscovery/report/stats.go
@@ -39,9 +39,13 @@ type statsDoc struct {
 // Both are needed — the aggregate says whether the run kept up, the per-partition
 // breakdown says which partition did not.
 type tailDoc struct {
-	PartitionsAssigned int   `json:"partitions_assigned"`
-	PartitionsRunning  int   `json:"partitions_running"`
-	RecordsRead        int64 `json:"records_read"`
+	PartitionsAssigned int `json:"partitions_assigned"`
+	PartitionsRunning  int `json:"partitions_running"`
+	// PartitionsStalled is how many live loops were retrying a failed fetch rather
+	// than reading. It is the count the health line escalates on, so the document
+	// has to carry it for a captured run to be diagnosable after the fact.
+	PartitionsStalled int   `json:"partitions_stalled"`
+	RecordsRead       int64 `json:"records_read"`
 	// Lag is measured to the last stable offset (KTD9); OpenTxnBacklog is the
 	// high-watermark gap, which is not something the reader can catch up on.
 	Lag                int64          `json:"lag"`
@@ -63,9 +67,12 @@ type partitionDoc struct {
 	HighWaterMark    int64  `json:"high_water_mark"`
 	Lag              int64  `json:"lag"`
 	OpenTxnBacklog   int64  `json:"open_txn_backlog"`
-	// Running and LastAdvance together separate a stalled partition from an idle
-	// one: both report zero lag, and only these say which happened.
+	// Running, Stalled and LastAdvance together separate a stalled partition from an
+	// idle one: both report zero lag, and only these say which happened. Stalled is
+	// the decisive one — a loop stuck retrying is still running, and neither has
+	// advanced.
 	Running     bool       `json:"running"`
+	Stalled     bool       `json:"stalled"`
 	LastAdvance *time.Time `json:"last_advance"`
 
 	RecordsRead        int64  `json:"records_read"`
@@ -141,8 +148,14 @@ func PrintKeepUp(w io.Writer, r Run) {
 
 	for _, p := range t.Partitions {
 		state := "live"
-		if !p.Running {
+		switch {
+		case !p.Running:
 			state = "STOPPED"
+		case p.Stalled:
+			// Distinct from STOPPED because the loop is alive and will keep trying,
+			// and distinct from live because it is not reading. Without this the
+			// partition renders identically to a healthy idle one.
+			state = "STALLED"
 		}
 		_, _ = fmt.Fprintf(w, "    %s[%d]: next %d, LSO %d, HWM %d, lag %d, backlog %d, %d %s, %s\n",
 			p.Topic, p.Partition, p.NextOffset, p.LastStableOffset, p.HighWaterMark,
@@ -243,6 +256,7 @@ func tailDocOf(s tail.Stats) tailDoc {
 	out := tailDoc{
 		PartitionsAssigned: s.PartitionsAssigned,
 		PartitionsRunning:  s.PartitionsRunning,
+		PartitionsStalled:  s.PartitionsStalled,
 		RecordsRead:        s.RecordsRead,
 		Lag:                s.Lag,
 		OpenTxnBacklog:     s.OpenTxnBacklog,
@@ -264,6 +278,7 @@ func tailDocOf(s tail.Stats) tailDoc {
 			Lag:                p.Lag,
 			OpenTxnBacklog:     p.OpenTxnBacklog,
 			Running:            p.Running,
+			Stalled:            p.Stalled,
 			RecordsRead:        p.RecordsRead,
 			AbortedBatches:     p.AbortedBatches,
 			DecodeErrors:       p.DecodeErrors,

--- a/internal/services/txndiscovery/report/stats.go
+++ b/internal/services/txndiscovery/report/stats.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
 	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
 )
 
@@ -24,9 +25,10 @@ type statsDoc struct {
 
 	ObservedTransactionalIDs int `json:"observed_transactional_ids"`
 
-	Tail                tailDoc        `json:"tail"`
-	TransactionStateLog txnStateDoc    `json:"transaction_state_log"`
-	ConsumerOffsetsLog  offsetsTailDoc `json:"consumer_offsets_log"`
+	Tail                    tailDoc        `json:"tail"`
+	TransactionStateLog     txnStateDoc    `json:"transaction_state_log"`
+	ConsumerOffsetsLog      offsetsTailDoc `json:"consumer_offsets_log"`
+	ConsumerGroupEnrichment enrichmentDoc  `json:"consumer_group_enrichment"`
 
 	// AuditLogWriteErrors is the count the summary warns on, recorded here too so a
 	// captured run's diagnostics say whether its audit trace is complete.
@@ -113,6 +115,25 @@ type offsetsTailDoc struct {
 	UnavailableReason string `json:"unavailable_reason"`
 }
 
+// enrichmentDoc is consumer-group enrichment's view: the cadence it actually achieved
+// and what it correlated.
+//
+// Passes against the run's enrichment_interval and observation_window is the whole
+// point of the block. This phase's admin calls are the run's slowest, so a run
+// configured for a pass every five seconds over a minute can complete four rather than
+// thirteen, and no other number in this document would say so.
+type enrichmentDoc struct {
+	Passes       int `json:"passes"`
+	PassFailures int `json:"pass_failures"`
+	// GroupsListed is the most groups any one pass saw, which separates a naming
+	// convention that matched nothing from credentials that could see no group at all.
+	GroupsListed int `json:"groups_listed"`
+	// Correlations counts links MADE. Compared against the naming attribution the
+	// summary reports, a surplus here is a correlation that was computed and then
+	// discarded before its observation was accumulated.
+	Correlations int `json:"correlations"`
+}
+
 type statsTxn struct {
 	TransactionalID  string    `json:"transactional_id"`
 	ProducerID       int64     `json:"producer_id"`
@@ -176,7 +197,16 @@ func PrintKeepUp(w io.Writer, r Run) {
 			ts.KeyDecodeErrors, ts.ValueDecodeErrors)
 	}
 
-	o := r.Offsets
+	printOffsetsKeepUp(w, r.Offsets)
+	printEnrichmentKeepUp(w, r.Enrichment)
+}
+
+// printOffsetsKeepUp writes the __consumer_offsets tail's section.
+//
+// Its own function because the unavailable case ends the section early, and inline that
+// early return would swallow every section written after it (R13 makes an unreadable
+// offsets log an ordinary outcome, not the end of the report).
+func printOffsetsKeepUp(w io.Writer, o discovery.ConsumerOffsetsStats) {
 	if o.Unavailable {
 		_, _ = fmt.Fprintf(w, "  consumer-offsets tail: did not run (%s)\n", o.UnavailableReason)
 		return
@@ -192,6 +222,23 @@ func PrintKeepUp(w io.Writer, r Run) {
 		o.PendingProducers,
 		o.PendingEvicted, plural64(o.PendingEvicted, "eviction", "evictions"),
 		o.KeyDecodeErrors, plural64(o.KeyDecodeErrors, "failure", "failures"))
+}
+
+// printEnrichmentKeepUp writes consumer-group enrichment's section: the cadence it
+// achieved, and what it saw and correlated.
+//
+// The pass count is the reason this section exists. Every other source's keep-up is a
+// question of whether the reader stayed level with a log; this phase's is whether it got
+// round at all, because its admin calls are the slowest thing the run does.
+//
+// Counts only — a group id, topic name or transactional id here would be exactly the
+// leak the counts-only terminal discipline exists to prevent.
+func printEnrichmentKeepUp(w io.Writer, e discovery.EnricherStats) {
+	_, _ = fmt.Fprintf(w, "  consumer-group enrichment: %d %s, %d failed, %d %s listed, %d %s\n",
+		e.Passes, plural(e.Passes, "pass", "passes"),
+		e.PassFailures,
+		e.GroupsListed, plural(e.GroupsListed, "group", "groups"),
+		e.Correlations, plural(e.Correlations, "correlation", "correlations"))
 }
 
 // WriteStatsJSON writes the diagnostics document for r to path.
@@ -224,6 +271,12 @@ func WriteStatsJSON(path string, r Run) error {
 			RecoveredTopics:   emptyIfNil(r.Offsets.RecoveredTopics),
 			Unavailable:       r.Offsets.Unavailable,
 			UnavailableReason: r.Offsets.UnavailableReason,
+		},
+		ConsumerGroupEnrichment: enrichmentDoc{
+			Passes:       r.Enrichment.Passes,
+			PassFailures: r.Enrichment.PassFailures,
+			GroupsListed: r.Enrichment.GroupsListed,
+			Correlations: r.Enrichment.Correlations,
 		},
 		AuditLogWriteErrors: r.AuditErrors,
 		Transactions:        make([]statsTxn, 0, len(r.Footprints)),

--- a/internal/services/txndiscovery/report/stats_test.go
+++ b/internal/services/txndiscovery/report/stats_test.go
@@ -1,0 +1,179 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/discovery"
+	"github.com/confluentinc/kcp/internal/services/txndiscovery/tail"
+)
+
+// writeStats writes the stats document for r into a fresh temp dir and returns its path
+// and its parsed body.
+func writeStats(t *testing.T, r Run) (string, map[string]any) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "txn-discovery-stats.json")
+	if err := WriteStatsJSON(path, r); err != nil {
+		t.Fatalf("write stats: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stats: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("stats is not valid JSON: %v\n--- stats ---\n%s", err, raw)
+	}
+	return path, doc
+}
+
+// at walks a JSON document by key, failing the test when a step is missing.
+func at(t *testing.T, doc map[string]any, path ...string) any {
+	t.Helper()
+	var cur any = doc
+	for i, key := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("%v is not an object at step %q", path[:i], key)
+		}
+		cur, ok = m[key]
+		if !ok {
+			t.Fatalf("stats document has no %v (keys at that level: %v)", path[:i+1], keysOf(m))
+		}
+	}
+	return cur
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// num reads a JSON number as a float, failing on anything else.
+func num(t *testing.T, v any) float64 {
+	t.Helper()
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("expected a number, got %T (%v)", v, v)
+	}
+	return f
+}
+
+// statsRun exercises every counter the keep-up signal is built from, with distinct
+// values so a document that wires the wrong field is caught rather than passing on a
+// coincidence.
+func statsRun() Run {
+	return Run{
+		Duration:      2 * time.Minute,
+		Interval:      20 * time.Second,
+		ActiveSources: []string{discovery.SourceTxnStateLog, discovery.SourceConsumerOffsets},
+		Tail: tail.Stats{
+			PartitionsAssigned: 2,
+			PartitionsRunning:  1,
+			RecordsRead:        1300,
+			Lag:                77,
+			OpenTxnBacklog:     11,
+			AbortedBatches:     5,
+			DecodeErrors:       3,
+			LeadershipErrors:   2,
+			UnclassifiedErrors: 1,
+			OffsetResets:       4,
+			TransportErrors:    6,
+			Partitions: []tail.PartitionStats{
+				{
+					Topic: "__transaction_state", Partition: 7,
+					NextOffset: 900, LastStableOffset: 977, HighWaterMark: 988,
+					Lag: 77, OpenTxnBacklog: 11, Running: true,
+					RecordsRead: 1000, AbortedBatches: 5, DecodeErrors: 3,
+				},
+				{
+					Topic: "__consumer_offsets", Partition: 12,
+					NextOffset: 300, LastStableOffset: 300, HighWaterMark: 300,
+					Lag: 0, OpenTxnBacklog: 0, Running: false,
+					RecordsRead: 300, LastError: "kafka server: Not the leader",
+				},
+			},
+		},
+		TxnState: discovery.TxnStateStats{
+			RecordsSeen: 1000, Footprints: 40, Empty: 3, Committed: 30, Aborted: 2, Tombstones: 1,
+			KeyDecodeErrors: 8, ValueDecodeErrors: 9,
+		},
+		Offsets: discovery.ConsumerOffsetsStats{
+			RecordsSeen: 300, TxnRecords: 25, KeyDecodeErrors: 6,
+			PendingProducers: 2, PendingEvicted: 14,
+			GroupsLinked: 3, Correlations: 4,
+			RecoveredTopics: []string{"in-a", "in-b"},
+		},
+	}
+}
+
+func TestStatsJSONCarriesRecordsReadLagAndPerSourceDecodeFailures(t *testing.T) {
+	_, doc := statsRun2Doc(t)
+
+	// Records read, per source and in aggregate.
+	if got := num(t, at(t, doc, "tail", "records_read")); got != 1300 {
+		t.Errorf("tail.records_read = %v, want 1300", got)
+	}
+	if got := num(t, at(t, doc, "transaction_state_log", "records_seen")); got != 1000 {
+		t.Errorf("transaction_state_log.records_seen = %v, want 1000", got)
+	}
+	if got := num(t, at(t, doc, "consumer_offsets_log", "records_seen")); got != 300 {
+		t.Errorf("consumer_offsets_log.records_seen = %v, want 300", got)
+	}
+
+	// Lag: aggregate, and per partition (KTD9 — measured to the last stable offset,
+	// with the high-watermark gap reported separately).
+	if got := num(t, at(t, doc, "tail", "lag")); got != 77 {
+		t.Errorf("tail.lag = %v, want 77", got)
+	}
+	if got := num(t, at(t, doc, "tail", "open_txn_backlog")); got != 11 {
+		t.Errorf("tail.open_txn_backlog = %v, want 11", got)
+	}
+	parts, ok := at(t, doc, "tail", "partitions").([]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("tail.partitions = %v, want 2 entries", at(t, doc, "tail", "partitions"))
+	}
+	p0, _ := parts[0].(map[string]any)
+	if got := num(t, p0["lag"]); got != 77 {
+		t.Errorf("partitions[0].lag = %v, want 77", got)
+	}
+	if got := num(t, p0["last_stable_offset"]); got != 977 {
+		t.Errorf("partitions[0].last_stable_offset = %v, want 977", got)
+	}
+	if got := num(t, p0["next_offset"]); got != 900 {
+		t.Errorf("partitions[0].next_offset = %v, want 900", got)
+	}
+	if running, _ := p0["running"].(bool); !running {
+		t.Errorf("partitions[0].running = %v, want true", p0["running"])
+	}
+	p1, _ := parts[1].(map[string]any)
+	if running, _ := p1["running"].(bool); running {
+		t.Errorf("partitions[1].running = %v, want false", p1["running"])
+	}
+
+	// Decode failures, kept per source: the summary aggregates them, but which half
+	// of which record drifted is what makes the alarm actionable.
+	if got := num(t, at(t, doc, "tail", "decode_errors")); got != 3 {
+		t.Errorf("tail.decode_errors = %v, want 3", got)
+	}
+	if got := num(t, at(t, doc, "transaction_state_log", "key_decode_errors")); got != 8 {
+		t.Errorf("transaction_state_log.key_decode_errors = %v, want 8", got)
+	}
+	if got := num(t, at(t, doc, "transaction_state_log", "value_decode_errors")); got != 9 {
+		t.Errorf("transaction_state_log.value_decode_errors = %v, want 9", got)
+	}
+	if got := num(t, at(t, doc, "consumer_offsets_log", "key_decode_errors")); got != 6 {
+		t.Errorf("consumer_offsets_log.key_decode_errors = %v, want 6", got)
+	}
+}
+
+func statsRun2Doc(t *testing.T) (string, map[string]any) {
+	t.Helper()
+	return writeStats(t, statsRun())
+}

--- a/internal/services/txndiscovery/report/stats_test.go
+++ b/internal/services/txndiscovery/report/stats_test.go
@@ -175,6 +175,43 @@ func TestStatsJSONCarriesRecordsReadLagAndPerSourceDecodeFailures(t *testing.T) 
 	}
 }
 
+func TestStatsJSONAndKeepUpDetailIdentifyWhichPartitionsAreStalled(t *testing.T) {
+	// The health line can only say how many partitions are retrying a failed
+	// fetch. Acting on that needs the ones that are, and neither running nor lag
+	// can point at them: a stuck loop is still running and reports zero lag.
+	r := statsRun()
+	r.Tail.PartitionsStalled = 1
+	r.Tail.Partitions[0].Stalled = true
+	r.Tail.Partitions[0].LastError = "write tcp 10.0.0.1:9092: write: broken pipe"
+
+	_, doc := writeStats(t, r)
+	if got := num(t, at(t, doc, "tail", "partitions_stalled")); got != 1 {
+		t.Errorf("tail.partitions_stalled = %v, want 1", got)
+	}
+	parts, ok := at(t, doc, "tail", "partitions").([]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("tail.partitions = %v, want 2 entries", at(t, doc, "tail", "partitions"))
+	}
+	p0, _ := parts[0].(map[string]any)
+	if stalled, _ := p0["stalled"].(bool); !stalled {
+		t.Errorf("partitions[0].stalled = %v, want true", p0["stalled"])
+	}
+	if running, _ := p0["running"].(bool); !running {
+		t.Errorf("partitions[0].running = %v, want true: a stalled loop has not exited, which is the whole problem", p0["running"])
+	}
+	p1, _ := parts[1].(map[string]any)
+	if stalled, _ := p1["stalled"].(bool); stalled {
+		t.Errorf("partitions[1].stalled = %v, want false", p1["stalled"])
+	}
+
+	var buf bytes.Buffer
+	PrintKeepUp(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "1000 records, STALLED") {
+		t.Errorf("keep-up detail does not mark the stalled partition\n--- keep-up ---\n%s", out)
+	}
+}
+
 func TestWriteStatsJSONFailsActionablyWhenTheOutputDirectoryDoesNotExist(t *testing.T) {
 	dir := t.TempDir()
 	missing := filepath.Join(dir, "no-such-dir")

--- a/internal/services/txndiscovery/report/stats_test.go
+++ b/internal/services/txndiscovery/report/stats_test.go
@@ -224,6 +224,55 @@ func TestKeepUpDetailBreaksDownEverySourceAndEveryPartition(t *testing.T) {
 	}
 }
 
+func TestStatsJSONCarriesEveryFootprintEvenWithHostileNames(t *testing.T) {
+	// The stats document is the artifact that carries per-transaction detail, so it
+	// takes the same hostile names the YAML does. JSON has no plain-scalar style to
+	// get wrong, but that has to be asserted rather than assumed: the audit writer's
+	// equivalent forgery became possible the moment its encoder was swapped out.
+	r := statsRun()
+	r.Footprints = []discovery.TxnFootprint{
+		{
+			TxnID:            hostileNames[len(hostileNames)-1], // the newline forgery probe
+			ProducerID:       991,
+			Topics:           hostileNames,
+			ReadProcessWrite: true,
+			Sources:          []string{discovery.SourceTxnStateLog, discovery.SourceConsumerOffsets},
+			Samples:          3,
+		},
+		{TxnID: "plain-txn", ProducerID: 992, Topics: []string{"plain-topic"}, Samples: 1},
+	}
+
+	_, doc := writeStats(t, r)
+
+	if got := num(t, at(t, doc, "observed_transactional_ids")); got != 2 {
+		t.Errorf("observed_transactional_ids = %v, want 2", got)
+	}
+	txns, ok := at(t, doc, "transactions").([]any)
+	if !ok || len(txns) != 2 {
+		t.Fatalf("transactions = %v, want 2 entries", at(t, doc, "transactions"))
+	}
+	first, _ := txns[0].(map[string]any)
+	if got, _ := first["transactional_id"].(string); got != r.Footprints[0].TxnID {
+		t.Errorf("transactional_id round-tripped to %q, want %q", got, r.Footprints[0].TxnID)
+	}
+	topics, _ := first["topics"].([]any)
+	if len(topics) != len(hostileNames) {
+		t.Fatalf("topics round-tripped to %d entries, want %d", len(topics), len(hostileNames))
+	}
+	for i, want := range hostileNames {
+		if got, _ := topics[i].(string); got != want {
+			t.Errorf("topics[%d] round-tripped to %q, want %q", i, got, want)
+		}
+	}
+	if got := num(t, first["producer_id"]); got != 991 {
+		t.Errorf("producer_id = %v, want 991", got)
+	}
+	sources, _ := first["sources"].([]any)
+	if len(sources) != 2 {
+		t.Errorf("sources = %v, want 2 entries", sources)
+	}
+}
+
 func statsRun2Doc(t *testing.T) (string, map[string]any) {
 	t.Helper()
 	return writeStats(t, statsRun())

--- a/internal/services/txndiscovery/report/stats_test.go
+++ b/internal/services/txndiscovery/report/stats_test.go
@@ -112,6 +112,9 @@ func statsRun() Run {
 			GroupsLinked: 3, Correlations: 4,
 			RecoveredTopics: []string{"in-a", "in-b"},
 		},
+		Enrichment: discovery.EnricherStats{
+			Passes: 13, PassFailures: 2, GroupsListed: 41, Correlations: 5,
+		},
 	}
 }
 
@@ -212,6 +215,28 @@ func TestStatsJSONAndKeepUpDetailIdentifyWhichPartitionsAreStalled(t *testing.T)
 	}
 }
 
+// The cadence question the stats document exists to answer for every other source:
+// --interval 5s over a 60s window should yield thirteen enrichment passes, and a
+// captured run has to say how many it got. Without these counters a run that enriched
+// four times and one that enriched thirteen produce an identical document.
+func TestStatsJSONCarriesTheEnrichmentPassCadenceAndWhatItCorrelated(t *testing.T) {
+	_, doc := writeStats(t, statsRun())
+
+	for _, c := range []struct {
+		key  string
+		want float64
+	}{
+		{"passes", 13},
+		{"pass_failures", 2},
+		{"groups_listed", 41},
+		{"correlations", 5},
+	} {
+		if got := num(t, at(t, doc, "consumer_group_enrichment", c.key)); got != c.want {
+			t.Errorf("consumer_group_enrichment.%s = %v, want %v", c.key, got, c.want)
+		}
+	}
+}
+
 func TestWriteStatsJSONFailsActionablyWhenTheOutputDirectoryDoesNotExist(t *testing.T) {
 	dir := t.TempDir()
 	missing := filepath.Join(dir, "no-such-dir")
@@ -254,6 +279,10 @@ func TestKeepUpDetailBreaksDownEverySourceAndEveryPartition(t *testing.T) {
 		"consumer-offsets tail: 300 records, 25 txn offset-commits, 3 groups linked, 2 input topics recovered",
 		"14 pending evictions",
 		"6 key decode failures",
+		// The cadence the operator asked for against the cadence they got. This is the
+		// block an operator reads after the health line warns, and enrichment's pass
+		// count was the one source it could not account for.
+		"consumer-group enrichment: 13 passes, 2 failed, 41 groups listed, 5 correlations",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("keep-up detail is missing %q\n--- keep-up ---\n%s", want, out)

--- a/internal/services/txndiscovery/report/stats_test.go
+++ b/internal/services/txndiscovery/report/stats_test.go
@@ -1,9 +1,11 @@
 package report
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,6 +172,55 @@ func TestStatsJSONCarriesRecordsReadLagAndPerSourceDecodeFailures(t *testing.T) 
 	}
 	if got := num(t, at(t, doc, "consumer_offsets_log", "key_decode_errors")); got != 6 {
 		t.Errorf("consumer_offsets_log.key_decode_errors = %v, want 6", got)
+	}
+}
+
+func TestWriteStatsJSONFailsActionablyWhenTheOutputDirectoryDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "no-such-dir")
+
+	err := WriteStatsJSON(filepath.Join(missing, "txn-discovery-stats.json"), statsRun())
+	if err == nil {
+		t.Fatal("writing into a nonexistent directory succeeded")
+	}
+	for _, want := range []string{missing, "does not exist"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read temp dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("failed write left %d entries behind: %v", len(entries), entries)
+	}
+}
+
+func TestKeepUpDetailBreaksDownEverySourceAndEveryPartition(t *testing.T) {
+	var buf bytes.Buffer
+	PrintKeepUp(&buf, statsRun())
+	out := buf.String()
+
+	for _, want := range []string{
+		// Aggregate fetch state, including the error taxonomy the health line reduces
+		// to one number.
+		"fetch: 1/2 partitions live, 1300 records read, lag 77, open-txn backlog 11",
+		"3 decode, 2 leadership, 1 unclassified, 4 offset reset, 6 transport",
+		// Per partition, so a stalled one is identifiable rather than merely counted.
+		"__transaction_state[7]: next 900, LSO 977, HWM 988, lag 77, backlog 11, 1000 records, live",
+		"__consumer_offsets[12]: next 300, LSO 300, HWM 300, lag 0, backlog 0, 300 records, STOPPED",
+		"last error: kafka server: Not the leader",
+		// Per source.
+		"transaction-state reader: 1000 records, 40 footprints, 30 committed / 2 aborted, 1 tombstone",
+		"decode failures: 8 key, 9 value",
+		"consumer-offsets tail: 300 records, 25 txn offset-commits, 3 groups linked, 2 input topics recovered",
+		"14 pending evictions",
+		"6 key decode failures",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("keep-up detail is missing %q\n--- keep-up ---\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/services/txndiscovery/report/testdata/summary.golden
+++ b/internal/services/txndiscovery/report/testdata/summary.golden
@@ -7,8 +7,9 @@
   transactions           : 9 committed, 2 aborted
   topics                 : 6 total — 5 in 2 groups, 1 individual
   read-process-write     : 1 group; consumed inputs recovered for 1 transaction
-  keep-up                : WARNING — 3/4 partitions live, 12 records of lag, 3 decode failures
+  keep-up                : WARNING — 3/4 partitions live, 12 records of lag, 3 decode failures, 7 fetch failures
                            - 1 partition stopped early, so part of the window went unobserved
+                           - 1 partition is retrying a failed fetch rather than reading, so the zero lag above means nothing was read, not that the reader caught up
                            - the reader did not catch up to the last stable offset, so the window was not fully observed
                            - the internal record format may have drifted, so footprints may be missing
   WARNING: 5 audit log lines failed to reach disk, so the trace is incomplete — a coupling it should record may be missing.

--- a/internal/services/txndiscovery/report/testdata/summary.golden
+++ b/internal/services/txndiscovery/report/testdata/summary.golden
@@ -1,0 +1,23 @@
+============================================================
+ Transaction discovery summary
+============================================================
+  window                 : 1m30s (enrichment interval 15s)
+  sources                : transaction-state-log, consumer-groups, consumer-offsets-log
+  transactions read      : 40 record(s) on the transaction-state log, 2 transactional id(s) observed
+  transactions           : 9 committed, 2 aborted
+  topics                 : 6 total — 5 in 2 groups, 1 individual
+  read-process-write     : 1 group; consumed inputs recovered for 1 transaction
+  keep-up                : WARNING — 3/4 partitions live, 12 records of lag, 3 decode failures
+                           - 1 partition stopped early, so part of the window went unobserved
+                           - the reader did not catch up to the last stable offset, so the window was not fully observed
+                           - the internal record format may have drifted, so footprints may be missing
+  WARNING: 5 audit log lines failed to reach disk, so the trace is incomplete — a coupling it should record may be missing.
+
+Transaction groups (topics coupled by a shared transaction — migrate each group atomically):
+  group-1: 3 topics, 1 transactional id  [read-process-write]
+  group-2: 2 topics, 1 transactional id
+
+Read-process-write (exactly-once consume-transform-produce) apps detected.
+  2 topics are coupled by consume-transform-produce transactions.
+  Consumed input topics were recovered and folded into their groups by:
+    - exact producer-id correlation via __consumer_offsets: 1 transaction, 1 input topic

--- a/internal/services/txndiscovery/tail/fetcher.go
+++ b/internal/services/txndiscovery/tail/fetcher.go
@@ -77,6 +77,39 @@ func buildFetchRequest(spec FetchSpec) *sarama.FetchRequest {
 	return req
 }
 
+// errorClass names how the fetch loop recovers from a failed fetch.
+type errorClass int
+
+const (
+	// classLeadership: the partition's leader moved. Refresh metadata, back
+	// off, retry from the same offset.
+	classLeadership errorClass = iota
+	// classOffset: the reader's position is outside the retained range.
+	// Reseek to the log start rather than retrying a dead offset forever.
+	classOffset
+	// classUnclassified: an error code this reader does not recognise. It is
+	// counted and surfaced, never a reason to exit the loop.
+	classUnclassified
+)
+
+// classifyKafkaError maps a partition-level Kafka error to its recovery.
+func classifyKafkaError(kerr sarama.KError) errorClass {
+	switch kerr {
+	case sarama.ErrNotLeaderForPartition,
+		sarama.ErrLeaderNotAvailable,
+		// A stale cached leader epoch is the routine outcome of a leader move,
+		// not a corruption: refresh and retry rather than give up.
+		sarama.ErrFencedLeaderEpoch,
+		sarama.ErrUnknownLeaderEpoch,
+		sarama.ErrReplicaNotAvailable:
+		return classLeadership
+	case sarama.ErrOffsetOutOfRange:
+		return classOffset
+	default:
+		return classUnclassified
+	}
+}
+
 // abortTracker maintains the set of producer ids whose in-flight transaction
 // was rolled back, for one fetch response.
 //

--- a/internal/services/txndiscovery/tail/fetcher.go
+++ b/internal/services/txndiscovery/tail/fetcher.go
@@ -185,7 +185,39 @@ func (s *SaramaClient) Fetch(leader Leader, spec FetchSpec) (*sarama.FetchRespon
 	if b == nil {
 		return nil, fmt.Errorf("no open connection to broker %d", leader.ID)
 	}
-	return b.Fetch(buildFetchRequest(spec))
+	resp, err := b.Fetch(buildFetchRequest(spec))
+	if err != nil {
+		s.discard(b)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// discard closes and forgets a broker whose round trip failed, so the next
+// Leader call dials a new connection instead of reusing the broken one.
+//
+// This is the half of surviving a broker restart that a metadata refresh cannot
+// do. A sarama Broker never recovers from a failed round trip on its own:
+// neither the write path nor responseReceiver closes the socket, and once the
+// response reader has latched an error every later request on that Broker fails
+// with it. Nor does refreshing help by itself — client.updateMetadata keeps the
+// existing *Broker whenever the address is unchanged, which is precisely what a
+// broker restarting in place looks like. Closing it here is what makes the Open
+// inside the next Leader call redial.
+//
+// Any failed fetch qualifies, not just an obviously networky one, because any
+// error surfaced from a sarama round trip leaves the Broker in that latched
+// state. The cost of over-discarding — on, say, a version error that never
+// reached the wire — is one redial.
+func (s *SaramaClient) discard(b *sarama.Broker) {
+	// Already-closed brokers report ErrNotConnected, which is the state wanted.
+	_ = b.Close()
+	s.mu.Lock()
+	delete(s.brokers, b.ID())
+	// The negotiated version goes with the connection: a broker that comes back
+	// may be a different build advertising a different Fetch ceiling.
+	delete(s.versions, b.ID())
+	s.mu.Unlock()
 }
 
 // errorClass names how the fetch loop recovers from a failed fetch.

--- a/internal/services/txndiscovery/tail/fetcher.go
+++ b/internal/services/txndiscovery/tail/fetcher.go
@@ -2,8 +2,10 @@ package tail
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/IBM/sarama"
 )
@@ -21,6 +23,11 @@ const (
 	DefaultFetchVersionCeiling int16 = 11
 )
 
+// ErrFetchVersionUnsupported reports a broker that cannot serve a fetch at the
+// minimum version this reader needs. It is fatal at startup rather than
+// retriable: no amount of waiting will make an old broker grow the fields.
+var ErrFetchVersionUnsupported = errors.New("broker does not support a new enough Fetch API version")
+
 // negotiateFetchVersion picks the Fetch API version to use against one broker:
 // the lower of the local ceiling and the broker's advertised maximum, floored
 // at MinFetchVersion (KTD3).
@@ -37,10 +44,10 @@ func negotiateFetchVersion(keys []sarama.ApiVersionsResponseKey, ceiling int16) 
 		}
 	}
 	if advertised < 0 {
-		return 0, fmt.Errorf("broker did not advertise the Fetch API, so no fetch version could be negotiated")
+		return 0, fmt.Errorf("%w: broker did not advertise the Fetch API at all", ErrFetchVersionUnsupported)
 	}
 	if advertised < MinFetchVersion {
-		return 0, fmt.Errorf("broker advertises a maximum Fetch API version of %d, but reading committed transactional data needs at least v%d (isolation level, last stable offset and the aborted-transaction list)", advertised, MinFetchVersion)
+		return 0, fmt.Errorf("%w: broker advertises a maximum Fetch API version of %d, but reading committed transactional data needs at least v%d (isolation level, last stable offset and the aborted-transaction list)", ErrFetchVersionUnsupported, advertised, MinFetchVersion)
 	}
 	version := ceiling
 	if advertised < version {
@@ -75,6 +82,110 @@ func buildFetchRequest(spec FetchSpec) *sarama.FetchRequest {
 	// cannot fail the fetch after a leader move.
 	req.AddBlock(spec.Topic, spec.Partition, spec.Offset, spec.MaxPartitionBytes, -1)
 	return req
+}
+
+// SaramaClient is the production Client, backed by a sarama.Client. It does
+// not own that client and never closes it.
+type SaramaClient struct {
+	client  sarama.Client
+	ceiling int16
+
+	mu sync.Mutex
+	// brokers maps a broker id to the open connection Leader resolved, so
+	// Fetch can route to it without re-resolving.
+	brokers map[int32]*sarama.Broker
+	// versions caches the negotiated Fetch version per broker, since a
+	// broker's advertised ceiling does not change while it is up.
+	versions map[int32]int16
+}
+
+// NewSaramaClient adapts a sarama.Client to the seam. A ceiling of zero or
+// less uses DefaultFetchVersionCeiling.
+func NewSaramaClient(c sarama.Client, ceiling int16) *SaramaClient {
+	if ceiling <= 0 {
+		ceiling = DefaultFetchVersionCeiling
+	}
+	return &SaramaClient{
+		client:   c,
+		ceiling:  ceiling,
+		brokers:  make(map[int32]*sarama.Broker),
+		versions: make(map[int32]int16),
+	}
+}
+
+// Partitions lists a topic's partition ids.
+func (s *SaramaClient) Partitions(topic string) ([]int32, error) {
+	return s.client.Partitions(topic)
+}
+
+// Offset resolves a partition's earliest or latest offset.
+func (s *SaramaClient) Offset(topic string, partition int32, pos StartPosition) (int64, error) {
+	which := sarama.OffsetOldest
+	if pos == StartLatest {
+		which = sarama.OffsetNewest
+	}
+	return s.client.GetOffset(topic, partition, which)
+}
+
+// Leader resolves the current leader of a partition and the Fetch version
+// negotiated against it.
+//
+// Error text deliberately names the partition and never the topic: every
+// command error is logged to kcp.log, which operators attach to support
+// tickets, and a topic name there discloses customer business structure.
+func (s *SaramaClient) Leader(topic string, partition int32) (Leader, error) {
+	b, err := s.client.Leader(topic, partition)
+	if err != nil {
+		return Leader{}, fmt.Errorf("failed to resolve the leader for partition %d: %w", partition, err)
+	}
+	version, err := s.fetchVersion(b)
+	if err != nil {
+		return Leader{}, err
+	}
+	s.mu.Lock()
+	s.brokers[b.ID()] = b
+	s.mu.Unlock()
+	return Leader{ID: b.ID(), Addr: b.Addr(), FetchVersion: version}, nil
+}
+
+// fetchVersion negotiates, and then remembers, the Fetch version for a broker.
+func (s *SaramaClient) fetchVersion(b *sarama.Broker) (int16, error) {
+	s.mu.Lock()
+	if v, ok := s.versions[b.ID()]; ok {
+		s.mu.Unlock()
+		return v, nil
+	}
+	s.mu.Unlock()
+
+	resp, err := b.ApiVersions(&sarama.ApiVersionsRequest{Version: 0})
+	if err != nil {
+		return 0, fmt.Errorf("failed to read the API versions advertised by broker %d: %w", b.ID(), err)
+	}
+	version, err := negotiateFetchVersion(resp.ApiKeys, s.ceiling)
+	if err != nil {
+		return 0, fmt.Errorf("broker %d cannot serve this reader: %w", b.ID(), err)
+	}
+
+	s.mu.Lock()
+	s.versions[b.ID()] = version
+	s.mu.Unlock()
+	return version, nil
+}
+
+// RefreshMetadata forces a metadata refresh for the named topics.
+func (s *SaramaClient) RefreshMetadata(topics ...string) error {
+	return s.client.RefreshMetadata(topics...)
+}
+
+// Fetch performs one fetch round-trip against the broker Leader resolved.
+func (s *SaramaClient) Fetch(leader Leader, spec FetchSpec) (*sarama.FetchResponse, error) {
+	s.mu.Lock()
+	b := s.brokers[leader.ID]
+	s.mu.Unlock()
+	if b == nil {
+		return nil, fmt.Errorf("no open connection to broker %d", leader.ID)
+	}
+	return b.Fetch(buildFetchRequest(spec))
 }
 
 // errorClass names how the fetch loop recovers from a failed fetch.

--- a/internal/services/txndiscovery/tail/fetcher.go
+++ b/internal/services/txndiscovery/tail/fetcher.go
@@ -1,0 +1,211 @@
+package tail
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/IBM/sarama"
+)
+
+const (
+	// fetchAPIKey is the Kafka protocol API key for Fetch.
+	fetchAPIKey int16 = 1
+	// MinFetchVersion is the floor for a fetch request. v4 is the first
+	// version carrying the isolation level, the last stable offset and the
+	// aborted-transaction list, all three of which this reader needs.
+	MinFetchVersion int16 = 4
+	// DefaultFetchVersionCeiling is the highest version this reader will ask
+	// for. v11 is what sarama's own consumer tops out at for the pinned
+	// version, so nothing above it is exercised anywhere in sarama.
+	DefaultFetchVersionCeiling int16 = 11
+)
+
+// negotiateFetchVersion picks the Fetch API version to use against one broker:
+// the lower of the local ceiling and the broker's advertised maximum, floored
+// at MinFetchVersion (KTD3).
+//
+// Reading the sarama client's configured Kafka version instead would pin the
+// request at whatever that constant happens to be — v11 for kcp — which is
+// worse against an older broker than simply asking what it supports.
+func negotiateFetchVersion(keys []sarama.ApiVersionsResponseKey, ceiling int16) (int16, error) {
+	advertised := int16(-1)
+	for _, k := range keys {
+		if k.ApiKey == fetchAPIKey {
+			advertised = k.MaxVersion
+			break
+		}
+	}
+	if advertised < 0 {
+		return 0, fmt.Errorf("broker did not advertise the Fetch API, so no fetch version could be negotiated")
+	}
+	if advertised < MinFetchVersion {
+		return 0, fmt.Errorf("broker advertises a maximum Fetch API version of %d, but reading committed transactional data needs at least v%d (isolation level, last stable offset and the aborted-transaction list)", advertised, MinFetchVersion)
+	}
+	version := ceiling
+	if advertised < version {
+		version = advertised
+	}
+	if version < MinFetchVersion {
+		version = MinFetchVersion
+	}
+	return version, nil
+}
+
+// buildFetchRequest turns a FetchSpec into a wire request. sarama exposes no
+// helper for the version ladder, so it is hand-rolled here to mirror the
+// unexported brokerConsumer.fetchNewMessages: MaxBytes from v3, the isolation
+// level from v4, and the fetch-session fields from v7.
+func buildFetchRequest(spec FetchSpec) *sarama.FetchRequest {
+	req := &sarama.FetchRequest{
+		Version:     spec.Version,
+		MaxWaitTime: spec.MaxWaitMS,
+		MinBytes:    spec.MinBytes,
+		MaxBytes:    spec.MaxBytes,
+		Isolation:   spec.Isolation,
+	}
+	if spec.Version >= 7 {
+		// KIP-227 incremental fetch sessions are not implemented here. Session
+		// id 0 with epoch -1 tells the broker not to open a session whose id
+		// this reader would only ignore.
+		req.SessionID = 0
+		req.SessionEpoch = -1
+	}
+	// A leader epoch of -1 disables the epoch check, so a stale cached epoch
+	// cannot fail the fetch after a leader move.
+	req.AddBlock(spec.Topic, spec.Partition, spec.Offset, spec.MaxPartitionBytes, -1)
+	return req
+}
+
+// abortTracker maintains the set of producer ids whose in-flight transaction
+// was rolled back, for one fetch response.
+//
+// Isolation: ReadCommitted does not remove aborted records at the wire level.
+// It bounds the fetch at the last stable offset and attaches the aborted list;
+// discarding the records is client-side work a raw reader inherits. Missing it
+// credits rolled-back transactions as real.
+//
+// Scope is one response, mirroring sarama's own consumer: the broker re-sends
+// every aborted transaction that overlaps the records it returns, so a set
+// carried across fetches could only go stale, never gain information.
+type abortTracker struct {
+	pending []*sarama.AbortedTransaction
+	active  map[int64]struct{}
+}
+
+func newAbortTracker(list []*sarama.AbortedTransaction) *abortTracker {
+	pending := make([]*sarama.AbortedTransaction, 0, len(list))
+	for _, t := range list {
+		if t != nil {
+			pending = append(pending, t)
+		}
+	}
+	sort.Slice(pending, func(i, j int) bool { return pending[i].FirstOffset < pending[j].FirstOffset })
+	return &abortTracker{pending: pending, active: make(map[int64]struct{}, len(pending))}
+}
+
+// advanceTo marks every aborted transaction whose first offset the reader has
+// now reached as active.
+func (a *abortTracker) advanceTo(lastOffset int64) {
+	for len(a.pending) > 0 && a.pending[0].FirstOffset <= lastOffset {
+		a.active[a.pending[0].ProducerID] = struct{}{}
+		a.pending = a.pending[1:]
+	}
+}
+
+// isAborted reports whether records from this producer are currently inside a
+// rolled-back transaction.
+func (a *abortTracker) isAborted(producerID int64) bool {
+	_, ok := a.active[producerID]
+	return ok
+}
+
+// clear drops a producer from the aborted set, called when its abort marker is
+// reached. Without it the producer's next, committed transaction would be
+// filtered out too.
+func (a *abortTracker) clear(producerID int64) {
+	delete(a.active, producerID)
+}
+
+// controlRecordType decodes the marker carried by a control batch's single
+// record key: an int16 version followed by an int16 type. sarama's own decoder
+// for this is unexported, so it is hand-rolled here — and, being a
+// broker-supplied binary format, it is bounds-checked rather than trusted.
+func controlRecordType(rb *sarama.RecordBatch) (sarama.ControlRecordType, error) {
+	if rb == nil || len(rb.Records) == 0 || rb.Records[0] == nil {
+		return sarama.ControlRecordUnknown, fmt.Errorf("control batch carries no record")
+	}
+	key := rb.Records[0].Key
+	if len(key) < 4 {
+		return sarama.ControlRecordUnknown, fmt.Errorf("control record key is %d bytes, want at least 4", len(key))
+	}
+	switch binary.BigEndian.Uint16(key[2:4]) {
+	case 0:
+		return sarama.ControlRecordAbort, nil
+	case 1:
+		return sarama.ControlRecordCommit, nil
+	default:
+		// The Java client treats an unrecognised control type as ignorable
+		// rather than corrupt, and so does sarama.
+		return sarama.ControlRecordUnknown, nil
+	}
+}
+
+// StartPosition selects where a partition's read begins.
+type StartPosition int
+
+const (
+	// StartEarliest begins at the partition's log start offset.
+	StartEarliest StartPosition = iota
+	// StartLatest begins at the partition's next-to-be-produced offset.
+	StartLatest
+)
+
+// TopicSpec names one topic to tail and where its partitions start.
+type TopicSpec struct {
+	Topic string
+	Start StartPosition
+}
+
+// Leader identifies the broker currently leading a partition, together with
+// the Fetch API version negotiated against that broker (KTD3). Resolution and
+// negotiation are paired because a leader move is exactly when the negotiated
+// version may change.
+type Leader struct {
+	ID           int32
+	Addr         string
+	FetchVersion int16
+}
+
+// FetchSpec fully describes one fetch round-trip. It is the value a Client
+// turns into a sarama.FetchRequest, and the value a fake asserts on.
+type FetchSpec struct {
+	Topic             string
+	Partition         int32
+	Offset            int64
+	Version           int16
+	MaxWaitMS         int32
+	MinBytes          int32
+	MaxBytes          int32
+	MaxPartitionBytes int32
+	Isolation         sarama.IsolationLevel
+}
+
+// Client is the seam below the fetch loop (KTD2). Leader, RefreshMetadata and
+// Fetch are the three operations the loop needs to survive a leader move;
+// Partitions and Offset serve assignment discovery and the reseek that
+// ErrOffsetOutOfRange forces.
+type Client interface {
+	// Partitions lists a topic's partition ids.
+	Partitions(topic string) ([]int32, error)
+	// Offset resolves a partition's earliest or latest offset.
+	Offset(topic string, partition int32, pos StartPosition) (int64, error)
+	// Leader resolves the current leader of a partition.
+	Leader(topic string, partition int32) (Leader, error)
+	// RefreshMetadata forces a metadata refresh for the named topics.
+	RefreshMetadata(topics ...string) error
+	// Fetch performs one fetch round-trip against the given leader. It takes
+	// no context: sarama.Broker.Fetch is not cancellable, so the caller bounds
+	// it with MaxWaitMS plus the client's read timeout instead.
+	Fetch(leader Leader, spec FetchSpec) (*sarama.FetchResponse, error)
+}

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -10,6 +10,7 @@ package tail
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -331,6 +332,9 @@ func (t *Tail) Start(ctx context.Context, topics []TopicSpec) (<-chan Batch, err
 	if err != nil {
 		return nil, err
 	}
+	if err := t.checkLeadersServeable(assignments); err != nil {
+		return nil, err
+	}
 
 	t.out = make(chan Batch)
 	t.sem = make(chan struct{}, t.opts.MaxConcurrentFetches)
@@ -379,6 +383,25 @@ func discover(c Client, topics []TopicSpec) ([]assignment, error) {
 		}
 	}
 	return out, nil
+}
+
+// checkLeadersServeable resolves each partition's leader once before any loop
+// starts, so a broker too old to serve a read-committed fetch is a fast,
+// actionable failure rather than a loop that retries for the whole window.
+//
+// Any other leader-resolution failure is left to the loops: a leader that is
+// momentarily unavailable is exactly what they are built to recover from.
+func (t *Tail) checkLeadersServeable(assignments []assignment) error {
+	for _, a := range assignments {
+		if _, err := t.client.Leader(a.topic, a.partition); err != nil {
+			if errors.Is(err, ErrFetchVersionUnsupported) {
+				return err
+			}
+			slog.Debug("⏭️ leader unresolved at startup; the partition loop will retry",
+				"partition", a.partition, "error", err)
+		}
+	}
+	return nil
 }
 
 // runPartition is the per-partition fetch loop.

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -50,6 +50,15 @@ type Options struct {
 	// data. Together with the client's read timeout it bounds shutdown
 	// latency, because an in-flight fetch cannot be cancelled.
 	MaxWaitTime time.Duration
+	// MinBytes is how much data the broker waits to accumulate before
+	// answering, unless MaxWaitTime elapses first.
+	MinBytes int32
+	// MaxBytes caps the whole response. With one partition per request it is
+	// the effective allocation bound against an untrusted broker.
+	MaxBytes int32
+	// MaxPartitionBytes caps one partition's share of a response, and so also
+	// determines how often batches arrive cut at the boundary.
+	MaxPartitionBytes int32
 	// IdleBackoff is the pause after a fetch that returned no records.
 	IdleBackoff time.Duration
 	// BackoffBase is the first retry wait after a failed fetch. It doubles on
@@ -71,6 +80,20 @@ type Options struct {
 func New(c Client, opts Options) *Tail {
 	if opts.MaxWaitTime <= 0 {
 		opts.MaxWaitTime = DefaultMaxWaitTime
+	}
+	if opts.MinBytes <= 0 {
+		opts.MinBytes = DefaultMinBytes
+	}
+	if opts.MaxPartitionBytes <= 0 {
+		opts.MaxPartitionBytes = DefaultMaxPartitionBytes
+	}
+	if opts.MaxBytes <= 0 {
+		opts.MaxBytes = DefaultMaxBytes
+	}
+	if opts.MaxBytes < opts.MaxPartitionBytes {
+		// A response bound below the per-partition bound would silently
+		// truncate every fetch; raise it rather than stall.
+		opts.MaxBytes = opts.MaxPartitionBytes
 	}
 	if opts.IdleBackoff <= 0 {
 		opts.IdleBackoff = DefaultIdleBackoff
@@ -100,7 +123,12 @@ const (
 	// available rather than batching up to MaxWaitTime.
 	DefaultMinBytes int32 = 1
 	// DefaultMaxPartitionBytes bounds one partition's share of a response.
+	// Internal metadata topic records are small, so a mebibyte is generous
+	// while keeping peak memory at MaxConcurrentFetches times this.
 	DefaultMaxPartitionBytes int32 = 1 << 20
+	// DefaultMaxBytes bounds a whole response. One partition is requested per
+	// fetch, so it matches the per-partition bound rather than exceeding it.
+	DefaultMaxBytes int32 = 1 << 20
 	// DefaultIdleBackoff is the pause after a fetch that returned nothing. A
 	// real broker already blocked for MaxWaitTime, so this only stops a
 	// hot loop when the broker answers immediately.
@@ -441,9 +469,9 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			Offset:            offset,
 			Version:           leader.FetchVersion,
 			MaxWaitMS:         int32(t.opts.MaxWaitTime / time.Millisecond),
-			MinBytes:          DefaultMinBytes,
-			MaxBytes:          DefaultMaxPartitionBytes,
-			MaxPartitionBytes: DefaultMaxPartitionBytes,
+			MinBytes:          t.opts.MinBytes,
+			MaxBytes:          t.opts.MaxBytes,
+			MaxPartitionBytes: t.opts.MaxPartitionBytes,
 			Isolation:         sarama.ReadCommitted,
 		}
 		resp, err, ok := t.fetch(ctx, leader, spec)
@@ -484,59 +512,20 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 		}
 		attempt = 0
 
-		next := offset
-		emitted := false
-		aborted := newAbortTracker(block.AbortedTransactions)
-		for _, records := range block.RecordsSet {
-			batch, last, ok := decodeBatch(a, leader, records.RecordBatch)
-			if !ok {
-				continue
-			}
-			aborted.advanceTo(records.RecordBatch.LastOffset())
-			if batch.Control {
-				// A control batch is the transaction marker itself, never
-				// aborted data. An abort marker ends its producer's rolled-back
-				// transaction, so the producer's next one must not be filtered.
-				typ, cerr := controlRecordType(records.RecordBatch)
-				switch {
-				case cerr != nil:
-					// The marker is unreadable, so whether this producer's
-					// transaction aborted or committed is unknown. Leaving it
-					// in the aborted set keeps filtering rather than crediting
-					// possibly rolled-back records as real.
-					st.mu.Lock()
-					st.decodeErrors++
-					st.mu.Unlock()
-				case typ == sarama.ControlRecordAbort:
-					aborted.clear(batch.ProducerID)
-				}
-			} else if batch.IsTransactional && aborted.isAborted(batch.ProducerID) {
-				// Skipped, but still consumed: the offset advances past the
-				// records that were decoded, or the loop refetches them.
-				st.mu.Lock()
-				st.abortedBatches++
-				st.mu.Unlock()
-				next = last + 1
-				continue
-			}
-			delivered := int64(len(batch.Records))
-			if !t.emit(ctx, batch) {
-				return
-			}
-			st.record(func(p *partitionState) { p.recordsRead += delivered })
-			emitted = true
-			next = last + 1
+		next, emitted, alive := t.consumeBlock(ctx, a, st, leader, block, offset)
+		if !alive {
+			return
 		}
 		advanced := next > offset
 		offset = next
-		st.mu.Lock()
-		st.nextOffset = offset
-		st.lastStableOffset = block.LastStableOffset
-		st.highWaterMark = block.HighWaterMarkOffset
-		if advanced {
-			st.lastAdvance = time.Now()
-		}
-		st.mu.Unlock()
+		st.record(func(p *partitionState) {
+			p.nextOffset = offset
+			p.lastStableOffset = block.LastStableOffset
+			p.highWaterMark = block.HighWaterMarkOffset
+			if advanced {
+				p.lastAdvance = time.Now()
+			}
+		})
 
 		if !emitted {
 			// A real broker already held the fetch open for MaxWaitTime, so
@@ -545,6 +534,68 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			t.opts.Sleep(ctx, t.opts.IdleBackoff)
 		}
 	}
+}
+
+// consumeBlock walks one partition's returned batches, filtering the ones that
+// belong to rolled-back transactions and emitting the rest.
+//
+// It reports the offset to fetch from next, whether anything was emitted, and
+// whether the loop is still alive — false meaning the context ended mid-send.
+// The next offset is always derived from records that were actually decoded,
+// never from a batch header's last offset, because a batch cut at the fetch
+// boundary claims records this response did not carry.
+func (t *Tail) consumeBlock(
+	ctx context.Context,
+	a assignment,
+	st *partitionState,
+	leader Leader,
+	block *sarama.FetchResponseBlock,
+	offset int64,
+) (next int64, emitted bool, alive bool) {
+	next = offset
+	aborted := newAbortTracker(block.AbortedTransactions)
+
+	for _, records := range block.RecordsSet {
+		batch, last, ok := decodeBatch(a, leader, records.RecordBatch)
+		if !ok {
+			continue
+		}
+		aborted.advanceTo(records.RecordBatch.LastOffset())
+
+		switch {
+		case batch.Control:
+			// A control batch is the transaction marker itself, never aborted
+			// data. An abort marker ends its producer's rolled-back
+			// transaction, so the producer's next one must not be filtered.
+			typ, cerr := controlRecordType(records.RecordBatch)
+			switch {
+			case cerr != nil:
+				// The marker is unreadable, so whether this producer's
+				// transaction aborted or committed is unknown. Leaving it in
+				// the aborted set keeps filtering rather than crediting
+				// possibly rolled-back records as real.
+				st.record(func(p *partitionState) { p.decodeErrors++ })
+			case typ == sarama.ControlRecordAbort:
+				aborted.clear(batch.ProducerID)
+			}
+
+		case batch.IsTransactional && aborted.isAborted(batch.ProducerID):
+			// Dropped, but still consumed: the offset advances past the
+			// records that were decoded, or the loop refetches them forever.
+			st.record(func(p *partitionState) { p.abortedBatches++ })
+			next = last + 1
+			continue
+		}
+
+		delivered := int64(len(batch.Records))
+		if !t.emit(ctx, batch) {
+			return next, emitted, false
+		}
+		st.record(func(p *partitionState) { p.recordsRead += delivered })
+		emitted = true
+		next = last + 1
+	}
+	return next, emitted, true
 }
 
 // backoffFor returns the wait before retry number attempt, counting from zero:

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -57,6 +57,10 @@ type Options struct {
 	// BackoffMax caps the retry wait, so a long outage does not turn into an
 	// unbounded pause that outlives the observation window.
 	BackoffMax time.Duration
+	// MaxConcurrentFetches caps how many fetches are in flight at once across
+	// every partition. It bounds both the load put on the source cluster and
+	// peak memory, which is this cap times MaxPartitionBytes.
+	MaxConcurrentFetches int
 	// Sleep is the injectable wait used for backoff and idle polling. Tests
 	// replace it so the suite never waits on a real timer.
 	Sleep func(ctx context.Context, d time.Duration)
@@ -75,6 +79,9 @@ func New(c Client, opts Options) *Tail {
 	}
 	if opts.BackoffMax <= 0 {
 		opts.BackoffMax = DefaultBackoffMax
+	}
+	if opts.MaxConcurrentFetches <= 0 {
+		opts.MaxConcurrentFetches = DefaultMaxConcurrentFetches
 	}
 	if opts.Sleep == nil {
 		opts.Sleep = sleepCtx
@@ -105,6 +112,14 @@ const (
 	// responsive within a run measured in minutes while still throttling a
 	// broker that is down for a long time.
 	DefaultBackoffMax = 5 * time.Second
+	// DefaultMaxConcurrentFetches caps in-flight fetches across all
+	// partitions. The two internal topics default to 50 partitions each, so
+	// uncapped this would be 100 simultaneous long polls against a customer's
+	// production cluster. Sixteen bounds peak memory at 16 x
+	// MaxPartitionBytes (16 MiB by default) and still cycles 100 partitions
+	// roughly every MaxWaitTime x 100/16 — a few seconds, which is ample for
+	// a run measured in minutes to hours.
+	DefaultMaxConcurrentFetches = 16
 )
 
 // PartitionStats reports one partition's progress.
@@ -131,6 +146,9 @@ type PartitionStats struct {
 	// has. A stalled partition reports zero lag, so this is the only signal
 	// separating it from a genuinely caught-up one.
 	LastAdvance time.Time
+	// RecordsRead counts records delivered from this partition. Records
+	// dropped by the abort filter are counted in AbortedBatches instead.
+	RecordsRead int64
 	// AbortedBatches counts batches dropped because their producer's
 	// transaction was rolled back.
 	AbortedBatches int64
@@ -157,6 +175,8 @@ type Stats struct {
 	PartitionsAssigned int
 	// PartitionsRunning is how many of those still have a live fetch loop.
 	PartitionsRunning int
+	// RecordsRead is the total number of records delivered to consumers.
+	RecordsRead int64
 	// Lag is the sum of the per-partition last-stable-offset lags.
 	Lag int64
 	// OpenTxnBacklog is the sum of the per-partition high-watermark-to-LSO gaps.
@@ -191,6 +211,22 @@ type Tail struct {
 	wg    sync.WaitGroup
 	out   chan Batch
 	parts []*partitionState
+	// sem bounds in-flight fetches across every partition loop.
+	sem chan struct{}
+}
+
+// fetch performs one fetch round-trip, holding a concurrency slot for its
+// duration. It reports ok false when the context ended before a slot came
+// free, so the caller stops rather than queueing behind a shutdown.
+func (t *Tail) fetch(ctx context.Context, leader Leader, spec FetchSpec) (resp *sarama.FetchResponse, err error, ok bool) {
+	select {
+	case t.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, nil, false
+	}
+	defer func() { <-t.sem }()
+	resp, err = t.client.Fetch(leader, spec)
+	return resp, err, true
 }
 
 // partitionState is one partition's mutable progress, read concurrently by
@@ -204,6 +240,7 @@ type partitionState struct {
 	highWaterMark    int64
 	running          bool
 	lastAdvance      time.Time
+	recordsRead      int64
 	abortedBatches   int64
 	decodeErrors     int64
 	leadershipErrors int64
@@ -227,6 +264,7 @@ func (p *partitionState) snapshot() PartitionStats {
 		OpenTxnBacklog:     nonNegative(p.highWaterMark - p.lastStableOffset),
 		Running:            p.running,
 		LastAdvance:        p.lastAdvance,
+		RecordsRead:        p.recordsRead,
 		AbortedBatches:     p.abortedBatches,
 		DecodeErrors:       p.decodeErrors,
 		LeadershipErrors:   p.leadershipErrors,
@@ -271,6 +309,7 @@ func (t *Tail) Stats() Stats {
 		if ps.Running {
 			s.PartitionsRunning++
 		}
+		s.RecordsRead += ps.RecordsRead
 		s.Lag += ps.Lag
 		s.OpenTxnBacklog += ps.OpenTxnBacklog
 		s.AbortedBatches += ps.AbortedBatches
@@ -294,6 +333,7 @@ func (t *Tail) Start(ctx context.Context, topics []TopicSpec) (<-chan Batch, err
 	}
 
 	t.out = make(chan Batch)
+	t.sem = make(chan struct{}, t.opts.MaxConcurrentFetches)
 	for _, a := range assignments {
 		st := &partitionState{topic: a.topic, partition: a.partition, nextOffset: a.offset, running: true}
 		t.parts = append(t.parts, st)
@@ -355,6 +395,11 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 	}
 
 	for {
+		// Cancellation is checked here and nowhere else in the request path:
+		// sarama.Broker.Fetch takes no context, so an in-flight request is
+		// bounded by MaxWaitTime plus the client's read timeout rather than
+		// abandoned. What this guarantees is that no *new* request is issued
+		// once the context is done.
 		if ctx.Err() != nil {
 			return
 		}
@@ -378,7 +423,10 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			MaxPartitionBytes: DefaultMaxPartitionBytes,
 			Isolation:         sarama.ReadCommitted,
 		}
-		resp, err := t.client.Fetch(leader, spec)
+		resp, err, ok := t.fetch(ctx, leader, spec)
+		if !ok {
+			return
+		}
 		if err != nil {
 			// No response at all, so no error code to classify. This is what a
 			// broker restart looks like from here.
@@ -391,9 +439,13 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 		}
 		block := resp.GetBlock(a.topic, a.partition)
 		if block == nil {
-			// A response that omits the partition entirely is malformed, not a
-			// reason to give up on the partition.
-			st.record(func(p *partitionState) { p.transportErrors++ })
+			// A response that answers the request but omits the partition is
+			// malformed. The broker is untrusted input, so this is counted and
+			// retried rather than dereferenced.
+			st.record(func(p *partitionState) {
+				p.transportErrors++
+				p.lastError = "fetch response omitted the requested partition"
+			})
 			retry()
 			continue
 		}
@@ -444,9 +496,11 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 				next = last + 1
 				continue
 			}
+			delivered := int64(len(batch.Records))
 			if !t.emit(ctx, batch) {
 				return
 			}
+			st.record(func(p *partitionState) { p.recordsRead += delivered })
 			emitted = true
 			next = last + 1
 		}

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -171,9 +171,20 @@ type PartitionStats struct {
 	// loop that exited reads as zero lag and is otherwise indistinguishable
 	// from a healthy idle one.
 	Running bool
+	// Stalled reports that this partition's most recent fetch attempt failed and
+	// nothing has been fetched cleanly since — it is retrying, not reading.
+	//
+	// It exists because neither Running nor Lag can say so. A loop stuck
+	// retrying is still running, and a partition that never fetched
+	// successfully holds a zero LastStableOffset, so its lag computes as zero.
+	// By both of those signals a broken partition looks exactly like a healthy
+	// idle one. This is latched on a failed fetch and cleared by the next clean
+	// one, which is what keeps an idle partition — whose empty fetches still
+	// succeed — from reading as broken.
+	Stalled bool
 	// LastAdvance is when this partition's offset last moved, zero if it never
-	// has. A stalled partition reports zero lag, so this is the only signal
-	// separating it from a genuinely caught-up one.
+	// has. It says how long since progress, which Stalled cannot: a partition
+	// can be fetching cleanly and still not be advancing.
 	LastAdvance time.Time
 	// RecordsRead counts records delivered from this partition. Records
 	// dropped by the abort filter are counted in AbortedBatches instead.
@@ -204,6 +215,11 @@ type Stats struct {
 	PartitionsAssigned int
 	// PartitionsRunning is how many of those still have a live fetch loop.
 	PartitionsRunning int
+	// PartitionsStalled is how many live loops are retrying a failed fetch
+	// rather than reading. It counts only running partitions: one that exited is
+	// already reported by PartitionsRunning, and counting it twice would say two
+	// things went wrong where one did.
+	PartitionsStalled int
 	// RecordsRead is the total number of records delivered to consumers.
 	RecordsRead int64
 	// Lag is the sum of the per-partition last-stable-offset lags.
@@ -268,6 +284,7 @@ type partitionState struct {
 	lastStableOffset int64
 	highWaterMark    int64
 	running          bool
+	stalled          bool
 	lastAdvance      time.Time
 	recordsRead      int64
 	abortedBatches   int64
@@ -292,6 +309,7 @@ func (p *partitionState) snapshot() PartitionStats {
 		Lag:                nonNegative(p.lastStableOffset - p.nextOffset),
 		OpenTxnBacklog:     nonNegative(p.highWaterMark - p.lastStableOffset),
 		Running:            p.running,
+		Stalled:            p.stalled,
 		LastAdvance:        p.lastAdvance,
 		RecordsRead:        p.recordsRead,
 		AbortedBatches:     p.abortedBatches,
@@ -308,6 +326,15 @@ func (p *partitionState) snapshot() PartitionStats {
 func (p *partitionState) setRunning(v bool) {
 	p.mu.Lock()
 	p.running = v
+	p.mu.Unlock()
+}
+
+// setStalled latches or clears the "retrying, not reading" flag. It is called
+// on every failed fetch and on every clean one, so the flag always describes the
+// most recent attempt rather than the worst thing that ever happened.
+func (p *partitionState) setStalled(v bool) {
+	p.mu.Lock()
+	p.stalled = v
 	p.mu.Unlock()
 }
 
@@ -337,6 +364,9 @@ func (t *Tail) Stats() Stats {
 		ps := p.snapshot()
 		if ps.Running {
 			s.PartitionsRunning++
+			if ps.Stalled {
+				s.PartitionsStalled++
+			}
 		}
 		s.RecordsRead += ps.RecordsRead
 		s.Lag += ps.Lag
@@ -458,6 +488,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 		if err != nil {
 			st.record(func(p *partitionState) {
 				p.transportErrors++
+				p.stalled = true
 				p.lastError = err.Error()
 			})
 			t.refreshAfterTransportError(a)
@@ -484,6 +515,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			// broker restart looks like from here.
 			st.record(func(p *partitionState) {
 				p.transportErrors++
+				p.stalled = true
 				p.lastError = err.Error()
 			})
 			t.refreshAfterTransportError(a)
@@ -497,6 +529,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			// retried rather than dereferenced.
 			st.record(func(p *partitionState) {
 				p.transportErrors++
+				p.stalled = true
 				p.lastError = "fetch response omitted the requested partition"
 			})
 			t.refreshAfterTransportError(a)
@@ -504,6 +537,10 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			continue
 		}
 		if block.Err != sarama.ErrNoError {
+			// Every classified error leaves the partition not reading: a
+			// leadership error must be retried, and a reseek has moved the
+			// position without yet fetching from it.
+			st.setStalled(true)
 			next, backoff := t.recover(a, st, block.Err, offset)
 			offset = next
 			if backoff {
@@ -514,6 +551,10 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			continue
 		}
 		attempt = 0
+		// A clean fetch is the only thing that clears a stall, and an empty
+		// response is a clean fetch: an idle partition is reading, it just has
+		// nothing to read.
+		st.setStalled(false)
 
 		next, emitted, alive := t.consumeBlock(ctx, a, st, leader, block, offset)
 		if !alive {

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -1,0 +1,437 @@
+// Package tail is a continuous, resumable reader over raw sarama Broker.Fetch.
+//
+// sarama's ConsumerMessage discards the record-batch header, so the high-level
+// consumer cannot see the producer id that ties a transactional offset commit
+// to its transaction. The raw fetch path exposes it, at the cost of owning
+// everything the high-level consumer would have handled: partition discovery,
+// leader resolution, offset tracking, failover, aborted-transaction filtering
+// and lag accounting.
+package tail
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+// Record is one fully decoded record from a fetched batch.
+type Record struct {
+	Offset    int64
+	Key       []byte
+	Value     []byte
+	Timestamp time.Time
+}
+
+// Batch is one record batch delivered to a consumer with its header intact —
+// the producer id, transactional flag and control flag the high-level consumer
+// would have discarded.
+type Batch struct {
+	Topic           string
+	Partition       int32
+	Leader          int32
+	BaseOffset      int64
+	ProducerID      int64
+	ProducerEpoch   int16
+	IsTransactional bool
+	Control         bool
+	Records         []Record
+}
+
+// Options configures a Tail. The zero value is usable: every field falls back
+// to its package default.
+type Options struct {
+	// MaxWaitTime bounds how long a broker holds a fetch open waiting for
+	// data. Together with the client's read timeout it bounds shutdown
+	// latency, because an in-flight fetch cannot be cancelled.
+	MaxWaitTime time.Duration
+	// IdleBackoff is the pause after a fetch that returned no records.
+	IdleBackoff time.Duration
+	// Sleep is the injectable wait used for backoff and idle polling. Tests
+	// replace it so the suite never waits on a real timer.
+	Sleep func(ctx context.Context, d time.Duration)
+}
+
+// New builds a Tail over the given seam.
+func New(c Client, opts Options) *Tail {
+	if opts.MaxWaitTime <= 0 {
+		opts.MaxWaitTime = DefaultMaxWaitTime
+	}
+	if opts.IdleBackoff <= 0 {
+		opts.IdleBackoff = DefaultIdleBackoff
+	}
+	if opts.Sleep == nil {
+		opts.Sleep = sleepCtx
+	}
+	return &Tail{client: c, opts: opts}
+}
+
+// Default tuning constants.
+const (
+	// DefaultMaxWaitTime is how long a broker may hold a fetch open. It is the
+	// dominant term in shutdown latency, since an in-flight fetch cannot be
+	// cancelled.
+	DefaultMaxWaitTime = 500 * time.Millisecond
+	// DefaultMinBytes is 1 so the broker returns as soon as any record is
+	// available rather than batching up to MaxWaitTime.
+	DefaultMinBytes int32 = 1
+	// DefaultMaxPartitionBytes bounds one partition's share of a response.
+	DefaultMaxPartitionBytes int32 = 1 << 20
+	// DefaultIdleBackoff is the pause after a fetch that returned nothing. A
+	// real broker already blocked for MaxWaitTime, so this only stops a
+	// hot loop when the broker answers immediately.
+	DefaultIdleBackoff = 50 * time.Millisecond
+)
+
+// PartitionStats reports one partition's progress.
+type PartitionStats struct {
+	Topic            string
+	Partition        int32
+	NextOffset       int64
+	LastStableOffset int64
+	HighWaterMark    int64
+	// Lag is LastStableOffset minus NextOffset (KTD9). Under ReadCommitted the
+	// broker returns nothing past the last stable offset, so measuring against
+	// the high watermark instead would show a permanent floor whenever any
+	// transaction is open.
+	Lag int64
+	// OpenTxnBacklog is HighWaterMark minus LastStableOffset: records written
+	// inside transactions the coordinator has not yet decided. It is reported
+	// separately because it is not something the reader can catch up on.
+	OpenTxnBacklog int64
+	// Running reports whether this partition's fetch loop is still alive. A
+	// loop that exited reads as zero lag and is otherwise indistinguishable
+	// from a healthy idle one.
+	Running bool
+	// LastAdvance is when this partition's offset last moved, zero if it never
+	// has. A stalled partition reports zero lag, so this is the only signal
+	// separating it from a genuinely caught-up one.
+	LastAdvance time.Time
+	// AbortedBatches counts batches dropped because their producer's
+	// transaction was rolled back.
+	AbortedBatches int64
+	// DecodeErrors counts broker-supplied structures this partition could not
+	// parse.
+	DecodeErrors int64
+}
+
+// Stats is the aggregate view across every assigned partition.
+type Stats struct {
+	// PartitionsAssigned is how many partitions the tail took on.
+	PartitionsAssigned int
+	// PartitionsRunning is how many of those still have a live fetch loop.
+	PartitionsRunning int
+	// Lag is the sum of the per-partition last-stable-offset lags.
+	Lag int64
+	// OpenTxnBacklog is the sum of the per-partition high-watermark-to-LSO gaps.
+	OpenTxnBacklog int64
+	// AbortedBatches counts batches dropped because their producer's
+	// transaction was rolled back.
+	AbortedBatches int64
+	// DecodeErrors counts broker-supplied structures this reader could not
+	// parse. It is the format-drift alarm, so it is never swallowed.
+	DecodeErrors int64
+	Partitions   []PartitionStats
+}
+
+// Tail reads a set of topics continuously, one fetch loop per partition,
+// fanning every decoded batch into a single channel.
+type Tail struct {
+	client Client
+	opts   Options
+
+	wg    sync.WaitGroup
+	out   chan Batch
+	parts []*partitionState
+}
+
+// partitionState is one partition's mutable progress, read concurrently by
+// Stats while its loop advances it.
+type partitionState struct {
+	mu               sync.Mutex
+	topic            string
+	partition        int32
+	nextOffset       int64
+	lastStableOffset int64
+	highWaterMark    int64
+	running          bool
+	lastAdvance      time.Time
+	abortedBatches   int64
+	decodeErrors     int64
+}
+
+func (p *partitionState) snapshot() PartitionStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return PartitionStats{
+		Topic:            p.topic,
+		Partition:        p.partition,
+		NextOffset:       p.nextOffset,
+		LastStableOffset: p.lastStableOffset,
+		HighWaterMark:    p.highWaterMark,
+		Lag:              nonNegative(p.lastStableOffset - p.nextOffset),
+		OpenTxnBacklog:   nonNegative(p.highWaterMark - p.lastStableOffset),
+		Running:          p.running,
+		LastAdvance:      p.lastAdvance,
+		AbortedBatches:   p.abortedBatches,
+		DecodeErrors:     p.decodeErrors,
+	}
+}
+
+// setRunning records whether this partition's loop is alive.
+func (p *partitionState) setRunning(v bool) {
+	p.mu.Lock()
+	p.running = v
+	p.mu.Unlock()
+}
+
+// nonNegative clamps a computed lag at zero. A negative value is meaningless
+// and would corrupt the aggregate.
+func nonNegative(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// Stats returns a point-in-time snapshot of every partition's progress.
+func (t *Tail) Stats() Stats {
+	s := Stats{
+		PartitionsAssigned: len(t.parts),
+		Partitions:         make([]PartitionStats, 0, len(t.parts)),
+	}
+	for _, p := range t.parts {
+		ps := p.snapshot()
+		if ps.Running {
+			s.PartitionsRunning++
+		}
+		s.Lag += ps.Lag
+		s.OpenTxnBacklog += ps.OpenTxnBacklog
+		s.AbortedBatches += ps.AbortedBatches
+		s.DecodeErrors += ps.DecodeErrors
+		s.Partitions = append(s.Partitions, ps)
+	}
+	return s
+}
+
+// Start resolves the assignment for every topic, spawns one fetch loop per
+// partition, and returns the channel they fan into. The channel closes once
+// every loop has exited, which happens when ctx is done.
+func (t *Tail) Start(ctx context.Context, topics []TopicSpec) (<-chan Batch, error) {
+	assignments, err := discover(t.client, topics)
+	if err != nil {
+		return nil, err
+	}
+
+	t.out = make(chan Batch)
+	for _, a := range assignments {
+		st := &partitionState{topic: a.topic, partition: a.partition, nextOffset: a.offset, running: true}
+		t.parts = append(t.parts, st)
+		t.wg.Add(1)
+		go func(a assignment, st *partitionState) {
+			defer t.wg.Done()
+			t.runPartition(ctx, a, st)
+		}(a, st)
+	}
+	go func() {
+		t.wg.Wait()
+		close(t.out)
+	}()
+	return t.out, nil
+}
+
+// Wait blocks until every partition loop has exited.
+func (t *Tail) Wait() { t.wg.Wait() }
+
+// assignment is one partition to read and where to start.
+type assignment struct {
+	topic     string
+	partition int32
+	offset    int64
+}
+
+// discover resolves each topic's partitions and their start offsets.
+func discover(c Client, topics []TopicSpec) ([]assignment, error) {
+	var out []assignment
+	for _, ts := range topics {
+		parts, err := c.Partitions(ts.Topic)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list partitions: %w", err)
+		}
+		sorted := append([]int32(nil), parts...)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+		for _, p := range sorted {
+			off, err := c.Offset(ts.Topic, p, ts.Start)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve start offset for partition %d: %w", p, err)
+			}
+			out = append(out, assignment{topic: ts.Topic, partition: p, offset: off})
+		}
+	}
+	return out, nil
+}
+
+// runPartition is the per-partition fetch loop.
+func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionState) {
+	defer st.setRunning(false)
+
+	offset := a.offset
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		leader, err := t.client.Leader(a.topic, a.partition)
+		if err != nil {
+			continue
+		}
+		spec := FetchSpec{
+			Topic:             a.topic,
+			Partition:         a.partition,
+			Offset:            offset,
+			Version:           leader.FetchVersion,
+			MaxWaitMS:         int32(t.opts.MaxWaitTime / time.Millisecond),
+			MinBytes:          DefaultMinBytes,
+			MaxBytes:          DefaultMaxPartitionBytes,
+			MaxPartitionBytes: DefaultMaxPartitionBytes,
+			Isolation:         sarama.ReadCommitted,
+		}
+		resp, err := t.client.Fetch(leader, spec)
+		if err != nil {
+			continue
+		}
+		block := resp.GetBlock(a.topic, a.partition)
+		if block == nil {
+			continue
+		}
+
+		next := offset
+		emitted := false
+		aborted := newAbortTracker(block.AbortedTransactions)
+		for _, records := range block.RecordsSet {
+			batch, last, ok := decodeBatch(a, leader, records.RecordBatch)
+			if !ok {
+				continue
+			}
+			aborted.advanceTo(records.RecordBatch.LastOffset())
+			if batch.Control {
+				// A control batch is the transaction marker itself, never
+				// aborted data. An abort marker ends its producer's rolled-back
+				// transaction, so the producer's next one must not be filtered.
+				typ, cerr := controlRecordType(records.RecordBatch)
+				switch {
+				case cerr != nil:
+					// The marker is unreadable, so whether this producer's
+					// transaction aborted or committed is unknown. Leaving it
+					// in the aborted set keeps filtering rather than crediting
+					// possibly rolled-back records as real.
+					st.mu.Lock()
+					st.decodeErrors++
+					st.mu.Unlock()
+				case typ == sarama.ControlRecordAbort:
+					aborted.clear(batch.ProducerID)
+				}
+			} else if batch.IsTransactional && aborted.isAborted(batch.ProducerID) {
+				// Skipped, but still consumed: the offset advances past the
+				// records that were decoded, or the loop refetches them.
+				st.mu.Lock()
+				st.abortedBatches++
+				st.mu.Unlock()
+				next = last + 1
+				continue
+			}
+			if !t.emit(ctx, batch) {
+				return
+			}
+			emitted = true
+			next = last + 1
+		}
+		advanced := next > offset
+		offset = next
+		st.mu.Lock()
+		st.nextOffset = offset
+		st.lastStableOffset = block.LastStableOffset
+		st.highWaterMark = block.HighWaterMarkOffset
+		if advanced {
+			st.lastAdvance = time.Now()
+		}
+		st.mu.Unlock()
+
+		if !emitted {
+			// A real broker already held the fetch open for MaxWaitTime, so
+			// this only matters when it answered immediately; without it the
+			// loop hot-spins on an idle partition.
+			t.opts.Sleep(ctx, t.opts.IdleBackoff)
+		}
+	}
+}
+
+// decodeBatch turns a sarama RecordBatch into a Batch, reporting the offset of
+// the last fully decoded record. ok is false when the batch carried no
+// decodable record.
+func decodeBatch(a assignment, leader Leader, rb *sarama.RecordBatch) (Batch, int64, bool) {
+	// A pre-0.11 message set decodes with RecordBatch nil. It cannot carry a
+	// producer id, so there is nothing here to correlate; skip it.
+	if rb == nil {
+		return Batch{}, 0, false
+	}
+	b := Batch{
+		Topic:           a.topic,
+		Partition:       a.partition,
+		Leader:          leader.ID,
+		BaseOffset:      rb.FirstOffset,
+		ProducerID:      rb.ProducerID,
+		ProducerEpoch:   rb.ProducerEpoch,
+		IsTransactional: rb.IsTransactional,
+		Control:         rb.Control,
+	}
+	var last int64
+	for _, r := range rb.Records {
+		if r == nil {
+			continue
+		}
+		off := rb.FirstOffset + r.OffsetDelta
+		b.Records = append(b.Records, Record{
+			Offset:    off,
+			Key:       r.Key,
+			Value:     r.Value,
+			Timestamp: rb.FirstTimestamp.Add(r.TimestampDelta),
+		})
+		last = off
+	}
+	if len(b.Records) == 0 {
+		return b, 0, false
+	}
+	// last, not rb.LastOffset(): PartialTrailingRecord means the batch was cut
+	// at the fetch boundary, so the header's last offset covers records that
+	// were never decoded. Advancing past them would silently skip records and
+	// drop topics from a transaction's footprint.
+	return b, last, true
+}
+
+// emit hands a batch to the consumer, reporting false when ctx is done.
+func (t *Tail) emit(ctx context.Context, b Batch) bool {
+	// A consumer that has stopped reading must not pin the loop open, or
+	// shutdown deadlocks behind an unread send.
+	select {
+	case t.out <- b:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// sleepCtx is the default Sleep: a context-aware pause.
+func sleepCtx(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+}

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -11,6 +11,7 @@ package tail
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -50,6 +51,12 @@ type Options struct {
 	MaxWaitTime time.Duration
 	// IdleBackoff is the pause after a fetch that returned no records.
 	IdleBackoff time.Duration
+	// BackoffBase is the first retry wait after a failed fetch. It doubles on
+	// each consecutive failure and resets on the next success.
+	BackoffBase time.Duration
+	// BackoffMax caps the retry wait, so a long outage does not turn into an
+	// unbounded pause that outlives the observation window.
+	BackoffMax time.Duration
 	// Sleep is the injectable wait used for backoff and idle polling. Tests
 	// replace it so the suite never waits on a real timer.
 	Sleep func(ctx context.Context, d time.Duration)
@@ -62,6 +69,12 @@ func New(c Client, opts Options) *Tail {
 	}
 	if opts.IdleBackoff <= 0 {
 		opts.IdleBackoff = DefaultIdleBackoff
+	}
+	if opts.BackoffBase <= 0 {
+		opts.BackoffBase = DefaultBackoffBase
+	}
+	if opts.BackoffMax <= 0 {
+		opts.BackoffMax = DefaultBackoffMax
 	}
 	if opts.Sleep == nil {
 		opts.Sleep = sleepCtx
@@ -84,6 +97,14 @@ const (
 	// real broker already blocked for MaxWaitTime, so this only stops a
 	// hot loop when the broker answers immediately.
 	DefaultIdleBackoff = 50 * time.Millisecond
+	// DefaultBackoffBase is the first retry wait after a failed fetch. It is
+	// short because the common failure — a leader move — resolves as soon as
+	// the metadata refresh lands.
+	DefaultBackoffBase = 100 * time.Millisecond
+	// DefaultBackoffMax caps the retry wait. Five seconds keeps a partition
+	// responsive within a run measured in minutes while still throttling a
+	// broker that is down for a long time.
+	DefaultBackoffMax = 5 * time.Second
 )
 
 // PartitionStats reports one partition's progress.
@@ -116,6 +137,18 @@ type PartitionStats struct {
 	// DecodeErrors counts broker-supplied structures this partition could not
 	// parse.
 	DecodeErrors int64
+	// LeadershipErrors counts fetches rejected because this partition's leader
+	// moved.
+	LeadershipErrors int64
+	// UnclassifiedErrors counts error codes with no specific recovery.
+	UnclassifiedErrors int64
+	// OffsetResets counts reseeks to this partition's log start.
+	OffsetResets int64
+	// TransportErrors counts fetches that failed without a usable response.
+	TransportErrors int64
+	// LastError is the most recent fetch failure on this partition, empty if
+	// there has not been one. It is what surfaces an unrecognised code.
+	LastError string
 }
 
 // Stats is the aggregate view across every assigned partition.
@@ -134,7 +167,19 @@ type Stats struct {
 	// DecodeErrors counts broker-supplied structures this reader could not
 	// parse. It is the format-drift alarm, so it is never swallowed.
 	DecodeErrors int64
-	Partitions   []PartitionStats
+	// LeadershipErrors counts fetches rejected because the partition's leader
+	// moved, each of which forced a metadata refresh and a retry.
+	LeadershipErrors int64
+	// UnclassifiedErrors counts Kafka error codes this reader has no specific
+	// recovery for. They are backed off and surfaced, never fatal.
+	UnclassifiedErrors int64
+	// OffsetResets counts reseeks to the log start after the reader's position
+	// fell out of the retained range.
+	OffsetResets int64
+	// TransportErrors counts fetches that failed without a response at all,
+	// which is what a broker restart looks like from here.
+	TransportErrors int64
+	Partitions      []PartitionStats
 }
 
 // Tail reads a set of topics continuously, one fetch loop per partition,
@@ -161,23 +206,34 @@ type partitionState struct {
 	lastAdvance      time.Time
 	abortedBatches   int64
 	decodeErrors     int64
+	leadershipErrors int64
+
+	unclassifiedErrors int64
+	offsetResets       int64
+	transportErrors    int64
+	lastError          string
 }
 
 func (p *partitionState) snapshot() PartitionStats {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return PartitionStats{
-		Topic:            p.topic,
-		Partition:        p.partition,
-		NextOffset:       p.nextOffset,
-		LastStableOffset: p.lastStableOffset,
-		HighWaterMark:    p.highWaterMark,
-		Lag:              nonNegative(p.lastStableOffset - p.nextOffset),
-		OpenTxnBacklog:   nonNegative(p.highWaterMark - p.lastStableOffset),
-		Running:          p.running,
-		LastAdvance:      p.lastAdvance,
-		AbortedBatches:   p.abortedBatches,
-		DecodeErrors:     p.decodeErrors,
+		Topic:              p.topic,
+		Partition:          p.partition,
+		NextOffset:         p.nextOffset,
+		LastStableOffset:   p.lastStableOffset,
+		HighWaterMark:      p.highWaterMark,
+		Lag:                nonNegative(p.lastStableOffset - p.nextOffset),
+		OpenTxnBacklog:     nonNegative(p.highWaterMark - p.lastStableOffset),
+		Running:            p.running,
+		LastAdvance:        p.lastAdvance,
+		AbortedBatches:     p.abortedBatches,
+		DecodeErrors:       p.decodeErrors,
+		LeadershipErrors:   p.leadershipErrors,
+		UnclassifiedErrors: p.unclassifiedErrors,
+		OffsetResets:       p.offsetResets,
+		TransportErrors:    p.transportErrors,
+		LastError:          p.lastError,
 	}
 }
 
@@ -186,6 +242,13 @@ func (p *partitionState) setRunning(v bool) {
 	p.mu.Lock()
 	p.running = v
 	p.mu.Unlock()
+}
+
+// record applies a mutation under the partition's lock.
+func (p *partitionState) record(fn func(*partitionState)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fn(p)
 }
 
 // nonNegative clamps a computed lag at zero. A negative value is meaningless
@@ -212,6 +275,10 @@ func (t *Tail) Stats() Stats {
 		s.OpenTxnBacklog += ps.OpenTxnBacklog
 		s.AbortedBatches += ps.AbortedBatches
 		s.DecodeErrors += ps.DecodeErrors
+		s.LeadershipErrors += ps.LeadershipErrors
+		s.UnclassifiedErrors += ps.UnclassifiedErrors
+		s.OffsetResets += ps.OffsetResets
+		s.TransportErrors += ps.TransportErrors
 		s.Partitions = append(s.Partitions, ps)
 	}
 	return s
@@ -279,12 +346,25 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 	defer st.setRunning(false)
 
 	offset := a.offset
+	// attempt counts consecutive failures; it drives the backoff curve and
+	// resets on the next fetch that comes back clean.
+	attempt := 0
+	retry := func() {
+		t.opts.Sleep(ctx, backoffFor(t.opts.BackoffBase, t.opts.BackoffMax, attempt))
+		attempt++
+	}
+
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 		leader, err := t.client.Leader(a.topic, a.partition)
 		if err != nil {
+			st.record(func(p *partitionState) {
+				p.transportErrors++
+				p.lastError = err.Error()
+			})
+			retry()
 			continue
 		}
 		spec := FetchSpec{
@@ -300,12 +380,34 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 		}
 		resp, err := t.client.Fetch(leader, spec)
 		if err != nil {
+			// No response at all, so no error code to classify. This is what a
+			// broker restart looks like from here.
+			st.record(func(p *partitionState) {
+				p.transportErrors++
+				p.lastError = err.Error()
+			})
+			retry()
 			continue
 		}
 		block := resp.GetBlock(a.topic, a.partition)
 		if block == nil {
+			// A response that omits the partition entirely is malformed, not a
+			// reason to give up on the partition.
+			st.record(func(p *partitionState) { p.transportErrors++ })
+			retry()
 			continue
 		}
+		if block.Err != sarama.ErrNoError {
+			next, backoff := t.recover(a, st, block.Err, offset)
+			offset = next
+			if backoff {
+				retry()
+			} else {
+				attempt = 0
+			}
+			continue
+		}
+		attempt = 0
 
 		next := offset
 		emitted := false
@@ -365,6 +467,68 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 			// loop hot-spins on an idle partition.
 			t.opts.Sleep(ctx, t.opts.IdleBackoff)
 		}
+	}
+}
+
+// backoffFor returns the wait before retry number attempt, counting from zero:
+// base, then doubling, capped at max. Deterministic rather than jittered —
+// there is one reader per partition, not a thundering herd to spread out.
+func backoffFor(base, max time.Duration, attempt int) time.Duration {
+	d := base
+	for i := 0; i < attempt && d < max; i++ {
+		d *= 2
+	}
+	if d > max {
+		d = max
+	}
+	return d
+}
+
+// recover applies the recovery for one classified fetch error, returning the
+// offset to fetch from next and whether the caller should back off first. It
+// never signals an exit: a partition loop that gives up silently is the
+// failure mode this component exists to avoid.
+func (t *Tail) recover(a assignment, st *partitionState, kerr sarama.KError, offset int64) (int64, bool) {
+	switch classifyKafkaError(kerr) {
+	case classLeadership:
+		// The leader moved. Refresh so the next Leader call resolves the new
+		// one, then retry from the same offset.
+		st.record(func(p *partitionState) {
+			p.leadershipErrors++
+			p.lastError = kerr.Error()
+		})
+		if rerr := t.client.RefreshMetadata(a.topic); rerr != nil {
+			slog.Debug("⏭️ metadata refresh after a leadership error failed", "partition", a.partition, "error", rerr)
+		}
+		return offset, true
+
+	case classOffset:
+		// The remembered position fell outside the retained range, so retrying
+		// it would loop on a dead offset forever. Reseek to the log start.
+		earliest, oerr := t.client.Offset(a.topic, a.partition, StartEarliest)
+		if oerr != nil {
+			slog.Debug("⏭️ could not resolve the earliest offset for a reseek", "partition", a.partition, "error", oerr)
+			return offset, true
+		}
+		st.record(func(p *partitionState) {
+			p.offsetResets++
+			p.nextOffset = earliest
+		})
+		slog.Warn("⚠️ fetch offset is outside the retained range; reseeking to the log start",
+			"partition", a.partition, "from", offset, "to", earliest)
+		return earliest, false
+
+	default:
+		// An error code with no specific recovery. Counting and surfacing it
+		// is the whole point: a loop that exited here would read downstream as
+		// a partition that simply had no data.
+		st.record(func(p *partitionState) {
+			p.unclassifiedErrors++
+			p.lastError = kerr.Error()
+		})
+		slog.Warn("⚠️ unrecognised Kafka error while fetching; backing off and retrying",
+			"partition", a.partition, "code", int16(kerr))
+		return offset, true
 	}
 }
 

--- a/internal/services/txndiscovery/tail/tail.go
+++ b/internal/services/txndiscovery/tail/tail.go
@@ -460,6 +460,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 				p.transportErrors++
 				p.lastError = err.Error()
 			})
+			t.refreshAfterTransportError(a)
 			retry()
 			continue
 		}
@@ -485,6 +486,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 				p.transportErrors++
 				p.lastError = err.Error()
 			})
+			t.refreshAfterTransportError(a)
 			retry()
 			continue
 		}
@@ -497,6 +499,7 @@ func (t *Tail) runPartition(ctx context.Context, a assignment, st *partitionStat
 				p.transportErrors++
 				p.lastError = "fetch response omitted the requested partition"
 			})
+			t.refreshAfterTransportError(a)
 			retry()
 			continue
 		}
@@ -610,6 +613,26 @@ func backoffFor(base, max time.Duration, attempt int) time.Duration {
 		d = max
 	}
 	return d
+}
+
+// refreshAfterTransportError re-resolves the partition's leader after a fetch
+// that failed without a usable response.
+//
+// A transport error is what a broker restart looks like from here — there is no
+// Kafka error code to classify, just a socket that stopped working — and the
+// leader behind it is cached. Backing off alone would retry the very connection
+// that just failed, for the rest of the run: R11's broker half needs the leader
+// re-resolved, exactly as a leadership error does.
+//
+// The caller still backs off afterwards. Refreshing is not an alternative to
+// waiting: a broker that is genuinely down must not be hammered, so the two are
+// paired rather than traded off, and the transport counter keeps moving so
+// --stats-out still distinguishes a dead socket from a leader election.
+func (t *Tail) refreshAfterTransportError(a assignment) {
+	if rerr := t.client.RefreshMetadata(a.topic); rerr != nil {
+		slog.Debug("⏭️ metadata refresh after a transport error failed",
+			"partition", a.partition, "error", rerr)
+	}
 }
 
 // recover applies the recovery for one classified fetch error, returning the

--- a/internal/services/txndiscovery/tail/tail_mockbroker_test.go
+++ b/internal/services/txndiscovery/tail/tail_mockbroker_test.go
@@ -1,0 +1,342 @@
+package tail
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the production seam against sarama's own MockBroker, so
+// the FetchRequest is really encoded, really parsed by sarama's broker-side
+// decoder, and the response really decoded back. That is what the hand-rolled
+// fake structurally cannot prove: a version ladder that omits a field the wire
+// format requires fails here and nowhere else.
+
+// fetchAPIKeys advertises a broker's supported API versions with the Fetch
+// ceiling under test.
+func fetchAPIKeys(fetchMax int16) []sarama.ApiVersionsResponseKey {
+	return []sarama.ApiVersionsResponseKey{
+		{ApiKey: 0, MinVersion: 0, MaxVersion: 8}, // Produce
+		{ApiKey: fetchAPIKey, MinVersion: 0, MaxVersion: fetchMax},
+		{ApiKey: 2, MinVersion: 0, MaxVersion: 5},  // ListOffsets
+		{ApiKey: 3, MinVersion: 0, MaxVersion: 9},  // Metadata
+		{ApiKey: 18, MinVersion: 0, MaxVersion: 3}, // ApiVersions
+	}
+}
+
+// newTestClient builds a real sarama client pointed at the given seed broker.
+func newTestClient(t *testing.T, addr string) sarama.Client {
+	t.Helper()
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_6_0_0
+	cfg.Metadata.AllowAutoTopicCreation = false
+	cfg.Metadata.Retry.Max = 1
+	cfg.Net.ReadTimeout = 2 * time.Second
+	cfg.Net.WriteTimeout = 2 * time.Second
+
+	client, err := sarama.NewClient([]string{addr}, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// servedResponse builds the fetch response the mock hands back: three
+// transactional records from one producer, plus its commit marker.
+func servedResponse(topic string, version int16) *sarama.FetchResponse {
+	r := &sarama.FetchResponse{Version: version}
+	r.AddError(topic, 0, sarama.ErrNoError)
+	r.SetLastStableOffset(topic, 0, 4)
+	r.GetBlock(topic, 0).HighWaterMarkOffset = 4
+	r.AddRecordBatch(topic, 0, sarama.ByteEncoder("k0"), sarama.ByteEncoder("v0"), 0, 7777, true)
+	r.AddRecordBatch(topic, 0, sarama.ByteEncoder("k1"), sarama.ByteEncoder("v1"), 1, 7777, true)
+	r.AddRecordBatch(topic, 0, sarama.ByteEncoder("k2"), sarama.ByteEncoder("v2"), 2, 7777, true)
+	r.AddControlRecord(topic, 0, 3, 7777, sarama.ControlRecordCommit)
+	return r
+}
+
+// emptyServedResponse is what the mock returns once the log is drained.
+func emptyServedResponse(topic string, version int16) *sarama.FetchResponse {
+	r := &sarama.FetchResponse{Version: version}
+	r.AddError(topic, 0, sarama.ErrNoError)
+	r.SetLastStableOffset(topic, 0, 4)
+	r.GetBlock(topic, 0).HighWaterMarkOffset = 4
+	return r
+}
+
+// lastFetchRequest returns the most recent FetchRequest the mock decoded.
+func lastFetchRequest(t *testing.T, b *sarama.MockBroker) *sarama.FetchRequest {
+	t.Helper()
+	var found *sarama.FetchRequest
+	for _, rr := range b.History() {
+		if req, ok := rr.Request.(*sarama.FetchRequest); ok {
+			found = req
+		}
+	}
+	require.NotNil(t, found, "the mock broker never decoded a FetchRequest")
+	return found
+}
+
+func TestAFetchRequestRoundTripsAgainstAMockBrokerAtTheNegotiatedVersion(t *testing.T) {
+	const topic = "txn-state"
+	const version = int16(11)
+
+	broker := sarama.NewMockBroker(t, 1)
+	defer broker.Close()
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t).SetApiKeys(fetchAPIKeys(version)),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetController(broker.BrokerID()).
+			SetLeader(topic, 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(topic, 0, sarama.OffsetOldest, 0).
+			SetOffset(topic, 0, sarama.OffsetNewest, 4),
+		"FetchRequest": sarama.NewMockSequence(
+			servedResponse(topic, version),
+			emptyServedResponse(topic, version),
+		),
+	})
+
+	seam := NewSaramaClient(newTestClient(t, broker.Addr()), DefaultFetchVersionCeiling)
+
+	tl := New(seam, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 4, cancel)
+
+	// The records that come back must be the ones the mock served, having
+	// travelled through real encode and decode in both directions.
+	require.Len(t, got, 4)
+	for i := 0; i < 3; i++ {
+		require.Len(t, got[i].Records, 1)
+		assert.Equal(t, int64(i), got[i].Records[0].Offset)
+		assert.Equal(t, "k"+string(rune('0'+i)), string(got[i].Records[0].Key))
+		assert.Equal(t, "v"+string(rune('0'+i)), string(got[i].Records[0].Value))
+		assert.Equal(t, int64(7777), got[i].ProducerID, "the producer id must survive the wire")
+		assert.True(t, got[i].IsTransactional)
+		assert.False(t, got[i].Control)
+	}
+	assert.True(t, got[3].Control, "the commit marker must arrive flagged as a control batch")
+
+	// And the request the broker actually decoded must carry the negotiated
+	// version with its version-gated fields.
+	req := lastFetchRequest(t, broker)
+	assert.Equal(t, version, req.Version)
+	assert.Equal(t, sarama.ReadCommitted, req.Isolation)
+	assert.Equal(t, int32(0), req.SessionID)
+	assert.Equal(t, int32(-1), req.SessionEpoch)
+	assert.Positive(t, req.MaxBytes)
+	assert.Positive(t, req.MaxWaitTime)
+
+	// Four, not three: a control batch carries a record of its own, and it was
+	// read from the log like any other.
+	assert.Equal(t, int64(4), tl.Stats().RecordsRead)
+	assert.Equal(t, int64(0), tl.Stats().Lag, "the reader is caught up to the last stable offset")
+}
+
+func TestTheRequestVersionClampsToTheBrokersAdvertisedFetchCeiling(t *testing.T) {
+	const topic = "txn-state"
+	// An older broker: it tops out at Fetch v6, well below the local ceiling.
+	const version = int16(6)
+
+	broker := sarama.NewMockBroker(t, 1)
+	defer broker.Close()
+
+	served := &sarama.FetchResponse{Version: version}
+	served.AddError(topic, 0, sarama.ErrNoError)
+	served.SetLastStableOffset(topic, 0, 2)
+	served.GetBlock(topic, 0).HighWaterMarkOffset = 2
+	served.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("old-broker"), 0, 31337, true)
+
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t).SetApiKeys(fetchAPIKeys(version)),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetController(broker.BrokerID()).
+			SetLeader(topic, 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(topic, 0, sarama.OffsetOldest, 0).
+			SetOffset(topic, 0, sarama.OffsetNewest, 2),
+		"FetchRequest": sarama.NewMockSequence(served, emptyServedResponse(topic, version)),
+	})
+
+	seam := NewSaramaClient(newTestClient(t, broker.Addr()), DefaultFetchVersionCeiling)
+
+	tl := New(seam, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Equal(t, "old-broker", string(got[0].Records[0].Value))
+	assert.Equal(t, int64(31337), got[0].ProducerID)
+
+	req := lastFetchRequest(t, broker)
+	assert.Equal(t, version, req.Version, "the request must clamp to what the broker advertises")
+	assert.Equal(t, sarama.ReadCommitted, req.Isolation, "the isolation level is still carried at v6")
+	assert.Equal(t, int32(0), req.SessionEpoch, "the session fields are not on the wire below v7")
+}
+
+func TestABrokerAdvertisingBelowVersion4FailsFastWithAnActionableError(t *testing.T) {
+	const topic = "txn-state"
+
+	broker := sarama.NewMockBroker(t, 1)
+	defer broker.Close()
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		// Fetch v3 predates the isolation level, the last stable offset and
+		// the aborted-transaction list, so read-committed reading is simply
+		// not expressible against this broker.
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t).SetApiKeys(fetchAPIKeys(3)),
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetController(broker.BrokerID()).
+			SetLeader(topic, 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(topic, 0, sarama.OffsetOldest, 0).
+			SetOffset(topic, 0, sarama.OffsetNewest, 0),
+	})
+
+	seam := NewSaramaClient(newTestClient(t, broker.Addr()), DefaultFetchVersionCeiling)
+
+	tl := New(seam, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.Error(t, err, "an unsupportable broker must fail at startup, not retry forever")
+	assert.ErrorIs(t, err, ErrFetchVersionUnsupported)
+	assert.Contains(t, err.Error(), "v4", "the error must name the version the reader needs")
+	assert.NotContains(t, err.Error(), topic, "no topic name may reach an error, which is logged to kcp.log")
+}
+
+// spySeam wraps the production seam to record what each fetch actually asked
+// for. The request still goes over the wire; only the ask is observed, because
+// a FetchRequest's per-partition blocks are not readable from outside sarama.
+type spySeam struct {
+	Client
+	mu      sync.Mutex
+	specs   []FetchSpec
+	leaders []Leader
+}
+
+func (s *spySeam) Fetch(l Leader, spec FetchSpec) (*sarama.FetchResponse, error) {
+	s.mu.Lock()
+	s.specs = append(s.specs, spec)
+	s.leaders = append(s.leaders, l)
+	s.mu.Unlock()
+	return s.Client.Fetch(l, spec)
+}
+
+// fetchesTo returns the specs issued against a given broker id.
+func (s *spySeam) fetchesTo(id int32) []FetchSpec {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []FetchSpec
+	for i, l := range s.leaders {
+		if l.ID == id {
+			out = append(out, s.specs[i])
+		}
+	}
+	return out
+}
+
+func TestMovingTheLeaderResumesAgainstTheNewBrokerWithNoGapOrDuplication(t *testing.T) {
+	const topic = "txn-state"
+	const version = int16(11)
+
+	oldLeader := sarama.NewMockBroker(t, 1)
+	defer oldLeader.Close()
+	newLeader := sarama.NewMockBroker(t, 2)
+	defer newLeader.Close()
+
+	// Before the move: broker 1 leads and serves offsets 0..2, then starts
+	// rejecting because leadership has gone elsewhere.
+	before := &sarama.FetchResponse{Version: version}
+	before.AddError(topic, 0, sarama.ErrNoError)
+	before.SetLastStableOffset(topic, 0, 5)
+	before.GetBlock(topic, 0).HighWaterMarkOffset = 5
+	before.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("r0"), 0, 900, true)
+	before.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("r1"), 1, 900, true)
+	before.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("r2"), 2, 900, true)
+
+	moved := &sarama.FetchResponse{Version: version}
+	moved.AddError(topic, 0, sarama.ErrNotLeaderForPartition)
+
+	// After the move: broker 2 serves the rest.
+	after := &sarama.FetchResponse{Version: version}
+	after.AddError(topic, 0, sarama.ErrNoError)
+	after.SetLastStableOffset(topic, 0, 5)
+	after.GetBlock(topic, 0).HighWaterMarkOffset = 5
+	after.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("r3"), 3, 900, true)
+	after.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("r4"), 4, 900, true)
+
+	// The first metadata answer names broker 1; every later one names broker 2,
+	// which is what a leader election looks like to a client.
+	metadataBefore := sarama.NewMockMetadataResponse(t).
+		SetBroker(oldLeader.Addr(), oldLeader.BrokerID()).
+		SetController(oldLeader.BrokerID()).
+		SetLeader(topic, 0, oldLeader.BrokerID())
+	metadataAfter := sarama.NewMockMetadataResponse(t).
+		SetBroker(oldLeader.Addr(), oldLeader.BrokerID()).
+		SetBroker(newLeader.Addr(), newLeader.BrokerID()).
+		SetController(oldLeader.BrokerID()).
+		SetLeader(topic, 0, newLeader.BrokerID())
+
+	oldLeader.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t).SetApiKeys(fetchAPIKeys(version)),
+		"MetadataRequest":    sarama.NewMockSequence(metadataBefore, metadataAfter),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(topic, 0, sarama.OffsetOldest, 0).
+			SetOffset(topic, 0, sarama.OffsetNewest, 5),
+		"FetchRequest": sarama.NewMockSequence(before, moved),
+	})
+	newLeader.SetHandlerByMap(map[string]sarama.MockResponse{
+		"ApiVersionsRequest": sarama.NewMockApiVersionsResponse(t).SetApiKeys(fetchAPIKeys(version)),
+		"MetadataRequest":    metadataAfter,
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(topic, 0, sarama.OffsetOldest, 0).
+			SetOffset(topic, 0, sarama.OffsetNewest, 5),
+		"FetchRequest": sarama.NewMockSequence(after, emptyServedResponse(topic, version)),
+	})
+
+	seam := &spySeam{Client: NewSaramaClient(newTestClient(t, oldLeader.Addr()), DefaultFetchVersionCeiling)}
+
+	tl := New(seam, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 5, cancel)
+
+	var offsets []int64
+	var values []string
+	var leaders []int32
+	for _, b := range got {
+		for _, rec := range b.Records {
+			offsets = append(offsets, rec.Offset)
+			values = append(values, string(rec.Value))
+		}
+		leaders = append(leaders, b.Leader)
+	}
+	assert.Equal(t, []int64{0, 1, 2, 3, 4}, offsets, "the move must leave no gap and no duplicate")
+	assert.Equal(t, []string{"r0", "r1", "r2", "r3", "r4"}, values)
+	assert.Equal(t, []int32{1, 1, 1, 2, 2}, leaders, "the last two batches came from the new leader")
+
+	toNew := seam.fetchesTo(newLeader.BrokerID())
+	require.NotEmpty(t, toNew, "the reader must actually fetch from the new leader")
+	assert.Equal(t, int64(3), toNew[0].Offset, "the retry resumes from the last offset consumed, not from scratch")
+
+	assert.Equal(t, int64(1), tl.Stats().LeadershipErrors)
+	assert.Equal(t, int64(5), tl.Stats().RecordsRead)
+}

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -222,6 +223,26 @@ func afterCall(n int, inner func(spec FetchSpec, call int) (*sarama.FetchRespons
 		}
 		return inner(spec, call)
 	}
+}
+
+// read drains n batches from out without cancelling, so a test can inspect
+// stats while the loops are still alive.
+func read(t *testing.T, out <-chan Batch, n int) []Batch {
+	t.Helper()
+	var got []Batch
+	deadline := time.After(5 * time.Second)
+	for len(got) < n {
+		select {
+		case b, ok := <-out:
+			if !ok {
+				t.Fatalf("channel closed after %d of %d batches", len(got), n)
+			}
+			got = append(got, b)
+		case <-deadline:
+			t.Fatalf("timed out after %d of %d batches", len(got), n)
+		}
+	}
+	return got
 }
 
 // drain reads until the output channel closes.
@@ -1060,4 +1081,219 @@ func TestATransportErrorRetriesWithBackoffThatGrowsIsCappedAndResets(t *testing.
 		"a successful fetch resets the curve, so one blip does not permanently slow the reader")
 
 	assert.Equal(t, int64(7), tl.Stats().TransportErrors)
+}
+
+func TestAPartitionLevelErrorDoesNotAbortSiblingPartitions(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1)
+	for _, p := range []int32{0, 1} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	// Partition 0 is permanently broken; partition 1 is healthy. The signal
+	// that the broken loop survived is that it fetches again at all.
+	var broken atomic.Int64
+	retried := make(chan struct{})
+	var once sync.Once
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if spec.Partition == 0 {
+			if broken.Add(1) >= 3 {
+				once.Do(func() { close(retried) })
+			}
+			return blockError(topic, 0, sarama.KError(58)), nil
+		}
+		r := fetchResponse(topic, 1, spec.Offset+1, spec.Offset+1)
+		addBatch(r, topic, 1, batchOf(spec.Offset, 100, 0, true, "healthy"))
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := read(t, out, 2)
+	waitFor(t, retried, "the broken partition to retry rather than exit")
+
+	for _, b := range got {
+		assert.Equal(t, int32(1), b.Partition, "the healthy partition keeps delivering")
+	}
+
+	byPartition := map[int32]PartitionStats{}
+	for _, p := range tl.Stats().Partitions {
+		byPartition[p.Partition] = p
+	}
+	assert.True(t, byPartition[0].Running, "the broken partition must keep retrying, not exit")
+	assert.True(t, byPartition[1].Running)
+	assert.Positive(t, byPartition[0].UnclassifiedErrors)
+	assert.Zero(t, byPartition[1].UnclassifiedErrors, "one partition's error must not be charged to another")
+
+	cancel()
+	drain(t, out)
+}
+
+func TestAResponseMissingThePartitionBlockIsHandledWithoutPanicking(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			// A response that answers the request but omits the partition
+			// entirely. The broker is untrusted input; this must not panic.
+			return &sarama.FetchResponse{Version: 11}, nil
+		}
+		r := fetchResponse(topic, 0, 1, 1)
+		if spec.Offset == 0 {
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "survived"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Equal(t, "survived", string(got[0].Records[0].Value))
+	specs := c.fetchSpecs()
+	assert.Equal(t, int64(0), specs[1].Offset, "a malformed response advances nothing")
+	assert.Positive(t, tl.Stats().TransportErrors, "a malformed response is counted, not ignored")
+}
+
+func TestABlockedFetchLeavesAtMostOneRequestInFlightAndIssuesNoMore(t *testing.T) {
+	// sarama.Broker.Fetch takes no context and cannot be cancelled, so
+	// shutdown waits for the in-flight request to come back on its own. What
+	// must hold is that no *further* request is issued once the context is
+	// done — the reader stops at the boundary, it does not abandon the socket.
+	const topic = "t"
+	c := singlePartition(topic, 0)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			once.Do(func() { close(entered) })
+			<-release
+		}
+		return fetchResponse(topic, 0, 0, 0), nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+
+	waitFor(t, entered, "the fetch to be issued")
+	cancel()
+	close(release)
+
+	drain(t, out)
+
+	assert.Len(t, c.fetchSpecs(), 1, "no fetch may be issued after the context is done")
+	assert.Equal(t, 0, tl.Stats().PartitionsRunning)
+}
+
+// --- keep-up counters ------------------------------------------------------
+
+func TestRecordsReadIsCountedPerPartitionAndAggregated(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1)
+	for _, p := range []int32{0, 1} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if spec.Partition == 0 && spec.Offset == 0 {
+			r := fetchResponse(topic, 0, 3, 3)
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "a", "b"))
+			addBatch(r, topic, 0, batchOf(2, 100, 0, true, "c"))
+			return r, nil
+		}
+		if spec.Partition == 1 && spec.Offset == 0 {
+			r := fetchResponse(topic, 1, 1, 1)
+			addBatch(r, topic, 1, batchOf(0, 200, 0, true, "d"))
+			return r, nil
+		}
+		return fetchResponse(topic, spec.Partition, spec.Offset, spec.Offset), nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	collect(t, out, 3, cancel)
+
+	stats := tl.Stats()
+	byPartition := map[int32]PartitionStats{}
+	for _, p := range stats.Partitions {
+		byPartition[p.Partition] = p
+	}
+	assert.Equal(t, int64(3), byPartition[0].RecordsRead)
+	assert.Equal(t, int64(1), byPartition[1].RecordsRead)
+	assert.Equal(t, int64(4), stats.RecordsRead, "the keep-up signal needs an aggregate record count")
+}
+
+func TestConcurrentFetchesAreCapped(t *testing.T) {
+	// __transaction_state and __consumer_offsets default to 50 partitions
+	// each, so one loop per partition means up to 100 simultaneous long-poll
+	// fetches against a customer's production cluster for a run measured in
+	// hours. The cap is what keeps that bounded.
+	const (
+		topic      = "t"
+		partitions = 8
+		cap        = 2
+	)
+
+	c := newFakeClient()
+	parts := make([]int32, partitions)
+	for i := range parts {
+		parts[i] = int32(i)
+		c.setOffset(topic, int32(i), StartEarliest, 0)
+		c.setLeader(topic, int32(i), Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	c.setPartitions(topic, parts...)
+
+	var inFlight, peak atomic.Int64
+	reached, responder := afterCall(partitions*3, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		now := inFlight.Add(1)
+		for {
+			old := peak.Load()
+			if now <= old || peak.CompareAndSwap(old, now) {
+				break
+			}
+		}
+		// Hold the request open long enough that an uncapped reader would
+		// overlap many partitions at once.
+		time.Sleep(2 * time.Millisecond)
+		inFlight.Add(-1)
+		return fetchResponse(topic, spec.Partition, 0, 0), nil
+	})
+	c.respondWith(responder)
+
+	opts := testOptions(nil)
+	opts.MaxConcurrentFetches = cap
+
+	tl := New(c, opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "enough fetches to observe the concurrency peak")
+	cancel()
+	drain(t, out)
+
+	assert.LessOrEqual(t, peak.Load(), int64(cap),
+		"at most %d fetches may be in flight at once, but %d were", cap, peak.Load())
+	assert.Positive(t, peak.Load())
 }

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -702,6 +702,79 @@ func TestOnlyAPartitionThatAdvancedRecordsALastAdvanceTime(t *testing.T) {
 	assert.Equal(t, int64(0), byPartition[1].Lag, "the stalled partition's lag is zero, which is exactly why liveness is needed")
 }
 
+func TestAPartitionStuckRetryingAFailedFetchReportsItselfStalled(t *testing.T) {
+	// The gap the liveness counts leave open. A loop that keeps retrying is
+	// still running, and a partition that never fetched successfully holds a
+	// zero last stable offset, so its lag computes as zero: by both existing
+	// signals it is indistinguishable from a healthy, caught-up, idle
+	// partition. Whether its last fetch failed is the difference.
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	retrying := make(chan struct{})
+	var once sync.Once
+	var attempts atomic.Int64
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if attempts.Add(1) >= 3 {
+			once.Do(func() { close(retrying) })
+		}
+		return nil, brokenPipe()
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, retrying, "the partition to keep retrying a failing fetch")
+
+	stats := tl.Stats()
+	require.Len(t, stats.Partitions, 1)
+	assert.True(t, stats.Partitions[0].Running, "the loop must keep retrying rather than exit")
+	assert.Zero(t, stats.Partitions[0].Lag, "the lag of a partition that never fetched is zero, which is why it cannot be the signal")
+	assert.True(t, stats.Partitions[0].Stalled,
+		"a partition whose last fetch failed is not reading, however alive its loop is")
+	assert.Equal(t, 1, stats.PartitionsStalled)
+
+	cancel()
+	drain(t, out)
+}
+
+func TestAnIdlePartitionIsNotStalledAndACleanFetchClearsAStall(t *testing.T) {
+	// The cry-wolf case, and why the stall is latched on a failed fetch rather
+	// than inferred from having read nothing. An idle partition answers with
+	// empty but SUCCESSFUL fetches, which is what a healthy caught-up reader
+	// looks like; and a partition that recovered has fetched cleanly since, so
+	// its failure belongs in the counters, not in the health verdict.
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	recovered, responder := afterCall(3, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			return nil, brokenPipe()
+		}
+		return fetchResponse(topic, 0, 0, 0), nil
+	})
+	c.respondWith(responder)
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, recovered, "the partition to fetch cleanly again after the failure")
+
+	stats := tl.Stats()
+	require.Len(t, stats.Partitions, 1)
+	assert.False(t, stats.Partitions[0].Stalled, "a clean fetch clears the stall, however empty the response was")
+	assert.Equal(t, 0, stats.PartitionsStalled)
+	assert.Zero(t, stats.Partitions[0].RecordsRead, "an idle partition reads nothing, and that is not a fault")
+	assert.Positive(t, stats.TransportErrors, "the failure it recovered from must still be counted")
+
+	cancel()
+	drain(t, out)
+}
+
 // --- abort filtering -------------------------------------------------------
 
 func TestABatchBelongingToAnAbortedTransactionIsNotEmitted(t *testing.T) {

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -1,0 +1,818 @@
+package tail
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fake client (the KTD2 seam) -------------------------------------------
+
+// fakeClient implements Client without a broker. It records every fetch spec
+// and every metadata refresh so a test can assert on what the loop asked for,
+// and it lets a test move a leader mid-stream, which is the behaviour a
+// one-method fake around Fetch cannot express.
+type fakeClient struct {
+	mu sync.Mutex
+
+	partitions map[string][]int32
+	offsets    map[string]int64
+	leaders    map[string]Leader
+
+	fetches   []FetchSpec
+	refreshes []string
+
+	respond func(spec FetchSpec, call int) (*sarama.FetchResponse, error)
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		partitions: map[string][]int32{},
+		offsets:    map[string]int64{},
+		leaders:    map[string]Leader{},
+	}
+}
+
+func offsetKey(topic string, partition int32, pos StartPosition) string {
+	return topic + "/" + string(rune('0'+partition)) + "/" + string(rune('0'+int(pos)))
+}
+
+func partKey(topic string, partition int32) string {
+	return topic + "/" + string(rune('0'+partition))
+}
+
+func (f *fakeClient) setPartitions(topic string, parts ...int32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.partitions[topic] = parts
+}
+
+func (f *fakeClient) setOffset(topic string, partition int32, pos StartPosition, offset int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.offsets[offsetKey(topic, partition, pos)] = offset
+}
+
+func (f *fakeClient) setLeader(topic string, partition int32, l Leader) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.leaders[partKey(topic, partition)] = l
+}
+
+func (f *fakeClient) respondWith(fn func(spec FetchSpec, call int) (*sarama.FetchResponse, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.respond = fn
+}
+
+func (f *fakeClient) fetchSpecs() []FetchSpec {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]FetchSpec(nil), f.fetches...)
+}
+
+func (f *fakeClient) refreshedTopics() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.refreshes...)
+}
+
+func (f *fakeClient) Partitions(topic string) ([]int32, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p, ok := f.partitions[topic]
+	if !ok {
+		return nil, sarama.ErrUnknownTopicOrPartition
+	}
+	return p, nil
+}
+
+func (f *fakeClient) Offset(topic string, partition int32, pos StartPosition) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.offsets[offsetKey(topic, partition, pos)], nil
+}
+
+func (f *fakeClient) Leader(topic string, partition int32) (Leader, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	l, ok := f.leaders[partKey(topic, partition)]
+	if !ok {
+		return Leader{}, sarama.ErrLeaderNotAvailable
+	}
+	return l, nil
+}
+
+func (f *fakeClient) RefreshMetadata(topics ...string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refreshes = append(f.refreshes, topics...)
+	return nil
+}
+
+func (f *fakeClient) Fetch(leader Leader, spec FetchSpec) (*sarama.FetchResponse, error) {
+	f.mu.Lock()
+	call := len(f.fetches)
+	f.fetches = append(f.fetches, spec)
+	respond := f.respond
+	f.mu.Unlock()
+	if respond == nil {
+		return &sarama.FetchResponse{}, nil
+	}
+	return respond(spec, call)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// testOptions returns Options with every wait replaced by a recorder, so the
+// suite never sleeps for a meaningful duration.
+func testOptions(sleeps *[]time.Duration) Options {
+	var mu sync.Mutex
+	return Options{
+		Sleep: func(ctx context.Context, d time.Duration) {
+			mu.Lock()
+			if sleeps != nil {
+				*sleeps = append(*sleeps, d)
+			}
+			mu.Unlock()
+		},
+	}
+}
+
+// singlePartition wires a fake with one topic/partition led by broker 1.
+func singlePartition(topic string, start int64) *fakeClient {
+	c := newFakeClient()
+	c.setPartitions(topic, 0)
+	c.setOffset(topic, 0, StartEarliest, start)
+	c.setOffset(topic, 0, StartLatest, start)
+	c.setLeader(topic, 0, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	return c
+}
+
+// collect drains n batches from out, then cancels and waits for the channel to
+// close. It fails the test if the batches do not arrive in time.
+func collect(t *testing.T, out <-chan Batch, n int, cancel context.CancelFunc) []Batch {
+	t.Helper()
+	var got []Batch
+	deadline := time.After(5 * time.Second)
+	for len(got) < n {
+		select {
+		case b, ok := <-out:
+			if !ok {
+				t.Fatalf("channel closed after %d of %d batches", len(got), n)
+			}
+			got = append(got, b)
+		case <-deadline:
+			t.Fatalf("timed out after %d of %d batches", len(got), n)
+		}
+	}
+	cancel()
+	drain(t, out)
+	return got
+}
+
+// waitFor blocks until ch is closed, failing the test on timeout.
+func waitFor(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+// afterCall returns a channel closed once the fake has served n fetches, and
+// the responder wrapper that closes it.
+func afterCall(n int, inner func(spec FetchSpec, call int) (*sarama.FetchResponse, error)) (<-chan struct{}, func(FetchSpec, int) (*sarama.FetchResponse, error)) {
+	reached := make(chan struct{})
+	var once sync.Once
+	return reached, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call+1 >= n {
+			once.Do(func() { close(reached) })
+		}
+		return inner(spec, call)
+	}
+}
+
+// drain reads until the output channel closes.
+func drain(t *testing.T, out <-chan Batch) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the output channel to close")
+		}
+	}
+}
+
+// addBatch appends a hand-built record batch to a response block, so a test
+// can control header fields sarama's convenience builders do not expose.
+func addBatch(r *sarama.FetchResponse, topic string, partition int32, rb *sarama.RecordBatch) {
+	blk := r.GetBlock(topic, partition)
+	records := &sarama.Records{RecordBatch: rb}
+	blk.RecordsSet = append(blk.RecordsSet, records)
+}
+
+// batchOf builds a version-2 record batch carrying one record per value.
+func batchOf(firstOffset int64, producerID int64, epoch int16, transactional bool, values ...string) *sarama.RecordBatch {
+	rb := &sarama.RecordBatch{
+		Version:         2,
+		FirstOffset:     firstOffset,
+		LastOffsetDelta: int32(len(values) - 1),
+		ProducerID:      producerID,
+		ProducerEpoch:   epoch,
+		IsTransactional: transactional,
+	}
+	for i, v := range values {
+		rb.Records = append(rb.Records, &sarama.Record{OffsetDelta: int64(i), Value: []byte(v)})
+	}
+	return rb
+}
+
+// fetchResponse builds an empty, error-free response block with the given
+// last-stable-offset and high watermark.
+func fetchResponse(topic string, partition int32, lso, hwm int64) *sarama.FetchResponse {
+	r := &sarama.FetchResponse{Version: 11}
+	r.AddError(topic, partition, sarama.ErrNoError)
+	r.SetLastStableOffset(topic, partition, lso)
+	r.GetBlock(topic, partition).HighWaterMarkOffset = hwm
+	return r
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestRecordsAreEmittedInOffsetOrderAndTheNextFetchResumesAfterTheLastOffset(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if spec.Offset != 0 {
+			return fetchResponse(topic, 0, 3, 3), nil
+		}
+		r := fetchResponse(topic, 0, 3, 3)
+		r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("a"), 0, 100, true)
+		r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("b"), 1, 100, true)
+		r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("c"), 2, 100, true)
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+
+	got := collect(t, out, 3, cancel)
+
+	var values []string
+	var offsets []int64
+	for _, b := range got {
+		require.Len(t, b.Records, 1)
+		values = append(values, string(b.Records[0].Value))
+		offsets = append(offsets, b.Records[0].Offset)
+	}
+	assert.Equal(t, []string{"a", "b", "c"}, values)
+	assert.Equal(t, []int64{0, 1, 2}, offsets)
+
+	specs := c.fetchSpecs()
+	require.GreaterOrEqual(t, len(specs), 2, "expected a follow-up fetch")
+	assert.Equal(t, int64(0), specs[0].Offset)
+	assert.Equal(t, int64(3), specs[1].Offset, "the next fetch must resume from the last offset plus one")
+}
+
+func TestLagIsLastStableOffsetMinusNextOffsetPerPartitionAndAggregated(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1)
+	for _, p := range []int32{0, 1} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		switch spec.Partition {
+		case 0:
+			r := fetchResponse(topic, 0, 10, 10)
+			if spec.Offset == 0 {
+				r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("a"), 0, 100, true)
+				r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("b"), 1, 100, true)
+			}
+			return r, nil
+		default:
+			r := fetchResponse(topic, 1, 5, 5)
+			if spec.Offset == 0 {
+				r.AddRecordBatch(topic, 1, nil, sarama.ByteEncoder("c"), 0, 100, true)
+			}
+			return r, nil
+		}
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	collect(t, out, 3, cancel)
+
+	stats := tl.Stats()
+	require.Len(t, stats.Partitions, 2)
+	byPartition := map[int32]PartitionStats{}
+	for _, p := range stats.Partitions {
+		byPartition[p.Partition] = p
+	}
+	assert.Equal(t, int64(2), byPartition[0].NextOffset)
+	assert.Equal(t, int64(8), byPartition[0].Lag, "partition 0: LSO 10 minus next offset 2")
+	assert.Equal(t, int64(1), byPartition[1].NextOffset)
+	assert.Equal(t, int64(4), byPartition[1].Lag, "partition 1: LSO 5 minus next offset 1")
+	assert.Equal(t, int64(12), stats.Lag, "aggregate lag is the sum of the per-partition lags")
+}
+
+func TestAnOpenTransactionReportsAsBacklogNotAsReaderLag(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		// The high watermark runs six offsets ahead of the last stable offset:
+		// a transaction is open, so a read-committed reader is fully caught up
+		// at offset 1 even though the log holds more.
+		r := fetchResponse(topic, 0, 1, 7)
+		if spec.Offset == 0 {
+			r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("a"), 0, 100, true)
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	collect(t, out, 1, cancel)
+
+	stats := tl.Stats()
+	require.Len(t, stats.Partitions, 1)
+	assert.Equal(t, int64(0), stats.Partitions[0].Lag, "a caught-up reader has no lag while a transaction is open")
+	assert.Equal(t, int64(6), stats.Partitions[0].OpenTxnBacklog, "the high-watermark-to-LSO gap is open-transaction backlog")
+	assert.Equal(t, int64(0), stats.Lag)
+	assert.Equal(t, int64(6), stats.OpenTxnBacklog)
+}
+
+func TestAnEmptyFetchResponseAdvancesNothingAndDoesNotSpin(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 5)
+	reached, responder := afterCall(3, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		return fetchResponse(topic, 0, 5, 5), nil
+	})
+	c.respondWith(responder)
+
+	var sleeps []time.Duration
+	tl := New(c, testOptions(&sleeps))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "three fetches")
+	cancel()
+	drain(t, out)
+
+	for i, spec := range c.fetchSpecs() {
+		assert.Equal(t, int64(5), spec.Offset, "fetch %d must not have advanced past an empty response", i)
+	}
+	assert.Equal(t, int64(5), tl.Stats().Partitions[0].NextOffset)
+
+	require.NotEmpty(t, sleeps, "an empty response must yield before refetching, or the loop hot-spins")
+	for _, d := range sleeps {
+		assert.Greater(t, d, time.Duration(0), "the idle yield must be a real pause")
+	}
+}
+
+func TestALegacyMessageSetIsSkippedWithoutDereferencingNil(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 2, 2)
+		if spec.Offset == 0 {
+			// A pre-0.11 message set decodes with RecordBatch nil.
+			r.AddMessage(topic, 0, nil, sarama.ByteEncoder("legacy"), 0)
+			r.AddRecordBatch(topic, 0, nil, sarama.ByteEncoder("modern"), 1, 100, true)
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Records, 1)
+	assert.Equal(t, "modern", string(got[0].Records[0].Value))
+}
+
+func TestTheBatchHeaderReachesTheConsumerIntact(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 3, 3)
+		if spec.Offset == 0 {
+			addBatch(r, topic, 0, batchOf(0, 4242, 7, true, "a", "b"))
+			r.AddControlRecord(topic, 0, 2, 4242, sarama.ControlRecordCommit)
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 2, cancel)
+
+	require.Len(t, got, 2)
+	data := got[0]
+	assert.Equal(t, int64(4242), data.ProducerID, "the producer id is the whole reason for the raw fetch path")
+	assert.Equal(t, int16(7), data.ProducerEpoch)
+	assert.True(t, data.IsTransactional)
+	assert.False(t, data.Control)
+	assert.Equal(t, int64(0), data.BaseOffset)
+	assert.Equal(t, topic, data.Topic)
+	assert.Equal(t, int32(0), data.Partition)
+	assert.Equal(t, int32(1), data.Leader)
+
+	ctrl := got[1]
+	assert.True(t, ctrl.Control, "a transaction marker must reach the consumer flagged as a control batch")
+	assert.Equal(t, int64(4242), ctrl.ProducerID)
+	assert.True(t, ctrl.IsTransactional)
+}
+
+func TestNegotiateFetchVersionClampsToTheBrokerCeilingWithVersion4AsTheFloor(t *testing.T) {
+	fetchKey := func(max int16) []sarama.ApiVersionsResponseKey {
+		return []sarama.ApiVersionsResponseKey{
+			{ApiKey: 0, MinVersion: 0, MaxVersion: 9}, // Produce, to prove the key lookup discriminates
+			{ApiKey: fetchAPIKey, MinVersion: 0, MaxVersion: max},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		keys      []sarama.ApiVersionsResponseKey
+		ceiling   int16
+		want      int16
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "broker at or above the ceiling pins the ceiling", keys: fetchKey(13), ceiling: 11, want: 11},
+		{name: "broker below the ceiling clamps down", keys: fetchKey(6), ceiling: 11, want: 6},
+		{name: "broker exactly at the floor is accepted", keys: fetchKey(4), ceiling: 11, want: 4},
+		{name: "a ceiling below the floor is raised to the floor", keys: fetchKey(11), ceiling: 2, want: 4},
+		{
+			name: "a broker advertising below the floor is an actionable error", keys: fetchKey(3), ceiling: 11,
+			wantErr: true, errSubstr: "advertises a maximum Fetch API version of 3",
+		},
+		{
+			name: "a broker that does not advertise Fetch at all is an actionable error",
+			keys: []sarama.ApiVersionsResponseKey{{ApiKey: 0, MaxVersion: 9}}, ceiling: 11,
+			wantErr: true, errSubstr: "did not advertise the Fetch API",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := negotiateFetchVersion(tt.keys, tt.ceiling)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildFetchRequestCarriesTheNegotiatedVersionAndSessionFields(t *testing.T) {
+	spec := FetchSpec{
+		Topic:             "t",
+		Partition:         3,
+		Offset:            77,
+		MaxWaitMS:         500,
+		MinBytes:          1,
+		MaxBytes:          2 << 20,
+		MaxPartitionBytes: 1 << 20,
+		Isolation:         sarama.ReadCommitted,
+	}
+
+	for _, version := range []int16{4, 5, 6, 7, 8, 9, 10, 11} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			s := spec
+			s.Version = version
+			req := buildFetchRequest(s)
+
+			assert.Equal(t, version, req.Version)
+			assert.Equal(t, int32(500), req.MaxWaitTime)
+			assert.Equal(t, int32(1), req.MinBytes)
+			assert.Equal(t, int32(2<<20), req.MaxBytes, "MaxBytes is encoded from v3 up, and the floor here is v4")
+			assert.Equal(t, sarama.ReadCommitted, req.Isolation)
+
+			if version >= 7 {
+				// Session id 0 with epoch -1 tells the broker not to open a
+				// fetch session, which this reader never uses (KIP-227).
+				assert.Equal(t, int32(0), req.SessionID)
+				assert.Equal(t, int32(-1), req.SessionEpoch)
+			} else {
+				assert.Equal(t, int32(0), req.SessionID)
+				assert.Equal(t, int32(0), req.SessionEpoch, "the session fields are not part of the wire format below v7")
+			}
+		})
+	}
+}
+
+func TestCancellingTheContextStopsEveryPartitionLoopAndClosesTheOutput(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1, 2)
+	for _, p := range []int32{0, 1, 2} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	// Every partition always has a record waiting, so every loop is trying to
+	// hand a batch to a consumer that never reads one.
+	reached, responder := afterCall(3, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, spec.Partition, spec.Offset+1, spec.Offset+1)
+		addBatch(r, topic, spec.Partition, batchOf(spec.Offset, 100, 0, true, "v"))
+		return r, nil
+	})
+	c.respondWith(responder)
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "every partition to issue a fetch")
+
+	cancel()
+
+	stopped := make(chan struct{})
+	go func() { tl.Wait(); close(stopped) }()
+	waitFor(t, stopped, "every partition loop to exit while blocked on an unread send")
+
+	drain(t, out)
+
+	issued := len(c.fetchSpecs())
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, issued, len(c.fetchSpecs()), "no fetch may be issued once the context is done")
+}
+
+func TestAPartitionLoopThatExitsIsReportedInTheLivenessCounts(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1)
+	for _, p := range []int32{0, 1} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	reached, responder := afterCall(2, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		return fetchResponse(topic, spec.Partition, 0, 0), nil
+	})
+	c.respondWith(responder)
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "both partitions to fetch")
+
+	running := tl.Stats()
+	assert.Equal(t, 2, running.PartitionsAssigned)
+	assert.Equal(t, 2, running.PartitionsRunning)
+
+	cancel()
+	drain(t, out)
+
+	stopped := tl.Stats()
+	assert.Equal(t, 2, stopped.PartitionsAssigned, "an exited partition stays in the assigned count")
+	assert.Equal(t, 0, stopped.PartitionsRunning, "a loop that exits must show up as no longer running")
+	for _, p := range stopped.Partitions {
+		assert.False(t, p.Running, "partition %d must report itself stopped", p.Partition)
+	}
+}
+
+func TestOnlyAPartitionThatAdvancedRecordsALastAdvanceTime(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0, 1)
+	for _, p := range []int32{0, 1} {
+		c.setOffset(topic, p, StartEarliest, 0)
+		c.setLeader(topic, p, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	}
+	// Partition 1 never produces a record: it is caught up at offset 0, so its
+	// lag is zero and only a last-advance time distinguishes it from a
+	// partition that has silently stopped moving.
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if spec.Partition == 1 {
+			return fetchResponse(topic, 1, 0, 0), nil
+		}
+		r := fetchResponse(topic, 0, spec.Offset+1, spec.Offset+1)
+		addBatch(r, topic, 0, batchOf(spec.Offset, 100, 0, true, "v"))
+		return r, nil
+	})
+
+	before := time.Now()
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	collect(t, out, 3, cancel)
+
+	byPartition := map[int32]PartitionStats{}
+	for _, p := range tl.Stats().Partitions {
+		byPartition[p.Partition] = p
+	}
+	assert.False(t, byPartition[0].LastAdvance.IsZero(), "an advancing partition must record when it last moved")
+	assert.False(t, byPartition[0].LastAdvance.Before(before))
+	assert.True(t, byPartition[1].LastAdvance.IsZero(), "a partition that never advanced must not look like it did")
+	assert.Equal(t, int64(0), byPartition[1].Lag, "the stalled partition's lag is zero, which is exactly why liveness is needed")
+}
+
+// --- abort filtering -------------------------------------------------------
+
+func TestABatchBelongingToAnAbortedTransactionIsNotEmitted(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 2, 2)
+		if spec.Offset == 0 {
+			// ReadCommitted bounds the fetch at the last stable offset and
+			// hands back the aborted list; it does not remove the records.
+			r.GetBlock(topic, 0).AbortedTransactions = []*sarama.AbortedTransaction{
+				{ProducerID: 500, FirstOffset: 0},
+			}
+			addBatch(r, topic, 0, batchOf(0, 500, 0, true, "rolled-back"))
+			addBatch(r, topic, 0, batchOf(1, 600, 0, true, "committed"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(600), got[0].ProducerID, "the aborted producer's batch must be dropped, not credited as real")
+	assert.Equal(t, "committed", string(got[0].Records[0].Value))
+	assert.Equal(t, int64(1), tl.Stats().AbortedBatches, "a dropped batch must be counted, not silently discarded")
+}
+
+func TestAnAbortControlBatchClearsItsProducerSoLaterBatchesAreEmitted(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 3, 3)
+		if spec.Offset == 0 {
+			r.GetBlock(topic, 0).AbortedTransactions = []*sarama.AbortedTransaction{
+				{ProducerID: 500, FirstOffset: 0},
+			}
+			addBatch(r, topic, 0, batchOf(0, 500, 0, true, "rolled-back"))
+			r.AddControlRecord(topic, 0, 1, 500, sarama.ControlRecordAbort)
+			// Same producer id, next transaction, committed. Leaving 500 in
+			// the aborted set would silently drop it.
+			addBatch(r, topic, 0, batchOf(2, 500, 1, true, "committed-later"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 2, cancel)
+
+	require.Len(t, got, 2)
+	assert.True(t, got[0].Control, "the abort marker itself still reaches the consumer")
+	assert.Equal(t, "committed-later", string(got[1].Records[0].Value))
+	assert.Equal(t, int64(500), got[1].ProducerID)
+	assert.Equal(t, int64(1), tl.Stats().AbortedBatches, "only the batch inside the rolled-back transaction is dropped")
+}
+
+// --- partial batches -------------------------------------------------------
+
+func TestAPartialTrailingRecordAdvancesOnlyPastFullyDecodedRecords(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 5, 5)
+		switch spec.Offset {
+		case 0:
+			// The batch header claims offsets 0..4, but the fetch boundary cut
+			// it after offset 2. Trusting the header would skip 3 and 4 — and
+			// a dropped record is a dropped topic in a transaction footprint.
+			rb := batchOf(0, 100, 0, true, "a", "b", "c")
+			rb.LastOffsetDelta = 4
+			rb.PartialTrailingRecord = true
+			addBatch(r, topic, 0, rb)
+		case 3:
+			addBatch(r, topic, 0, batchOf(3, 100, 0, true, "d", "e"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 2, cancel)
+
+	var offsets []int64
+	var values []string
+	for _, b := range got {
+		for _, rec := range b.Records {
+			offsets = append(offsets, rec.Offset)
+			values = append(values, string(rec.Value))
+		}
+	}
+	assert.Equal(t, []int64{0, 1, 2, 3, 4}, offsets, "the cut records must be refetched, not skipped")
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, values)
+
+	specs := c.fetchSpecs()
+	require.GreaterOrEqual(t, len(specs), 2)
+	assert.Equal(t, int64(3), specs[1].Offset, "the refetch resumes at the first record that was cut")
+}
+
+// --- decode errors ---------------------------------------------------------
+
+func TestAnUndecodableControlRecordIsCountedAndKeepsFilteringItsProducer(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		r := fetchResponse(topic, 0, 4, 4)
+		if spec.Offset == 0 {
+			r.GetBlock(topic, 0).AbortedTransactions = []*sarama.AbortedTransaction{
+				{ProducerID: 500, FirstOffset: 0},
+			}
+			addBatch(r, topic, 0, batchOf(0, 500, 0, true, "rolled-back"))
+
+			// A truncated control-record key: two bytes where four are needed.
+			// The marker cannot be read, so whether producer 500's transaction
+			// aborted or committed is unknown.
+			truncated := &sarama.RecordBatch{
+				Version: 2, FirstOffset: 1, ProducerID: 500,
+				IsTransactional: true, Control: true,
+				Records: []*sarama.Record{{OffsetDelta: 0, Key: []byte{0x00, 0x00}}},
+			}
+			addBatch(r, topic, 0, truncated)
+
+			addBatch(r, topic, 0, batchOf(2, 500, 0, true, "still-suspect"))
+			addBatch(r, topic, 0, batchOf(3, 700, 0, true, "unrelated"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 2, cancel)
+
+	require.Len(t, got, 2)
+	assert.True(t, got[0].Control)
+	assert.Equal(t, int64(700), got[1].ProducerID,
+		"an unreadable abort marker must not be taken as a commit; producer 500 stays filtered")
+
+	stats := tl.Stats()
+	assert.Equal(t, int64(1), stats.DecodeErrors, "format drift must be counted, since it is the drift alarm")
+	assert.Equal(t, int64(2), stats.AbortedBatches)
+	assert.Equal(t, int64(4), stats.Partitions[0].NextOffset,
+		"the offset advances past decoded records only, including the ones that were filtered")
+}

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -1297,3 +1297,64 @@ func TestConcurrentFetchesAreCapped(t *testing.T) {
 		"at most %d fetches may be in flight at once, but %d were", cap, peak.Load())
 	assert.Positive(t, peak.Load())
 }
+
+func TestEveryFetchCarriesTheConfiguredAllocationBoundsAndIsolation(t *testing.T) {
+	// The response size bounds are the allocation limit against an untrusted
+	// broker, so they must be explicit on every request rather than left to a
+	// library default that a dependency bump could change.
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	reached, responder := afterCall(1, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		return fetchResponse(topic, 0, 0, 0), nil
+	})
+	c.respondWith(responder)
+
+	opts := testOptions(nil)
+	opts.MaxWaitTime = 750 * time.Millisecond
+	opts.MinBytes = 1
+	opts.MaxBytes = 3 << 20
+	opts.MaxPartitionBytes = 2 << 20
+
+	tl := New(c, opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "a fetch to be issued")
+	cancel()
+	drain(t, out)
+
+	spec := c.fetchSpecs()[0]
+	assert.Equal(t, int32(750), spec.MaxWaitMS)
+	assert.Equal(t, int32(1), spec.MinBytes)
+	assert.Equal(t, int32(3<<20), spec.MaxBytes)
+	assert.Equal(t, int32(2<<20), spec.MaxPartitionBytes)
+	assert.Equal(t, sarama.ReadCommitted, spec.Isolation,
+		"read-uncommitted would surface records from transactions that later abort")
+}
+
+func TestTheDefaultAllocationBoundsAreExplicitNotLibraryDefaults(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	reached, responder := afterCall(1, func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		return fetchResponse(topic, 0, 0, 0), nil
+	})
+	c.respondWith(responder)
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	waitFor(t, reached, "a fetch to be issued")
+	cancel()
+	drain(t, out)
+
+	spec := c.fetchSpecs()[0]
+	assert.Equal(t, DefaultMaxPartitionBytes, spec.MaxPartitionBytes)
+	assert.Equal(t, DefaultMaxBytes, spec.MaxBytes)
+	assert.Equal(t, DefaultMinBytes, spec.MinBytes)
+	assert.Equal(t, sarama.ReadCommitted, spec.Isolation)
+}

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1081,6 +1082,100 @@ func TestATransportErrorRetriesWithBackoffThatGrowsIsCappedAndResets(t *testing.
 		"a successful fetch resets the curve, so one blip does not permanently slow the reader")
 
 	assert.Equal(t, int64(7), tl.Stats().TransportErrors)
+}
+
+// brokenPipe is the error a restarted broker actually surfaces: no response, no
+// Kafka error code, just a dead socket. Its rendered text is the one observed
+// against a real broker — "write tcp 10.0.0.1:9092: write: broken pipe".
+func brokenPipe() error {
+	return &net.OpError{
+		Op:   "write",
+		Net:  "tcp",
+		Addr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 9092},
+		Err:  errors.New("write: broken pipe"),
+	}
+}
+
+func TestATransportErrorRefreshesMetadataAndRetriesAgainstTheNewLeader(t *testing.T) {
+	// R11's broker half. A restart arrives as a transport error, not a
+	// leadership one, and the leader it invalidates is cached: without a
+	// refresh the loop re-resolves nothing and retries the same dead
+	// connection for the rest of the run, reading zero records while still
+	// reporting itself as running with zero lag.
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.onRefreshDo(func() {
+		c.setLeader(topic, 0, Leader{ID: 2, Addr: "b2:9092", FetchVersion: 11})
+	})
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			return nil, brokenPipe()
+		}
+		r := fetchResponse(topic, 0, 1, 1)
+		if spec.Offset == 0 {
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "after-reconnect"))
+		}
+		return r, nil
+	})
+
+	var sleeps []time.Duration
+	tl := New(c, testOptions(&sleeps))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Contains(t, c.refreshedTopics(), topic,
+		"a transport error must force a metadata refresh, or the loop keeps retrying the leader it already failed against")
+
+	leaders := c.leadersFetched()
+	require.GreaterOrEqual(t, len(leaders), 2)
+	assert.Equal(t, int32(1), leaders[0].ID)
+	assert.Equal(t, int32(2), leaders[1].ID, "the retry must go to the newly resolved leader")
+
+	specs := c.fetchSpecs()
+	assert.Equal(t, int64(0), specs[1].Offset, "the retry resumes from the same offset, with no gap")
+	assert.Equal(t, "after-reconnect", string(got[0].Records[0].Value))
+
+	// Refreshing is not a licence to hammer a broker that is genuinely down:
+	// the backoff still applies, and it is still the transport counter that
+	// moves, so --stats-out keeps the distinction from a leader election.
+	assert.NotEmpty(t, sleeps, "a transport error must back off as well as refresh")
+	stats := tl.Stats()
+	assert.Equal(t, int64(1), stats.TransportErrors)
+	assert.Equal(t, int64(0), stats.LeadershipErrors, "a dead socket is not a leadership error")
+	assert.Contains(t, stats.Partitions[0].LastError, "broken pipe")
+}
+
+func TestAFailedFetchDropsTheCachedConnectionSoTheNextLeaderCallRedials(t *testing.T) {
+	// The other half of surviving a restart, and the half a metadata refresh
+	// cannot do. A sarama Broker never recovers from a failed round trip on its
+	// own: neither the write path nor responseReceiver closes the socket, and
+	// client.updateMetadata keeps the existing *Broker whenever the address is
+	// unchanged — which is exactly what a broker that restarts in place looks
+	// like. Unless this adapter forgets the connection, every retry, refreshed
+	// metadata or not, is issued down the same dead socket.
+	s := NewSaramaClient(nil, 0)
+	b := sarama.NewBroker("127.0.0.1:1")
+	id := b.ID()
+	s.brokers[id] = b
+	s.versions[id] = 11
+
+	_, err := s.Fetch(Leader{ID: id, Addr: b.Addr(), FetchVersion: 11}, FetchSpec{
+		Topic: "t", Version: 11, MaxWaitMS: 100, MinBytes: 1,
+		MaxBytes: 1024, MaxPartitionBytes: 1024, Isolation: sarama.ReadCommitted,
+	})
+	require.Error(t, err, "a fetch down an unopened connection must fail")
+
+	s.mu.Lock()
+	_, cachedBroker := s.brokers[id]
+	_, cachedVersion := s.versions[id]
+	s.mu.Unlock()
+
+	assert.False(t, cachedBroker, "a failed fetch must drop the cached connection, or every retry reuses the dead socket")
+	assert.False(t, cachedVersion, "the version negotiated over the dead connection must be dropped with it: the broker may come back on a different build")
 }
 
 func TestAPartitionLevelErrorDoesNotAbortSiblingPartitions(t *testing.T) {

--- a/internal/services/txndiscovery/tail/tail_test.go
+++ b/internal/services/txndiscovery/tail/tail_test.go
@@ -2,6 +2,7 @@ package tail
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -25,10 +26,12 @@ type fakeClient struct {
 	offsets    map[string]int64
 	leaders    map[string]Leader
 
-	fetches   []FetchSpec
-	refreshes []string
+	fetches      []FetchSpec
+	fetchLeaders []Leader
+	refreshes    []string
 
-	respond func(spec FetchSpec, call int) (*sarama.FetchResponse, error)
+	respond   func(spec FetchSpec, call int) (*sarama.FetchResponse, error)
+	onRefresh func()
 }
 
 func newFakeClient() *fakeClient {
@@ -111,15 +114,36 @@ func (f *fakeClient) Leader(topic string, partition int32) (Leader, error) {
 
 func (f *fakeClient) RefreshMetadata(topics ...string) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.refreshes = append(f.refreshes, topics...)
+	hook := f.onRefresh
+	f.mu.Unlock()
+	// Run outside the lock: the hook typically moves a leader, which locks.
+	if hook != nil {
+		hook()
+	}
 	return nil
+}
+
+// onRefreshDo installs a side effect for the next metadata refresh, which is
+// how a test moves a partition's leader mid-stream.
+func (f *fakeClient) onRefreshDo(fn func()) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onRefresh = fn
+}
+
+// leadersFetched returns the leader each fetch was issued against.
+func (f *fakeClient) leadersFetched() []Leader {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]Leader(nil), f.fetchLeaders...)
 }
 
 func (f *fakeClient) Fetch(leader Leader, spec FetchSpec) (*sarama.FetchResponse, error) {
 	f.mu.Lock()
 	call := len(f.fetches)
 	f.fetches = append(f.fetches, spec)
+	f.fetchLeaders = append(f.fetchLeaders, leader)
 	respond := f.respond
 	f.mu.Unlock()
 	if respond == nil {
@@ -815,4 +839,225 @@ func TestAnUndecodableControlRecordIsCountedAndKeepsFilteringItsProducer(t *test
 	assert.Equal(t, int64(2), stats.AbortedBatches)
 	assert.Equal(t, int64(4), stats.Partitions[0].NextOffset,
 		"the offset advances past decoded records only, including the ones that were filtered")
+}
+
+// --- error classification --------------------------------------------------
+
+// blockError builds a response whose partition block carries a Kafka error.
+func blockError(topic string, partition int32, kerr sarama.KError) *sarama.FetchResponse {
+	r := &sarama.FetchResponse{Version: 11}
+	r.AddError(topic, partition, kerr)
+	return r
+}
+
+func TestNotLeaderForPartitionRefreshesMetadataAndRetriesAgainstTheNewLeader(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.onRefreshDo(func() {
+		c.setLeader(topic, 0, Leader{ID: 2, Addr: "b2:9092", FetchVersion: 11})
+	})
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			return blockError(topic, 0, sarama.ErrNotLeaderForPartition), nil
+		}
+		r := fetchResponse(topic, 0, 1, 1)
+		if spec.Offset == 0 {
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "after-move"))
+		}
+		return r, nil
+	})
+
+	var sleeps []time.Duration
+	tl := New(c, testOptions(&sleeps))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Contains(t, c.refreshedTopics(), topic, "a leadership error must force a metadata refresh")
+
+	leaders := c.leadersFetched()
+	require.GreaterOrEqual(t, len(leaders), 2)
+	assert.Equal(t, int32(1), leaders[0].ID)
+	assert.Equal(t, int32(2), leaders[1].ID, "the retry must go to the newly resolved leader")
+
+	specs := c.fetchSpecs()
+	assert.Equal(t, int64(0), specs[1].Offset, "the retry resumes from the same offset, with no gap")
+	assert.Equal(t, "after-move", string(got[0].Records[0].Value))
+
+	assert.NotEmpty(t, sleeps, "a leadership error must back off before retrying")
+	// Receiving a batch at all proves the loop survived the error rather than
+	// treating it as fatal.
+	assert.Equal(t, int64(1), tl.Stats().LeadershipErrors)
+}
+
+func TestEveryLeadershipErrorIsRetriableAfterRefreshRatherThanFatal(t *testing.T) {
+	// A stale cached leader epoch is the routine outcome of a leader move; if
+	// the epoch codes were fatal, R11's recovery would never happen.
+	codes := []sarama.KError{
+		sarama.ErrNotLeaderForPartition,
+		sarama.ErrLeaderNotAvailable,
+		sarama.ErrFencedLeaderEpoch,
+		sarama.ErrUnknownLeaderEpoch,
+		sarama.ErrReplicaNotAvailable,
+	}
+
+	for _, code := range codes {
+		t.Run(code.Error(), func(t *testing.T) {
+			const topic = "t"
+			c := singlePartition(topic, 0)
+			c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+				if call == 0 {
+					return blockError(topic, 0, code), nil
+				}
+				r := fetchResponse(topic, 0, 1, 1)
+				if spec.Offset == 0 {
+					addBatch(r, topic, 0, batchOf(0, 100, 0, true, "recovered"))
+				}
+				return r, nil
+			})
+
+			tl := New(c, testOptions(nil))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+			require.NoError(t, err)
+			got := collect(t, out, 1, cancel)
+
+			assert.Equal(t, "recovered", string(got[0].Records[0].Value))
+			assert.Contains(t, c.refreshedTopics(), topic, "%s must force a metadata refresh", code)
+			assert.Equal(t, int64(1), tl.Stats().LeadershipErrors, "%s must be classified as a leadership error", code)
+			assert.Equal(t, int64(0), tl.Stats().UnclassifiedErrors)
+		})
+	}
+}
+
+func TestAnUnrecognisedErrorCodeIsCountedAndSurfacedWithoutExitingTheLoop(t *testing.T) {
+	const topic = "t"
+	// A code this build of sarama has no name for — the case a broker upgrade
+	// introduces. The one outcome that must never happen is a loop that quietly
+	// stops, because that reads downstream as "this partition had no data".
+	unknown := sarama.KError(999)
+
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if call == 0 {
+			return blockError(topic, 0, unknown), nil
+		}
+		r := fetchResponse(topic, 0, 1, 1)
+		if spec.Offset == 0 {
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "kept-going"))
+		}
+		return r, nil
+	})
+
+	var sleeps []time.Duration
+	tl := New(c, testOptions(&sleeps))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Equal(t, "kept-going", string(got[0].Records[0].Value), "the loop must keep reading past an unknown code")
+
+	stats := tl.Stats()
+	assert.Equal(t, int64(1), stats.UnclassifiedErrors)
+	assert.Equal(t, int64(0), stats.LeadershipErrors, "an unknown code must not be mistaken for a leadership error")
+	assert.Empty(t, c.refreshedTopics(), "an unknown code is no reason to refresh metadata")
+	assert.Contains(t, stats.Partitions[0].LastError, "999", "the code must be surfaced, not swallowed")
+	assert.NotEmpty(t, sleeps, "an unknown code must back off rather than spin")
+}
+
+func TestOffsetOutOfRangeReseeksToEarliestRatherThanLoopingOnADeadOffset(t *testing.T) {
+	const topic = "t"
+	c := newFakeClient()
+	c.setPartitions(topic, 0)
+	// The reader's remembered position has been retained away: the log now
+	// starts at 5, but the tail was told to begin at 100.
+	c.setOffset(topic, 0, StartEarliest, 5)
+	c.setOffset(topic, 0, StartLatest, 100)
+	c.setLeader(topic, 0, Leader{ID: 1, Addr: "b1:9092", FetchVersion: 11})
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		if spec.Offset >= 100 {
+			return blockError(topic, 0, sarama.ErrOffsetOutOfRange), nil
+		}
+		r := fetchResponse(topic, 0, 6, 6)
+		if spec.Offset == 5 {
+			addBatch(r, topic, 0, batchOf(5, 100, 0, true, "from-earliest"))
+		}
+		return r, nil
+	})
+
+	tl := New(c, testOptions(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartLatest}})
+	require.NoError(t, err)
+	got := collect(t, out, 1, cancel)
+
+	assert.Equal(t, int64(5), got[0].Records[0].Offset, "the reader must resume from the log start, not spin on a dead offset")
+	specs := c.fetchSpecs()
+	require.GreaterOrEqual(t, len(specs), 2)
+	assert.Equal(t, int64(100), specs[0].Offset)
+	assert.Equal(t, int64(5), specs[1].Offset, "the reseek target is the partition's earliest available offset")
+	assert.Equal(t, int64(1), tl.Stats().OffsetResets)
+}
+
+func TestATransportErrorRetriesWithBackoffThatGrowsIsCappedAndResets(t *testing.T) {
+	const topic = "t"
+	c := singlePartition(topic, 0)
+	c.respondWith(func(spec FetchSpec, call int) (*sarama.FetchResponse, error) {
+		switch {
+		case call < 6, call == 7:
+			// A broker restart looks like this: the connection fails outright,
+			// with no response and so no Kafka error code to classify.
+			return nil, errors.New("write tcp 10.0.0.1:9092: connection reset by peer")
+		case call == 6:
+			r := fetchResponse(topic, 0, 2, 2)
+			addBatch(r, topic, 0, batchOf(0, 100, 0, true, "first"))
+			return r, nil
+		default:
+			r := fetchResponse(topic, 0, 2, 2)
+			if spec.Offset == 1 {
+				addBatch(r, topic, 0, batchOf(1, 100, 0, true, "second"))
+			}
+			return r, nil
+		}
+	})
+
+	var sleeps []time.Duration
+	opts := testOptions(&sleeps)
+	opts.BackoffBase = 10 * time.Millisecond
+	opts.BackoffMax = 40 * time.Millisecond
+
+	tl := New(c, opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, err := tl.Start(ctx, []TopicSpec{{Topic: topic, Start: StartEarliest}})
+	require.NoError(t, err)
+	got := collect(t, out, 2, cancel)
+
+	assert.Equal(t, "first", string(got[0].Records[0].Value))
+	assert.Equal(t, "second", string(got[1].Records[0].Value), "the reader resumes with no gap after a transport failure")
+
+	require.GreaterOrEqual(t, len(sleeps), 7)
+	assert.Equal(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+	}, sleeps[:6], "backoff doubles from the base and is capped, so a long outage does not become an unbounded wait")
+	assert.Equal(t, 10*time.Millisecond, sleeps[6],
+		"a successful fetch resets the curve, so one blip does not permanently slow the reader")
+
+	assert.Equal(t, int64(7), tl.Stats().TransportErrors)
 }

--- a/internal/services/txndiscovery/txnlog/decode.go
+++ b/internal/services/txndiscovery/txnlog/decode.go
@@ -174,11 +174,20 @@ func (r *reader) fail() {
 
 // need reports whether n more bytes are available, latching the truncation error
 // when they are not. Every sized read goes through it.
+//
+// The comparison is written as `n > len(r.b)-r.pos` rather than the more obvious
+// `r.pos+n > len(r.b)` because n is broker-supplied and, in the flexible encoding,
+// arrives from a uvarint rather than an int16 — so it reaches 2^63-1, `r.pos+n`
+// overflows to a NEGATIVE number, and the obvious form reads that as "in bounds"
+// and lets the caller slice with a negative index. Subtraction cannot overflow
+// here: pos never exceeds len(b), which holds because every site that advances pos
+// is gated by this function (the sole exception, uvarint, advances by however much
+// binary.Uvarint consumed from r.b[r.pos:], which is bounded by the same length).
 func (r *reader) need(n int) bool {
 	if r.err != nil {
 		return false
 	}
-	if n < 0 || r.pos+n > len(r.b) {
+	if n < 0 || n > len(r.b)-r.pos {
 		r.fail()
 		return false
 	}

--- a/internal/services/txndiscovery/txnlog/decode.go
+++ b/internal/services/txndiscovery/txnlog/decode.go
@@ -21,6 +21,40 @@ import (
 
 var errTruncated = errors.New("txnlog: truncated record")
 
+// maxTopicEntries caps how many TopicPartitions entries one transaction's footprint may
+// materialise. Exceeding it is a decode error, in the same fail-loud spirit as an
+// unsupported schema version: a footprint this large means the record is not what this
+// decoder thinks it is, and guessing is worse than stopping.
+//
+// The cap is needed because bounding the entry COUNT against the bytes remaining does
+// not bound the MEMORY. An entry costs 40 bytes decoded against as few as 3 bytes on the
+// wire (flexible: uvarint topic length, uvarint partition count, uvarint tagged-field
+// count), and append's ~1.25x regrowth churns roughly 5x the final slice on the way up.
+// A record of honest, well-formed, minimal entries therefore allocates ~37x its length
+// in the classic encoding and ~74x in the flexible one, with no guard entitled to reject
+// it — the count is truthful, there are simply a lot of entries. kcp leaves sarama's
+// MaxResponseSize at its 100 MiB default and a broker need not honour the requested
+// MaxPartitionBytes, so the reachable end of that is ~1.4 GB of live slice and ~3 GB
+// peak during the final regrowth: an OOM-killed multi-hour observation window.
+//
+// 100,000 is chosen to sit far above any legitimate footprint and still far below any
+// allocation worth worrying about:
+//
+//   - Legitimate side. An entry here is one TOPIC in a transaction, not one partition.
+//     __transaction_state and __consumer_offsets default to 50 partitions each; the
+//     largest Kafka Streams footprints are realistically low thousands of
+//     topic-partitions, spread across far fewer topics. 100,000 also exceeds the total
+//     topic count of essentially any real cluster — brokers hit metadata limits well
+//     before that — and a transaction cannot touch more topics than its cluster has. So
+//     the cap is orders of magnitude clear of anything a real producer can produce.
+//   - Allocation side. 100,000 x 40 bytes is 4 MB of entries, ~9 MB peak across the last
+//     regrowth. Single-digit MB is a cost a long-running scan can absorb; gigabytes are
+//     not.
+//
+// The count is known before any entry is read, so exceeding the cap costs no allocation
+// at all rather than a capped one.
+const maxTopicEntries = 100_000
+
 // Key is a decoded __transaction_state record key.
 type Key struct {
 	Version         int16
@@ -307,6 +341,15 @@ func (r *reader) partitions(flexible bool) []TopicPartitions {
 	// allocation.
 	if n < 0 || n > len(r.b)-r.pos {
 		r.fail()
+		return nil
+	}
+	// The guard above rejects a count the remaining bytes cannot back. It says nothing
+	// about a count they CAN back, which is the other half of the problem: see
+	// maxTopicEntries. Distinct wording from errTruncated on purpose — "the bytes ran
+	// out" and "the bytes were all there and there were too many of them" point at
+	// opposite causes when a broker's internal schema drifts.
+	if n > maxTopicEntries {
+		r.err = fmt.Errorf("txnlog: transaction footprint declares %d topic entries, above the %d limit", n, maxTopicEntries)
 		return nil
 	}
 

--- a/internal/services/txndiscovery/txnlog/decode.go
+++ b/internal/services/txndiscovery/txnlog/decode.go
@@ -1,9 +1,11 @@
-// Package txnlog decodes records from Kafka's internal __transaction_state topic.
+// Package txnlog decodes records from Kafka's internal __transaction_state and
+// __consumer_offsets topics.
 //
-// There is no off-the-shelf Go decoder for this format: TransactionLogKey /
-// TransactionLogValue are broker-internal record schemas, not part of the client
-// wire protocol, so no Kafka client library exposes them. This is a hand port of
-// Kafka's TransactionLogKey.json / TransactionLogValue.json schemas.
+// There is no off-the-shelf Go decoder for these formats: TransactionLogKey /
+// TransactionLogValue and the __consumer_offsets record keys are broker-internal
+// record schemas, not part of the client wire protocol, so no Kafka client library
+// for Go exposes them. These are hand ports of Kafka's TransactionLogKey.json,
+// TransactionLogValue.json, OffsetCommitKey.json and GroupMetadataKey.json schemas.
 //
 // The broker is an untrusted input source here: these records are not covered by
 // the stable client protocol and can drift across broker versions. Every read is

--- a/internal/services/txndiscovery/txnlog/decode.go
+++ b/internal/services/txndiscovery/txnlog/decode.go
@@ -1,0 +1,334 @@
+// Package txnlog decodes records from Kafka's internal __transaction_state topic.
+//
+// There is no off-the-shelf Go decoder for this format: TransactionLogKey /
+// TransactionLogValue are broker-internal record schemas, not part of the client
+// wire protocol, so no Kafka client library exposes them. This is a hand port of
+// Kafka's TransactionLogKey.json / TransactionLogValue.json schemas.
+//
+// The broker is an untrusted input source here: these records are not covered by
+// the stable client protocol and can drift across broker versions. Every read is
+// bounds-checked and every unknown schema version is rejected, so malformed or
+// truncated input produces an error rather than a panic or a large allocation.
+package txnlog
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+var errTruncated = errors.New("txnlog: truncated record")
+
+// Key is a decoded __transaction_state record key.
+type Key struct {
+	Version         int16
+	TransactionalID string
+}
+
+// Value is a decoded __transaction_state record value.
+type Value struct {
+	Version       int16
+	ProducerID    int64
+	ProducerEpoch int16
+	TimeoutMs     int32
+	Status        TxnStatus
+	Partitions    []TopicPartitions
+	LastUpdateMs  int64
+	StartMs       int64
+}
+
+// TopicPartitions is one topic and its partitions enrolled in the transaction.
+type TopicPartitions struct {
+	Topic      string
+	Partitions []int32
+}
+
+// Topics returns just the topic names in the footprint.
+func (v Value) Topics() []string {
+	out := make([]string, 0, len(v.Partitions))
+	for _, p := range v.Partitions {
+		out = append(out, p.Topic)
+	}
+	return out
+}
+
+// TxnStatus is the transaction state stored in a log record.
+type TxnStatus int8
+
+const (
+	StatusEmpty             TxnStatus = 0
+	StatusOngoing           TxnStatus = 1
+	StatusPrepareCommit     TxnStatus = 2
+	StatusPrepareAbort      TxnStatus = 3
+	StatusCompleteCommit    TxnStatus = 4
+	StatusCompleteAbort     TxnStatus = 5
+	StatusDead              TxnStatus = 6
+	StatusPrepareEpochFence TxnStatus = 7
+)
+
+// HasFootprint reports whether records in this state carry a topic-partition set.
+// Once a transaction completes (or is empty/dead) the coordinator clears the set.
+func (s TxnStatus) HasFootprint() bool {
+	switch s {
+	case StatusOngoing, StatusPrepareCommit, StatusPrepareAbort:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s TxnStatus) String() string {
+	switch s {
+	case StatusEmpty:
+		return "Empty"
+	case StatusOngoing:
+		return "Ongoing"
+	case StatusPrepareCommit:
+		return "PrepareCommit"
+	case StatusPrepareAbort:
+		return "PrepareAbort"
+	case StatusCompleteCommit:
+		return "CompleteCommit"
+	case StatusCompleteAbort:
+		return "CompleteAbort"
+	case StatusDead:
+		return "Dead"
+	case StatusPrepareEpochFence:
+		return "PrepareEpochFence"
+	default:
+		return fmt.Sprintf("Unknown(%d)", int8(s))
+	}
+}
+
+// DecodeKey decodes a __transaction_state record key. Only key version 0 exists.
+func DecodeKey(b []byte) (Key, error) {
+	r := newReader(b)
+	var k Key
+	k.Version = r.int16()
+	if k.Version != 0 {
+		return k, fmt.Errorf("txnlog: unsupported key version %d", k.Version)
+	}
+	k.TransactionalID = r.str()
+	if r.err != nil {
+		return k, r.err
+	}
+	return k, nil
+}
+
+// DecodeValue decodes a __transaction_state record value (schema v0 or v1).
+//
+// Two encodings exist. v0 is the classic (non-flexible) encoding; v1 is "flexible" —
+// compact (varint-prefixed) strings and arrays plus a trailing tagged-fields section
+// on every struct. Both are decoded, reading only the normal fields (the footprint)
+// and skipping tagged fields. The leading int16 schema version selects the encoding.
+func DecodeValue(b []byte) (Value, error) {
+	r := newReader(b)
+	var v Value
+	v.Version = r.int16()
+	if v.Version < 0 || v.Version > 1 {
+		// This is the format-drift signal: a version we don't understand means the
+		// internal schema changed, so we fail loudly rather than mis-parse.
+		return v, fmt.Errorf("txnlog: unsupported value version %d", v.Version)
+	}
+	flexible := v.Version >= 1
+
+	v.ProducerID = r.int64()
+	v.ProducerEpoch = r.int16()
+	v.TimeoutMs = r.int32()
+	v.Status = TxnStatus(r.int8())
+	v.Partitions = r.partitions(flexible)
+	v.LastUpdateMs = r.int64()
+	v.StartMs = r.int64()
+	if flexible {
+		r.skipTaggedFields() // top-level struct
+	}
+
+	if r.err != nil {
+		return v, r.err
+	}
+	return v, nil
+}
+
+// --- primitive reader ---
+
+// reader is a sticky-error, bounds-checked cursor over a broker-supplied byte
+// slice. Once a read runs past the end of the buffer the error latches and every
+// subsequent read is a no-op returning a zero value, so a decoder can read a whole
+// record straight through and check err once at the end instead of after every
+// field. Sibling decoders in this package share it.
+type reader struct {
+	b   []byte
+	pos int
+	err error
+}
+
+func newReader(b []byte) *reader { return &reader{b: b} }
+
+func (r *reader) fail() {
+	if r.err == nil {
+		r.err = errTruncated
+	}
+}
+
+// need reports whether n more bytes are available, latching the truncation error
+// when they are not. Every sized read goes through it.
+func (r *reader) need(n int) bool {
+	if r.err != nil {
+		return false
+	}
+	if n < 0 || r.pos+n > len(r.b) {
+		r.fail()
+		return false
+	}
+	return true
+}
+
+func (r *reader) int8() int8 {
+	if !r.need(1) {
+		return 0
+	}
+	v := int8(r.b[r.pos])
+	r.pos++
+	return v
+}
+
+func (r *reader) int16() int16 {
+	if !r.need(2) {
+		return 0
+	}
+	v := int16(binary.BigEndian.Uint16(r.b[r.pos:]))
+	r.pos += 2
+	return v
+}
+
+func (r *reader) int32() int32 {
+	if !r.need(4) {
+		return 0
+	}
+	v := int32(binary.BigEndian.Uint32(r.b[r.pos:]))
+	r.pos += 4
+	return v
+}
+
+func (r *reader) int64() int64 {
+	if !r.need(8) {
+		return 0
+	}
+	v := int64(binary.BigEndian.Uint64(r.b[r.pos:]))
+	r.pos += 8
+	return v
+}
+
+// str reads a classic (non-flexible) string: int16 length then bytes (-1 = null).
+func (r *reader) str() string {
+	n := int(r.int16())
+	if r.err != nil || n < 0 {
+		return ""
+	}
+	if !r.need(n) {
+		return ""
+	}
+	s := string(r.b[r.pos : r.pos+n])
+	r.pos += n
+	return s
+}
+
+func (r *reader) uvarint() uint64 {
+	if r.err != nil {
+		return 0
+	}
+	v, n := binary.Uvarint(r.b[r.pos:])
+	if n <= 0 {
+		r.fail()
+		return 0
+	}
+	r.pos += n
+	return v
+}
+
+// compactStr reads a flexible compact string: uvarint(len+1) then bytes (0 = null).
+func (r *reader) compactStr() string {
+	c := r.uvarint()
+	if r.err != nil || c == 0 {
+		return ""
+	}
+	n := int(c) - 1
+	if !r.need(n) {
+		return ""
+	}
+	s := string(r.b[r.pos : r.pos+n])
+	r.pos += n
+	return s
+}
+
+func (r *reader) int32Slice(count int) []int32 {
+	// Each int32 is 4 bytes, so a count larger than the remaining bytes is corrupt.
+	// Checked before the make() so a corrupt count cannot size an allocation.
+	if r.err != nil || count < 0 || count > (len(r.b)-r.pos)/4 {
+		r.fail()
+		return nil
+	}
+	out := make([]int32, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, r.int32())
+	}
+	return out
+}
+
+// partitions reads the nullable TransactionPartitions array in either encoding.
+func (r *reader) partitions(flexible bool) []TopicPartitions {
+	var n int
+	if flexible {
+		c := r.uvarint()
+		if r.err != nil || c == 0 { // 0 = null
+			return nil
+		}
+		n = int(c) - 1
+	} else {
+		ln := r.int32()
+		if r.err != nil || ln < 0 { // -1 = null
+			return nil
+		}
+		n = int(ln)
+	}
+	// Every entry costs at least one byte on the wire, so a count exceeding the bytes
+	// left is corrupt. Checked before the make() so a corrupt count cannot size an
+	// allocation.
+	if n < 0 || n > len(r.b)-r.pos {
+		r.fail()
+		return nil
+	}
+
+	out := make([]TopicPartitions, 0, n)
+	for i := 0; i < n && r.err == nil; i++ {
+		var tp TopicPartitions
+		if flexible {
+			tp.Topic = r.compactStr()
+			c := r.uvarint()
+			if c > 0 {
+				tp.Partitions = r.int32Slice(int(c) - 1)
+			}
+			r.skipTaggedFields() // PartitionsSchema struct
+		} else {
+			tp.Topic = r.str()
+			tp.Partitions = r.int32Slice(int(r.int32()))
+		}
+		out = append(out, tp)
+	}
+	return out
+}
+
+// skipTaggedFields consumes a flexible-version tagged-fields section: a uvarint count
+// followed by that many (tag uvarint, size uvarint, size bytes) entries. We keep only
+// the normal fields, so tagged fields are skipped.
+func (r *reader) skipTaggedFields() {
+	count := r.uvarint()
+	for i := uint64(0); i < count && r.err == nil; i++ {
+		_ = r.uvarint() // tag
+		size := int(r.uvarint())
+		if !r.need(size) {
+			return
+		}
+		r.pos += size
+	}
+}

--- a/internal/services/txndiscovery/txnlog/decode.go
+++ b/internal/services/txndiscovery/txnlog/decode.go
@@ -310,7 +310,16 @@ func (r *reader) partitions(flexible bool) []TopicPartitions {
 		return nil
 	}
 
-	out := make([]TopicPartitions, 0, n)
+	// The guard above bounds the COUNT against the bytes remaining; it does not bound
+	// the ALLOCATION, because a TopicPartitions costs 40 bytes in memory and one byte on
+	// the wire. Sizing the prealloc from n directly therefore amplifies the record 40x,
+	// and a count merely proportional to a large record's own size passes the guard —
+	// sarama's response cap is 100 MiB, so that is ~4 GiB and an OOM-killed run. Capping
+	// the prealloc independently of the untrusted count costs a few appends on the
+	// legitimate path (a real footprint of >1024 topics is not a thing) and lets the
+	// bytes themselves, via r.err, decide how far the loop actually gets.
+	const maxPrealloc = 1024
+	out := make([]TopicPartitions, 0, min(n, maxPrealloc))
 	for i := 0; i < n && r.err == nil; i++ {
 		var tp TopicPartitions
 		if flexible {

--- a/internal/services/txndiscovery/txnlog/decode_test.go
+++ b/internal/services/txndiscovery/txnlog/decode_test.go
@@ -1,0 +1,389 @@
+package txnlog
+
+import (
+	"encoding/binary"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- wire-format fixture builders ---
+//
+// These hand-assemble the Kafka broker-internal record layout byte by byte. They
+// are deliberately NOT built with a Kafka encoding library: a fixture produced by
+// the same library the decoder is written against would only prove the decoder
+// agrees with itself, and would keep agreeing after a shared misunderstanding of
+// the format. Assembling the bytes independently is what makes these tests able to
+// catch a decoder that reads the wrong field width or order.
+
+func be16(v int16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(v))
+	return b
+}
+
+func be32(v int32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(v))
+	return b
+}
+
+func be64(v int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+func uvar(v uint64) []byte {
+	b := make([]byte, binary.MaxVarintLen64)
+	return b[:binary.PutUvarint(b, v)]
+}
+
+// kstr encodes a classic (non-flexible) string: int16 length, then the bytes.
+func kstr(s string) []byte { return append(be16(int16(len(s))), s...) }
+
+// cstr encodes a flexible compact string: uvarint(len+1), then the bytes.
+func cstr(s string) []byte { return append(uvar(uint64(len(s))+1), s...) }
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func TestDecodeKey_V0(t *testing.T) {
+	// Key schema v0: int16 version, then a classic string transactional id.
+	b := concat(
+		be16(0),            // version = 0
+		kstr("my-app-0_0"), // transactionalId
+	)
+
+	k, err := DecodeKey(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(0), k.Version)
+	assert.Equal(t, "my-app-0_0", k.TransactionalID)
+}
+
+func TestDecodeValue_V0_ClassicEncodingWithMultipleTopics(t *testing.T) {
+	// Value schema v0 is the classic (non-flexible) encoding: fixed-width integers,
+	// int16-prefixed strings, int32-prefixed arrays, no tagged-field sections. One
+	// of the topics is internal, which is what the footprint of a read-process-write
+	// transaction looks like on the wire.
+	b := concat(
+		be16(0),     // version = 0
+		be64(42),    // producerId
+		be16(5),     // producerEpoch
+		be32(60000), // timeoutMs
+		[]byte{1},   // status = Ongoing
+		be32(2),     // partitions array length = 2
+
+		kstr("t1"),                 // topic
+		be32(1),                    // partitionIds length = 1
+		be32(0),                    // partition 0
+		kstr("__consumer_offsets"), // topic
+		be32(1),                    // partitionIds length = 1
+		be32(12),                   // partition 12
+
+		be64(1000), // lastUpdateMs
+		be64(900),  // startMs
+	)
+
+	v, err := DecodeValue(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(0), v.Version)
+	assert.Equal(t, int64(42), v.ProducerID)
+	assert.Equal(t, int16(5), v.ProducerEpoch)
+	assert.Equal(t, int32(60000), v.TimeoutMs)
+	assert.Equal(t, StatusOngoing, v.Status)
+	assert.Equal(t, []TopicPartitions{
+		{Topic: "t1", Partitions: []int32{0}},
+		{Topic: "__consumer_offsets", Partitions: []int32{12}},
+	}, v.Partitions)
+	assert.Equal(t, []string{"t1", "__consumer_offsets"}, v.Topics())
+	assert.Equal(t, int64(1000), v.LastUpdateMs)
+	assert.Equal(t, int64(900), v.StartMs)
+}
+
+func TestDecodeValue_V1_FlexibleEncoding(t *testing.T) {
+	// Value schema v1 is the "flexible" encoding: strings and arrays carry a
+	// uvarint(len+1) prefix instead of a fixed-width one, and every struct ends with
+	// a tagged-fields section. Fixed-width integer fields are unaffected.
+	b := concat(
+		be16(1),     // version = 1 -> flexible
+		be64(7),     // producerId
+		be16(1),     // producerEpoch
+		be32(30000), // timeoutMs
+		[]byte{2},   // status = PrepareCommit
+		uvar(1+1),   // compact partitions array length = 1
+
+		cstr("a"), // topic
+		uvar(1+1), // compact partitionIds length = 1
+		be32(3),   // partition 3
+		uvar(0),   // PartitionsSchema tagged fields = 0
+
+		be64(2), // lastUpdateMs
+		be64(1), // startMs
+		uvar(0), // top-level tagged fields = 0
+	)
+
+	v, err := DecodeValue(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(1), v.Version)
+	assert.Equal(t, int64(7), v.ProducerID)
+	assert.Equal(t, StatusPrepareCommit, v.Status)
+	assert.Equal(t, []TopicPartitions{{Topic: "a", Partitions: []int32{3}}}, v.Partitions)
+	assert.Equal(t, int64(2), v.LastUpdateMs)
+	assert.Equal(t, int64(1), v.StartMs)
+}
+
+func TestDecodeValue_V1_SkipsPopulatedTaggedFields(t *testing.T) {
+	// Tagged fields are how Kafka adds optional fields to a flexible schema without
+	// a version bump, so a broker upgrade can start populating them at any time. We
+	// read none of them, but we must step over them exactly: the first topic below
+	// carries a populated tagged-fields section, so the second topic only decodes if
+	// the skip consumed the right number of bytes.
+	b := concat(
+		be16(1),    // version = 1 -> flexible
+		be64(9),    // producerId
+		be16(0),    // producerEpoch
+		be32(1000), // timeoutMs
+		[]byte{1},  // status = Ongoing
+		uvar(2+1),  // compact partitions array length = 2
+
+		cstr("x"),          // topic
+		uvar(1+1),          // compact partitionIds length = 1
+		be32(0),            // partition 0
+		uvar(1),            // PartitionsSchema tagged fields: ONE entry
+		uvar(99),           // tag = 99
+		uvar(2),            // size = 2
+		[]byte{0xAB, 0xCD}, // opaque tagged payload
+
+		cstr("y"), // topic
+		uvar(1+1), // compact partitionIds length = 1
+		be32(7),   // partition 7
+		uvar(0),   // PartitionsSchema tagged fields = 0
+
+		be64(0), // lastUpdateMs
+		be64(0), // startMs
+
+		uvar(1),                  // top-level tagged fields: ONE entry
+		uvar(5),                  // tag = 5
+		uvar(3),                  // size = 3
+		[]byte{0x01, 0x02, 0x03}, // opaque tagged payload
+	)
+
+	v, err := DecodeValue(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x", "y"}, v.Topics())
+	assert.Equal(t, []TopicPartitions{
+		{Topic: "x", Partitions: []int32{0}},
+		{Topic: "y", Partitions: []int32{7}},
+	}, v.Partitions)
+}
+
+func TestTxnStatus_HasFootprint(t *testing.T) {
+	// Only the in-flight states carry a topic-partition set. Once a transaction
+	// completes — or is empty, dead, or fenced — the coordinator clears the set, so
+	// treating those records as footprints would silently shrink a transaction's
+	// topics back to nothing.
+	cases := map[TxnStatus]bool{
+		StatusEmpty:             false,
+		StatusOngoing:           true,
+		StatusPrepareCommit:     true,
+		StatusPrepareAbort:      true,
+		StatusCompleteCommit:    false,
+		StatusCompleteAbort:     false,
+		StatusDead:              false,
+		StatusPrepareEpochFence: false,
+	}
+
+	for status, want := range cases {
+		assert.Equal(t, want, status.HasFootprint(), "HasFootprint for status %d", int8(status))
+	}
+}
+
+func TestTxnStatus_String(t *testing.T) {
+	// Callers bucket counters by status name, so an unrecognised code has to render
+	// as something distinguishable rather than collapsing into a known bucket.
+	cases := map[TxnStatus]string{
+		StatusEmpty:             "Empty",
+		StatusOngoing:           "Ongoing",
+		StatusPrepareCommit:     "PrepareCommit",
+		StatusPrepareAbort:      "PrepareAbort",
+		StatusCompleteCommit:    "CompleteCommit",
+		StatusCompleteAbort:     "CompleteAbort",
+		StatusDead:              "Dead",
+		StatusPrepareEpochFence: "PrepareEpochFence",
+		TxnStatus(42):           "Unknown(42)",
+	}
+
+	for status, want := range cases {
+		assert.Equal(t, want, status.String())
+	}
+}
+
+// --- abuse cases: the broker is untrusted input ---
+
+func TestDecodeKey_UnsupportedVersionIsRejected(t *testing.T) {
+	// Only key version 0 exists today. A future version could reorder or retype
+	// fields, so decoding one on the assumption it still looks like v0 would hand
+	// back a plausible-looking transactional id that is actually garbage. Fail loud.
+	b := concat(
+		be16(1),   // version = 1 -> does not exist
+		kstr("x"), // a byte sequence that IS a valid v0 body
+	)
+
+	_, err := DecodeKey(b)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported key version")
+}
+
+func TestDecodeValue_UnsupportedVersionIsRejected(t *testing.T) {
+	// Both of these bodies are structurally valid for one of the two encodings, so a
+	// decoder that guessed at the encoding from the version would return clean,
+	// wrong data. Rejecting the version is what makes format drift loud.
+	tests := map[string][]byte{
+		"above the known range": concat(
+			be16(2), // version = 2 -> unknown
+			be64(1), be16(0), be32(0),
+			[]byte{1}, // status
+			uvar(0),   // compact partitions array = null
+			be64(0), be64(0),
+			uvar(0), // tagged fields = 0
+		),
+		"negative": concat(
+			be16(-1), // version = -1 -> nonsense
+			be64(1), be16(0), be32(0),
+			[]byte{1}, // status
+			be32(0),   // classic partitions array length = 0
+			be64(0), be64(0),
+		),
+	}
+
+	for name, b := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := DecodeValue(b)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported value version")
+		})
+	}
+}
+
+func TestDecodeValue_EveryTruncatedPrefixErrorsWithoutPanicking(t *testing.T) {
+	// A fetch can be cut at any byte boundary, and a compacted or drifted record can
+	// end anywhere. Walking every prefix of a known-good record is the cheapest way
+	// to prove no read path indexes past the end of the buffer.
+	valid := map[string][]byte{
+		"v0 classic": concat(
+			be16(0), be64(42), be16(5), be32(60000),
+			[]byte{1}, // Ongoing
+			be32(1),   // one topic
+			kstr("t1"), be32(1), be32(0),
+			be64(1), be64(2),
+		),
+		"v1 flexible with tagged fields": concat(
+			be16(1), be64(7), be16(1), be32(30000),
+			[]byte{2}, // PrepareCommit
+			uvar(1+1), // one topic
+			cstr("a"), uvar(1+1), be32(3),
+			uvar(1), uvar(99), uvar(2), []byte{0xAB, 0xCD}, // populated tagged fields
+			be64(2), be64(1),
+			uvar(0),
+		),
+	}
+
+	for name, full := range valid {
+		t.Run(name, func(t *testing.T) {
+			// Sanity: the un-truncated record must decode, or the prefixes prove nothing.
+			_, err := DecodeValue(full)
+			require.NoError(t, err, "fixture itself must be valid")
+
+			for i := 0; i < len(full); i++ {
+				var decodeErr error
+				require.NotPanics(t, func() { _, decodeErr = DecodeValue(full[:i]) },
+					"prefix length %d panicked", i)
+				require.Error(t, decodeErr, "prefix length %d decoded without error", i)
+			}
+		})
+	}
+}
+
+func TestDecodeKey_EveryTruncatedPrefixErrorsWithoutPanicking(t *testing.T) {
+	full := concat(be16(0), kstr("my-app-0_0"))
+
+	_, err := DecodeKey(full)
+	require.NoError(t, err, "fixture itself must be valid")
+
+	for i := 0; i < len(full); i++ {
+		var decodeErr error
+		require.NotPanics(t, func() { _, decodeErr = DecodeKey(full[:i]) },
+			"prefix length %d panicked", i)
+		require.Error(t, decodeErr, "prefix length %d decoded without error", i)
+	}
+}
+
+func TestDecodeValue_ArrayCountLargerThanBufferIsRejectedBeforeAllocating(t *testing.T) {
+	// An array's element count is broker-supplied, and every element needs at least
+	// one byte on the wire, so a count exceeding the bytes left is impossible. Sizing
+	// an allocation from it first and discovering the truncation second turns a
+	// corrupt 40-byte record into a multi-gigabyte allocation. Erroring is not enough
+	// on its own — the rejection has to happen before the make().
+	const (
+		hugeTopicCount     = 2_000_000  // x40 bytes/element if allocated
+		hugePartitionCount = 20_000_000 // x4 bytes/element if allocated
+		allocBudget        = 1 << 20    // 1 MiB
+	)
+
+	tests := map[string][]byte{
+		"classic topic array count exceeds buffer": concat(
+			be16(0), be64(1), be16(0), be32(0),
+			[]byte{1},            // status
+			be32(hugeTopicCount), // array length, with zero bytes following
+		),
+		"flexible topic array count exceeds buffer": concat(
+			be16(1), be64(1), be16(0), be32(0),
+			[]byte{1},              // status
+			uvar(hugeTopicCount+1), // compact array length, with zero bytes following
+		),
+		"partition id count exceeds buffer": concat(
+			be16(0), be64(1), be16(0), be32(0),
+			[]byte{1}, // status
+			be32(1),   // one topic
+			kstr("t"),
+			be32(hugePartitionCount), // partitionIds length, with zero bytes following
+		),
+		"negative partition id count": concat(
+			be16(0), be64(1), be16(0), be32(0),
+			[]byte{1}, // status
+			be32(1),   // one topic
+			kstr("t"),
+			be32(-1), // a negative length is not a null marker here
+		),
+	}
+
+	for name, b := range tests {
+		t.Run(name, func(t *testing.T) {
+			var before, after runtime.MemStats
+			var decodeErr error
+
+			runtime.ReadMemStats(&before)
+			require.NotPanics(t, func() { _, decodeErr = DecodeValue(b) })
+			runtime.ReadMemStats(&after)
+
+			require.Error(t, decodeErr)
+			assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocBudget),
+				"decoding a %d-byte record allocated more than %d bytes, so the count was trusted before it was checked",
+				len(b), allocBudget)
+		})
+	}
+}

--- a/internal/services/txndiscovery/txnlog/decode_test.go
+++ b/internal/services/txndiscovery/txnlog/decode_test.go
@@ -491,3 +491,96 @@ func TestDecodeValue_UvarintLengthNearMaxInt64DoesNotOverflowTheBoundsGuard(t *t
 		})
 	}
 }
+
+// minimalFootprintRecord builds a COMPLETE, WELL-FORMED value record whose topic array
+// holds n minimal entries: an empty topic name and an empty partition list.
+//
+// Nothing here is corrupt, truncated or inconsistent — the declared count matches the
+// entries that follow and every length prefix is honest — so none of the package's
+// bounds guards have grounds to reject it. That is what separates this shape from the
+// count-driven amplification the guards already catch. It is simply the cheapest legal
+// wire encoding of a TopicPartitions: 6 bytes classic, 3 bytes flexible, against 40
+// bytes of decoded struct.
+func minimalFootprintRecord(n int, flexible bool) []byte {
+	if flexible {
+		return concat(
+			be16(1), be64(1), be16(0), be32(0), []byte{1}, // header, status = Ongoing
+			uvar(uint64(n)+1), // compact array length
+			bytes.Repeat(concat(uvar(1), uvar(1), uvar(0)), n), // "" topic, empty partitions, no tagged fields
+			be64(1000), be64(900), uvar(0),
+		)
+	}
+	return concat(
+		be16(0), be64(1), be16(0), be32(0), []byte{1}, // header, status = Ongoing
+		be32(int32(n)), // array length
+		bytes.Repeat(concat(be16(0), be32(0)), n), // "" topic, zero partitions
+		be64(1000), be64(900),
+	)
+}
+
+var footprintEncodings = map[string]bool{"classic topic array": false, "flexible topic array": true}
+
+func TestDecodeValue_ManyMinimalEntriesDoNotAmplifyIntoTheTopicArray(t *testing.T) {
+	// Capping the PREALLOC closed the count-driven amplification but moved the same
+	// amplification into append's regrowth. A TopicPartitions costs 40 bytes in memory
+	// against as few as 3 bytes on the wire, and growing a slice to N elements churns
+	// roughly 5x its final size, so a record made ENTIRELY of minimal well-formed
+	// entries still allocates tens of times its own length.
+	//
+	// This is not the shape the existing guards catch. Those reject a count that the
+	// remaining bytes cannot possibly back; here the count is honest and every entry is
+	// legal — there are simply a lot of them. kcp does not lower sarama's 100 MiB
+	// response cap, and a broker is not obliged to honour the requested
+	// MaxPartitionBytes, so the reachable ceiling is ~1.4 GB of live slice with ~3 GB
+	// peak during the final regrowth. Asserting only on the returned value passes
+	// throughout: the record decodes perfectly.
+	const (
+		// Comfortably past any cap this package would plausibly set, so the decoder is
+		// forced to decide on the count rather than materialise its way to the answer.
+		entries = 200_000
+
+		// A well-formed record may cost a small constant multiple of its own bytes; it
+		// may not cost tens of times them.
+		allocPerInputByte = 4
+	)
+
+	for name, flexible := range footprintEncodings {
+		t.Run(name, func(t *testing.T) {
+			b := minimalFootprintRecord(entries, flexible)
+
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			require.NotPanics(t, func() { _, _ = DecodeValue(b) })
+			runtime.ReadMemStats(&after)
+
+			got := after.TotalAlloc - before.TotalAlloc
+			budget := uint64(allocPerInputByte * len(b))
+			assert.Less(t, got, budget,
+				"decoding %d bytes of well-formed minimal entries allocated %d bytes (%.1fx the input, budget %d): "+
+					"the entry count is honest, so nothing rejects it — the decoder has to bound how many entries it will materialise",
+				len(b), got, float64(got)/float64(len(b)), budget)
+		})
+	}
+}
+
+func TestDecodeValue_FootprintAtTheEntryLimitDecodesAndOneEntryBeyondIsRejected(t *testing.T) {
+	// Proves the cap is where the constant says it is, in both encodings, and that it
+	// does not truncate a legitimate large footprint into a short one. The over-limit
+	// error must also be tellable apart from a truncation: the two mean opposite things
+	// when a real broker's schema drifts, one "the bytes ran out" and the other "the
+	// bytes were all there and there were too many of them".
+	for name, flexible := range footprintEncodings {
+		t.Run(name, func(t *testing.T) {
+			atLimit := minimalFootprintRecord(maxTopicEntries, flexible)
+			v, err := DecodeValue(atLimit)
+			require.NoError(t, err, "a footprint of exactly %d entries is within the cap and must decode", maxTopicEntries)
+			require.Len(t, v.Partitions, maxTopicEntries, "the whole footprint must be returned, not a truncated prefix of it")
+
+			overLimit := minimalFootprintRecord(maxTopicEntries+1, flexible)
+			_, err = DecodeValue(overLimit)
+			require.Error(t, err, "a footprint of %d entries is past the cap and must be rejected", maxTopicEntries+1)
+			assert.NotErrorIs(t, err, errTruncated, "an over-limit footprint must not be reported as a truncated record")
+			assert.Contains(t, err.Error(), "topic entries", "the error must name what was exceeded so a real schema drift is diagnosable")
+		})
+	}
+}

--- a/internal/services/txndiscovery/txnlog/decode_test.go
+++ b/internal/services/txndiscovery/txnlog/decode_test.go
@@ -2,6 +2,7 @@ package txnlog
 
 import (
 	"encoding/binary"
+	"math"
 	"runtime"
 	"testing"
 
@@ -384,6 +385,57 @@ func TestDecodeValue_ArrayCountLargerThanBufferIsRejectedBeforeAllocating(t *tes
 			assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocBudget),
 				"decoding a %d-byte record allocated more than %d bytes, so the count was trusted before it was checked",
 				len(b), allocBudget)
+		})
+	}
+}
+
+func TestDecodeValue_UvarintLengthNearMaxInt64DoesNotOverflowTheBoundsGuard(t *testing.T) {
+	// The bounds guard used to test `pos + n > len(b)`. In the classic encoding n comes
+	// from an int16 and cannot exceed 32767, so the sum never overflows — which is why
+	// every existing truncation test passes. In the FLEXIBLE encoding n comes from a
+	// uvarint and can be up to 2^63-1, so `pos + n` wraps to a negative number, the
+	// guard reads it as "in bounds", and the slice that follows panics:
+	//
+	//	panic: runtime error: slice bounds out of range [:-9223372036854775783]
+	//
+	// The package's stated invariant is that malformed broker input yields a counted
+	// error, never a panic. Nothing in kcp recovers, and this decodes on a reader
+	// goroutine, so a ~30-byte malformed record kills a multi-hour observation window
+	// with no YAML, no stats and an unclosed audit log.
+	tests := map[string][]byte{
+		// compactStr: n := int(uvarint) - 1, straight into need(n) and then a slice.
+		"compact string length": concat(
+			be16(1),   // version 1 = flexible
+			be64(1),   // producerId
+			be16(0),   // producerEpoch
+			be32(0),   // timeoutMs
+			[]byte{1}, // status = Ongoing
+			uvar(2),   // compact array: one topic entry
+			uvar(math.MaxInt64),
+		),
+		// skipTaggedFields: need(size) passes, `pos += size` drives pos negative, and
+		// the NEXT read panics rather than this one — the corruption outlives the field.
+		"tagged field size": concat(
+			be16(1),   // version 1 = flexible
+			be64(1),   // producerId
+			be16(0),   // producerEpoch
+			be32(0),   // timeoutMs
+			[]byte{1}, // status = Ongoing
+			uvar(2),   // compact array: one topic entry
+			cstr("t"), // topic
+			uvar(0),   // partition ids: null compact array
+			uvar(1),   // tagged fields: one entry
+			uvar(0),   // tag number
+			uvar(math.MaxInt64),
+		),
+	}
+
+	for name, b := range tests {
+		t.Run(name, func(t *testing.T) {
+			var decodeErr error
+			require.NotPanics(t, func() { _, decodeErr = DecodeValue(b) },
+				"a %d-byte malformed record panicked instead of erroring", len(b))
+			require.Error(t, decodeErr)
 		})
 	}
 }

--- a/internal/services/txndiscovery/txnlog/decode_test.go
+++ b/internal/services/txndiscovery/txnlog/decode_test.go
@@ -1,6 +1,7 @@
 package txnlog
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"runtime"
@@ -384,6 +385,57 @@ func TestDecodeValue_ArrayCountLargerThanBufferIsRejectedBeforeAllocating(t *tes
 			require.Error(t, decodeErr)
 			assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocBudget),
 				"decoding a %d-byte record allocated more than %d bytes, so the count was trusted before it was checked",
+				len(b), allocBudget)
+		})
+	}
+}
+
+func TestDecodeValue_LargeRecordDoesNotAmplifyItsOwnSizeIntoTheTopicArrayPrealloc(t *testing.T) {
+	// The array-count guard reasons "every entry costs at least one byte on the wire",
+	// so it accepts any count up to the bytes remaining. That bounds the COUNT, not the
+	// ALLOCATION: a TopicPartitions is a string header plus a slice header, 40 bytes, so
+	// a count merely PROPORTIONAL to the record's own size sails through the guard and
+	// preallocates 40x the record.
+	//
+	// This is what the existing count-exceeds-buffer test misses. It uses a small record
+	// with an absurd count, which the guard correctly rejects. The reachable shape is a
+	// large record with a self-consistent count, and kcp does not lower
+	// sarama.MaxResponseSize from its 100 MiB default (nor can it make a broker honour
+	// the requested MaxPartitionBytes), so one response drives a ~4 GiB allocation and
+	// OOM-kills a multi-hour run. Asserting only on the returned error passes throughout.
+	const allocBudget = 4 << 20 // 4 MiB, four times the record
+
+	// 0xFF filler so the first loop iteration fails fast: what is being measured is the
+	// prealloc, not the cost of parsing a megabyte of plausible entries.
+	filler := bytes.Repeat([]byte{0xFF}, 1<<20)
+	header := concat(
+		be16(0),   // version, overwritten per case below
+		be64(1),   // producerId
+		be16(0),   // producerEpoch
+		be32(0),   // timeoutMs
+		[]byte{1}, // status = Ongoing
+	)
+
+	classic := concat(header, be32(int32(len(filler))), filler)
+	flexible := concat(header, uvar(uint64(len(filler))+1), filler)
+	flexible[1] = 1 // version 1 = flexible
+
+	for name, b := range map[string][]byte{
+		"classic topic array":  classic,
+		"flexible topic array": flexible,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var before, after runtime.MemStats
+			var decodeErr error
+
+			runtime.ReadMemStats(&before)
+			require.NotPanics(t, func() { _, decodeErr = DecodeValue(b) })
+			runtime.ReadMemStats(&after)
+
+			require.Error(t, decodeErr)
+			assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocBudget),
+				"decoding a %d-byte record allocated more than %d bytes: the entry count was "+
+					"bounded against the bytes remaining, but the allocation it sizes is 40 bytes an entry",
 				len(b), allocBudget)
 		})
 	}

--- a/internal/services/txndiscovery/txnlog/fuzz_test.go
+++ b/internal/services/txndiscovery/txnlog/fuzz_test.go
@@ -1,0 +1,205 @@
+package txnlog
+
+import (
+	"bytes"
+	"math"
+	"runtime"
+	"testing"
+)
+
+// Fuzz targets for the three broker-internal record decoders.
+//
+// These decoders are the package's whole untrusted-input surface: the records are not
+// covered by the stable client protocol, they drift across broker versions, and whoever
+// controls the broker's bytes controls every length prefix and array count in them.
+//
+// Each target asserts the two invariants the package documents, and NOT that decoding
+// succeeds — a decode error is the correct outcome for almost all random input, so
+// asserting success would only teach the fuzzer to stop exploring:
+//
+//  1. No panic. Nothing in kcp calls recover() and these decode on a reader goroutine,
+//     so a panic is an unconditionally fatal end to a multi-hour observation window.
+//  2. Allocation bounded by INPUT SIZE. This is the property an error-only assertion
+//     silently passes: the pre-fix decoder returned a perfectly good "truncated record"
+//     error while allocating 40 MiB from a 1 MiB input, because the guard bounded the
+//     array COUNT and the count sized an allocation of 40 bytes an entry.
+
+const (
+	// fuzzAllocFloor is a fixed allowance added to every budget, covering two things.
+	// First, the decoder's own size-independent ceiling: the topic-array prealloc is
+	// capped at 1024 entries x 40 bytes ~= 40 KiB regardless of input. Second, noise —
+	// runtime.MemStats.TotalAlloc is process-wide and cumulative, so under `go test
+	// -fuzz` the fuzzing engine's own goroutines contribute to the delta. A floor this
+	// far above the decoder's ceiling keeps the target from flaking on that noise while
+	// still leaving the per-byte term to do the actual work on large inputs.
+	fuzzAllocFloor = 1 << 20
+
+	// valueAllocPerInputByte bounds DecodeValue's growth in input size.
+	//
+	// Chosen at 12 to sit between the two things that have to be separated. Below it:
+	// the fixed decoder ceiling and every legitimate footprint, which allocate in the
+	// tens of kilobytes. Above it: the finding-2 regression, which allocated 40.0x its
+	// input (41943280 bytes from 1048597) — reverting that fix has to make this target
+	// fail, and at 12 it does, with room to spare.
+	//
+	// It is deliberately NOT the decoder's structural worst case. A TopicPartitions
+	// costs 40 bytes in memory against as few as 3 bytes on the wire, and append's
+	// regrowth multiplies the total by a further ~5, so a large input consisting
+	// ENTIRELY of minimal well-formed entries can still exceed this. That residual is
+	// real and is called out in the fix for finding 2; this constant is set to catch the
+	// count-driven amplification, not to certify the structural ratio.
+	valueAllocPerInputByte = 12
+
+	// keyAllocPerInputByte bounds the two key decoders, which allocate only the strings
+	// they copy out — never more than the input itself. 4 leaves room for the string
+	// headers and the size-class rounding on a short copy without leaving room for an
+	// allocation driven by anything other than the bytes present.
+	keyAllocPerInputByte = 4
+)
+
+// assertGracefulAndBounded runs decode on in and asserts the two invariants. Any panic
+// propagates as a fuzz failure with the input recorded, which is the behaviour wanted:
+// the panic itself is the defect, and re-raising it keeps the stack intact.
+func assertGracefulAndBounded(t *testing.T, in []byte, perByte uint64, decode func([]byte)) {
+	t.Helper()
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	decode(in)
+	runtime.ReadMemStats(&after)
+
+	got := after.TotalAlloc - before.TotalAlloc
+	budget := uint64(fuzzAllocFloor) + perByte*uint64(len(in))
+	if got > budget {
+		t.Fatalf("decoding %d bytes allocated %d, over the %d budget (%d + %d/byte): "+
+			"allocation is being driven by a broker-supplied count rather than by the bytes present",
+			len(in), got, budget, fuzzAllocFloor, perByte)
+	}
+}
+
+// --- shared seeds ---
+
+// pocUvarintOverflowCompactStr is the finding-1 reproduction for the compactStr path: a
+// flexible v1 value whose topic length is a uvarint near MaxInt64, so `pos + n` overflows
+// int64, the bounds guard reads the negative sum as in-bounds, and the slice panics.
+func pocUvarintOverflowCompactStr() []byte {
+	return concat(
+		be16(1), be64(1), be16(0), be32(0), []byte{1},
+		uvar(2), // compact array: one topic entry
+		uvar(math.MaxInt64),
+	)
+}
+
+// pocUvarintOverflowTaggedField is the finding-1 reproduction for the skipTaggedFields
+// path, where the guard passes, `pos += size` drives pos negative, and the NEXT read is
+// what panics.
+func pocUvarintOverflowTaggedField() []byte {
+	return concat(
+		be16(1), be64(1), be16(0), be32(0), []byte{1},
+		uvar(2), cstr("t"), uvar(0),
+		uvar(1), uvar(0), uvar(math.MaxInt64),
+	)
+}
+
+// pocCountAmplification is the finding-2 reproduction: a large record whose topic-array
+// count is merely PROPORTIONAL to its own size, so it passes the "every entry costs a
+// byte on the wire" guard while sizing a 40-bytes-an-entry prealloc.
+func pocCountAmplification() []byte {
+	filler := bytes.Repeat([]byte{0xFF}, 1<<20)
+	return concat(be16(0), be64(1), be16(0), be32(0), []byte{1}, be32(int32(len(filler))), filler)
+}
+
+// validValueV0 is the classic-encoding fixture from decode_test.go, including the
+// internal topic that makes a footprint read-process-write.
+func validValueV0() []byte {
+	return concat(
+		be16(0), be64(42), be16(5), be32(60000), []byte{1},
+		be32(2),
+		kstr("t1"), be32(1), be32(0),
+		kstr("__consumer_offsets"), be32(1), be32(12),
+		be64(1000), be64(900),
+	)
+}
+
+// validValueV1 is the flexible-encoding fixture: compact lengths plus a tagged-fields
+// section on every struct.
+func validValueV1() []byte {
+	return concat(
+		be16(1), be64(7), be16(1), be32(30000), []byte{2},
+		uvar(1+1),
+		cstr("a"), uvar(1+1), be32(3), uvar(0),
+		be64(2000), be64(1900), uvar(0),
+	)
+}
+
+// addPrefixes seeds truncated prefixes of b. A record cut short is the ordinary case
+// this decoder meets on a real cluster — a fetch response ends at a partition boundary —
+// so every prefix has to end in a counted error rather than a panic.
+func addPrefixes(f *testing.F, b []byte) {
+	for _, n := range []int{0, 1, 2, 3, 5, 8, 13, 17, 21, 30} {
+		if n <= len(b) {
+			f.Add(b[:n])
+		}
+	}
+}
+
+// --- targets ---
+
+func FuzzDecodeValue(f *testing.F) {
+	f.Add(pocUvarintOverflowCompactStr())
+	f.Add(pocUvarintOverflowTaggedField())
+	f.Add(pocCountAmplification())
+	f.Add(validValueV0())
+	f.Add(validValueV1())
+	addPrefixes(f, validValueV0())
+	addPrefixes(f, validValueV1())
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		assertGracefulAndBounded(t, b, valueAllocPerInputByte, func(in []byte) {
+			v, err := DecodeValue(in)
+			if err == nil {
+				// Touch the decoded footprint so a decoder that returned success while
+				// leaving a slice header pointing somewhere impossible is caught here
+				// rather than in the caller that reads it.
+				_ = v.Topics()
+			}
+		})
+	})
+}
+
+func FuzzDecodeKey(f *testing.F) {
+	valid := concat(be16(0), kstr("my-app-0_0"))
+	f.Add(valid)
+	f.Add(concat(be16(0), be16(math.MaxInt16)))       // length past the end
+	f.Add(concat(be16(0), be16(-1)))                  // null string marker
+	f.Add(concat(be16(1), kstr("x")))                 // unsupported version
+	f.Add(concat(be16(0), be16(0), be16(0), be16(0))) // a control-marker-shaped key
+	addPrefixes(f, valid)
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		assertGracefulAndBounded(t, b, keyAllocPerInputByte, func(in []byte) {
+			_, _ = DecodeKey(in)
+		})
+	})
+}
+
+func FuzzDecodeOffsetKey(f *testing.F) {
+	commitV0 := concat(be16(0), kstr("payments-eos"), kstr("orders.in"), be32(7))
+	commitV1 := concat(be16(1), kstr("inventory-eos"), kstr("stock.updates"), be32(3))
+	groupMetaV2 := concat(be16(2), kstr("payments-eos"))
+
+	f.Add(commitV0)
+	f.Add(commitV1)
+	f.Add(groupMetaV2)
+	f.Add(concat(be16(3), kstr("g")))                      // unsupported version
+	f.Add(concat(be16(0), be16(math.MaxInt16), kstr("t"))) // group length past the end
+	f.Add(concat(be16(0), kstr("g"), be16(math.MaxInt16))) // topic length past the end
+	addPrefixes(f, commitV0)
+	addPrefixes(f, groupMetaV2)
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		assertGracefulAndBounded(t, b, keyAllocPerInputByte, func(in []byte) {
+			_, _ = DecodeOffsetKey(in)
+		})
+	})
+}

--- a/internal/services/txndiscovery/txnlog/fuzz_test.go
+++ b/internal/services/txndiscovery/txnlog/fuzz_test.go
@@ -40,14 +40,23 @@ const (
 	// the fixed decoder ceiling and every legitimate footprint, which allocate in the
 	// tens of kilobytes. Above it: the finding-2 regression, which allocated 40.0x its
 	// input (41943280 bytes from 1048597) — reverting that fix has to make this target
-	// fail, and at 12 it does, with room to spare.
+	// fail on the pocCountAmplification seed, and at 12 it does, with room to spare.
 	//
-	// It is deliberately NOT the decoder's structural worst case. A TopicPartitions
-	// costs 40 bytes in memory against as few as 3 bytes on the wire, and append's
-	// regrowth multiplies the total by a further ~5, so a large input consisting
-	// ENTIRELY of minimal well-formed entries can still exceed this. That residual is
-	// real and is called out in the fix for finding 2; this constant is set to catch the
-	// count-driven amplification, not to certify the structural ratio.
+	// It stays at 12 rather than being tightened onto maxTopicEntries, because that cap
+	// does NOT bound the ratio this constant measures. It bounds the ABSOLUTE: the worst
+	// case is now ~22 MB of churn (~8 MB peak) instead of the ~3 GB a 100 MiB response
+	// could previously drive. The worst RATIO is untouched at ~74x, because the cap is
+	// reached with a proportionally smaller input — 100,000 flexible entries is 300 KB in
+	// and 22 MB out, exactly the ratio a 100 MiB input used to give. Certifying that as a
+	// true bound would mean raising this to 71+, at which point neither regression above
+	// clears the budget and this target stops catching either. The two goals cannot share
+	// one per-byte term, so this one keeps the teeth; the cap itself is held by the unit
+	// tests, which is where an assertion that needs a ~300 KB input belongs anyway.
+	//
+	// The corollary is a rule for seeds, and it is why the finding-3 reproduction is not
+	// one: this budget is deliberately BELOW what a legitimate at-the-cap footprint costs,
+	// so any seed near the cap turns a correct decode into a reported crasher. See the
+	// note above FuzzDecodeValue's seeds.
 	valueAllocPerInputByte = 12
 
 	// keyAllocPerInputByte bounds the two key decoders, which allocate only the strings
@@ -108,6 +117,27 @@ func pocCountAmplification() []byte {
 	filler := bytes.Repeat([]byte{0xFF}, 1<<20)
 	return concat(be16(0), be64(1), be16(0), be32(0), []byte{1}, be32(int32(len(filler))), filler)
 }
+
+// The finding-3 reproduction — a wholly WELL-FORMED record carrying more minimal entries
+// than maxTopicEntries allows — is deliberately NOT seeded here. It lives in
+// TestDecodeValue_ManyMinimalEntriesDoNotAmplifyIntoTheTopicArray instead, which runs
+// under the same plain `go test` and catches the same regression.
+//
+// Seeding it would make this target FLAKY, which the unit test cannot be. To exercise the
+// cap an input must declare more than maxTopicEntries entries, so the smallest one is
+// ~300 KB. Drop its count just under the cap — a one-bit mutation of a 3-byte uvarint,
+// and integer fields are exactly what a fuzzer mutates — and the record becomes
+// LEGITIMATE: ~100,000 real entries, ~22 MB allocated, against a budget of 1 MiB +
+// 12/byte = 4.6 MB. That is a reported crasher for input the decoder handled correctly,
+// and it would be one bit-flip from a seed rather than a fluke. Not seeding is what keeps
+// it out of reach: the fuzzer will not assemble 300 KB of well-formed minimal entries by
+// chance. So the seed buys no regression coverage the unit tests lack, and its only novel
+// exploration is around the one boundary that misreports.
+//
+// Keeping the corpus small also keeps execs cheap — the Go fuzzer ships every corpus
+// entry between coordinator and worker on each exec — though run-to-run exec counts on
+// this target vary by more than 2x, so that is a reason to prefer small seeds, not a
+// measurement anyone should quote.
 
 // validValueV0 is the classic-encoding fixture from decode_test.go, including the
 // internal topic that makes a footprint read-process-write.

--- a/internal/services/txndiscovery/txnlog/offsetkey.go
+++ b/internal/services/txndiscovery/txnlog/offsetkey.go
@@ -1,0 +1,58 @@
+package txnlog
+
+import "fmt"
+
+// OffsetKey is a decoded __consumer_offsets record key.
+//
+// Two different schemas share the __consumer_offsets topic, and Version says which
+// one this record carried. Topic and Partition are only meaningful for an offset
+// commit (versions 0 and 1); a group-metadata record (version 2) leaves Topic empty
+// and Partition zero. Callers correlating consumed topics must therefore treat an
+// empty Topic as "not an offset commit" rather than as partition 0 of an unnamed
+// topic.
+type OffsetKey struct {
+	Version   int16
+	Group     string
+	Topic     string
+	Partition int32
+}
+
+// DecodeOffsetKey decodes a __consumer_offsets record key.
+//
+// Like the __transaction_state schemas in this package, these are broker-internal
+// record formats rather than part of the stable client wire protocol, so nothing in
+// the Kafka client ecosystem for Go exposes them and they are hand-ported here from
+// Kafka's OffsetCommitKey.json and GroupMetadataKey.json.
+//
+// A leading int16 version selects the schema. Versions 0 and 1 are OffsetCommitKey
+// {group, topic, partition} — an actual committed offset, and the record this
+// decoder exists to read. Version 2 is GroupMetadataKey {group}: consumer-group
+// state, carrying no topic. Both encodings are classic (non-flexible), so strings
+// are int16-length-prefixed and there are no tagged-field sections.
+//
+// Anything else is rejected. The two schemas are structurally similar enough that a
+// decoder guessing at an unknown version would return a confident, wrong topic name
+// rather than an obvious failure, and that name would be published as a real
+// consumed topic. Failing loudly is what makes format drift visible.
+func DecodeOffsetKey(b []byte) (OffsetKey, error) {
+	r := newReader(b)
+	var k OffsetKey
+	k.Version = r.int16()
+	switch k.Version {
+	case 0, 1:
+		k.Group = r.str()
+		k.Topic = r.str()
+		k.Partition = r.int32()
+	case 2:
+		k.Group = r.str()
+	default:
+		// A truncated key reads as version 0 with the error already latched, so it
+		// falls to the case above and is reported as truncated by the check below,
+		// never as an unsupported version.
+		return k, fmt.Errorf("txnlog: unsupported offset key version %d", k.Version)
+	}
+	if r.err != nil {
+		return k, r.err
+	}
+	return k, nil
+}

--- a/internal/services/txndiscovery/txnlog/offsetkey_test.go
+++ b/internal/services/txndiscovery/txnlog/offsetkey_test.go
@@ -1,0 +1,232 @@
+package txnlog
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The fixtures below are hand-assembled bytes, using the same builders as
+// decode_test.go (be16/be32/kstr/concat). They are deliberately NOT produced by a
+// Kafka encoding library. The POC this decoder replaces built its fixtures with
+// franz-go's kmsg — the very package that also did the decoding — so its tests could
+// only ever prove that kmsg agrees with kmsg. Laying the bytes out by hand, against
+// Kafka's OffsetCommitKey.json / GroupMetadataKey.json schemas, is what makes these
+// tests capable of catching a decoder that reads the wrong field width or order.
+
+func TestDecodeOffsetKey_V0(t *testing.T) {
+	// OffsetCommitKey v0: int16 version, then classic (int16-length-prefixed) strings
+	// for group and topic, then an int32 partition. Non-flexible: no compact lengths
+	// and no tagged-field sections anywhere.
+	b := concat(
+		be16(0),              // version = 0
+		kstr("payments-eos"), // group
+		kstr("orders.in"),    // topic
+		be32(7),              // partition
+	)
+
+	k, err := DecodeOffsetKey(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(0), k.Version)
+	assert.Equal(t, "payments-eos", k.Group)
+	assert.Equal(t, "orders.in", k.Topic)
+	assert.Equal(t, int32(7), k.Partition)
+}
+
+func TestDecodeOffsetKey_V1(t *testing.T) {
+	// OffsetCommitKey v1 is byte-identical in layout to v0 — Kafka bumped the version
+	// for the record VALUE (v1 added commit_timestamp / expire_timestamp), and the key
+	// schema came along for the ride. The decoder must accept it and read the same
+	// three fields; rejecting it would silently drop every offset commit written by a
+	// broker using the v1 key, which is most of them.
+	b := concat(
+		be16(1),               // version = 1
+		kstr("inventory-eos"), // group
+		kstr("stock.updates"), // topic
+		be32(3),               // partition
+	)
+
+	k, err := DecodeOffsetKey(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(1), k.Version)
+	assert.Equal(t, "inventory-eos", k.Group)
+	assert.Equal(t, "stock.updates", k.Topic)
+	assert.Equal(t, int32(3), k.Partition)
+}
+
+func TestDecodeOffsetKey_V2_GroupMetadataCarriesGroupOnly(t *testing.T) {
+	// Version 2 is a different schema sharing the same topic: GroupMetadataKey, which
+	// records consumer-group state rather than a committed offset. It carries the group
+	// and nothing else — no topic, no partition. __consumer_offsets interleaves both
+	// schemas, so a decoder that assumed every key was an OffsetCommitKey would read the
+	// group-metadata body's trailing bytes as a topic name and invent a consumed topic
+	// out of group state. Topic must come back empty so the caller can skip the record.
+	b := concat(
+		be16(2),              // version = 2 -> GroupMetadataKey
+		kstr("payments-eos"), // group, and the whole body
+	)
+
+	k, err := DecodeOffsetKey(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, int16(2), k.Version)
+	assert.Equal(t, "payments-eos", k.Group)
+	assert.Empty(t, k.Topic, "group metadata carries no consumed topic")
+}
+
+// --- abuse cases: the broker is untrusted input ---
+
+func TestDecodeOffsetKey_UnsupportedVersionIsRejected(t *testing.T) {
+	// Every body below is a structurally valid v0 OffsetCommitKey, so a decoder that
+	// ignored the version — or that treated anything unrecognised as v0 — would return
+	// clean, confident, wrong data. __consumer_offsets key schemas have been extended
+	// before (v2 added group metadata), so a v3 is a question of when, not if, and the
+	// correlation in U8 keys on the topic name this returns. Rejecting the version is
+	// what turns that future format drift into a counted decode error instead of a
+	// phantom topic silently folded into a migration group.
+	tests := map[string]int16{
+		"above the known range": 3,
+		"far above":             999,
+		"negative":              -1,
+	}
+
+	for name, version := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := concat(
+				be16(version),
+				kstr("g"), // a byte sequence that IS a valid v0 body
+				kstr("t"), //
+				be32(0),   //
+			)
+
+			_, err := DecodeOffsetKey(b)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported offset key version")
+		})
+	}
+}
+
+func TestDecodeOffsetKey_ShorterThanVersionPrefixIsRejected(t *testing.T) {
+	// The version prefix is the one field read before any routing decision, so a key
+	// too short to hold it is the input most likely to reach an unguarded index. An
+	// empty key is not hypothetical either: __consumer_offsets carries tombstones, and
+	// a fetch can be cut at any byte boundary.
+	tests := map[string][]byte{
+		"nil":       nil,
+		"empty":     {},
+		"one byte":  {0x00},
+		"half of a": {0xFF},
+	}
+
+	for name, b := range tests {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() { _, err = DecodeOffsetKey(b) })
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDecodeOffsetKey_EveryTruncatedPrefixErrorsWithoutPanicking(t *testing.T) {
+	// Walking every prefix of a known-good key is the cheapest proof that no read path
+	// indexes past the end of the buffer. It covers the cut landing mid-length-prefix,
+	// mid-string, and mid-partition — the boundaries a single hand-picked fixture
+	// would miss.
+	valid := map[string][]byte{
+		"v0 offset commit":  concat(be16(0), kstr("payments-eos"), kstr("orders.in"), be32(7)),
+		"v1 offset commit":  concat(be16(1), kstr("inventory-eos"), kstr("stock.updates"), be32(3)),
+		"v2 group metadata": concat(be16(2), kstr("payments-eos")),
+	}
+
+	for name, full := range valid {
+		t.Run(name, func(t *testing.T) {
+			// Sanity: the un-truncated key must decode, or the prefixes prove nothing.
+			_, err := DecodeOffsetKey(full)
+			require.NoError(t, err, "fixture itself must be valid")
+
+			for i := 0; i < len(full); i++ {
+				var decodeErr error
+				require.NotPanics(t, func() { _, decodeErr = DecodeOffsetKey(full[:i]) },
+					"prefix length %d panicked", i)
+				require.Error(t, decodeErr, "prefix length %d decoded without error", i)
+			}
+		})
+	}
+}
+
+func TestDecodeOffsetKey_LengthPrefixBeyondBufferDoesNotOverread(t *testing.T) {
+	// A string's length prefix is broker-supplied, so a drifted or truncated key can
+	// declare more bytes than it carries. Returning an error is NOT sufficient evidence
+	// that this is handled: the record key handed to the decoder is a sub-slice of a
+	// much larger shared fetch buffer, so it has capacity well past its length. An
+	// unguarded `b[pos : pos+n]` stays inside that capacity and is therefore perfectly
+	// legal Go — it silently splices whatever the adjacent record contains into the
+	// group or topic name, with no panic and no error to count.
+	//
+	// That is the failure this test exists to catch, and it is not theoretical: with the
+	// reader's bounds check removed, the v2 case below returns the sentinel verbatim.
+	// The recovered name would then flow into txn-discovery.yaml and the audit log as a
+	// real consumed topic.
+	secret := []byte("ADJACENT-RECORD-BYTES-NOT-OURS")
+
+	// The backing array holds the sentinel; the decoder is only handed the prefix up to
+	// and including the length field, which declares the sentinel's length.
+	backing := concat(be16(2), be16(int16(len(secret))), secret)
+	b := backing[:4]
+	require.Greater(t, cap(b), len(b), "fixture must have spare capacity or it proves nothing")
+
+	var k OffsetKey
+	var err error
+	require.NotPanics(t, func() { k, err = DecodeOffsetKey(b) })
+
+	require.Error(t, err, "a group length longer than the key must be rejected")
+	assert.NotContains(t, k.Group, string(secret),
+		"decoder read past the end of the supplied key into adjacent buffer memory")
+}
+
+func TestDecodeOffsetKey_OversizedLengthPrefixIsRejectedBeforeAllocating(t *testing.T) {
+	// The companion bound to the over-read test above: a declared length must be
+	// checked against the bytes actually present before it is allowed to size an
+	// allocation. A classic string length is an int16, so the ceiling here is 32 KiB
+	// rather than the gigabytes an int32 array count could ask for — the budget is a
+	// backstop that pins the bound if a future field ever carries a wider length, not
+	// the primary teeth. The over-read assertion above is what has teeth for this key.
+	const allocBudget = 1 << 20 // 1 MiB
+
+	tests := map[string][]byte{
+		"group length exceeds buffer": concat(
+			be16(0),     // version = 0
+			be16(32767), // group length: the int16 maximum, with zero bytes following
+		),
+		"topic length exceeds buffer": concat(
+			be16(0),     // version = 0
+			kstr("g"),   // a well-formed group
+			be16(32767), // topic length, with zero bytes following
+		),
+		"group metadata length exceeds buffer": concat(
+			be16(2),     // version = 2
+			be16(32767), // group length, with zero bytes following
+		),
+	}
+
+	for name, b := range tests {
+		t.Run(name, func(t *testing.T) {
+			var before, after runtime.MemStats
+			var decodeErr error
+
+			runtime.ReadMemStats(&before)
+			require.NotPanics(t, func() { _, decodeErr = DecodeOffsetKey(b) })
+			runtime.ReadMemStats(&after)
+
+			require.Error(t, decodeErr)
+			assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocBudget),
+				"decoding a %d-byte key allocated more than %d bytes, so the declared length was trusted before it was checked",
+				len(b), allocBudget)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `kcp migration txn-discovery`, a command that observes a live Kafka cluster for a set window, reconstructs which topics are coupled by transactions, and writes a reviewable `txn-discovery.yaml` alongside a live JSONL audit trace explaining every grouping decision.

Topics coupled by a Kafka transaction must migrate together. Move one without the others and an in-flight transaction spans two clusters, which no cluster link can reconcile. Until now a migration engineer had no way to discover that coupling from kcp — they inferred it from application knowledge, which is exactly the knowledge a customer engagement lacks.

This is a sarama-based reimplementation of the franz-go POC in `utils/transaction-discovery/`, with real test coverage and kcp's full authentication surface (including MSK IAM, which the POC lacks). The POC is untouched and still builds independently.

## Why the Kafka layer was rebuilt rather than ported

`sarama.ConsumerMessage` discards the record-batch header, so the high-level consumer cannot see the producer ID that ties a transactional offset commit to its transaction. That producer ID is what recovers consumed input topics for **non-Streams** exactly-once applications, where no naming convention exists to correlate on. Keeping the capability meant hand-rolling a fetch loop over raw `sarama.Broker.Fetch`, which brings partition discovery, leader resolution, offset tracking, failover, and — most easily missed — **aborted-transaction filtering** into this codebase's ownership. `Isolation: ReadCommitted` does not filter aborted records at the wire level; it bounds the fetch at the last stable offset and attaches an `AbortedTransactions` list, and discarding those records is client-side work.

## What landed

14 planned units, executed test-first:

| Area | Detail |
|---|---|
| Decoders | `TransactionLogKey`/`TransactionLogValue` and a hand-rolled `__consumer_offsets` commit-key decoder, with literal-byte fixtures rather than an encoder from the library under test |
| Tail component | Continuous resumable reader over raw `Broker.Fetch`: abort filtering, partial-batch handling, per-partition liveness, LSO-based lag, Fetch-version clamping against the broker's advertised ceiling |
| Sources | `__transaction_state` reader (source of truth), consumer-group enrichment via the Streams naming convention, `__consumer_offsets` tail with exact producer-ID correlation |
| Grouping | Union-find with internal topics filtered **before** the union, deterministic output |
| Output | Counts-only terminal summary, `txn-discovery.yaml`, `--stats-out` JSON, and a change-only JSONL audit log — all three written `0600` |
| Command | Migration's auth flag idiom, fail-fast preflight distinguishing an unknown topic from an authorization failure, `--dry-run` |
| Suites | Single-node docker-compose suite (in CI) and an opt-in three-broker leader-failover suite (not in CI) |

Also: `Metadata.AllowAutoTopicCreation = false` in kcp's shared sarama client construction. sarama defaults it to `true`, so a metadata request naming a nonexistent topic could make a permissive broker create it — turning a discovery tool into one that mutates the cluster it inspects.

## Defects this work surfaced and fixed

Several were latent in the design or the POC rather than introduced here. All were found by tests written to fail first.

- **Integer overflow in the decoder's bounds guard (HIGH).** `need()` compared `pos+n > len(b)`; with `n` from a uvarint, `pos+n` overflowed int64 and went negative, so the guard passed and the slice panicked. There is no `recover()` in kcp and this runs on a reader goroutine, so a ~30-byte malformed record killed a multi-hour observation window. Reachable via two independent paths.
- **Allocation amplification.** A 20-byte record could allocate 80 MB — and still returned a clean error, so an error-only assertion passed while proving nothing. Now bounded by a capped prealloc plus a hard entry cap.
- **Silent buffer over-read.** Stripping the bounds guard from `str()` produced no panic — a record key is a sub-slice of a larger fetch buffer, so reading past `len` into `cap` is legal Go. It spliced 12 bytes of adjacent buffer into a group name. Only the `__consumer_offsets` v2 shape exposed it; v0 and v1 masked it via a trailing bounds-checked read.
- **JSONL forgery.** A newline inside a topic name, without proper encoding, produced a complete well-formed *forged* audit record — in the artifact whose sole purpose is explaining why topics were grouped.
- **`goccy/go-yaml` silently drops TAB characters** from plain scalars: `"a\tb"` round-trips as `"ab"`. Kafka constrains topic names, but `transactional.id` is free-form, so a silently altered id would point an operator at a transaction that does not exist. (`gopkg.in/yaml.v3` was evaluated and is worse — it emits an unparseable document for a leading newline.)
- **Transport errors never reconnected (broke R11).** A broker restart surfaces as a broken pipe, classified as *transport*, and only the *leadership* branch refreshed metadata — so the stale `*sarama.Broker` was never replaced and the loop retried a dead socket. Measured: 98 of 100 partitions read zero records after a restart. Refreshing alone was insufficient: `client.updateBroker` retains the existing broker when the address is unchanged, and sarama never closes a poisoned socket, so the connection is now explicitly discarded.
- **The health line reported OK while 98 partitions were dead.** LSO-based lag is zero for a partition that never fetched, and a loop stuck retrying still counts as running. A per-partition stalled flag now discriminates: an idle partition's empty fetches still *succeed*, so it never latches.
- **Windows: the audit log failed unconditionally.** Go synthesizes `0666` for any writable file, so the `0600` assertion rejected every freshly created file on first run. kcp ships a Windows binary and the audit log is on by default.
- **The POC's `resolveWith` had a silent data-loss path**: it deleted the buffered entry before the send, so a pass racing the end of the window lost the recovery with no counter moving and nothing left for the final flush.
- **Consumer-group enrichment computed correlations and threw them away.** Its admin calls shared one TCP connection with the tail's 100 fetch loops; sarama pipelines per connection and delivers responses in order, so admin requests queued behind long-poll fetches — 6.5–8.1s for `ListConsumerGroups`, 17.6–29.3s for `ListConsumerGroupOffsets`, against 206–461ms on an independent connection. A `5s` interval yielded 4–8 passes per 60s window instead of 13, and the pass that could finally correlate straddled the window's end, where the send took the cancelled branch. The POC never had this — it uses three separate clients. Fixed by giving the enricher its own client (passes per window: **5, 4 → 13, 13**) plus a final pass at window close.
- **Shutdown could hang unboundedly with no escape.** `FinalEnrich`'s 10s context bounded nothing, because `sarama.ClusterAdmin`'s methods take no context — it made `1 + G` blocking round trips after cancellation. Worse, `signal.NotifyContext` is one-shot, so a second Ctrl-C during the drain did nothing; the only exit was `SIGKILL`, which loses all three artifacts. Both halves fixed.

## Security posture

The broker is treated as the untrusted input source. Three broker-internal binary wire formats are parsed, none part of the stable client protocol; malformed, truncated, or format-drifted input must produce a counted decode error, never a panic or an unbounded allocation. Three fuzz targets (`FuzzDecodeValue`, `FuzzDecodeOffsetKey`, `FuzzDecodeKey`) assert no-panic **and** allocation bounded by input size, seeded with the two PoC inputs above so both regressions execute under plain `go test` in CI without `-fuzz`.

Topic names and transactional ids identify customer business structure. The terminal reports counts only; the artifacts carry the names and are all `0600`. **No topic name or transactional id reaches any `slog` call at any level** — `kcp.log` is unconditionally Debug+ and is the file operators attach to support tickets. Credentials are never persisted to an artifact or a log line.

Two security review passes were run in fresh contexts (full diff, then a scoped delta). **Zero Critical, zero High outstanding.** One reviewer finding was rebutted with evidence rather than implemented: the claim that a control marker registers `"\x00"` as a real transactional id is unreachable, because `handle()` returns on the value-decode error before `catalog.Observe`, and `Observe` refuses an empty id. A second was withdrawn by the reviewer on re-test.

## Deliberately deferred

Recorded rather than fixed, with reasoning:

- **Unbounded broker-keyed maps.** `TxnCatalog`, `Accumulator.byTxn`, and the offsets tail's `recovered`/`correlations` grow with distinct broker-supplied strings. Capping them may be wrong for legitimately large clusters, so the decision is left explicit rather than guessed. The pending-sighting buffer *is* bounded, by count and TTL.
- **Hardlink TOCTOU on the audit path.** `O_NOFOLLOW` plus an `Fstat` on the handle closes the symlink race; a hardlink to an existing 0600 file is not covered. `fs.protected_hardlinks=1` and the mode gate narrow it substantially.
- **Decoder ratio.** The worst allocation ratio remains ~74x (a 40-byte struct from ~3 wire bytes, plus append regrowth), now bounded absolutely at ~21.5 MiB per malformed record. Assessed as acceptable: transient, single-threaded, and loudly visible as a decode-error rate.
- **`--insecure-skip-tls-verify` is honoured only by SASL/SCRAM.** The other three TLS-bearing constructors in shared `internal/client` code drop it. The flag is now **rejected** in `PreRunE` when it cannot be honoured, rather than silently ignored; threading it through shared plumbing used by other commands is a separate change.
- **PLAIN-over-TLS is not offered.** `--use-sasl-plain` resolves to kcp's no-TLS variant. The pre-existing cleartext warning does fire; the flag help now says so too, and a warning naming the flag fires once per run.
- **Shutdown latency is bounded only for the enrichment pass.** With a fully unresponsive broker, the drain is dominated by the tail's 100 partition loops, which remain unbounded for the same root cause (blocking sarama calls). Time-to-exit was unchanged at 149s in that scenario; the restored SIGINT abort is what rescues the operator.
- **`--interval` semantics.** Now that the enricher has its own connection, full cadence is restored; the counter added to `--stats-out` makes any future regression visible rather than silent.

## Verification

```
make test-go                 63 packages, 2095 tests, 0 failures
-race (txndiscovery + cmd)   11 packages green
golangci-lint (untagged)             0 issues
golangci-lint (e2e_txndiscovery)     0 issues
golangci-lint (e2e_txndiscovery_ha)  0 issues
make test-txn-discovery      14/14, three consecutive green runs (~231s)
make test-txn-discovery-ha    8/8, ~309s
make test-schema-registry    green
make test-osk-scan           green (all auth methods)
make test-migration          64 subtests, full CFK lifecycle, green
```

The broker-touching suites matter beyond this feature: they are the evidence that disabling auto topic creation is inert for existing commands, which the plan flagged as an assumption. `make test-migration` in particular exercises consumer groups and cluster links — the coordinator-resolution path where auto-create could plausibly have been load-bearing.

`utils/transaction-discovery/` is byte-for-byte unchanged and still builds independently (R26). No `go.mod`/`go.sum` change, and no `kcp-state.json` schema change, so no version bump, upcaster, fixture, or freeze entry (R28).

### The failover suite's negative control

Green alone would not have proved much, so the recovery handler was stubbed. The run **exited 0**, wrote artifacts, and the premise test passed. The offset-continuity assertion **passed** (a stalled reader has no gap — it just stops) and the LSO-lag assertion **passed** (`24/24 live, 0 records of lag` while eight partitions never read again). Only the phase ledger caught it:

```
transactions are missing from the output, by phase:
  map[mid:[zzha-mid-c0-txn zzha-mid-c3-txn zzha-mid-c6-txn]
      post:[zzha-post-c0-txn zzha-post-c3-txn zzha-post-c6-txn]]
  killed node 1, which led __transaction_state partitions [1 3 6 9]
```

Every transactional id in all three phases is pinned to the coordinator being killed — a transactional id's coordinator *is* the leader of the `__transaction_state` partition its footprint lands in. Unpinned, a third of the transactions would sit on undisturbed partitions and a reader that recovered on none could still pass.

## Scope boundaries

Nothing in kcp consumes `txn-discovery.yaml` — wiring these groups into migration batching is the eventual goal and explicitly not this work. Confluent Cloud and MSK Serverless remain unsupported (they do not expose `__transaction_state`; the command fails fast rather than degrading). The compaction blind spot is not solved: a workload whose footprint records were compacted before the window opened is unrecoverable, which is what the keep-up signal exists to tell an operator.

## Note for reviewers

Code review was **deliberately deferred** on this branch rather than run inline — a review conducted inside the session that wrote 19k lines is weaker than the same review run fresh. A `mega-review` pass on this PR in a clean context is the review.

Worth a close look: the tail component (`internal/services/txndiscovery/tail/`) is where the risk concentrates, because it replaces machinery sarama's high-level consumer provides for free and its failure modes are quiet rather than loud. Its coupling to sarama internals — closing brokers the shared `sarama.Client` owns, which is safe only because every sarama use site calls `Open` first — is correct today and commented, but it is the sharpest dependency on unspecified behaviour in the change.

**MSK broker-version compatibility is unproven.** The suites run against Confluent's image. The Fetch-version clamp against the broker's advertised ceiling should degrade correctly on an older MSK Provisioned cluster, but that path is untested until someone runs it against one. Flagged for manual verification before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
