### PR TITLE
fix(connect-scan): bound curl calls with a connect/max-time timeout

### DIFF
--- a/integration-tests/connect-scan/setup.sh
+++ b/integration-tests/connect-scan/setup.sh
@@ -20,11 +20,14 @@ CONNECTOR_JSON='{
 }'
 
 # wait_rest <label> <base-url> [curl-auth-args...] — poll the Connect REST root.
+# --connect-timeout/--max-time bound each attempt so a listener that accepts the
+# TCP connection but never completes the TLS handshake (or never responds) fails
+# that attempt in seconds instead of hanging the whole retry loop indefinitely.
 wait_rest() {
   local label="$1" url="$2"; shift 2
   echo "Waiting for Kafka Connect REST — $label ($url)..."
   for i in $(seq 1 60); do
-    if curl -s "$@" "$url/" > /dev/null 2>&1; then
+    if curl -s --connect-timeout 3 --max-time 5 "$@" "$url/" > /dev/null 2>&1; then
       echo "  $label ready!"
       return 0
     fi
@@ -39,7 +42,7 @@ create_connector() {
   echo "Creating test connector — $label..."
   for i in $(seq 1 30); do
     local code
-    code=$(curl -s -o /dev/null -w "%{http_code}" "$@" -X POST "$url/connectors" \
+    code=$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w "%{http_code}" "$@" -X POST "$url/connectors" \
       -H "Content-Type: application/json" -d "$CONNECTOR_JSON" 2>/dev/null)
     if [ "$code" = "201" ] || [ "$code" = "200" ]; then
       echo "  connector created on $label (HTTP $code)"
@@ -80,7 +83,7 @@ create_connector "basic-tls" "https://localhost:18087" "${BASIC_TLS_AUTH[@]}"
 # ── Jolokia on the unauthenticated worker (:18781) for the metrics subtest ────
 echo "Waiting for Jolokia on the unauthenticated Connect worker (:18781)..."
 for i in $(seq 1 30); do
-  if curl -s http://localhost:18781/jolokia/version > /dev/null 2>&1; then
+  if curl -s --connect-timeout 3 --max-time 5 http://localhost:18781/jolokia/version > /dev/null 2>&1; then
     echo "  Jolokia ready!"
     break
   fi


### PR DESCRIPTION
The `kafka connect scan` Semaphore job has hung and eventually been killed after ~38 minutes ([job 2058e5ee](https://semaphore.ci.confluent.io/jobs/2058e5ee-7d87-4445-9511-b7a718705130), PR #410) instead of failing fast — the job log shows it stuck mid-run with no further progress, no error, and no test output.

The cause is in `integration-tests/connect-scan/setup.sh`: `wait_rest`, `create_connector`, and the Jolokia readiness check all call `curl` with no `--connect-timeout`/`--max-time`. If a Connect worker's listener accepts the TCP connection but never completes the TLS handshake or response — which is what happened to the mTLS worker on that run — curl blocks on that single attempt indefinitely instead of failing it and moving on, so the existing 60x/30x retry loops never get a chance to run out and report a real error.

Adding `--connect-timeout 3 --max-time 5` to all three call sites bounds each attempt to a few seconds, so a stuck listener now fails its retry loop with a clear `ERROR: ... REST did not become ready in time` in ~2 minutes instead of hanging until the CI job is force-killed.

**Verification:**
- Synthetic stuck-listener test: curl against a socket that accepts but never responds now returns in ~6s with exit code 28 (`CURLE_OPERATION_TIMEDOUT`) instead of hanging.
- `make test-kafka-connect` passes locally with the fix in place — all four Connect workers (including mTLS) come up and `TestConnectScanAuthMethods`/`TestConnectScanMetrics` pass in 32.7s, confirming the added timeouts don't regress the happy path.

Not a regression from any in-flight PR — `integration-tests/connect-scan/` hasn't changed since #400; this is a pre-existing gap that only bites when a worker's listener actually gets stuck.
