### PR TITLE
Add Trivy vulnerability scan to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,3 +5,9 @@ if command -v golangci-lint >/dev/null 2>&1; then
 else
   echo "warning: golangci-lint not installed, skipping Go lint"
 fi
+
+if command -v trivy >/dev/null 2>&1; then
+  trivy fs --scanners vuln --show-suppressed --severity HIGH,CRITICAL --exit-code 1 . || exit 1
+else
+  echo "warning: trivy not installed, skipping vulnerability scan"
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,10 +173,16 @@ minutes.
 # Install golangci-lint
 brew install golangci-lint
 
+# Install trivy
+brew install trivy
+
 # Run Go linters
 make lint
 
-# Install git pre-commit hooks (runs linters automatically on commit)
+# Run Trivy vulnerability scan
+make trivy
+
+# Install git pre-commit hooks (runs linters and trivy scan automatically on commit)
 make pre-commit-install
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,16 @@ uninstall: ## Uninstall from /usr/local/bin (requires sudo)
 # Code Quality
 # ==============================================================================
 
-.PHONY: fmt lint pre-commit-install
+.PHONY: fmt lint trivy pre-commit-install
 
 fmt: ## Format Go code
 	gofmt -s -w .
 
 lint: ## Run Go linters (golangci-lint)
 	golangci-lint run --config .golangci.yml ./...
+
+trivy: ## Run Trivy vulnerability scan
+	trivy fs --scanners vuln --show-suppressed --severity HIGH,CRITICAL --exit-code 1 .
 
 pre-commit-install: ## Install git pre-commit hooks
 	git config --local core.hooksPath .githooks


### PR DESCRIPTION
Mirrors the Semaphore CI trivy fs scan so devs catch HIGH/CRITICAL vulns locally before pushing. Skips with a warning if trivy isn't installed, same as the existing golangci-lint check.
trivy isn't installed, same as the existing golangci-lint check.
