### PR TITLE
feat(migration): add hidden --run-report flag to migration execute

### DIFF
--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -41,6 +41,7 @@ var (
 	detectUnroutedProducersDuration time.Duration
 	consumerOffsetSyncDrainDuration time.Duration
 	promoteBatchSize                int
+	runReport                       string
 )
 
 func NewMigrationExecuteCmd() *cobra.Command {
@@ -100,6 +101,7 @@ the migration state file and must be provided each time.`,
 	optionalFlags.IntVar(&promoteBatchSize, "promote-batch-size", 0, "Maximum number of mirror topics to promote per batch. 0 (the default) promotes all topics at once. When set (>0), each batch is promoted and confirmed STOPPED before the next batch is submitted.")
 	optionalFlags.DurationVar(&detectUnroutedProducersDuration, "detect-unrouted-producers-duration", 0, "Time to monitor source offsets after fencing to detect producers still writing directly to the source cluster (bypassing the gateway); a detected increase aborts the migration before switchover. 0 (the default) skips the check; minimum 10s if set.")
 	optionalFlags.DurationVar(&consumerOffsetSyncDrainDuration, "consumer-offset-sync-drain-duration", 0, "How long to wait after fencing before disabling the cluster link's consumer.offset.sync.enable. The fence freezes source consumer offsets, so this drain lets the link propagate the final offsets to the destination, reducing (best-effort, not guaranteed) messages reprocessed after switchover. Has no effect unless the migration was initialised with --pause-consumer-offset-sync. 0 (the default) disables the wait.")
+	optionalFlags.StringVar(&runReport, "run-report", "", "Write per-stage migration timings to <path> as JSON.")
 	migrationExecuteCmd.Flags().AddFlagSet(optionalFlags)
 	groups[optionalFlags] = "Optional Flags"
 
@@ -165,6 +167,13 @@ the migration state file and must be provided each time.`,
 
 		return nil
 	})
+
+	// Hidden pending schema validation by the migration performance rig, which is
+	// its first consumer; intended to become user-facing, since the natural
+	// audience for per-stage timings is someone rehearsing their own migration.
+	// AddFlagSet shares the *pflag.Flag, so this also hides it from the grouped
+	// FlagUsages printed by SetUsageFunc above.
+	_ = migrationExecuteCmd.Flags().MarkHidden("run-report")
 
 	_ = migrationExecuteCmd.MarkFlagRequired("migration-id")
 	_ = migrationExecuteCmd.MarkFlagRequired("lag-threshold")
@@ -297,5 +306,6 @@ func parseMigrationExecutorOpts(state migration.MigrationState, config migration
 		InsecureSkipTLSVerify: insecureSkipTLSVerify,
 		RolloutTimeout:        rolloutTimeout,
 		PromoteBatchSize:      promoteBatchSize,
+		RunReportPath:         runReport,
 	}
 }

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -45,6 +45,9 @@ type MigrationExecutorOpts struct {
 	// synchronous batches of this size, waiting for each batch to reach
 	// STOPPED before promoting the next.
 	PromoteBatchSize int
+	// RunReportPath, when non-empty, is where per-stage timings are written as
+	// JSON. Empty (the default) disables the report.
+	RunReportPath string
 }
 
 type MigrationExecutor struct {
@@ -98,15 +101,29 @@ func (m *MigrationExecutor) Run() error {
 		m.opts.MigrationStateFile,
 	)
 
+	// The run report is stamped on the way out whatever the outcome: a migration
+	// that failed — or one whose lag never converged — is a result worth
+	// recording, and a caller timing the run needs the stages that did complete.
+	runReport := migration.NewRunReportRecorder(
+		m.opts.RunReportPath,
+		config.MigrationId,
+		len(config.Topics),
+		m.opts.LagThreshold,
+		config.CurrentState,
+	)
+	orchestrator.SetRunReportRecorder(runReport)
+	var execErr error
+	defer func() { runReport.Finish(config.CurrentState, execErr) }()
+
 	clusterLinkConfig := migration.BuildClusterLinkConfig(&config, m.opts.ClusterApiKey, m.opts.ClusterApiSecret)
 
 	// The consumer-offset-sync pause runs INSIDE the FSM (the
 	// pause_offset_sync stage, right after fencing) so destination offsets
 	// stay fresh through the lag and fence phases instead of going stale for
 	// the whole run. Only the restore below remains a bookend.
-	if err := orchestrator.Execute(ctx, m.opts.LagThreshold, m.opts.ClusterApiKey, m.opts.ClusterApiSecret); err != nil {
-		migration.WarnIfPausedOnExecuteFailure(&config, err)
-		return fmt.Errorf("failed to execute migration: %w", err)
+	if execErr = orchestrator.Execute(ctx, m.opts.LagThreshold, m.opts.ClusterApiKey, m.opts.ClusterApiSecret); execErr != nil {
+		migration.WarnIfPausedOnExecuteFailure(&config, execErr)
+		return fmt.Errorf("failed to execute migration: %w", execErr)
 	}
 
 	// Post-execute bookend: restore consumer.offset.sync.enable. Soft-fail

--- a/internal/services/migration/atomic_write.go
+++ b/internal/services/migration/atomic_write.go
@@ -1,0 +1,46 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to filePath via a uniquely-named temp file in the
+// same directory, then renames it onto the target.
+//
+// The mode is pinned explicitly rather than left to os.CreateTemp's 0600, so
+// callers that need a different mode get it deterministically and callers that
+// want 0600 are not relying on an implementation detail. The real file is only
+// ever replaced by the rename and is never truncated or deleted directly, so a
+// crash before the rename leaves the previous contents intact — which is what
+// makes it safe for a file the migration rewrites repeatedly as it progresses.
+func writeFileAtomic(filePath string, data []byte, perm os.FileMode) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+
+	if err := tmpFile.Chmod(perm); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to set temp file permissions: %w", err)
+	}
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, filePath); err != nil {
+		_ = os.Remove(tmpName) // best-effort cleanup of temp file on error
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -96,7 +96,8 @@ type MigrationOrchestrator struct {
 	actions        *MigrationActions
 	migrationState *MigrationState
 	stateFilePath  string
-	reporter       *reporter // user-facing terminal output
+	reporter       *reporter          // user-facing terminal output
+	runReport      *RunReportRecorder // per-stage timings; nil when not requested
 }
 
 // NewMigrationOrchestrator creates a new migration orchestrator with injected dependencies
@@ -202,6 +203,14 @@ func NewMigrationOrchestrator(
 	return orchestrator
 }
 
+// SetRunReportRecorder attaches a run-report recorder, which records per-stage
+// timings as Execute walks the workflow. A nil recorder (the default) disables
+// reporting; it is a setter rather than a constructor argument so the init path,
+// which builds an orchestrator for a single transition, is untouched.
+func (o *MigrationOrchestrator) SetRunReportRecorder(r *RunReportRecorder) {
+	o.runReport = r
+}
+
 // Initialize triggers the initialization event
 func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, clusterApiSecret string) error {
 	params := ExecutionParams{ClusterApiKey: clusterApiKey, ClusterApiSecret: clusterApiSecret}
@@ -228,9 +237,15 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 	}
 
 	// Drive execution from canonical workflow - single source of truth
+	//
+	// Stage timings are taken here rather than on the FSM's before/after
+	// callbacks: looplab runs the named before_<EVENT> callback — which is where
+	// the step's actual work happens — BEFORE the general before_event one, so
+	// before_event fires after the work is already done and cannot mark a start.
 	for _, step := range canonicalWorkflow {
 		if !o.canTransition(step.Event) {
 			slog.Debug("skipping already-completed step", "step", step.Description, "event", step.Event)
+			o.runReport.StageSkipped(step.Event)
 			continue // Skip already-completed steps (enables resumability)
 		}
 
@@ -238,9 +253,12 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 			o.reporter.section(header)
 		}
 		slog.Debug("executing migration step", "step", step.Description)
+		o.runReport.StageStarted(step.Event, step.FromState, step.ToState)
 		if err := o.fsm.Event(ctx, step.Event, params); err != nil {
+			o.runReport.StageFailed(err)
 			return o.handleStepFailure(ctx, step, err, params)
 		}
+		o.runReport.StageEnded(o.config.CurrentState)
 		if err := o.PersistState(); err != nil {
 			return fmt.Errorf("failed during %s: %w", step.Description, err)
 		}

--- a/internal/services/migration/run_report.go
+++ b/internal/services/migration/run_report.go
@@ -1,0 +1,212 @@
+package migration
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/confluentinc/kcp/internal/build_info"
+)
+
+// Run outcomes. A run that never reaches the end of the workflow loop is
+// "failed"; there is deliberately no "partial" value, because a report found on
+// disk with neither outcome set is itself the signal that kcp was killed
+// mid-run (see RunReportRecorder's incremental flush).
+const (
+	RunOutcomeCompleted = "completed"
+	RunOutcomeFailed    = "failed"
+)
+
+// RunReportStage is one committed (or attempted) workflow transition, timed.
+//
+// Only forward steps that actually ran appear here — steps skipped because the
+// migration was resumed past them are listed by name in RunReport.SkippedStages
+// instead, so every entry in Stages carries real timings and a consumer never
+// has to test for a zero timestamp.
+type RunReportStage struct {
+	Event      string    `json:"event"`
+	From       string    `json:"from"`
+	To         string    `json:"to"`
+	Started    time.Time `json:"started"`
+	Ended      time.Time `json:"ended"`
+	DurationMs int64     `json:"duration_ms"`
+	Failed     bool      `json:"failed,omitempty"`
+	Error      string    `json:"error,omitempty"`
+}
+
+// RunReport is the machine-readable record of one `kcp migration execute` run:
+// what it did, in what order, and how long each stage took.
+//
+// It is deliberately self-contained and free of anything about the environment
+// the run happened in — no run identifiers, no infrastructure timings, no
+// experiment parameters. Callers that need that context (the migration
+// performance rig, for one) wrap this document rather than adding fields to it,
+// so it stays meaningful on its own for anyone timing a rehearsal of their own
+// migration.
+//
+// It carries no credentials and no topic names — only the topic count.
+type RunReport struct {
+	MigrationId   string           `json:"migration_id"`
+	KcpVersion    string           `json:"kcp_version"`
+	KcpCommit     string           `json:"kcp_commit,omitempty"`
+	Topics        int              `json:"topics"`
+	LagThreshold  int64            `json:"lag_threshold"`
+	StartedAt     time.Time        `json:"started_at"`
+	EndedAt       time.Time        `json:"ended_at"`
+	DurationMs    int64            `json:"duration_ms"`
+	Stages        []RunReportStage `json:"stages"`
+	SkippedStages []string         `json:"skipped_stages,omitempty"`
+	FinalState    string           `json:"final_state"`
+	Outcome       string           `json:"outcome,omitempty"`
+	Error         string           `json:"error,omitempty"`
+}
+
+// RunReportRecorder accumulates a RunReport and flushes it to disk.
+//
+// Every method is safe on a nil receiver, so the orchestrator holds one
+// unconditionally and the no-report path costs a nil check rather than a
+// conditional at each call site.
+//
+// The report is rewritten after every stage rather than once at the end. Two
+// poll loops inside execute have no convergence bound of their own (lag checking
+// and promotion), so a caller that imposes an external deadline and kills the
+// process is an expected way for a run to end — and an incremental flush leaves
+// the stages that did complete on disk, where a single write at exit would leave
+// nothing. Each flush is a whole-file atomic replace, so a kill during one
+// cannot corrupt the previous version.
+type RunReportRecorder struct {
+	path    string
+	report  RunReport
+	current *RunReportStage
+}
+
+// NewRunReportRecorder returns a recorder writing to path, or nil if path is
+// empty — which is what makes every method's nil-receiver tolerance load-bearing
+// rather than defensive.
+func NewRunReportRecorder(path, migrationId string, topics int, lagThreshold int64, initialState string) *RunReportRecorder {
+	if path == "" {
+		return nil
+	}
+	r := &RunReportRecorder{
+		path: path,
+		report: RunReport{
+			MigrationId:  migrationId,
+			KcpVersion:   build_info.Version,
+			KcpCommit:    build_info.Commit,
+			Topics:       topics,
+			LagThreshold: lagThreshold,
+			StartedAt:    time.Now(),
+			Stages:       []RunReportStage{},
+			FinalState:   initialState,
+		},
+	}
+	// Written immediately, before any stage runs. The first stage of a loaded migration is
+	// lag checking, which has no convergence bound — so a caller that imposes a deadline
+	// and kills the process may do so before ANY stage completes. Without this the file
+	// would never exist and the report would be indistinguishable from "the flag was never
+	// passed", when in fact it says something specific: the run died waiting on its first
+	// stage. Observed on a real run that was killed after 18 minutes in wait_for_lags.
+	r.flush()
+	return r
+}
+
+// StageStarted opens a stage. The from/to states come from the workflow edge
+// definition rather than the live FSM, so a stage records the transition it
+// attempted even when that transition is the one that failed.
+func (r *RunReportRecorder) StageStarted(event, from, to string) {
+	if r == nil {
+		return
+	}
+	r.current = &RunReportStage{
+		Event:   event,
+		From:    from,
+		To:      to,
+		Started: time.Now(),
+	}
+}
+
+// StageEnded closes the open stage as successful and flushes.
+func (r *RunReportRecorder) StageEnded(finalState string) {
+	if r == nil {
+		return
+	}
+	r.closeStage(nil)
+	r.report.FinalState = finalState
+	r.flush()
+}
+
+// StageFailed closes the open stage as failed and flushes. The run's own
+// outcome is not set here: a failed stage may still be followed by a
+// compensating rollback, and Finish owns the verdict.
+func (r *RunReportRecorder) StageFailed(err error) {
+	if r == nil {
+		return
+	}
+	r.closeStage(err)
+	r.flush()
+}
+
+// StageSkipped records a workflow step the run passed over because the
+// migration had already advanced beyond it.
+func (r *RunReportRecorder) StageSkipped(event string) {
+	if r == nil {
+		return
+	}
+	r.report.SkippedStages = append(r.report.SkippedStages, event)
+}
+
+// Finish stamps the run's verdict and writes the report a final time. It is
+// intended to be deferred, so it runs on the failure path as well — a run that
+// did not converge is a result worth recording, not an absence of one.
+func (r *RunReportRecorder) Finish(finalState string, runErr error) {
+	if r == nil {
+		return
+	}
+	// A stage still open here means the run ended without either closing path
+	// having run — a panic, or an early return that bypassed them. Close it so
+	// the timings stay consistent rather than dropping the stage entirely.
+	r.closeStage(runErr)
+
+	r.report.FinalState = finalState
+	r.report.EndedAt = time.Now()
+	r.report.DurationMs = r.report.EndedAt.Sub(r.report.StartedAt).Milliseconds()
+	if runErr != nil {
+		r.report.Outcome = RunOutcomeFailed
+		r.report.Error = runErr.Error()
+	} else {
+		r.report.Outcome = RunOutcomeCompleted
+	}
+	r.flush()
+}
+
+func (r *RunReportRecorder) closeStage(err error) {
+	if r.current == nil {
+		return
+	}
+	stage := *r.current
+	r.current = nil
+
+	stage.Ended = time.Now()
+	stage.DurationMs = stage.Ended.Sub(stage.Started).Milliseconds()
+	if err != nil {
+		stage.Failed = true
+		stage.Error = err.Error()
+	}
+	r.report.Stages = append(r.report.Stages, stage)
+}
+
+// flush replaces the report on disk. A write failure is logged and swallowed:
+// the report is an observability artifact, and losing it must never fail a
+// migration that is otherwise succeeding.
+func (r *RunReportRecorder) flush() {
+	data, err := json.MarshalIndent(r.report, "", "  ")
+	if err != nil {
+		slog.Warn("⚠️ failed to marshal migration run report", "error", err)
+		return
+	}
+	if err := writeFileAtomic(r.path, append(data, '\n'), 0600); err != nil {
+		slog.Warn("⚠️ failed to write migration run report", "path", r.path, "error", err)
+		return
+	}
+	slog.Debug("wrote migration run report", "path", r.path, "stages", len(r.report.Stages))
+}

--- a/internal/services/migration/run_report_test.go
+++ b/internal/services/migration/run_report_test.go
@@ -1,0 +1,268 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRunReport loads and decodes a run report written to disk.
+func readRunReport(t *testing.T, path string) RunReport {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "run report should exist at %s", path)
+
+	var report RunReport
+	require.NoError(t, json.Unmarshal(data, &report), "run report should be valid JSON")
+	return report
+}
+
+// stageEvents returns the recorded stage events in order, for comparing against
+// the workflow sequence without asserting on timings.
+func stageEvents(report RunReport) []string {
+	events := make([]string, 0, len(report.Stages))
+	for _, s := range report.Stages {
+		events = append(events, s.Event)
+	}
+	return events
+}
+
+// TestRunReport_NilRecorderIsInert covers the disabled path: NewRunReportRecorder
+// returns nil for an empty path, and every method must tolerate that, because the
+// orchestrator calls them unconditionally.
+func TestRunReport_NilRecorderIsInert(t *testing.T) {
+	r := NewRunReportRecorder("", "migration-1", 3, 0, StateUninitialized)
+	require.Nil(t, r, "an empty path should disable reporting")
+
+	// None of these may panic.
+	r.StageStarted(EventFence, StateLagsOk, StateFenced)
+	r.StageEnded(StateFenced)
+	r.StageSkipped(EventInitialize)
+	r.StageFailed(errors.New("boom"))
+	r.Finish(StateFenced, nil)
+}
+
+// TestRunReport_FullWorkflow drives a real orchestrator run and asserts the
+// report describes it: every forward stage, in workflow order, with a completed
+// outcome. This tests the wiring, not just the writer — the recorder is only
+// useful if the orchestrator actually calls it at the right points.
+func TestRunReport_FullWorkflow(t *testing.T) {
+	orch, config, _ := newHappyPathOrchestrator(t, StateUninitialized, nil)
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+
+	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 42, config.CurrentState)
+	require.NotNil(t, recorder)
+	orch.SetRunReportRecorder(recorder)
+
+	err := orch.Execute(context.Background(), 42, "api-key", "api-secret")
+	require.NoError(t, err)
+	recorder.Finish(config.CurrentState, nil)
+
+	// Surface the artifact itself: this document is a consumer-facing contract,
+	// so `go test -v -run TestRunReport_FullWorkflow` should show what it emits.
+	raw, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+	t.Logf("run report:\n%s", raw)
+
+	report := readRunReport(t, reportPath)
+
+	assert.Equal(t, config.MigrationId, report.MigrationId)
+	assert.Equal(t, len(config.Topics), report.Topics)
+	assert.Equal(t, int64(42), report.LagThreshold)
+	assert.Equal(t, StateSwitched, report.FinalState)
+	assert.Equal(t, RunOutcomeCompleted, report.Outcome)
+	assert.Empty(t, report.Error)
+	assert.Empty(t, report.SkippedStages, "a run from uninitialized skips nothing")
+
+	// Every forward transition in the canonical workflow should be recorded, in order.
+	expected := make([]string, 0, len(canonicalWorkflow))
+	for _, step := range canonicalWorkflow {
+		expected = append(expected, step.Event)
+	}
+	assert.Equal(t, expected, stageEvents(report))
+
+	// Each stage must carry real timings and the edge it traversed.
+	for i, stage := range report.Stages {
+		assert.Equal(t, canonicalWorkflow[i].FromState, stage.From, "stage %s from-state", stage.Event)
+		assert.Equal(t, canonicalWorkflow[i].ToState, stage.To, "stage %s to-state", stage.Event)
+		assert.False(t, stage.Started.IsZero(), "stage %s should have a start time", stage.Event)
+		assert.False(t, stage.Ended.IsZero(), "stage %s should have an end time", stage.Event)
+		assert.GreaterOrEqual(t, stage.DurationMs, int64(0), "stage %s duration", stage.Event)
+		assert.False(t, stage.Failed, "stage %s should not be marked failed", stage.Event)
+	}
+
+	// The run's duration must cover the stages it contains.
+	assert.False(t, report.EndedAt.IsZero())
+	assert.GreaterOrEqual(t, report.DurationMs, int64(0))
+	assert.NotEmpty(t, report.KcpVersion, "the report should stamp the writing binary's version")
+}
+
+// TestRunReport_ResumeRecordsSkippedStages verifies that a resumed run
+// distinguishes stages it ran from stages it passed over. Skipped stages are
+// named in SkippedStages rather than appearing in Stages with zero timings, so a
+// consumer never has to test for a zero timestamp.
+func TestRunReport_ResumeRecordsSkippedStages(t *testing.T) {
+	orch, config, _ := newHappyPathOrchestrator(t, StateLagsOk, nil)
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+
+	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
+	orch.SetRunReportRecorder(recorder)
+
+	require.NoError(t, orch.Execute(context.Background(), 0, "api-key", "api-secret"))
+	recorder.Finish(config.CurrentState, nil)
+
+	report := readRunReport(t, reportPath)
+
+	// Resuming at lags_ok means initialize and wait_for_lags were already done.
+	assert.Equal(t, []string{EventInitialize, EventWaitForLags}, report.SkippedStages)
+	assert.NotContains(t, stageEvents(report), EventInitialize)
+	assert.NotContains(t, stageEvents(report), EventWaitForLags)
+	assert.Equal(t, EventFence, report.Stages[0].Event, "the first stage run should be the fence")
+	assert.Equal(t, RunOutcomeCompleted, report.Outcome)
+}
+
+// TestRunReport_FailedRunIsRecorded is the case the perf rig depends on: a run
+// that does not complete must still leave a report naming the stage that failed.
+// A failure is a result, not an absence of one.
+func TestRunReport_FailedRunIsRecorded(t *testing.T) {
+	overrides := orchestratorOverrides{
+		applyGatewayYAMLFn: func(ctx context.Context, namespace, name string, yaml []byte) error {
+			return fmt.Errorf("apply gateway failed: forbidden")
+		},
+	}
+	orch, config, _ := newHappyPathOrchestrator(t, StateUninitialized, nil, overrides)
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+
+	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
+	orch.SetRunReportRecorder(recorder)
+
+	execErr := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	require.Error(t, execErr)
+	recorder.Finish(config.CurrentState, execErr)
+
+	report := readRunReport(t, reportPath)
+
+	assert.Equal(t, RunOutcomeFailed, report.Outcome)
+	assert.Contains(t, report.Error, "forbidden")
+	assert.Equal(t, StateLagsOk, report.FinalState, "the fence failed, so the run ends at lags_ok")
+
+	// The fence stage should be present and flagged, not silently dropped.
+	fence := report.Stages[len(report.Stages)-1]
+	assert.Equal(t, EventFence, fence.Event)
+	assert.True(t, fence.Failed, "the failing stage must be marked failed")
+	assert.Contains(t, fence.Error, "forbidden")
+	assert.False(t, fence.Ended.IsZero(), "a failed stage still needs an end time")
+
+	// The stages that succeeded before it must be recorded as successes.
+	assert.Equal(t, []string{EventInitialize, EventWaitForLags, EventFence}, stageEvents(report))
+	assert.False(t, report.Stages[0].Failed)
+	assert.False(t, report.Stages[1].Failed)
+}
+
+// TestRunReport_WrittenBeforeAnyStage covers the case that actually happened: a loaded
+// migration was killed after 18 minutes in wait_for_lags — its first stage — so no stage
+// ever completed. Without an initial write the report would not exist at all, and a
+// missing file cannot be told apart from the flag never having been passed. The file has
+// to say "this run started and got no further".
+func TestRunReport_WrittenBeforeAnyStage(t *testing.T) {
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+	r := NewRunReportRecorder(reportPath, "migration-1", 10, 200, StateInitialized)
+	require.NotNil(t, r)
+
+	report := readRunReport(t, reportPath)
+	assert.Equal(t, "migration-1", report.MigrationId)
+	assert.Equal(t, 10, report.Topics)
+	assert.Equal(t, int64(200), report.LagThreshold)
+	assert.Equal(t, StateInitialized, report.FinalState)
+	assert.Empty(t, report.Stages, "no stage has run yet")
+	assert.Empty(t, report.Outcome, "an unfinished run must not claim an outcome")
+	assert.False(t, report.StartedAt.IsZero(), "the start time is the useful fact here")
+}
+
+// TestRunReport_FlushesIncrementally covers the kill case. Lag checking and
+// promotion have no convergence bound of their own, so an external deadline
+// killing the process is an expected ending — and the stages that completed
+// before the kill must already be on disk. A report with stages but no outcome
+// is precisely the signal that this happened.
+func TestRunReport_FlushesIncrementally(t *testing.T) {
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+	r := NewRunReportRecorder(reportPath, "migration-1", 2, 0, StateUninitialized)
+
+	r.StageStarted(EventInitialize, StateUninitialized, StateInitialized)
+	r.StageEnded(StateInitialized)
+
+	// Simulate the kill: a second stage opens but never closes, and Finish is
+	// never reached.
+	r.StageStarted(EventWaitForLags, StateInitialized, StateLagsOk)
+
+	report := readRunReport(t, reportPath)
+	require.Len(t, report.Stages, 1, "the completed stage should already be on disk")
+	assert.Equal(t, EventInitialize, report.Stages[0].Event)
+	assert.Equal(t, StateInitialized, report.FinalState)
+	assert.Empty(t, report.Outcome, "an unfinished run must not claim an outcome")
+}
+
+// TestRunReport_FinishClosesAnOpenStage guards the path where the run ends with
+// a stage still open, so its timing is preserved rather than dropped.
+func TestRunReport_FinishClosesAnOpenStage(t *testing.T) {
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+	r := NewRunReportRecorder(reportPath, "migration-1", 2, 0, StateUninitialized)
+
+	r.StageStarted(EventWaitForLags, StateInitialized, StateLagsOk)
+	r.Finish(StateInitialized, errors.New("context deadline exceeded"))
+
+	report := readRunReport(t, reportPath)
+	require.Len(t, report.Stages, 1, "the open stage should be closed, not dropped")
+	assert.Equal(t, EventWaitForLags, report.Stages[0].Event)
+	assert.True(t, report.Stages[0].Failed)
+	assert.Contains(t, report.Stages[0].Error, "deadline")
+	assert.Equal(t, RunOutcomeFailed, report.Outcome)
+}
+
+// TestRunReport_WrittenAt0600 keeps the report at the same permissions as the
+// migration state file it sits beside.
+func TestRunReport_WrittenAt0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+	r := NewRunReportRecorder(reportPath, "migration-1", 1, 0, StateUninitialized)
+	r.Finish(StateUninitialized, nil)
+
+	info, err := os.Stat(reportPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// TestRunReport_NoCredentialsOrTopicNames pins the document's blast radius: it is
+// meant to be collected and archived, so it must not carry credentials, and it
+// records only a topic count rather than the topic names themselves.
+func TestRunReport_NoCredentialsOrTopicNames(t *testing.T) {
+	orch, config, _ := newHappyPathOrchestrator(t, StateUninitialized, []string{"secret-topic-name"})
+	reportPath := filepath.Join(t.TempDir(), "run-report.json")
+
+	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
+	orch.SetRunReportRecorder(recorder)
+
+	require.NoError(t, orch.Execute(context.Background(), 0, "api-key", "api-secret"))
+	recorder.Finish(config.CurrentState, nil)
+
+	raw, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+	contents := string(raw)
+
+	assert.NotContains(t, contents, "api-key")
+	assert.NotContains(t, contents, "api-secret")
+	assert.NotContains(t, contents, "secret-topic-name")
+	assert.Contains(t, contents, `"topics": 1`, "the topic count is kept")
+}

--- a/internal/services/migration/state.go
+++ b/internal/services/migration/state.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/confluentinc/kcp/internal/build_info"
@@ -181,39 +180,10 @@ func (ms *MigrationState) WriteToFile(filePath string) error {
 		return fmt.Errorf("failed to marshal migration state: %w", err)
 	}
 
-	// Atomic write: write to a uniquely-named temp file (created at mode 0600 by
-	// os.CreateTemp and pinned explicitly), then rename it onto the target. The
-	// migration state holds sensitive metadata, so it must never be group/world
-	// readable, even briefly or under an unusual umask. The real file is only
-	// ever replaced by the rename and is never deleted directly, so a crash
-	// before the rename leaves the previous migration state intact.
-	tmpFile, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
-	}
-	tmpName := tmpFile.Name()
-
-	if err := tmpFile.Chmod(0600); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("failed to set temp file permissions: %w", err)
-	}
-	if _, err := tmpFile.Write(data); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("failed to write temp file: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("failed to close temp file: %w", err)
-	}
-
-	if err := os.Rename(tmpName, filePath); err != nil {
-		_ = os.Remove(tmpName) // best-effort cleanup of temp file on error
-		return fmt.Errorf("failed to rename temp file: %w", err)
-	}
-
-	return nil
+	// The migration state holds sensitive metadata, so it must never be
+	// group/world readable, even briefly or under an unusual umask — hence 0600
+	// through the atomic writer.
+	return writeFileAtomic(filePath, data, 0600)
 }
 
 // UpsertMigration adds a new migration or updates an existing one by ID


### PR DESCRIPTION
## What this adds

A hidden `--run-report <path>` flag on `kcp migration execute`. When set, it writes
per-stage migration timings to a JSON file. When not set, nothing changes at all.

`execute` already walks a state machine — `wait_for_lags → fence → pause_offset_sync →
verify_fence → promote → switch`. This records how long each transition took:

```json
{
  "migration_id": "migration-7847bcf6-…",
  "kcp_version": "0.0.0-localdev",
  "kcp_commit": "c257cbe6…",
  "topics": 10,
  "lag_threshold": 400,
  "duration_ms": 374845,
  "stages": [
    { "event": "wait_for_lags", "from": "initialized", "to": "lags_ok",
      "started": "…", "ended": "…", "duration_ms": 877 },
    { "event": "fence", "from": "lags_ok", "to": "fenced",
      "started": "…", "ended": "…", "duration_ms": 174109 }
  ],
  "final_state": "switched",
  "outcome": "completed"
}
```

A failed stage is recorded with `failed: true` and the error text, and the file is
flushed after **every** stage rather than at the end — so a run killed mid-flight still
yields everything that completed. That matters because `CheckLags` and `PromoteTopics`
have no convergence bound of their own, so an external supervisor killing the process is
a normal outcome, not an exceptional one.

## Why

We are building an end-to-end live migration test against real infrastructure — two
Confluent Cloud Dedicated clusters, a real cluster link, EKS, CFK, a real Confluent
Gateway, and real client load through it — intended as a **release gate**: run it against
a build to answer "did this break the migration?"

The gate needs per-stage timings, not just a total. Two examples of what that bought
during development:

- A run stalled at the fence for its full 15-minute rollout timeout. The report showed
  `fence` at 900,963ms with `failed: true` and the rollout error, which is what
  identified the cause.
- Across three runs on separate environments, `promote` came in at 37.099s / 36.935s /
  37.135s and `switch` at 162.638s / 162.417s / 162.724s. That tightness makes these
  useful regression detectors — a build that moved `promote` to 60s would stand out
  immediately. It is also only visible at stage granularity.

## The honest alternative, and why not

**These timings are already derivable from `kcp.log`** by differencing the stage banners.
Checked against a real run:

| Stage | From log banners | From run report |
| --- | --- | --- |
| `wait_for_lags` | 2s | 2.149s |
| `fence` | 174s | 174.404s |
| `promote` | 43s | 42.767s |
| `switch` | 163s | 162.719s |

So this flag is a convenience, not a capability. The case for it is:

1. **No coupling to human-readable log strings.** A reworded banner or changed emoji
   silently breaks a scraper — and breaks it into wrong timings rather than a clean
   error. For an automated gate, where a false failure is worse than no gate, taking a
   dependency on log prose is the wrong trade.
2. **Structured outcome data** — `final_state`, `outcome`, per-stage `failed`/`error`,
   `skipped_stages` — rather than inferring them.
3. **Provenance.** `kcp_version` and `kcp_commit` recorded by kcp itself, which for a gate
   testing a specific build is the whole point.
4. Millisecond resolution. The 0.2s reproducibility above is invisible at 1s granularity.

If reviewers would rather the test rig scraped the log, that is a legitimate position and
this can be dropped — the rig would just carry the coupling instead.

## Footprint

```
run_report.go                212 ++    new, self-contained
run_report_test.go           268 ++    tests — nearly half the diff
atomic_write.go               46 ++    extracted from state.go
orchestrator.go               20 +-    one field, one setter, 4 call sites
migration_executor.go         23 +-    construct + defer Finish
cmd_migration_execute.go      10 ++    the flag
state.go                      38 --    SHRANK — now uses the shared helper
```

The four orchestrator call sites are on a **nil-tolerant** recorder: with no
`--run-report`, every method is a no-op and behaviour is byte-identical. `state.go` got
smaller because the atomic-write helper it already had was extracted and shared.

Stage timing is taken in `Execute`'s loop rather than in FSM callbacks, deliberately —
looplab's non-reentrant `eventMu` makes doing work inside a callback hazardous, and the
existing code already avoids it for rollback events.

## Why hidden

Following the existing precedent for `kcp migrate`, which is registered but hidden. This
is tooling support rather than a user-facing feature, so it is excluded from `--help` and
from generated docs, while still being covered by tests so a refactor cannot quietly
break it.

Happy to unhide and document it instead if reviewers prefer — the argument for that is
that a release gate depending on an undocumented flag is a slightly odd contract.

## Testing

- `run_report_test.go` — 268 lines covering stage recording, failure capture, skipped
  stages, incremental flush, nil-recorder tolerance and atomic write.
- `make test-go` green: 71 packages ok, 0 failed.
- Exercised against real infrastructure: four migrations reached `switched` on live
  Confluent Cloud clusters, plus the failure paths described above (a stalled fence
  rollout, and a run killed by an external deadline mid-stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
