### PR TITLE
fix(migration-infra): support MSK Serverless clusters for --type 5

### DIFF
--- a/cmd/create_asset/migration_infra/cmd_create_asset_migration_infra.go
+++ b/cmd/create_asset/migration_infra/cmd_create_asset_migration_infra.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/confluentinc/kcp/internal/services/hcl/hclrequests"
 	"github.com/confluentinc/kcp/internal/services/iampolicy"
 	"github.com/confluentinc/kcp/internal/types"
@@ -66,7 +67,9 @@ Type options:
 4. Private MSK endpoints — Jump Cluster (SASL/SCRAM)
 5. Private MSK endpoints — Jump Cluster (IAM, MSK only)
 
-> **Note:** External Outbound Cluster Linking (Types 2 and 3) is only supported for Enterprise clusters. Dedicated clusters with private MSK endpoints must use Jump Clusters (Type 4 or 5). Dedicated clusters with public MSK endpoints can use Type 1.`,
+> **Note:** External Outbound Cluster Linking (Types 2 and 3) is only supported for Enterprise clusters. Dedicated clusters with private MSK endpoints must use Jump Clusters (Type 4 or 5). Dedicated clusters with public MSK endpoints can use Type 1.
+
+> **Note:** MSK Serverless clusters only support Type 5 (Jump Cluster [IAM]), since Serverless offers SASL/IAM authentication only. --jump-cluster-instance-type and --jump-cluster-broker-storage are required for Serverless sources (Serverless has no broker configuration to default them from), and --jump-cluster-broker-subnet-cidr accepts any count.`,
 		Example: `  # Type 4 — Jump Cluster with SASL/SCRAM, against a private MSK
   kcp create-asset migration-infra \
       --state-file kcp-state.json \
@@ -151,10 +154,10 @@ Type options:
 	typeFourFlags.SortFlags = false
 	typeFourFlags.StringVar(&targetBootstrapEndpoint, "target-bootstrap-endpoint", "", "The bootstrap endpoint to use for the Confluent Cloud cluster.")
 	typeFourFlags.StringVar(&existingPrivateLinkVpceId, "existing-private-link-vpce-id", "", "The ID of the existing VPC endpoint for the Private Link connection to Confluent Cloud.")
-	typeFourFlags.IPNetSliceVar(&jumpClusterBrokerSubnetCidr, "jump-cluster-broker-subnet-cidr", []net.IPNet{}, "The CIDR blocks to use for the jump cluster broker subnets. You should provide as many CIDRs as the MSK cluster has broker nodes.")
+	typeFourFlags.IPNetSliceVar(&jumpClusterBrokerSubnetCidr, "jump-cluster-broker-subnet-cidr", []net.IPNet{}, "The CIDR blocks to use for the jump cluster broker subnets. You should provide as many CIDRs as the MSK cluster has broker nodes (for MSK Serverless sources, --type 5 only, any count is accepted: one jump cluster broker per CIDR).")
 	typeFourFlags.IPNetVar(&jumpClusterSetupHostSubnetCidr, "jump-cluster-setup-host-subnet-cidr", net.IPNet{}, "The CIDR block to use for the jump cluster setup host subnet.")
-	typeFourFlags.StringVar(&jumpClusterInstanceType, "jump-cluster-instance-type", "", "[Optional] The instance type to use for the jump cluster. (default: MSK broker type).")
-	typeFourFlags.IntVar(&jumpClusterBrokerStorage, "jump-cluster-broker-storage", 0, "[Optional] The storage size to use for the jump cluster brokers. (default: MSK cluster broker storage size).")
+	typeFourFlags.StringVar(&jumpClusterInstanceType, "jump-cluster-instance-type", "", "[Optional] The instance type to use for the jump cluster. (default: MSK broker type; required for MSK Serverless sources, --type 5 only, which have no broker type to default from).")
+	typeFourFlags.IntVar(&jumpClusterBrokerStorage, "jump-cluster-broker-storage", 0, "[Optional] The storage size to use for the jump cluster brokers. (default: MSK cluster broker storage size; required for MSK Serverless sources, --type 5 only, which have no broker storage to default from).")
 	migrationInfraCmd.Flags().AddFlagSet(typeFourFlags)
 	groups[typeFourFlags] = "Type Four Flags"
 
@@ -162,11 +165,11 @@ Type options:
 	typeFiveFlags.SortFlags = false
 	typeFiveFlags.StringVar(&targetBootstrapEndpoint, "target-bootstrap-endpoint", "", "The bootstrap endpoint to use for the Confluent Cloud cluster.")
 	typeFiveFlags.StringVar(&existingPrivateLinkVpceId, "existing-private-link-vpce-id", "", "The ID of the existing VPC endpoint for the Private Link connection to Confluent Cloud.")
-	typeFiveFlags.IPNetSliceVar(&jumpClusterBrokerSubnetCidr, "jump-cluster-broker-subnet-cidr", []net.IPNet{}, "The CIDR blocks to use for the jump cluster broker subnets. You should provide as many CIDRs as the MSK cluster has broker nodes.")
+	typeFiveFlags.IPNetSliceVar(&jumpClusterBrokerSubnetCidr, "jump-cluster-broker-subnet-cidr", []net.IPNet{}, "The CIDR blocks to use for the jump cluster broker subnets. You should provide as many CIDRs as the MSK cluster has broker nodes (for MSK Serverless sources any count is accepted: one jump cluster broker per CIDR).")
 	typeFiveFlags.IPNetVar(&jumpClusterSetupHostSubnetCidr, "jump-cluster-setup-host-subnet-cidr", net.IPNet{}, "The CIDR block to use for the jump cluster setup host subnet.")
 	typeFiveFlags.StringVar(&jumpClusterIamAuthRoleName, "jump-cluster-iam-auth-role-name", "", " The IAM role name to authenticate the cluster link between MSK and the jump cluster.")
-	typeFiveFlags.StringVar(&jumpClusterInstanceType, "jump-cluster-instance-type", "", "[Optional] The instance type to use for the jump cluster. (default: MSK broker type).")
-	typeFiveFlags.IntVar(&jumpClusterBrokerStorage, "jump-cluster-broker-storage", 0, "[Optional] The storage size to use for the jump cluster brokers. (default: MSK cluster broker storage size).")
+	typeFiveFlags.StringVar(&jumpClusterInstanceType, "jump-cluster-instance-type", "", "[Optional] The instance type to use for the jump cluster. (default: MSK broker type; required for MSK Serverless sources, which have no broker type to default from).")
+	typeFiveFlags.IntVar(&jumpClusterBrokerStorage, "jump-cluster-broker-storage", 0, "[Optional] The storage size to use for the jump cluster brokers. (default: MSK cluster broker storage size; required for MSK Serverless sources, which have no broker storage to default from).")
 	migrationInfraCmd.Flags().AddFlagSet(typeFiveFlags)
 	groups[typeFiveFlags] = "Type Five Flags"
 
@@ -192,9 +195,10 @@ Available Migration Types:
     Type 2: External Outbound Cluster Link [SASL/SCRAM] (Enterprise clusters only) (MSK & Apache Kafka)
     Type 3: External Outbound Cluster Link [Unauthenticated Plaintext] (Enterprise clusters only) (MSK & Apache Kafka)
     Type 4: Jump Cluster [SASL/SCRAM] (MSK & Apache Kafka)
-    Type 5: Jump Cluster [IAM] (MSK)
+    Type 5: Jump Cluster [IAM] (MSK, incl. MSK Serverless)
 
 Note: Types 2 and 3 are only supported for Enterprise clusters. Dedicated clusters with private endpoints must use Type 4 or 5.
+Note: MSK Serverless clusters only support Type 5, since Serverless offers SASL/IAM authentication only.
 
 Refer to the kcp docs for more information on each migration type.
 		`)
@@ -359,8 +363,13 @@ func parseMSKMigrationInfraOpts() (*MigrationInfraOpts, error) {
 		return nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	if cluster.AWSClientInformation.MskClusterConfig.Provisioned == nil {
-		return nil, fmt.Errorf("cluster %s has no provisioned configuration, this could be because the cluster is a serverless cluster which is not supported for migration", cluster.Name)
+	isServerless := cluster.AWSClientInformation.MskClusterConfig.ClusterType == kafkatypes.ClusterTypeServerless
+	if isServerless && targetType != types.JumpClusterIam {
+		return nil, fmt.Errorf("cluster %s is MSK Serverless: only --type 5 (Jump Cluster [IAM]) is supported, because Serverless clusters offer SASL/IAM authentication only", cluster.Name)
+	}
+
+	if !isServerless && cluster.AWSClientInformation.MskClusterConfig.Provisioned == nil {
+		return nil, fmt.Errorf("cluster %s has no provisioned configuration, cannot determine broker networking or sizing", cluster.Name)
 	}
 
 	// Recurring statefile values.
@@ -503,16 +512,29 @@ func parseMSKMigrationInfraOpts() (*MigrationInfraOpts, error) {
 		opts.MigrationWizardRequest.HasPublicEndpoints = false
 		opts.MigrationWizardRequest.UseJumpClusters = true
 
-		if len(jumpClusterBrokerSubnetCidr) != cluster.ClusterMetrics.MetricMetadata.NumberOfBrokerNodes {
-			return nil, fmt.Errorf("the number of jump cluster broker subnet CIDRs (%d) does not match the number of broker nodes in the MSK cluster (%d), you should provide as many CIDRs as the MSK cluster has broker nodes", len(jumpClusterBrokerSubnetCidr), cluster.ClusterMetrics.MetricMetadata.NumberOfBrokerNodes)
-		}
+		if isServerless {
+			// Serverless exposes no brokers - ListNodes is rejected outright by AWS -
+			// so there is no source broker count to size the jump cluster against and
+			// no BrokerNodeGroupInfo to default the instance type / storage from.
+			if jumpClusterInstanceType == "" {
+				return nil, fmt.Errorf("--jump-cluster-instance-type is required for MSK Serverless sources: Serverless clusters expose no broker configuration to default from")
+			}
 
-		if jumpClusterInstanceType == "" {
-			jumpClusterInstanceType = strings.TrimPrefix(aws.ToString(cluster.AWSClientInformation.MskClusterConfig.Provisioned.BrokerNodeGroupInfo.InstanceType), "kafka.")
-		}
+			if jumpClusterBrokerStorage == 0 {
+				return nil, fmt.Errorf("--jump-cluster-broker-storage is required for MSK Serverless sources: Serverless clusters expose no broker storage to default from")
+			}
+		} else {
+			if len(jumpClusterBrokerSubnetCidr) != cluster.ClusterMetrics.MetricMetadata.NumberOfBrokerNodes {
+				return nil, fmt.Errorf("the number of jump cluster broker subnet CIDRs (%d) does not match the number of broker nodes in the MSK cluster (%d), you should provide as many CIDRs as the MSK cluster has broker nodes", len(jumpClusterBrokerSubnetCidr), cluster.ClusterMetrics.MetricMetadata.NumberOfBrokerNodes)
+			}
 
-		if jumpClusterBrokerStorage == 0 {
-			jumpClusterBrokerStorage = int(*cluster.AWSClientInformation.MskClusterConfig.Provisioned.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize)
+			if jumpClusterInstanceType == "" {
+				jumpClusterInstanceType = strings.TrimPrefix(aws.ToString(cluster.AWSClientInformation.MskClusterConfig.Provisioned.BrokerNodeGroupInfo.InstanceType), "kafka.")
+			}
+
+			if jumpClusterBrokerStorage == 0 {
+				jumpClusterBrokerStorage = int(*cluster.AWSClientInformation.MskClusterConfig.Provisioned.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize)
+			}
 		}
 
 		opts.MigrationWizardRequest.TargetBootstrapEndpoint = targetBootstrapEndpoint

--- a/cmd/create_asset/migration_infra/serverless_test.go
+++ b/cmd/create_asset/migration_infra/serverless_test.go
@@ -1,0 +1,290 @@
+package migration_infra
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	serverlessClusterArn  = "arn:aws:kafka:us-east-1:123456789012:cluster/sl-cluster/000-1"
+	provisionedClusterArn = "arn:aws:kafka:us-east-1:123456789012:cluster/prov-cluster/111-2"
+)
+
+// resetMigrationInfraFlags zeroes every package-level flag variable
+// parseMSKMigrationInfraOpts reads. The flags are cobra-bound package
+// globals (cmd_create_asset_migration_infra.go), so tests calling the
+// parser directly must reset them between cases to avoid bleed-through.
+func resetMigrationInfraFlags(t *testing.T) {
+	t.Helper()
+
+	stateFile = ""
+	ccType = ""
+	migrationInfraType = ""
+	clusterLinkName = "test-link"
+
+	sourceType = "msk"
+	clusterId = ""
+	oskVpcId = ""
+	oskRegion = ""
+	sourceSaslScramMechanism = ""
+
+	existingInternetGateway = false
+	existingPrivateLinkVpceId = "vpce-test"
+	outputDir = ""
+
+	targetEnvironmentId = "env-test"
+	targetClusterId = "lkc-test"
+	targetRestEndpoint = "https://lkc-test.us-east-1.aws.confluent.cloud:443"
+	targetBootstrapEndpoint = "lkc-test.us-east-1.aws.confluent.cloud:9092"
+
+	extOutboundSubnetId = ""
+	extOutboundSecurityGroupId = ""
+
+	jumpClusterInstanceType = ""
+	jumpClusterBrokerStorage = 0
+	jumpClusterBrokerSubnetCidr = nil
+	jumpClusterSetupHostSubnetCidr = net.IPNet{}
+
+	jumpClusterIamAuthRoleName = "kcp-iam-migration"
+	targetClusterType = ""
+}
+
+// mustParseCIDRs parses a list of CIDR strings into []net.IPNet, matching
+// the shape pflag.IPNetSliceVar produces from --jump-cluster-broker-subnet-cidr.
+func mustParseCIDRs(t *testing.T, cidrs ...string) []net.IPNet {
+	t.Helper()
+
+	result := make([]net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, ipNet, err := net.ParseCIDR(c)
+		require.NoError(t, err, "invalid test CIDR %q", c)
+		result = append(result, *ipNet)
+	}
+	return result
+}
+
+// buildServerlessTestCluster returns an MSK Serverless DiscoveredCluster
+// fixture: no Provisioned config, cluster_networking populated the way the
+// discover fix populates it (VpcId/SubnetIds/SecurityGroups from
+// Serverless.VpcConfigs), and only a SASL/IAM bootstrap string - matching
+// the live demo-cluster used to validate this feature.
+func buildServerlessTestCluster() types.DiscoveredCluster {
+	return types.DiscoveredCluster{
+		Name:   "sl-cluster",
+		Arn:    serverlessClusterArn,
+		Region: "us-east-1",
+		AWSClientInformation: types.AWSClientInformation{
+			MskClusterConfig: kafkatypes.Cluster{
+				ClusterName: aws.String("sl-cluster"),
+				ClusterArn:  aws.String(serverlessClusterArn),
+				ClusterType: kafkatypes.ClusterTypeServerless,
+				Serverless: &kafkatypes.Serverless{
+					VpcConfigs: []kafkatypes.VpcConfig{
+						{
+							SubnetIds:        []string{"subnet-sl-1", "subnet-sl-2"},
+							SecurityGroupIds: []string{"sg-sl-1"},
+						},
+					},
+				},
+			},
+			ClusterNetworking: types.ClusterNetworking{
+				VpcId:          "vpc-serverless-1",
+				SubnetIds:      []string{"subnet-sl-1", "subnet-sl-2"},
+				SecurityGroups: []string{"sg-sl-1"},
+				Subnets: []types.SubnetInfo{
+					{SubnetId: "subnet-sl-1", AvailabilityZone: "us-east-1a", CidrBlock: "10.0.1.0/24"},
+					{SubnetId: "subnet-sl-2", AvailabilityZone: "us-east-1b", CidrBlock: "10.0.2.0/24"},
+				},
+			},
+			BootstrapBrokers: kafka.GetBootstrapBrokersOutput{
+				BootstrapBrokerStringSaslIam: aws.String("boot-sl.c1.kafka-serverless.us-east-1.amazonaws.com:9098"),
+			},
+		},
+		KafkaAdminClientInformation: types.KafkaAdminClientInformation{
+			ClusterID: "slcluster1",
+		},
+	}
+}
+
+// buildProvisionedTestCluster returns a Provisioned MSK DiscoveredCluster
+// fixture with 3 broker nodes, for the existing (unchanged) CIDR-count and
+// defaulting behaviour.
+func buildProvisionedTestCluster() types.DiscoveredCluster {
+	return types.DiscoveredCluster{
+		Name:   "prov-cluster",
+		Arn:    provisionedClusterArn,
+		Region: "us-east-1",
+		ClusterMetrics: types.ClusterMetrics{
+			MetricMetadata: types.MetricMetadata{
+				NumberOfBrokerNodes: 3,
+			},
+		},
+		AWSClientInformation: types.AWSClientInformation{
+			MskClusterConfig: kafkatypes.Cluster{
+				ClusterName: aws.String("prov-cluster"),
+				ClusterArn:  aws.String(provisionedClusterArn),
+				ClusterType: kafkatypes.ClusterTypeProvisioned,
+				Provisioned: &kafkatypes.Provisioned{
+					BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+						InstanceType:   aws.String("kafka.m5.large"),
+						ClientSubnets:  []string{"subnet-p-1", "subnet-p-2", "subnet-p-3"},
+						SecurityGroups: []string{"sg-p-1"},
+						StorageInfo: &kafkatypes.StorageInfo{
+							EbsStorageInfo: &kafkatypes.EBSStorageInfo{
+								VolumeSize: aws.Int32(100),
+							},
+						},
+					},
+				},
+			},
+			ClusterNetworking: types.ClusterNetworking{
+				VpcId:     "vpc-provisioned-1",
+				SubnetIds: []string{"subnet-p-1", "subnet-p-2", "subnet-p-3"},
+			},
+			BootstrapBrokers: kafka.GetBootstrapBrokersOutput{
+				BootstrapBrokerStringSaslIam: aws.String("boot-prov.kafka.us-east-1.amazonaws.com:9098"),
+			},
+		},
+		KafkaAdminClientInformation: types.KafkaAdminClientInformation{
+			ClusterID: "provcluster1",
+		},
+	}
+}
+
+// writeTestStateFile marshals a state file containing both fixture clusters
+// to a temp file and returns its path.
+func writeTestStateFile(t *testing.T) string {
+	t.Helper()
+
+	state := types.State{
+		MSKSources: &types.MSKSourcesState{
+			Regions: []types.DiscoveredRegion{
+				{
+					Name: "us-east-1",
+					Clusters: []types.DiscoveredCluster{
+						buildServerlessTestCluster(),
+						buildProvisionedTestCluster(),
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "kcp-state.json")
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+// TestParseMSKMigrationInfraOpts_ServerlessTypeGate covers change 2: MSK
+// Serverless clusters only support --type 5, because Serverless offers
+// SASL/IAM authentication only.
+func TestParseMSKMigrationInfraOpts_ServerlessTypeGate(t *testing.T) {
+	statePath := writeTestStateFile(t)
+
+	for _, typ := range []string{"1", "2", "3", "4"} {
+		t.Run("type "+typ, func(t *testing.T) {
+			resetMigrationInfraFlags(t)
+			stateFile = statePath
+			clusterId = serverlessClusterArn
+			migrationInfraType = typ
+
+			_, err := parseMSKMigrationInfraOpts()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "only --type 5")
+		})
+	}
+}
+
+// TestParseMSKMigrationInfraOpts_ServerlessSizingRequired covers change 3:
+// --jump-cluster-instance-type / --jump-cluster-broker-storage cannot be
+// defaulted for Serverless (no BrokerNodeGroupInfo to default from), so they
+// must error cleanly rather than nil-deref.
+func TestParseMSKMigrationInfraOpts_ServerlessSizingRequired(t *testing.T) {
+	statePath := writeTestStateFile(t)
+
+	t.Run("missing instance type", func(t *testing.T) {
+		resetMigrationInfraFlags(t)
+		stateFile = statePath
+		clusterId = serverlessClusterArn
+		migrationInfraType = "5"
+		jumpClusterBrokerStorage = 100
+		jumpClusterBrokerSubnetCidr = mustParseCIDRs(t, "10.0.54.0/24", "10.0.55.0/24", "10.0.56.0/24")
+
+		_, err := parseMSKMigrationInfraOpts()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--jump-cluster-instance-type is required")
+	})
+
+	t.Run("missing broker storage", func(t *testing.T) {
+		resetMigrationInfraFlags(t)
+		stateFile = statePath
+		clusterId = serverlessClusterArn
+		migrationInfraType = "5"
+		jumpClusterInstanceType = "m5.large"
+		jumpClusterBrokerSubnetCidr = mustParseCIDRs(t, "10.0.54.0/24", "10.0.55.0/24", "10.0.56.0/24")
+
+		_, err := parseMSKMigrationInfraOpts()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--jump-cluster-broker-storage is required")
+	})
+}
+
+// TestParseMSKMigrationInfraOpts_ServerlessSuccess proves --type 5 succeeds
+// end-to-end for a Serverless cluster once both sizing flags are supplied,
+// with a broker subnet CIDR count that has no relationship to a (nonexistent)
+// Serverless broker count.
+func TestParseMSKMigrationInfraOpts_ServerlessSuccess(t *testing.T) {
+	resetMigrationInfraFlags(t)
+	stateFile = writeTestStateFile(t)
+	clusterId = serverlessClusterArn
+	migrationInfraType = "5"
+	jumpClusterInstanceType = "m5.large"
+	jumpClusterBrokerStorage = 100
+	jumpClusterBrokerSubnetCidr = mustParseCIDRs(t, "10.0.54.0/24", "10.0.55.0/24", "10.0.56.0/24")
+	jumpClusterSetupHostSubnetCidr = mustParseCIDRs(t, "10.0.53.0/28")[0]
+
+	opts, err := parseMSKMigrationInfraOpts()
+	require.NoError(t, err)
+
+	req := opts.MigrationWizardRequest
+	assert.Equal(t, "vpc-serverless-1", req.VpcId)
+	assert.Equal(t, "boot-sl.c1.kafka-serverless.us-east-1.amazonaws.com:9098", req.SourceSaslIamBootstrapServers)
+	assert.Equal(t, "iam", req.JumpClusterAuthType)
+	assert.Equal(t, "m5.large", req.JumpClusterInstanceType)
+	assert.Equal(t, 100, req.JumpClusterBrokerStorage)
+	assert.Len(t, req.JumpClusterBrokerSubnetCidr, 3)
+	assert.Equal(t, types.JumpClusterIam, opts.MigrationType)
+}
+
+// TestParseMSKMigrationInfraOpts_ProvisionedCidrCountUnchanged proves the
+// existing Provisioned behaviour (CIDR count must equal broker count) is
+// untouched by the Serverless branching.
+func TestParseMSKMigrationInfraOpts_ProvisionedCidrCountUnchanged(t *testing.T) {
+	resetMigrationInfraFlags(t)
+	stateFile = writeTestStateFile(t)
+	clusterId = provisionedClusterArn
+	migrationInfraType = "5"
+	jumpClusterBrokerSubnetCidr = mustParseCIDRs(t, "10.0.54.0/24") // 1 CIDR, but the fixture has 3 broker nodes
+	jumpClusterSetupHostSubnetCidr = mustParseCIDRs(t, "10.0.53.0/28")[0]
+
+	_, err := parseMSKMigrationInfraOpts()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the number of broker nodes")
+}

--- a/cmd/discover/cluster_discoverer.go
+++ b/cmd/discover/cluster_discoverer.go
@@ -93,12 +93,13 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 	awsClientInfo.MskClusterConfig = *cluster.ClusterInfo
 
 	// MSK Serverless does not support several AWS-API metadata scans (VPC
-	// connections, nodes, SCRAM secrets, compatible versions, networking) or the
-	// AWS topic APIs. Announce it once per cluster; the individual per-scan skips
-	// stay in kcp.log at Debug.
+	// connections, nodes, SCRAM secrets, compatible versions) or the AWS topic
+	// APIs. Announce it once per cluster; the individual per-scan skips stay in
+	// kcp.log at Debug. Networking is scanned for Serverless too (see
+	// scanNetworkingInfo), just via a different AWS API shape.
 	isServerless := cluster.ClusterInfo.ClusterType == kafkatypes.ClusterTypeServerless
 	if isServerless {
-		slog.Warn("⚠️ MSK Serverless cluster; skipping unsupported scans (VPC connections, nodes, SCRAM secrets, compatible versions, networking, topics)")
+		slog.Warn("⚠️ MSK Serverless cluster; skipping unsupported scans (VPC connections, nodes, SCRAM secrets, compatible versions, topics)")
 	}
 
 	brokers, err := cd.getBootstrapBrokers(ctx, clusterArn)
@@ -143,15 +144,11 @@ func (cd *ClusterDiscoverer) discoverAWSClientInformation(ctx context.Context, c
 	}
 	awsClientInfo.CompatibleVersions = *versions
 
-	if isServerless {
-		slog.Debug("⏭️ skipping networking scan for MSK Serverless cluster")
-	} else {
-		networking, err := cd.scanNetworkingInfo(ctx, cluster, nodes)
-		if err != nil {
-			return nil, nil, err
-		}
-		awsClientInfo.ClusterNetworking = networking
+	networking, err := cd.scanNetworkingInfo(ctx, cluster, nodes)
+	if err != nil {
+		return nil, nil, err
 	}
+	awsClientInfo.ClusterNetworking = networking
 
 	switch {
 	case skipTopics:
@@ -285,11 +282,46 @@ func (cs *ClusterDiscoverer) getCompatibleKafkaVersions(ctx context.Context, clu
 }
 
 func (cd *ClusterDiscoverer) scanNetworkingInfo(ctx context.Context, cluster *kafka.DescribeClusterV2Output, nodes []kafkatypes.NodeInfo) (types.ClusterNetworking, error) {
-	if cluster.ClusterInfo == nil || cluster.ClusterInfo.Provisioned == nil || cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo == nil {
-		return types.ClusterNetworking{}, fmt.Errorf("cluster has no broker node group info, cannot determine networking")
+	if cluster.ClusterInfo == nil {
+		return types.ClusterNetworking{}, fmt.Errorf("cluster info is nil, cannot determine networking")
 	}
-	subnetIds := cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo.ClientSubnets
-	securityGroups := cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo.SecurityGroups
+
+	var subnetIds, securityGroups []string
+	isServerless := cluster.ClusterInfo.ClusterType == kafkatypes.ClusterTypeServerless
+
+	switch {
+	case isServerless:
+		// Serverless has no broker node group; its VPC attachment lives on
+		// Serverless.VpcConfigs instead of Provisioned.BrokerNodeGroupInfo. AWS
+		// permits more than one VpcConfig, so concatenate across all of them,
+		// deduping subnet IDs (security groups are commonly shared).
+		if cluster.ClusterInfo.Serverless == nil || len(cluster.ClusterInfo.Serverless.VpcConfigs) == 0 {
+			return types.ClusterNetworking{}, fmt.Errorf("serverless cluster has no VPC configuration, cannot determine networking")
+		}
+
+		seenSubnets := map[string]bool{}
+		seenSecurityGroups := map[string]bool{}
+		for _, vpcConfig := range cluster.ClusterInfo.Serverless.VpcConfigs {
+			for _, subnetId := range vpcConfig.SubnetIds {
+				if !seenSubnets[subnetId] {
+					seenSubnets[subnetId] = true
+					subnetIds = append(subnetIds, subnetId)
+				}
+			}
+			for _, sgId := range vpcConfig.SecurityGroupIds {
+				if !seenSecurityGroups[sgId] {
+					seenSecurityGroups[sgId] = true
+					securityGroups = append(securityGroups, sgId)
+				}
+			}
+		}
+	default:
+		if cluster.ClusterInfo.Provisioned == nil || cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo == nil {
+			return types.ClusterNetworking{}, fmt.Errorf("cluster has no broker node group info, cannot determine networking")
+		}
+		subnetIds = cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo.ClientSubnets
+		securityGroups = cluster.ClusterInfo.Provisioned.BrokerNodeGroupInfo.SecurityGroups
+	}
 
 	vpcId, err := cd.getVpcIdFromSubnets(ctx, subnetIds)
 	if err != nil {
@@ -301,7 +333,15 @@ func (cd *ClusterDiscoverer) scanNetworkingInfo(ctx context.Context, cluster *ka
 		return types.ClusterNetworking{}, fmt.Errorf("failed to get subnet details: %v", err)
 	}
 
-	subnetInfo := cd.createCombinedSubnetBrokerInfo(nodes, subnetDetails)
+	var subnetInfo []types.SubnetInfo
+	if isServerless {
+		// Serverless has no enumerable brokers (ListNodes is rejected outright by
+		// AWS), so there is no per-broker subnet mapping to build. Emit one entry
+		// per subnet instead, leaving the broker-only fields at their zero values.
+		subnetInfo = cd.createSubnetInfoWithoutBrokers(subnetIds, subnetDetails)
+	} else {
+		subnetInfo = cd.createCombinedSubnetBrokerInfo(nodes, subnetDetails)
+	}
 
 	return types.ClusterNetworking{
 		VpcId:          vpcId,
@@ -345,6 +385,23 @@ func (cd *ClusterDiscoverer) getSubnetDetails(ctx context.Context, subnetIds []s
 	}
 
 	return subnets, nil
+}
+
+// createSubnetInfoWithoutBrokers builds one SubnetInfo per subnet ID, in the
+// given order, for cluster types (MSK Serverless) that have no enumerable
+// broker nodes to map subnets to. SubnetMskBrokerId and PrivateIpAddress -
+// the two fields ListNodes would otherwise supply - are left at their zero
+// values.
+func (cd *ClusterDiscoverer) createSubnetInfoWithoutBrokers(subnetIds []string, subnetDetails map[string]types.SubnetInfo) []types.SubnetInfo {
+	var subnetInfo []types.SubnetInfo
+
+	for _, subnetId := range subnetIds {
+		if details, exists := subnetDetails[subnetId]; exists {
+			subnetInfo = append(subnetInfo, details)
+		}
+	}
+
+	return subnetInfo
 }
 
 func (cd *ClusterDiscoverer) createCombinedSubnetBrokerInfo(nodes []kafkatypes.NodeInfo, subnetDetails map[string]types.SubnetInfo) []types.SubnetInfo {

--- a/cmd/discover/cluster_discoverer_test.go
+++ b/cmd/discover/cluster_discoverer_test.go
@@ -91,17 +91,75 @@ func TestClusterDiscoverer_EmptySubnets(t *testing.T) {
 }
 
 func TestClusterDiscoverer_ServerlessCluster(t *testing.T) {
-	// Serverless cluster — networking scan skipped, no provisioned-only fields accessed.
+	// Serverless cluster — networking is scanned via Serverless.VpcConfigs
+	// (not Provisioned.BrokerNodeGroupInfo), so no provisioned-only fields
+	// are accessed and Discover succeeds.
 	msk, ec2svc, metrics := defaultStubs()
 	msk.describeClusterV2Fn = func(_ context.Context, _ string) (*kafka.DescribeClusterV2Output, error) {
 		return buildFullServerlessCluster(), nil
 	}
+	ec2svc.describeSubnetsFn = serverlessSubnetsStub
 
 	cd := newTestClusterDiscoverer(msk, ec2svc, metrics)
 	result, err := cd.Discover(context.Background(), testClusterArn, testRegion, true, true, "60s")
 
 	require.NoError(t, err)
 	assert.Equal(t, testClusterName, result.Name)
+}
+
+func TestClusterDiscoverer_ServerlessNetworking(t *testing.T) {
+	// Serverless clusters have no broker node group; their VPC attachment
+	// lives on Serverless.VpcConfigs instead. ListNodes is rejected by AWS
+	// for serverless clusters, so there are no broker nodes to map subnets
+	// to - subnet_msk_broker_id and private_ip_address stay at their zero
+	// values, one entry per subnet.
+	msk, ec2svc, metrics := defaultStubs()
+	msk.describeClusterV2Fn = func(_ context.Context, _ string) (*kafka.DescribeClusterV2Output, error) {
+		return buildFullServerlessCluster(), nil
+	}
+	ec2svc.describeSubnetsFn = serverlessSubnetsStub
+
+	cd := newTestClusterDiscoverer(msk, ec2svc, metrics)
+	result, err := cd.Discover(context.Background(), testClusterArn, testRegion, true, true, "60s")
+	require.NoError(t, err)
+
+	networking := result.AWSClientInformation.ClusterNetworking
+	assert.Equal(t, "vpc-serverless-1", networking.VpcId)
+	assert.Equal(t, []string{"subnet-sl-1", "subnet-sl-2"}, networking.SubnetIds)
+	assert.Equal(t, []string{"sg-sl-1"}, networking.SecurityGroups)
+
+	require.Len(t, networking.Subnets, 2)
+	assert.Equal(t, "subnet-sl-1", networking.Subnets[0].SubnetId)
+	assert.Equal(t, "us-east-1a", networking.Subnets[0].AvailabilityZone)
+	assert.Equal(t, "10.0.1.0/24", networking.Subnets[0].CidrBlock)
+	assert.Equal(t, 0, networking.Subnets[0].SubnetMskBrokerId)
+	assert.Equal(t, "", networking.Subnets[0].PrivateIpAddress)
+	assert.Equal(t, "subnet-sl-2", networking.Subnets[1].SubnetId)
+	assert.Equal(t, "us-east-1b", networking.Subnets[1].AvailabilityZone)
+	assert.Equal(t, "10.0.2.0/24", networking.Subnets[1].CidrBlock)
+}
+
+func TestClusterDiscoverer_ServerlessNoVpcConfigs(t *testing.T) {
+	// A serverless cluster whose Serverless block has no VpcConfigs should
+	// not happen in practice, but AWS's shape allows it — networking should
+	// error clearly, not panic on an empty slice.
+	msk, ec2svc, metrics := defaultStubs()
+	msk.describeClusterV2Fn = func(_ context.Context, _ string) (*kafka.DescribeClusterV2Output, error) {
+		return &kafka.DescribeClusterV2Output{
+			ClusterInfo: &kafkatypes.Cluster{
+				ClusterName: aws.String(testClusterName),
+				ClusterArn:  aws.String(testClusterArn),
+				ClusterType: kafkatypes.ClusterTypeServerless,
+				Serverless:  &kafkatypes.Serverless{},
+			},
+		}, nil
+	}
+
+	cd := newTestClusterDiscoverer(msk, ec2svc, metrics)
+	_, err := cd.Discover(context.Background(), testClusterArn, testRegion, true, true, "60s")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VPC configuration")
 }
 
 func TestClusterDiscoverer_SkipMetrics(t *testing.T) {

--- a/cmd/discover/testhelpers_test.go
+++ b/cmd/discover/testhelpers_test.go
@@ -206,14 +206,57 @@ func buildFullProvisionedCluster() *kafka.DescribeClusterV2Output {
 	}
 }
 
-// buildFullServerlessCluster returns a serverless cluster with all fields populated.
+// buildFullServerlessCluster returns a serverless cluster with all fields
+// populated — use as the baseline for happy-path tests. Its VpcConfigs
+// subnets match serverlessSubnetsStub, below.
 func buildFullServerlessCluster() *kafka.DescribeClusterV2Output {
 	return &kafka.DescribeClusterV2Output{
 		ClusterInfo: &kafkatypes.Cluster{
 			ClusterName: aws.String(testClusterName),
 			ClusterArn:  aws.String(testClusterArn),
 			ClusterType: kafkatypes.ClusterTypeServerless,
-			Serverless:  &kafkatypes.Serverless{},
+			Serverless: &kafkatypes.Serverless{
+				VpcConfigs: []kafkatypes.VpcConfig{
+					{
+						SubnetIds:        []string{"subnet-sl-1", "subnet-sl-2"},
+						SecurityGroupIds: []string{"sg-sl-1"},
+					},
+				},
+				ClientAuthentication: &kafkatypes.ServerlessClientAuthentication{
+					Sasl: &kafkatypes.ServerlessSasl{
+						Iam: &kafkatypes.Iam{Enabled: aws.Bool(true)},
+					},
+				},
+			},
 		},
 	}
+}
+
+// serverlessSubnetsStub provides AZ/CIDR details for the two subnets in
+// buildFullServerlessCluster's VpcConfigs. Wire it into
+// stubEC2Service.describeSubnetsFn for tests that exercise the serverless
+// networking scan.
+func serverlessSubnetsStub(_ context.Context, subnetIds []string) (*ec2.DescribeSubnetsOutput, error) {
+	details := map[string]ec2types.Subnet{
+		"subnet-sl-1": {
+			SubnetId:         aws.String("subnet-sl-1"),
+			VpcId:            aws.String("vpc-serverless-1"),
+			AvailabilityZone: aws.String("us-east-1a"),
+			CidrBlock:        aws.String("10.0.1.0/24"),
+		},
+		"subnet-sl-2": {
+			SubnetId:         aws.String("subnet-sl-2"),
+			VpcId:            aws.String("vpc-serverless-1"),
+			AvailabilityZone: aws.String("us-east-1b"),
+			CidrBlock:        aws.String("10.0.2.0/24"),
+		},
+	}
+
+	var subnets []ec2types.Subnet
+	for _, id := range subnetIds {
+		if s, ok := details[id]; ok {
+			subnets = append(subnets, s)
+		}
+	}
+	return &ec2.DescribeSubnetsOutput{Subnets: subnets}, nil
 }


### PR DESCRIPTION
Fixed a gap between the compatibility matrix and actual functionality of the `kcp create-asset` which claimed that `kcp create-asset migration-infra --type 5` supported MSK Serverless clusters. However, there was a explicit gate in the code preventing this possibility:
```golang
if cluster.AWSClientInformation.MskClusterConfig.Provisioned == nil {
    return nil, fmt.Errorf("cluster %s has no provisioned configuration, this could be because the cluster is a serverless cluster which is not supported for migration", cluster.Name)
}
```

Furthermore, Serverless clusters did not retrieve and store some required fields in the state file such as the 'Cluster Networking' (subnets, vpc id, etc.). 

Moreover, as a Serverless cluster does not have a set number of brokers nor a defined instance type and storage size compared to Provisioned; some validation in the `kcp create-asset migration-infra` command's flags for these, marking them required if the provided cluster is Serverless.