### PR TITLE
feat(osk): override broker metric names for relabelled exporters

### DIFF
--- a/cmd/scan/clusters/cmd_scan_clusters.go
+++ b/cmd/scan/clusters/cmd_scan_clusters.go
@@ -450,7 +450,7 @@ func collectJolokiaMetrics(ctx context.Context, clusterCreds types.OSKClusterAut
 		jolokiaOpts = append(jolokiaOpts, client.WithJolokiaTLS(caPool, clusterCreds.Jolokia.TLS.InsecureSkipVerify))
 	}
 
-	jmxService := jmx.NewJMXService(clusterCreds.Jolokia.Endpoints, jmx.BrokerMetricDefinitions(), "broker", jolokiaOpts...)
+	jmxService := jmx.NewJMXService(clusterCreds.Jolokia.Endpoints, jmx.BrokerMetricDefinitions(clusterCreds.Jolokia.MBeanOverrides), "broker", jolokiaOpts...)
 	return jmxService.CollectOverDuration(ctx, duration, interval)
 }
 
@@ -485,6 +485,6 @@ func collectPrometheusMetrics(ctx context.Context, clusterCreds types.OSKCluster
 	}
 
 	promClient := client.NewPrometheusClient(clusterCreds.Prometheus.URL, promOpts...)
-	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.BrokerQueryDefinitions(), labels)
+	promService := prometheussvc.NewPrometheusService(promClient, prometheussvc.BrokerQueryDefinitions(clusterCreds.Prometheus.MetricNames), labels)
 	return promService.CollectMetrics(ctx, queryRange)
 }

--- a/docs/assets/apache-kafka-configuration/credentials.md
+++ b/docs/assets/apache-kafka-configuration/credentials.md
@@ -137,6 +137,8 @@ jolokia:
   tls:                          # optional — omit for plain HTTP
     ca_cert: /path/to/ca.pem
     insecure_skip_verify: false
+  mbean_overrides:              # optional — see "Metric-name overrides" below
+    BytesInPerSec: "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec"
 ```
 
 | Field                       | Required | Description                                                          |
@@ -145,6 +147,7 @@ jolokia:
 | `auth.username` / `password`| no       | HTTP basic auth credentials.                                         |
 | `tls.ca_cert`               | no       | CA certificate for HTTPS Jolokia endpoints.                          |
 | `tls.insecure_skip_verify`  | no       | Skip TLS verification (test environments only).                      |
+| `mbean_overrides`           | no       | Map of logical metric label → MBean object name for agents that expose non-standard MBean names. See [Metric-name overrides](#metric-name-overrides). |
 
 ### `prometheus` — optional, for historical metrics
 
@@ -160,6 +163,9 @@ prometheus:
   filter:                       # optional — scope queries to a specific target
     labels:
       job: confluent/kafka-jmx-exporter
+  metric_names:                 # optional — see "Metric-name overrides" below
+    BytesInPerSec: acme_broker_bytesin_total
+    MessagesInPerSec: acme_broker_messagesin_total
 ```
 
 | Field                       | Required | Description                                                          |
@@ -169,10 +175,37 @@ prometheus:
 | `tls.ca_cert`               | no       | CA certificate for HTTPS Prometheus endpoints.                       |
 | `tls.insecure_skip_verify`  | no       | Skip TLS verification (test environments only).                      |
 | `filter.labels`             | no       | Map of Prometheus label selectors to scope queries. When set, all PromQL queries include these as `{key="value"}` filters. Useful when a single Prometheus scrapes multiple clusters. |
+| `metric_names`              | no       | Map of logical metric label → base Prometheus series name for exporters that relabel the standard series. See [Metric-name overrides](#metric-name-overrides). |
 
 `jolokia` and `prometheus` are mutually exclusive per scan invocation — `--metrics`
 selects which one `kcp` reads. You can keep both blocks in the file and switch
 between them by changing the flag.
+
+### Metric-name overrides
+
+If your Prometheus exporter relabels the standard broker series, or your Jolokia
+agent exposes broker MBeans under non-standard object names, the built-in queries
+return empty results. Rather than patching those names in source, repoint them per
+cluster: `prometheus.metric_names` maps a logical label to the base **series name**
+your exporter exposes, and `jolokia.mbean_overrides` maps a logical label to the
+**MBean object name** your agent exposes.
+
+Both key on the same seven logical labels:
+
+`BytesInPerSec`, `BytesOutPerSec`, `MessagesInPerSec`, `PartitionCount`,
+`GlobalPartitionCount`, `ClientConnectionCount`, `TotalLocalStorageUsage`.
+
+- **Only labels you need to change** must appear; unlisted labels keep their defaults.
+- **Keys are validated at load time** — an unknown or misspelled label (wrong case
+  included) is a hard error listing the valid labels, not a silent no-op.
+- **Prometheus overrides replace the base series name only.** `kcp` keeps its own
+  wrapping (`sum(rate(<name>[<window>]))`, `sum(<name>)`, the GiB conversion) and
+  `filter.labels` injection, so the override is a rename, not a full-query rewrite.
+  For `GlobalPartitionCount` the `{name="GlobalPartitionCount"}` discriminator is
+  preserved on top of the overridden series name.
+- If an overridden metric **still** returns no data, `kcp` logs it at **WARN**
+  (a plain missing default is logged at DEBUG) — the override was configured
+  precisely to fix an empty result, so a still-empty result is worth surfacing.
 
 ## Where to go next
 

--- a/docs/assets/apache-kafka-configuration/credentials.md
+++ b/docs/assets/apache-kafka-configuration/credentials.md
@@ -195,14 +195,21 @@ Both key on the same seven logical labels:
 `BytesInPerSec`, `BytesOutPerSec`, `MessagesInPerSec`, `PartitionCount`,
 `GlobalPartitionCount`, `ClientConnectionCount`, `TotalLocalStorageUsage`.
 
-- **Only labels you need to change** must appear; unlisted labels keep their defaults.
+- **Only labels you need to change** must appear; unlisted labels keep their
+  defaults. A key with an empty value (`BytesInPerSec: ""`) is treated as *no
+  override* and silently ignored — set a real name or omit the key entirely.
 - **Keys are validated at load time** — an unknown or misspelled label (wrong case
-  included) is a hard error listing the valid labels, not a silent no-op.
+  included) is a hard error listing the valid labels, not a silent no-op. Both
+  blocks are validated whenever the file loads, regardless of which one `--metrics`
+  selects, so a typo in the block you are *not* currently scanning with still fails
+  the scan.
 - **Prometheus overrides replace the base series name only.** `kcp` keeps its own
   wrapping (`sum(rate(<name>[<window>]))`, `sum(<name>)`, the GiB conversion) and
   `filter.labels` injection, so the override is a rename, not a full-query rewrite.
   For `GlobalPartitionCount` the `{name="GlobalPartitionCount"}` discriminator is
-  preserved on top of the overridden series name.
+  preserved on top of the overridden series name — so your relabelled series must
+  still carry the `name="GlobalPartitionCount"` label, or the preserved
+  discriminator filters it down to nothing.
 - If an overridden metric **still** returns no data, `kcp` logs it at **WARN**
   (a plain missing default is logged at DEBUG) — the override was configured
   precisely to fix an empty result, so a still-empty result is worth surfacing.

--- a/docs/assets/apache-kafka-configuration/credentials.md
+++ b/docs/assets/apache-kafka-configuration/credentials.md
@@ -195,6 +195,31 @@ Both key on the same seven logical labels:
 `BytesInPerSec`, `BytesOutPerSec`, `MessagesInPerSec`, `PartitionCount`,
 `GlobalPartitionCount`, `ClientConnectionCount`, `TotalLocalStorageUsage`.
 
+For example, if your Prometheus JMX Exporter publishes the byte-rate series under
+an `acme_` prefix and drops the `_total` suffix, map just the labels that changed
+— everything you omit keeps its default:
+
+```yaml
+prometheus:
+  url: http://prometheus.example.com:9090
+  metric_names:
+    BytesInPerSec: acme_kafka_bytesin     # default: kafka_server_brokertopicmetrics_bytesinpersec_total
+    BytesOutPerSec: acme_kafka_bytesout   # default: kafka_server_brokertopicmetrics_bytesoutpersec_total
+```
+
+`kcp` slots the name into its own wrapping, so it now runs
+`sum(rate(acme_kafka_bytesin[<window>]))` in place of the default. The Jolokia
+equivalent maps the same logical label to a full MBean object name (domain
+included) rather than a series name:
+
+```yaml
+jolokia:
+  endpoints:
+    - http://broker1.example.com:8778/jolokia
+  mbean_overrides:
+    BytesInPerSec: "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec"   # default domain: kafka.server
+```
+
 - **Only labels you need to change** must appear; unlisted labels keep their
   defaults. A key with an empty value (`BytesInPerSec: ""`) is treated as *no
   override* and silently ignored — set a real name or omit the key entirely.
@@ -213,6 +238,12 @@ Both key on the same seven logical labels:
 - If an overridden metric **still** returns no data, `kcp` logs it at **WARN**
   (a plain missing default is logged at DEBUG) — the override was configured
   precisely to fix an empty result, so a still-empty result is worth surfacing.
+- **An override is a rename, not a re-interpretation.** The series or bean you
+  point at must have the same *shape* as the default — a byte counter for the
+  `*PerSec` rates, a gauge for the counts, raw bytes for storage. Repointing at a
+  rate gauge or a differently-united series yields a *wrong value with no error*,
+  not an empty result. See
+  [What an override does not change](metrics-collection.md#what-an-override-does-not-change).
 
 ## Where to go next
 

--- a/docs/assets/apache-kafka-configuration/metrics-collection.md
+++ b/docs/assets/apache-kafka-configuration/metrics-collection.md
@@ -145,6 +145,15 @@ Prometheus JMX Exporter with a standard Kafka configuration. If your exporter
 uses custom relabelling rules that rename these metrics, the queries will return
 empty results.
 
+When that happens you have three options: fix the exporter's relabelling, add a
+Prometheus recording rule that re-publishes the series under its default name, or
+— without touching your monitoring stack — repoint `kcp` at the names your
+exporter actually exposes with `prometheus.metric_names` in
+`apache-kafka-credentials.yaml`. The same mechanism exists for non-standard JMX
+MBean names via `jolokia.mbean_overrides`. See
+[Metric-name overrides](credentials.md#metric-name-overrides) for the label list
+and semantics.
+
 ## Filtering by cluster (Prometheus)
 
 When a single Prometheus instance scrapes multiple Kafka clusters, use

--- a/docs/assets/apache-kafka-configuration/metrics-collection.md
+++ b/docs/assets/apache-kafka-configuration/metrics-collection.md
@@ -40,29 +40,16 @@ KAFKA_OPTS="-javaagent:/path/to/jolokia-agent.jar=port=8778,host=0.0.0.0"
 Each broker runs its own Jolokia endpoint, so for a multi-broker cluster you
 list every endpoint under `jolokia.endpoints` in `apache-kafka-credentials.yaml`.
 
-## Counter-based rates, not EWMA
-
-Kafka's JMX rate metrics (`BytesInPerSec`, `MessagesInPerSec`, …) ship several
-pre-computed fields including `OneMinuteRate`, `FiveMinuteRate` and
-`FifteenMinuteRate`. These are **exponentially weighted moving averages
-(EWMA)** — useful for dashboards, but unsuitable for aggregation: consecutive
-EWMA samples are highly correlated, so a min/max/average over them
-under-states the true variance in traffic.
-
-For the **Jolokia** backend, `kcp` reads the `Count` field — a monotonic
-counter of total bytes (or messages) since broker start — and computes the
-actual rate over each sample interval:
-
-```
-rate = (Count_current - Count_previous) / elapsed_seconds
-```
-
-This produces independent data points with real variance, accurately reflecting
-traffic over each interval.
-
-The **Prometheus** backend achieves the same result using PromQL's `rate()`
-function, which computes per-second rates from counters stored in Prometheus
-(see [Prometheus PromQL queries](#prometheus-promql-queries) below).
+> [!NOTE]
+> **Why counters, not the pre-computed rates.** Kafka's JMX rate metrics ship
+> `OneMinuteRate` / `FiveMinuteRate` / `FifteenMinuteRate` — exponentially
+> weighted moving averages, handy for dashboards but poor for aggregation:
+> consecutive samples are highly correlated, so a min/max/average over them
+> understates the true variance in traffic. Instead `kcp` reads the monotonic
+> `Count` and derives the rate itself over each interval — `(Count_current −
+> Count_previous) / elapsed` on Jolokia, PromQL's `rate()` on
+> [Prometheus](#prometheus-promql-queries) — yielding independent data points
+> that reflect real traffic.
 
 ## Scan duration and poll interval
 
@@ -154,6 +141,44 @@ exporter actually exposes with `prometheus.metric_names` in
 MBean names via `jolokia.mbean_overrides`. See
 [Metric-name overrides](credentials.md#metric-name-overrides) for the label list
 and semantics.
+
+## What an override does not change
+
+`prometheus.metric_names` and `jolokia.mbean_overrides` change **which identifier
+`kcp` queries** — a Prometheus series name or a JMX object name. They do **not**
+change how `kcp` reads the result. The series or bean you point at must match the
+*shape* of the default it replaces; if it doesn't, `kcp` records a wrong value with
+no error and — unlike a missing metric — no empty-result warning:
+
+| Metric(s)                                                        | Target must be…                                                                                                 |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `BytesInPerSec`, `BytesOutPerSec`, `MessagesInPerSec`            | a **monotonic counter** in **bytes** (or messages). Jolokia reads its `Count`; Prometheus wraps it in `rate()`. |
+| `PartitionCount`, `ClientConnectionCount`, `GlobalPartitionCount`| a plain **gauge**.                                                                                              |
+| `TotalLocalStorageUsage`                                         | raw **bytes** — `kcp` divides by 1024³ to report GiB.                                                           |
+
+> [!WARNING]
+> The sharpest trap is **counter vs. gauge**. `kcp` treats the three `*PerSec`
+> metrics as counters and derives the rate itself (`rate()` on Prometheus,
+> `Δcount / elapsed` on Jolokia). If you repoint one at a pre-averaged rate
+> **gauge** — an exporter mapping `OneMinuteRate`, or a native exporter that
+> already publishes a per-second value — the rate is taken *over a rate* and the
+> result is meaningless. Because the query still returns data, no warning fires.
+> A unit mismatch (bits instead of bytes; GiB instead of bytes for storage)
+> fails the same silent way: the number is simply wrong.
+
+Two more things an override does **not** touch:
+
+- **The Jolokia attribute is fixed** (`Count` for counters, `Value` for gauges).
+  The override changes the object name, not the attribute, so the bean you name
+  must expose its value under that same attribute.
+- **`GlobalPartitionCount` keeps its `{name="GlobalPartitionCount"}` discriminator**
+  on Prometheus, so an overridden series must still carry that `name` label (see
+  the [note above](#prometheus-promql-queries)).
+
+If your setup differs on unit, shape, read attribute, or per-broker aggregation —
+common when the same relabelling that renamed a metric also changed its `type:` or
+dropped a label — a name override alone is not enough. Fix it at the exporter, or
+add a Prometheus recording rule that republishes the series in the shape above.
 
 ## Filtering by cluster (Prometheus)
 

--- a/docs/assets/apache-kafka-configuration/metrics-collection.md
+++ b/docs/assets/apache-kafka-configuration/metrics-collection.md
@@ -131,8 +131,9 @@ endpoints and uses the first successful response. For **Prometheus**, the JMX
 Exporter must be scraping the controller pods/brokers for this metric to be
 available. With the default JMX Exporter configuration, the metric is exposed as
 `kafka_controller_kafkacontroller_value{name="GlobalPartitionCount"}`. If
-`GlobalPartitionCount` is not found, `kcp` will log an info message and the
-metric will be omitted from results — all other metrics will still be collected.
+`GlobalPartitionCount` is not found, `kcp` logs the omission — at WARN for
+Jolokia, DEBUG for Prometheus — and the metric is left out of the results; all
+other metrics are still collected.
 
 Ensure your Prometheus instance is scraping the Kafka controller nodes (not just
 broker nodes). In Kubernetes with KRaft mode, controllers may run as separate

--- a/integration-tests/osk-scan/credentials/jmx-bad-override.yaml
+++ b/integration-tests/osk-scan/credentials/jmx-bad-override.yaml
@@ -1,0 +1,19 @@
+clusters:
+  - id: osk-kafka
+    bootstrap_servers:
+      - localhost:9092
+    auth_method:
+      unauthenticated_plaintext:
+        use: true
+    jolokia:
+      endpoints:
+        - http://localhost:8778/jolokia
+      # Point BytesInPerSec at an MBean this agent does not expose. The read
+      # fails on every poll; kcp must degrade gracefully — omit BytesInPerSec,
+      # still collect the other metrics — and log the miss loudly (Warn) because
+      # an overridden MBean that returns nothing is actionable.
+      mbean_overrides:
+        BytesInPerSec: "acme.nonexistent:type=BrokerTopicMetrics,name=BytesInPerSec"
+    metadata:
+      environment: test
+      location: osk-scan

--- a/integration-tests/osk-scan/credentials/prometheus-bad-override.yaml
+++ b/integration-tests/osk-scan/credentials/prometheus-bad-override.yaml
@@ -1,0 +1,17 @@
+clusters:
+  - id: osk-kafka
+    bootstrap_servers:
+      - localhost:9092
+    auth_method:
+      unauthenticated_plaintext:
+        use: true
+    prometheus:
+      url: http://localhost:9290
+      # "BytesInPersec" is a wrong-case typo of the canonical "BytesInPerSec"
+      # label. The credential validator must reject it at load time rather than
+      # silently no-op, so the scan fails fast with a helpful message.
+      metric_names:
+        BytesInPersec: acme_broker_bytesin_total
+    metadata:
+      environment: test
+      location: osk-scan

--- a/integration-tests/osk-scan/credentials/prometheus-relabelled.yaml
+++ b/integration-tests/osk-scan/credentials/prometheus-relabelled.yaml
@@ -1,0 +1,17 @@
+clusters:
+  - id: osk-kafka
+    bootstrap_servers:
+      - localhost:9092
+    auth_method:
+      unauthenticated_plaintext:
+        use: true
+    prometheus:
+      url: http://localhost:9290
+      # Point the BytesInPerSec label at a relabelled series that only exists
+      # under this non-standard name (seeded by seed-prometheus-data.sh at a
+      # distinctively high rate). Proves metric_names substitution end-to-end.
+      metric_names:
+        BytesInPerSec: acme_broker_bytesin_total
+    metadata:
+      environment: test
+      location: osk-scan

--- a/integration-tests/osk-scan/osk_scan_test.go
+++ b/integration-tests/osk-scan/osk_scan_test.go
@@ -134,3 +134,69 @@ func TestOSKScanMetrics(t *testing.T) {
 		})
 	}
 }
+
+// TestOSKScanPrometheusMetricNameOverride proves the prometheus.metric_names
+// override end-to-end: the credential points BytesInPerSec at a relabelled
+// series (acme_broker_bytesin_total) that the seeder wrote at a deliberately
+// high, constant rate. If the override drove the query, BytesInPerSec's
+// aggregate reflects that series' magnitude (~9,000,000) — far above the
+// standard series' range (max ~170,000) — so the value itself proves the
+// override was used, not just that some data came back.
+func TestOSKScanPrometheusMetricNameOverride(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "state.json")
+	out, err := runScan(t, "--source-type", "apache-kafka",
+		"--credentials-file", credDir+"/prometheus-relabelled.yaml",
+		"--state-file", state,
+		"--metrics", "prometheus",
+		"--metrics-range", "30d")
+	require.NoError(t, err, out)
+
+	c := loadOSKCluster(t, state)
+	require.NotNil(t, c.ClusterMetrics, "no metrics collected")
+
+	agg, ok := c.ClusterMetrics.Aggregates["BytesInPerSec"]
+	require.True(t, ok, "BytesInPerSec must be collected via the relabelled series")
+	require.NotNil(t, agg.Maximum, "BytesInPerSec should have a maximum")
+	assert.Greater(t, *agg.Maximum, 1_000_000.0,
+		"BytesInPerSec must reflect the relabelled series' magnitude (~9,000,000), proving the override drove the query rather than the default series")
+}
+
+// TestOSKScanMetricNameOverrideValidation proves the "prove errors" path: an
+// unknown/typo'd override key is rejected at credential-load time, so the scan
+// fails fast with a helpful message instead of silently no-opping the override.
+func TestOSKScanMetricNameOverrideValidation(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "state.json")
+	out, err := runScan(t, "--source-type", "apache-kafka",
+		"--credentials-file", credDir+"/prometheus-bad-override.yaml",
+		"--state-file", state,
+		"--metrics", "prometheus",
+		"--metrics-range", "30d")
+
+	require.Error(t, err, "scan must fail on an unknown metric_names key; output: %s", out)
+	assert.Contains(t, out, "unknown metric label",
+		"error must name the problem so the user can self-correct")
+	assert.Contains(t, out, "BytesInPersec", "error must name the offending key")
+}
+
+// TestOSKScanJMXMBeanOverrideMissing proves the Jolokia override is threaded
+// end-to-end and degrades gracefully: BytesInPerSec is overridden to an MBean
+// the agent doesn't expose, so it is omitted from the results while every other
+// metric is still collected and the scan exits 0. (The unit tests assert the
+// accompanying loud Warn; here we prove the scan-level behaviour.)
+func TestOSKScanJMXMBeanOverrideMissing(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "state.json")
+	out, err := runScan(t, "--source-type", "apache-kafka",
+		"--credentials-file", credDir+"/jmx-bad-override.yaml",
+		"--state-file", state,
+		"--metrics", "jolokia",
+		"--metrics-duration", "10s", "--metrics-interval", "1s")
+	require.NoError(t, err, out)
+
+	c := loadOSKCluster(t, state)
+	require.NotNil(t, c.ClusterMetrics, "no metrics collected")
+	assert.NotEmpty(t, c.ClusterMetrics.Aggregates,
+		"other metrics must still be collected when one overridden MBean is missing")
+	_, ok := c.ClusterMetrics.Aggregates["BytesInPerSec"]
+	assert.False(t, ok,
+		"BytesInPerSec is overridden to a non-existent MBean and must be omitted, not defaulted")
+}

--- a/integration-tests/osk-scan/seed-prometheus-data.sh
+++ b/integration-tests/osk-scan/seed-prometheus-data.sh
@@ -32,6 +32,7 @@ i=0
 cum_bytes_in=0
 cum_bytes_out=0
 cum_msgs_in=0
+cum_acme_bytes_in=0
 while [ $t -le $NOW ]; do
   hour=$(( (t / 3600) % 24 ))
 
@@ -49,6 +50,15 @@ while [ $t -le $NOW ]; do
   rate_bytes_in=$(( 50000 + traffic_mult * 50000 + variance * 1000 ))
   cum_bytes_in=$(( cum_bytes_in + rate_bytes_in * STEP ))
   generate_metric_line "kafka_server_brokertopicmetrics_bytesinpersec_total" "$t" "$cum_bytes_in" >> "$METRICS_FILE"
+
+  # Relabelled BytesInPerSec series — the fixture for the prometheus.metric_names
+  # override test (credentials/prometheus-relabelled.yaml). It accumulates at a
+  # constant, deliberately high rate (9 MB/s) so that a scan which sourced
+  # BytesInPerSec via the override yields a sum(rate(...)) aggregate (~9,000,000)
+  # far above the standard series' range (max ~170,000). That magnitude gap is
+  # what proves the override actually drove the query rather than the default.
+  cum_acme_bytes_in=$(( cum_acme_bytes_in + 9000000 * STEP ))
+  generate_metric_line "acme_broker_bytesin_total" "$t" "$cum_acme_bytes_in" >> "$METRICS_FILE"
 
   # BytesOutPerSec rate: 30000-150000 bytes/sec
   rate_bytes_out=$(( 30000 + traffic_mult * 30000 + variance * 800 ))

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -200,7 +200,7 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 		for _, brokerClient := range s.clients {
 			value, err := brokerClient.ReadMBean(ctx, mb.MBean)
 			if err != nil {
-				slog.Warn("Failed to read MBean", "mbean", mb.Name, "error", err)
+				s.logMetricReadErrorOnce(mb.Name, "Failed to read MBean", err)
 				continue
 			}
 			if v, ok := value["Count"]; ok {
@@ -244,8 +244,15 @@ func (s *JMXService) collectRawSample(ctx context.Context) (*rawSample, error) {
 			}
 		}
 		if !found && !s.warnedControllerMissing[mb.MBean] {
-			slog.Warn("Controller MBean not available from any broker — metric will be omitted. Ensure your JMX exporter scrapes kafka.controller MBeans.",
-				"mbean", mb.MBean, "metric", mb.Name)
+			if s.metrics.OverriddenNames[mb.Name] {
+				// A not-found for an overridden MBean is actionable — the override
+				// was configured precisely to point at an MBean this agent exposes.
+				slog.Warn("Controller MBean not available from any broker — metric will be omitted. The mbean_overrides entry configured for this metric did not return data; verify the MBean name matches what your JMX exporter exposes.",
+					"mbean", mb.MBean, "metric", mb.Name)
+			} else {
+				slog.Warn("Controller MBean not available from any broker — metric will be omitted. Ensure your JMX exporter scrapes kafka.controller MBeans.",
+					"mbean", mb.MBean, "metric", mb.Name)
+			}
 			s.warnedControllerMissing[mb.MBean] = true
 		}
 	}

--- a/internal/services/jmx/jmx_service.go
+++ b/internal/services/jmx/jmx_service.go
@@ -39,30 +39,52 @@ type MetricDefinitions struct {
 	Aggregates             []AggregateMBeanConfig
 	PerConnectorAggregates []AggregateMBeanConfig
 	UnitConversions        map[string]float64
+	// OverriddenNames is the set of metric labels whose MBean came from a
+	// user-configured override rather than the default. A read failure for an
+	// overridden MBean is actionable (the override was set precisely to fix an
+	// empty result), so it is logged louder than a routine missing default.
+	// Nil when no overrides are configured.
+	OverriddenNames map[string]bool
 }
 
 // BrokerMetricDefinitions returns the standard Kafka broker metric definitions.
-func BrokerMetricDefinitions() MetricDefinitions {
-	return MetricDefinitions{
+// overrides maps a logical label (e.g. "BytesInPerSec") to the MBean object name
+// this cluster's Jolokia agent actually exposes; an entry with an empty value is
+// ignored. Pass nil for the defaults.
+func BrokerMetricDefinitions(overrides map[string]string) MetricDefinitions {
+	overridden := map[string]bool{}
+	name := func(label, def string) string {
+		if v, ok := overrides[label]; ok && v != "" {
+			overridden[label] = true
+			return v
+		}
+		return def
+	}
+
+	defs := MetricDefinitions{
 		Counters: []CounterMBeanConfig{
-			{"BytesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"},
-			{"BytesOutPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"},
-			{"MessagesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec"},
+			{"BytesInPerSec", name("BytesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec")},
+			{"BytesOutPerSec", name("BytesOutPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec")},
+			{"MessagesInPerSec", name("MessagesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec")},
 		},
 		Gauges: []GaugeMBeanConfig{
-			{"PartitionCount", "kafka.server:type=ReplicaManager,name=PartitionCount", "Value"},
+			{"PartitionCount", name("PartitionCount", "kafka.server:type=ReplicaManager,name=PartitionCount"), "Value"},
 		},
 		Controller: []GaugeMBeanConfig{
-			{"GlobalPartitionCount", "kafka.controller:type=KafkaController,name=GlobalPartitionCount", "Value"},
+			{"GlobalPartitionCount", name("GlobalPartitionCount", "kafka.controller:type=KafkaController,name=GlobalPartitionCount"), "Value"},
 		},
 		Aggregates: []AggregateMBeanConfig{
-			{"ClientConnectionCount", "kafka.server:type=socket-server-metrics,listener=*,networkProcessor=*", "connection-count"},
-			{"TotalLocalStorageUsage", "kafka.log:type=Log,name=Size,*", "Value"},
+			{"ClientConnectionCount", name("ClientConnectionCount", "kafka.server:type=socket-server-metrics,listener=*,networkProcessor=*"), "connection-count"},
+			{"TotalLocalStorageUsage", name("TotalLocalStorageUsage", "kafka.log:type=Log,name=Size,*"), "Value"},
 		},
 		UnitConversions: map[string]float64{
 			"TotalLocalStorageUsage": 1024 * 1024 * 1024,
 		},
 	}
+	if len(overridden) > 0 {
+		defs.OverriddenNames = overridden
+	}
+	return defs
 }
 
 // ConnectMetricDefinitions returns metric definitions for Kafka Connect workers.
@@ -156,9 +178,12 @@ func (s *JMXService) logMetricReadErrorOnce(metricName, msg string, err error) {
 	s.warnedMetricIssue[metricName] = true
 
 	switch {
-	case errors.Is(err, client.ErrJolokiaMBeanNotFound):
+	case errors.Is(err, client.ErrJolokiaMBeanNotFound) && !s.metrics.OverriddenNames[metricName]:
 		slog.Debug(msg, "mbean", metricName, "error", err)
 	default:
+		// A not-found for an overridden MBean is actionable — the override was
+		// configured precisely to point at an MBean this agent exposes — so it
+		// is surfaced at Warn rather than the routine Debug.
 		slog.Warn(msg, "mbean", metricName, "error", err)
 	}
 }

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confluentinc/kcp/internal/client"
 	"github.com/confluentinc/kcp/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,116 @@ func mockJolokiaServer(t *testing.T) *httptest.Server {
 	}))
 }
 
+func TestBrokerMetricDefinitions_NoOverrideRegression(t *testing.T) {
+	expected := MetricDefinitions{
+		Counters: []CounterMBeanConfig{
+			{"BytesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"},
+			{"BytesOutPerSec", "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"},
+			{"MessagesInPerSec", "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec"},
+		},
+		Gauges: []GaugeMBeanConfig{
+			{"PartitionCount", "kafka.server:type=ReplicaManager,name=PartitionCount", "Value"},
+		},
+		Controller: []GaugeMBeanConfig{
+			{"GlobalPartitionCount", "kafka.controller:type=KafkaController,name=GlobalPartitionCount", "Value"},
+		},
+		Aggregates: []AggregateMBeanConfig{
+			{"ClientConnectionCount", "kafka.server:type=socket-server-metrics,listener=*,networkProcessor=*", "connection-count"},
+			{"TotalLocalStorageUsage", "kafka.log:type=Log,name=Size,*", "Value"},
+		},
+		UnitConversions: map[string]float64{
+			"TotalLocalStorageUsage": 1024 * 1024 * 1024,
+		},
+	}
+
+	assert.Equal(t, expected, BrokerMetricDefinitions(nil))
+	assert.Equal(t, expected, BrokerMetricDefinitions(map[string]string{}))
+	assert.Nil(t, BrokerMetricDefinitions(nil).OverriddenNames)
+}
+
+func TestBrokerMetricDefinitions_Override(t *testing.T) {
+	overrides := map[string]string{
+		"BytesInPerSec":         "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec",     // counter
+		"PartitionCount":        "acme.kafka:type=ReplicaManager,name=PartitionCount",        // gauge
+		"GlobalPartitionCount":  "acme.kafka:type=KafkaController,name=GlobalPartitionCount", // controller
+		"ClientConnectionCount": "acme.kafka:type=socket-server-metrics,listener=*",          // aggregate
+	}
+	defs := BrokerMetricDefinitions(overrides)
+
+	assert.Equal(t, "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec", defs.Counters[0].MBean)
+	assert.Equal(t, "acme.kafka:type=ReplicaManager,name=PartitionCount", defs.Gauges[0].MBean)
+	assert.Equal(t, "acme.kafka:type=KafkaController,name=GlobalPartitionCount", defs.Controller[0].MBean)
+	assert.Equal(t, "acme.kafka:type=socket-server-metrics,listener=*", defs.Aggregates[0].MBean)
+
+	// Non-overridden aggregate keeps its default.
+	assert.Equal(t, "kafka.log:type=Log,name=Size,*", defs.Aggregates[1].MBean)
+
+	// OverriddenNames records exactly the overridden labels.
+	assert.Equal(t, map[string]bool{
+		"BytesInPerSec":         true,
+		"PartitionCount":        true,
+		"GlobalPartitionCount":  true,
+		"ClientConnectionCount": true,
+	}, defs.OverriddenNames)
+
+	// An empty override value is ignored.
+	defsEmpty := BrokerMetricDefinitions(map[string]string{"BytesInPerSec": ""})
+	assert.Equal(t, "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec", defsEmpty.Counters[0].MBean)
+	assert.Nil(t, defsEmpty.OverriddenNames)
+}
+
+func TestBrokerMetricDefinitions_LabelsMatchCanonicalSet(t *testing.T) {
+	defs := BrokerMetricDefinitions(nil)
+	var names []string
+	for _, c := range defs.Counters {
+		names = append(names, c.Name)
+	}
+	for _, g := range defs.Gauges {
+		names = append(names, g.Name)
+	}
+	for _, c := range defs.Controller {
+		names = append(names, c.Name)
+	}
+	for _, a := range defs.Aggregates {
+		names = append(names, a.Name)
+	}
+	assert.ElementsMatch(t, types.ValidBrokerMetricLabels(), names,
+		"BrokerMetricDefinitions names must match the canonical override label set")
+}
+
+func TestLogMetricReadErrorOnce_OverriddenMBeanNotFoundIsLoud(t *testing.T) {
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	defs := BrokerMetricDefinitions(map[string]string{
+		"PartitionCount": "acme.kafka:type=ReplicaManager,name=PartitionCount",
+	})
+	svc := NewJMXService([]string{"http://broker:8778/jolokia"}, defs, "broker")
+
+	notFound := fmt.Errorf("read failed: %w", client.ErrJolokiaMBeanNotFound)
+	// PartitionCount is overridden — a not-found is actionable → WARN.
+	svc.logMetricReadErrorOnce("PartitionCount", "Failed to read MBean", notFound)
+	// BytesOutPerSec is a default — a not-found is routine → DEBUG.
+	svc.logMetricReadErrorOnce("BytesOutPerSec", "Failed to read MBean", notFound)
+
+	var warnedOverridden, warnedDefault bool
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		if !strings.Contains(line, "level=WARN") {
+			continue
+		}
+		if strings.Contains(line, "PartitionCount") {
+			warnedOverridden = true
+		}
+		if strings.Contains(line, "BytesOutPerSec") {
+			warnedDefault = true
+		}
+	}
+	assert.True(t, warnedOverridden, "overridden MBean-not-found should be logged at WARN")
+	assert.False(t, warnedDefault, "non-overridden MBean-not-found stays at DEBUG")
+}
+
 func TestComputeSnapshot_RatesFromCounterDeltas(t *testing.T) {
 	prev := &rawSample{
 		timestamp: time.Now(),
@@ -67,7 +179,7 @@ func TestComputeSnapshot_RatesFromCounterDeltas(t *testing.T) {
 		gauges:    map[string]float64{"PartitionCount": 50, "GlobalPartitionCount": 20, "ClientConnectionCount": 5, "TotalLocalStorageUsage": 2147483648},
 	}
 
-	snapshot := computeSnapshot(prev, curr, BrokerMetricDefinitions().UnitConversions)
+	snapshot := computeSnapshot(prev, curr, BrokerMetricDefinitions(nil).UnitConversions)
 
 	assert.Equal(t, 1000.0, snapshot.metrics["BytesInPerSec"])
 	assert.Equal(t, 500.0, snapshot.metrics["BytesOutPerSec"])
@@ -155,7 +267,7 @@ func TestCollectOverDuration_ReturnsProcessedClusterMetrics(t *testing.T) {
 	server := mockJolokiaServer(t)
 	defer server.Close()
 
-	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(), "broker")
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(nil), "broker")
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
@@ -187,14 +299,14 @@ func TestCollectOverDuration_PopulatesQueryInfo(t *testing.T) {
 	server := mockJolokiaServer(t)
 	defer server.Close()
 
-	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(), "broker")
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(nil), "broker")
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.QueryInfo)
 
-	defs := BrokerMetricDefinitions()
+	defs := BrokerMetricDefinitions(nil)
 	expectedCount := len(defs.Counters) + len(defs.Gauges) + len(defs.Controller) + len(defs.Aggregates)
 	assert.Len(t, result.QueryInfo, expectedCount)
 
@@ -223,7 +335,7 @@ func TestCollectOverDuration_PopulatesQueryInfo(t *testing.T) {
 
 func TestBuildJMXQueryInfo(t *testing.T) {
 	brokerURLs := []string{"http://broker1:8778/jolokia", "http://broker2:8778/jolokia"}
-	defs := BrokerMetricDefinitions()
+	defs := BrokerMetricDefinitions(nil)
 	infos := buildJMXQueryInfo(brokerURLs, 5*time.Minute, 10*time.Second, defs, "broker")
 
 	expectedCount := len(defs.Counters) + len(defs.Gauges) + len(defs.Controller) + len(defs.Aggregates)
@@ -345,7 +457,7 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prevLogger) })
 
-	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(), "broker")
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(nil), "broker")
 	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
 
 	require.NoError(t, err)
@@ -454,7 +566,7 @@ func TestCollectRawSample_MissingSinkMBeanLogsDebugOnceNotWarn(t *testing.T) {
 }
 
 func TestCollectOverDuration_DurationMustExceedInterval(t *testing.T) {
-	svc := NewJMXService([]string{"http://localhost:1"}, BrokerMetricDefinitions(), "broker")
+	svc := NewJMXService([]string{"http://localhost:1"}, BrokerMetricDefinitions(nil), "broker")
 	_, err := svc.CollectOverDuration(context.Background(), 5*time.Second, 5*time.Second)
 
 	require.Error(t, err)

--- a/internal/services/jmx/jmx_service_test.go
+++ b/internal/services/jmx/jmx_service_test.go
@@ -485,6 +485,112 @@ func TestCollectOverDuration_ControllerMBeanGracefulOmission(t *testing.T) {
 	assert.True(t, queryNames["GlobalPartitionCount"], "QueryInfo should still include GlobalPartitionCount")
 }
 
+// TestCollectRawSample_MissingCounterMBeanDedupesAndStaysDebug is a regression
+// test: the Counters loop must route through logMetricReadErrorOnce like the
+// Gauges/Aggregates loops, so a missing default counter MBean is (a) logged at
+// Debug rather than Warn, and (b) deduped to once per scan rather than once
+// per poll.
+func TestCollectRawSample_MissingCounterMBeanDedupesAndStaysDebug(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response map[string]any
+		switch {
+		case strings.Contains(r.URL.Path, "BytesInPerSec"):
+			// Missing on this cluster — Jolokia reports not-found.
+			response = map[string]any{"status": 404, "error": "javax.management.InstanceNotFoundException: kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"}
+		default:
+			response = map[string]any{"status": 200, "value": map[string]any{"Count": 0.0, "Value": 0.0}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	svc := NewJMXService([]string{server.URL}, BrokerMetricDefinitions(nil), "broker")
+
+	// Poll multiple times, as CollectOverDuration would on every tick.
+	for i := 0; i < 3; i++ {
+		_, err := svc.collectRawSample(context.Background())
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 0, strings.Count(logBuf.String(), "level=WARN"),
+		"a missing default counter MBean is routine and must not log at WARN")
+	assert.Equal(t, 1, strings.Count(logBuf.String(), "Failed to read MBean"),
+		"missing counter MBean read failure should be deduped to once per scan, not once per poll")
+}
+
+// TestCollectRawSample_OverriddenCounterMBeanNotFoundIsLoud is the counter-loop
+// counterpart of TestLogMetricReadErrorOnce_OverriddenMBeanNotFoundIsLoud: an
+// overridden counter MBean that still isn't found is actionable and must be
+// logged at Warn, not Debug.
+func TestCollectRawSample_OverriddenCounterMBeanNotFoundIsLoud(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]any{"status": 404, "error": "javax.management.InstanceNotFoundException: acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	defs := BrokerMetricDefinitions(map[string]string{
+		"BytesInPerSec": "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec",
+	})
+	svc := NewJMXService([]string{server.URL}, defs, "broker")
+
+	_, err := svc.collectRawSample(context.Background())
+	require.NoError(t, err)
+
+	assert.Contains(t, logBuf.String(), "level=WARN",
+		"a not-found for an overridden counter MBean is actionable and must be logged at WARN")
+}
+
+// TestCollectOverDuration_OverriddenControllerMBeanMissingMentionsOverride is a
+// regression test: when the Controller MBean's label was overridden via
+// mbean_overrides and still isn't found on any broker, the caveat must point
+// at the override rather than the generic "ensure your exporter scrapes"
+// hint, which sends users chasing exporter config instead of the override
+// they just set.
+func TestCollectOverDuration_OverriddenControllerMBeanMissingMentionsOverride(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response map[string]any
+		switch {
+		case strings.Contains(r.URL.Path, "acme.kafka"):
+			response = map[string]any{"status": 404, "error": "javax.management.InstanceNotFoundException: acme.kafka:type=KafkaController,name=GlobalPartitionCount"}
+		default:
+			response = map[string]any{"status": 200, "value": map[string]any{"Count": 0.0, "Value": 0.0}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	defs := BrokerMetricDefinitions(map[string]string{
+		"GlobalPartitionCount": "acme.kafka:type=KafkaController,name=GlobalPartitionCount",
+	})
+	svc := NewJMXService([]string{server.URL}, defs, "broker")
+
+	result, err := svc.CollectOverDuration(context.Background(), 3*time.Second, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, logBuf.String(), "mbean_overrides",
+		"a missing overridden controller MBean should mention mbean_overrides, not just the generic exporter hint")
+}
+
 // mockSourceOnlyConnectJolokiaServer simulates a source-only Connect cluster:
 // sink-task-metrics MBeans don't exist (404 InstanceNotFoundException), while
 // everything else responds normally. This is the "no sink connectors" case

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -25,18 +25,49 @@ type MetricQuery struct {
 	// GroupByConnector indicates the query is aggregated with `sum by (connector) (...)`
 	// and results should be broken out per connector using the `connector` series label.
 	GroupByConnector bool
+	// Overridden is true when PrometheusMetric came from a user-configured
+	// metric-name override rather than the default series name. An overridden
+	// query that still returns no data is actionable (the override was set
+	// precisely to fix an empty result), so it is logged louder than a routine
+	// empty default.
+	Overridden bool
 }
 
 // BrokerQueryDefinitions returns the standard Kafka broker Prometheus queries.
-func BrokerQueryDefinitions() []MetricQuery {
+// overrides maps a logical label (e.g. "BytesInPerSec") to the base series name
+// this cluster's exporter actually exposes; an entry with an empty value is
+// ignored. The overridden name is substituted into kcp's existing query wrapping
+// and set as PrometheusMetric, so applyLabelFilter injection keeps working. Pass
+// nil for the defaults.
+func BrokerQueryDefinitions(overrides map[string]string) []MetricQuery {
+	name := func(label, def string) (string, bool) {
+		if v, ok := overrides[label]; ok && v != "" {
+			return v, true
+		}
+		return def, false
+	}
+
+	bytesIn, bytesInOv := name("BytesInPerSec", "kafka_server_brokertopicmetrics_bytesinpersec_total")
+	bytesOut, bytesOutOv := name("BytesOutPerSec", "kafka_server_brokertopicmetrics_bytesoutpersec_total")
+	messagesIn, messagesInOv := name("MessagesInPerSec", "kafka_server_brokertopicmetrics_messagesinpersec_total")
+	partitionCount, partitionCountOv := name("PartitionCount", "kafka_server_replicamanager_partitioncount")
+	globalPartition, globalPartitionOv := name("GlobalPartitionCount", "kafka_controller_kafkacontroller_value")
+	clientConn, clientConnOv := name("ClientConnectionCount", "kafka_server_socketservermetrics_connection_count")
+	logSize, logSizeOv := name("TotalLocalStorageUsage", "kafka_log_log_size")
+
+	// GlobalPartitionCount is distinguished by a {name="..."} discriminator on a
+	// shared controller series; an override replaces the base series name and the
+	// discriminator is preserved.
+	globalPartitionSel := globalPartition + `{name="GlobalPartitionCount"}`
+
 	return []MetricQuery{
-		{Label: "BytesInPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_bytesinpersec_total"},
-		{Label: "BytesOutPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_bytesoutpersec_total"},
-		{Label: "MessagesInPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_messagesinpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_messagesinpersec_total"},
-		{Label: "PartitionCount", Query: "sum(kafka_server_replicamanager_partitioncount)", PrometheusMetric: "kafka_server_replicamanager_partitioncount"},
-		{Label: "GlobalPartitionCount", Query: "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}", PrometheusMetric: "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}"},
-		{Label: "ClientConnectionCount", Query: "sum(kafka_server_socketservermetrics_connection_count)", PrometheusMetric: "kafka_server_socketservermetrics_connection_count"},
-		{Label: "TotalLocalStorageUsage", Query: "sum(kafka_log_log_size) / (1024*1024*1024)", PrometheusMetric: "kafka_log_log_size"},
+		{Label: "BytesInPerSec", Query: "sum(rate(" + bytesIn + "[%s]))", PrometheusMetric: bytesIn, Overridden: bytesInOv},
+		{Label: "BytesOutPerSec", Query: "sum(rate(" + bytesOut + "[%s]))", PrometheusMetric: bytesOut, Overridden: bytesOutOv},
+		{Label: "MessagesInPerSec", Query: "sum(rate(" + messagesIn + "[%s]))", PrometheusMetric: messagesIn, Overridden: messagesInOv},
+		{Label: "PartitionCount", Query: "sum(" + partitionCount + ")", PrometheusMetric: partitionCount, Overridden: partitionCountOv},
+		{Label: "GlobalPartitionCount", Query: globalPartitionSel, PrometheusMetric: globalPartitionSel, Overridden: globalPartitionOv},
+		{Label: "ClientConnectionCount", Query: "sum(" + clientConn + ")", PrometheusMetric: clientConn, Overridden: clientConnOv},
+		{Label: "TotalLocalStorageUsage", Query: "sum(" + logSize + ") / (1024*1024*1024)", PrometheusMetric: logSize, Overridden: logSizeOv},
 	}
 }
 
@@ -176,7 +207,11 @@ func (s *PrometheusService) CollectMetrics(ctx context.Context, queryRange time.
 			dataPoints += len(r.Values)
 		}
 		if dataPoints == 0 {
-			slog.Debug("Prometheus query returned no data points", "label", mq.Label, "query", query)
+			if mq.Overridden {
+				slog.Warn("⚠️ Overridden Prometheus metric returned no data points — check the configured metric_names value", "label", mq.Label, "query", query)
+			} else {
+				slog.Debug("Prometheus query returned no data points", "label", mq.Label, "query", query)
+			}
 		}
 
 		for _, result := range results {

--- a/internal/services/prometheus/prometheus_service.go
+++ b/internal/services/prometheus/prometheus_service.go
@@ -56,9 +56,11 @@ func BrokerQueryDefinitions(overrides map[string]string) []MetricQuery {
 	logSize, logSizeOv := name("TotalLocalStorageUsage", "kafka_log_log_size")
 
 	// GlobalPartitionCount is distinguished by a {name="..."} discriminator on a
-	// shared controller series; an override replaces the base series name and the
-	// discriminator is preserved.
-	globalPartitionSel := globalPartition + `{name="GlobalPartitionCount"}`
+	// shared controller series; an override replaces the base series name. If the
+	// override itself already carries a label selector (e.g. a job-scoped
+	// series), the discriminator is merged into it rather than appended as a
+	// second brace group, which would otherwise produce invalid PromQL.
+	globalPartitionSel := appendNameDiscriminator(globalPartition, "GlobalPartitionCount")
 
 	return []MetricQuery{
 		{Label: "BytesInPerSec", Query: "sum(rate(" + bytesIn + "[%s]))", PrometheusMetric: bytesIn, Overridden: bytesInOv},
@@ -150,6 +152,17 @@ func applyLabelFilter(query, metricName string, labels map[string]string) string
 
 	// No existing selector — add one
 	return query[:afterName] + "{" + labelStr + "}" + query[afterName:]
+}
+
+// appendNameDiscriminator appends a {name="value"} label matcher to a
+// Prometheus series name, merging it into an existing selector if the series
+// already carries one (e.g. from a metric-name override that points at a
+// job-scoped series) rather than producing a second, invalid brace group.
+func appendNameDiscriminator(series, name string) string {
+	if idx := strings.Index(series, "{"); idx >= 0 {
+		return series[:idx+1] + fmt.Sprintf(`name="%s",`, name) + series[idx+1:]
+	}
+	return series + fmt.Sprintf(`{name="%s"}`, name)
 }
 
 // SelectStep chooses an appropriate query step based on the time range

--- a/internal/services/prometheus/prometheus_service_test.go
+++ b/internal/services/prometheus/prometheus_service_test.go
@@ -272,6 +272,66 @@ func TestBrokerQueryDefinitions_LabelsMatchCanonicalSet(t *testing.T) {
 		"BrokerQueryDefinitions labels must match the canonical override label set")
 }
 
+// TestBrokerQueryDefinitions_GlobalPartitionCountOverride_BareSeriesName
+// covers the common case: the override is a bare series name with no
+// selector of its own, so the {name="..."} discriminator is simply appended.
+func TestBrokerQueryDefinitions_GlobalPartitionCountOverride_BareSeriesName(t *testing.T) {
+	defs := BrokerQueryDefinitions(map[string]string{"GlobalPartitionCount": "acme_controller_value"})
+
+	var global MetricQuery
+	for _, d := range defs {
+		if d.Label == "GlobalPartitionCount" {
+			global = d
+		}
+	}
+
+	assert.Equal(t, `acme_controller_value{name="GlobalPartitionCount"}`, global.Query)
+	assert.Equal(t, global.Query, global.PrometheusMetric)
+	assert.True(t, global.Overridden)
+}
+
+// TestBrokerQueryDefinitions_GlobalPartitionCountOverride_ExistingSelectorMerges
+// is a regression test: GlobalPartitionCount's query is built by appending a
+// static {name="GlobalPartitionCount"} discriminator to the override value. If
+// the override itself already carries a label selector (e.g. it points at a
+// job-scoped series), naively appending a second brace group produces invalid
+// PromQL (two adjacent selectors on one series). The discriminator must be
+// merged into the existing selector instead.
+func TestBrokerQueryDefinitions_GlobalPartitionCountOverride_ExistingSelectorMerges(t *testing.T) {
+	defs := BrokerQueryDefinitions(map[string]string{
+		"GlobalPartitionCount": `acme_controller_value{job="acme"}`,
+	})
+
+	var global MetricQuery
+	for _, d := range defs {
+		if d.Label == "GlobalPartitionCount" {
+			global = d
+		}
+	}
+
+	// A single, valid selector — not two adjacent brace groups.
+	assert.Equal(t, `acme_controller_value{name="GlobalPartitionCount",job="acme"}`, global.Query)
+	assert.Equal(t, global.Query, global.PrometheusMetric)
+	assert.NotContains(t, global.Query, "}{", "must not produce two adjacent brace groups")
+	assert.True(t, global.Overridden)
+}
+
+func TestAppendNameDiscriminator(t *testing.T) {
+	tests := []struct {
+		name   string
+		series string
+		want   string
+	}{
+		{"no existing selector", "acme_controller_value", `acme_controller_value{name="GlobalPartitionCount"}`},
+		{"merges into existing selector", `acme_controller_value{job="acme"}`, `acme_controller_value{name="GlobalPartitionCount",job="acme"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, appendNameDiscriminator(tt.series, "GlobalPartitionCount"))
+		})
+	}
+}
+
 func TestPrometheusService_CollectMetrics_OverriddenEmptyIsLoud(t *testing.T) {
 	// Only PartitionCount returns data; every other query is empty. This keeps
 	// allMetrics non-empty so the generic "no metrics collected" warning stays

--- a/internal/services/prometheus/prometheus_service_test.go
+++ b/internal/services/prometheus/prometheus_service_test.go
@@ -1,9 +1,11 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -76,7 +78,7 @@ func TestPrometheusService_CollectMetrics(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(nil), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
@@ -115,7 +117,7 @@ func TestPrometheusService_CollectMetrics_MissingMetric(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(nil), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 7*24*time.Hour)
 	require.NoError(t, err)
@@ -144,7 +146,7 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 	defer server.Close()
 
 	promClient := client.NewPrometheusClient(server.URL)
-	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(), nil)
+	svc := NewPrometheusService(promClient, BrokerQueryDefinitions(nil), nil)
 
 	result, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
 	require.NoError(t, err)
@@ -152,7 +154,7 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 	require.NotEmpty(t, result.QueryInfo)
 
 	// Should have one entry per query definition (7)
-	assert.Len(t, result.QueryInfo, len(BrokerQueryDefinitions()))
+	assert.Len(t, result.QueryInfo, len(BrokerQueryDefinitions(nil)))
 
 	for _, qi := range result.QueryInfo {
 		assert.Equal(t, types.MetricBackendPrometheus, qi.SourceType)
@@ -184,12 +186,139 @@ func TestPrometheusService_CollectMetrics_PopulatesQueryInfo(t *testing.T) {
 	assert.True(t, names["TotalLocalStorageUsage"])
 }
 
+func TestBrokerQueryDefinitions_NoOverrideRegression(t *testing.T) {
+	// With no overrides, output must be byte-identical to the historical defaults.
+	expected := []MetricQuery{
+		{Label: "BytesInPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_bytesinpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_bytesinpersec_total"},
+		{Label: "BytesOutPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_bytesoutpersec_total"},
+		{Label: "MessagesInPerSec", Query: "sum(rate(kafka_server_brokertopicmetrics_messagesinpersec_total[%s]))", PrometheusMetric: "kafka_server_brokertopicmetrics_messagesinpersec_total"},
+		{Label: "PartitionCount", Query: "sum(kafka_server_replicamanager_partitioncount)", PrometheusMetric: "kafka_server_replicamanager_partitioncount"},
+		{Label: "GlobalPartitionCount", Query: "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}", PrometheusMetric: "kafka_controller_kafkacontroller_value{name=\"GlobalPartitionCount\"}"},
+		{Label: "ClientConnectionCount", Query: "sum(kafka_server_socketservermetrics_connection_count)", PrometheusMetric: "kafka_server_socketservermetrics_connection_count"},
+		{Label: "TotalLocalStorageUsage", Query: "sum(kafka_log_log_size) / (1024*1024*1024)", PrometheusMetric: "kafka_log_log_size"},
+	}
+
+	assert.Equal(t, expected, BrokerQueryDefinitions(nil))
+	assert.Equal(t, expected, BrokerQueryDefinitions(map[string]string{}))
+}
+
+func TestBrokerQueryDefinitions_Override(t *testing.T) {
+	overrides := map[string]string{
+		"BytesInPerSec":          "acme_broker_bytesin_total",
+		"PartitionCount":         "acme_partition_count",
+		"TotalLocalStorageUsage": "acme_log_size",
+	}
+	defs := BrokerQueryDefinitions(overrides)
+
+	byLabel := make(map[string]MetricQuery)
+	for _, d := range defs {
+		byLabel[d.Label] = d
+	}
+
+	// Rate-wrapped metric: series substituted, %s rate window preserved, flagged overridden.
+	bytesIn := byLabel["BytesInPerSec"]
+	assert.Equal(t, "sum(rate(acme_broker_bytesin_total[%s]))", bytesIn.Query)
+	assert.Equal(t, "acme_broker_bytesin_total", bytesIn.PrometheusMetric)
+	assert.True(t, bytesIn.Overridden)
+
+	// Sum-wrapped gauge.
+	partition := byLabel["PartitionCount"]
+	assert.Equal(t, "sum(acme_partition_count)", partition.Query)
+	assert.Equal(t, "acme_partition_count", partition.PrometheusMetric)
+	assert.True(t, partition.Overridden)
+
+	// Arithmetic-wrapped metric keeps its conversion.
+	storage := byLabel["TotalLocalStorageUsage"]
+	assert.Equal(t, "sum(acme_log_size) / (1024*1024*1024)", storage.Query)
+	assert.Equal(t, "acme_log_size", storage.PrometheusMetric)
+	assert.True(t, storage.Overridden)
+
+	// A metric with no override keeps its default and is not flagged.
+	bytesOut := byLabel["BytesOutPerSec"]
+	assert.Equal(t, "sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec_total[%s]))", bytesOut.Query)
+	assert.False(t, bytesOut.Overridden)
+
+	// An empty override value is ignored (treated as no override).
+	defsEmpty := BrokerQueryDefinitions(map[string]string{"BytesInPerSec": ""})
+	for _, d := range defsEmpty {
+		if d.Label == "BytesInPerSec" {
+			assert.Equal(t, "kafka_server_brokertopicmetrics_bytesinpersec_total", d.PrometheusMetric)
+			assert.False(t, d.Overridden)
+		}
+	}
+}
+
+func TestBrokerQueryDefinitions_OverridePreservesLabelFilterInjection(t *testing.T) {
+	defs := BrokerQueryDefinitions(map[string]string{"BytesInPerSec": "acme_broker_bytesin_total"})
+	var bytesIn MetricQuery
+	for _, d := range defs {
+		if d.Label == "BytesInPerSec" {
+			bytesIn = d
+		}
+	}
+
+	// Resolve the rate window as CollectMetrics would, then inject label selectors.
+	resolved := fmt.Sprintf(bytesIn.Query, "5m")
+	filtered := applyLabelFilter(resolved, bytesIn.PrometheusMetric, map[string]string{"job": "acme"})
+	assert.Equal(t, "sum(rate(acme_broker_bytesin_total{job=\"acme\"}[5m]))", filtered)
+}
+
+func TestBrokerQueryDefinitions_LabelsMatchCanonicalSet(t *testing.T) {
+	var labels []string
+	for _, d := range BrokerQueryDefinitions(nil) {
+		labels = append(labels, d.Label)
+	}
+	assert.ElementsMatch(t, types.ValidBrokerMetricLabels(), labels,
+		"BrokerQueryDefinitions labels must match the canonical override label set")
+}
+
+func TestPrometheusService_CollectMetrics_OverriddenEmptyIsLoud(t *testing.T) {
+	// Only PartitionCount returns data; every other query is empty. This keeps
+	// allMetrics non-empty so the generic "no metrics collected" warning stays
+	// silent and we isolate the per-metric empty signal.
+	mockData := map[string][]float64{
+		"partitioncount": {50.0, 50.0},
+	}
+	server := newMockPrometheusServer(t, mockData)
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	promClient := client.NewPrometheusClient(server.URL)
+	// Override BytesInPerSec to a series the mock has no data for.
+	defs := BrokerQueryDefinitions(map[string]string{"BytesInPerSec": "totally_missing_series"})
+	svc := NewPrometheusService(promClient, defs, nil)
+
+	_, err := svc.CollectMetrics(context.Background(), 24*time.Hour)
+	require.NoError(t, err)
+
+	// An overridden query that still returns nothing is actionable → WARN.
+	// A non-overridden empty query (e.g. BytesOutPerSec) stays quiet (DEBUG).
+	var warnedBytesIn, warnedBytesOut bool
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		if !strings.Contains(line, "level=WARN") {
+			continue
+		}
+		if strings.Contains(line, "BytesInPerSec") {
+			warnedBytesIn = true
+		}
+		if strings.Contains(line, "BytesOutPerSec") {
+			warnedBytesOut = true
+		}
+	}
+	assert.True(t, warnedBytesIn, "overridden-but-empty metric should be logged at WARN")
+	assert.False(t, warnedBytesOut, "non-overridden empty metric should not be logged at WARN")
+}
+
 func TestBuildPrometheusQueryInfo(t *testing.T) {
 	end := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 	start := end.Add(-24 * time.Hour)
-	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end, BrokerQueryDefinitions(), nil)
+	infos := buildPrometheusQueryInfo("http://prom:9090", "5m", 60*time.Second, 24*time.Hour, start, end, BrokerQueryDefinitions(nil), nil)
 
-	assert.Len(t, infos, len(BrokerQueryDefinitions()))
+	assert.Len(t, infos, len(BrokerQueryDefinitions(nil)))
 
 	// Rate-based metrics should have rate() in the aggregation note
 	for _, info := range infos[:3] {

--- a/internal/types/credentials_osk.go
+++ b/internal/types/credentials_osk.go
@@ -4,8 +4,55 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strconv"
+	"strings"
 )
+
+// validBrokerMetricLabels is the canonical set of logical broker-metric labels
+// that metric-name overrides (prometheus.metric_names, jolokia.mbean_overrides)
+// may key on. It is the single source of truth shared by the credentials
+// validator and the Prometheus/JMX metric-definition builders; drift tests in
+// those packages assert their definitions cover exactly this set.
+var validBrokerMetricLabels = map[string]struct{}{
+	"BytesInPerSec":          {},
+	"BytesOutPerSec":         {},
+	"MessagesInPerSec":       {},
+	"PartitionCount":         {},
+	"GlobalPartitionCount":   {},
+	"ClientConnectionCount":  {},
+	"TotalLocalStorageUsage": {},
+}
+
+// ValidBrokerMetricLabels returns the canonical broker-metric labels, sorted for
+// a stable error message and stable test assertions.
+func ValidBrokerMetricLabels() []string {
+	labels := make([]string, 0, len(validBrokerMetricLabels))
+	for l := range validBrokerMetricLabels {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+// validateMetricNameOverrides ensures every override key is a known broker-metric
+// label, so a typo'd or wrong-case key is a loud error rather than a silent
+// no-op. fieldName names the offending config field. Only the (non-secret)
+// override keys are echoed — the override values are not.
+func validateMetricNameOverrides(overrides map[string]string, fieldName string) error {
+	var unknown []string
+	for key := range overrides {
+		if _, ok := validBrokerMetricLabels[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("%s: unknown metric label(s) %s; valid labels are: %s",
+		fieldName, strings.Join(unknown, ", "), strings.Join(ValidBrokerMetricLabels(), ", "))
+}
 
 // OSKCredentials represents the apache-kafka-credentials.yaml file
 type OSKCredentials struct {
@@ -35,6 +82,11 @@ type JolokiaConfig struct {
 	Endpoints []string           `yaml:"endpoints"`
 	Auth      *JolokiaAuthConfig `yaml:"auth,omitempty"`
 	TLS       *JolokiaTLSConfig  `yaml:"tls,omitempty"`
+	// MBeanOverrides maps a logical broker-metric label (e.g. "BytesInPerSec")
+	// to the MBean object name this cluster's JMX/Jolokia agent actually exposes,
+	// for agents that use non-standard MBean names. Keys must be one of the
+	// labels in ValidBrokerMetricLabels(); unknown keys are rejected at load time.
+	MBeanOverrides map[string]string `yaml:"mbean_overrides,omitempty"`
 }
 
 // JolokiaAuthConfig contains authentication credentials for Jolokia
@@ -55,6 +107,13 @@ type PrometheusConfig struct {
 	Auth   *PrometheusAuthConfig   `yaml:"auth,omitempty"`
 	TLS    *PrometheusTLSConfig    `yaml:"tls,omitempty"`
 	Filter *PrometheusFilterConfig `yaml:"filter,omitempty"`
+	// MetricNames maps a logical broker-metric label (e.g. "BytesInPerSec") to
+	// the base Prometheus series name this cluster's exporter actually exposes,
+	// for exporters that relabel the standard series. The name is substituted
+	// into kcp's existing query wrapping (sum/rate/selector), so filter.labels
+	// injection continues to work. Keys must be one of the labels in
+	// ValidBrokerMetricLabels(); unknown keys are rejected at load time.
+	MetricNames map[string]string `yaml:"metric_names,omitempty"`
 }
 
 // PrometheusFilterConfig holds label selectors to scope Prometheus queries to a specific target.
@@ -297,6 +356,9 @@ func validatePrometheusConfig(prom *PrometheusConfig) error {
 			return fmt.Errorf("tls ca_cert file not found: %s", prom.TLS.CACert)
 		}
 	}
+	if err := validateMetricNameOverrides(prom.MetricNames, "metric_names"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -317,6 +379,9 @@ func validateJolokiaConfig(jolokia *JolokiaConfig) error {
 		if _, err := os.Stat(jolokia.TLS.CACert); err != nil {
 			return fmt.Errorf("tls ca_cert file not found: %s", jolokia.TLS.CACert)
 		}
+	}
+	if err := validateMetricNameOverrides(jolokia.MBeanOverrides, "mbean_overrides"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/types/osk_credentials_test.go
+++ b/internal/types/osk_credentials_test.go
@@ -647,6 +647,186 @@ clusters:
 	assert.Equal(t, []string{"broker1:9092", "broker2:9092"}, creds.Clusters[0].BootstrapServers)
 }
 
+func TestNewOSKCredentialsFromFile_MetricNameOverrides(t *testing.T) {
+	content := `
+clusters:
+- id: prod-kafka-01
+  bootstrap_servers:
+  - broker1:9092
+  auth_method:
+    sasl_scram:
+      use: true
+      username: admin
+      password: secret
+  prometheus:
+    url: http://prom:9090
+    metric_names:
+      BytesInPerSec: acme_broker_bytesin_total
+      MessagesInPerSec: acme_broker_messagesin_total
+  jolokia:
+    endpoints:
+    - http://broker1:8778/jolokia
+    mbean_overrides:
+      BytesInPerSec: "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec"
+`
+	tmpFile := filepath.Join(t.TempDir(), "apache-kafka-credentials.yaml")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
+
+	creds, errs := NewOSKCredentialsFromFile(tmpFile)
+	require.Empty(t, errs)
+	require.NotNil(t, creds)
+	require.Len(t, creds.Clusters, 1)
+
+	require.NotNil(t, creds.Clusters[0].Prometheus)
+	assert.Equal(t, map[string]string{
+		"BytesInPerSec":    "acme_broker_bytesin_total",
+		"MessagesInPerSec": "acme_broker_messagesin_total",
+	}, creds.Clusters[0].Prometheus.MetricNames)
+
+	require.NotNil(t, creds.Clusters[0].Jolokia)
+	assert.Equal(t, map[string]string{
+		"BytesInPerSec": "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec",
+	}, creds.Clusters[0].Jolokia.MBeanOverrides)
+}
+
+func TestNewOSKCredentialsFromFile_NoOverrides(t *testing.T) {
+	content := `
+clusters:
+- id: prod-kafka-01
+  bootstrap_servers:
+  - broker1:9092
+  auth_method:
+    sasl_scram:
+      use: true
+      username: admin
+      password: secret
+  prometheus:
+    url: http://prom:9090
+`
+	tmpFile := filepath.Join(t.TempDir(), "apache-kafka-credentials.yaml")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
+
+	creds, errs := NewOSKCredentialsFromFile(tmpFile)
+	require.Empty(t, errs)
+	require.NotNil(t, creds)
+	require.Len(t, creds.Clusters, 1)
+	assert.Nil(t, creds.Clusters[0].Prometheus.MetricNames)
+}
+
+func TestOSKCredentials_Validate_UnknownPrometheusMetricNameKey(t *testing.T) {
+	creds := &OSKCredentials{
+		Clusters: []OSKClusterAuth{
+			{
+				ID:               "prod-kafka-01",
+				BootstrapServers: []string{"broker1:9092"},
+				AuthMethod: AuthMethodConfig{
+					SASLScram: &SASLScramConfig{Use: true, Username: "u", Password: "p"},
+				},
+				Prometheus: &PrometheusConfig{
+					URL: "http://prom:9090",
+					MetricNames: map[string]string{
+						"BytesInPerSec":  "acme_broker_bytesin_total", // valid
+						"BytesInPersec":  "typo_here",                 // invalid: wrong case
+						"NotARealMetric": "whatever",                  // invalid: unknown
+					},
+				},
+			},
+		},
+	}
+
+	valid, errs := creds.Validate()
+	assert.False(t, valid)
+	require.NotEmpty(t, errs)
+
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	// Names the bad keys
+	assert.Contains(t, joined, "BytesInPersec")
+	assert.Contains(t, joined, "NotARealMetric")
+	// Lists a valid label so the user can self-correct
+	assert.Contains(t, joined, "BytesInPerSec")
+	// Does not reject the valid key
+	assert.NotContains(t, joined, "acme_broker_bytesin_total")
+}
+
+func TestOSKCredentials_Validate_UnknownJolokiaMBeanOverrideKey(t *testing.T) {
+	creds := &OSKCredentials{
+		Clusters: []OSKClusterAuth{
+			{
+				ID:               "prod-kafka-01",
+				BootstrapServers: []string{"broker1:9092"},
+				AuthMethod: AuthMethodConfig{
+					SASLScram: &SASLScramConfig{Use: true, Username: "u", Password: "p"},
+				},
+				Jolokia: &JolokiaConfig{
+					Endpoints: []string{"http://broker1:8778/jolokia"},
+					MBeanOverrides: map[string]string{
+						"TotallyBogus": "acme.kafka:type=Foo",
+					},
+				},
+			},
+		},
+	}
+
+	valid, errs := creds.Validate()
+	assert.False(t, valid)
+	require.NotEmpty(t, errs)
+
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	assert.Contains(t, joined, "TotallyBogus")
+}
+
+func TestOSKCredentials_Validate_ValidOverrideKeysPass(t *testing.T) {
+	creds := &OSKCredentials{
+		Clusters: []OSKClusterAuth{
+			{
+				ID:               "prod-kafka-01",
+				BootstrapServers: []string{"broker1:9092"},
+				AuthMethod: AuthMethodConfig{
+					SASLScram: &SASLScramConfig{Use: true, Username: "u", Password: "p"},
+				},
+				Prometheus: &PrometheusConfig{
+					URL: "http://prom:9090",
+					MetricNames: map[string]string{
+						"BytesInPerSec":          "acme_broker_bytesin_total",
+						"TotalLocalStorageUsage": "acme_log_size",
+					},
+				},
+				Jolokia: &JolokiaConfig{
+					Endpoints: []string{"http://broker1:8778/jolokia"},
+					MBeanOverrides: map[string]string{
+						"GlobalPartitionCount": "acme.kafka:type=KafkaController,name=GlobalPartitionCount",
+					},
+				},
+			},
+		},
+	}
+
+	valid, errs := creds.Validate()
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+}
+
+func TestValidBrokerMetricLabels(t *testing.T) {
+	labels := ValidBrokerMetricLabels()
+	assert.ElementsMatch(t, []string{
+		"BytesInPerSec",
+		"BytesOutPerSec",
+		"MessagesInPerSec",
+		"PartitionCount",
+		"GlobalPartitionCount",
+		"ClientConnectionCount",
+		"TotalLocalStorageUsage",
+	}, labels)
+	// Returned sorted for a stable error message
+	assert.IsIncreasing(t, labels)
+}
+
 func TestNewOSKCredentialsFromFile_FileNotFound(t *testing.T) {
 	creds, errs := NewOSKCredentialsFromFile("/nonexistent/file.yaml")
 	assert.Nil(t, creds)


### PR DESCRIPTION
## Summary

Apache Kafka (OSK) users whose Prometheus exporter relabels the standard broker
series — or whose Jolokia agent exposes non-standard MBean names — could not
collect the affected metrics without patching kcp source: the built-in queries
matched nothing and silently returned empty results. This adds per-cluster
metric-name overrides in `apache-kafka-credentials.yaml`, so those users repoint
kcp at the names their infrastructure actually exposes — no source changes, no
recording rules required.

## What's new

Two optional maps, keyed on the seven logical broker-metric labels
(`BytesInPerSec`, `BytesOutPerSec`, `MessagesInPerSec`, `PartitionCount`,
`GlobalPartitionCount`, `ClientConnectionCount`, `TotalLocalStorageUsage`):

| Config key                  | Backend    | Overrides                          |
| --------------------------- | ---------- | ---------------------------------- |
| `prometheus.metric_names`   | Prometheus | base PromQL series name            |
| `jolokia.mbean_overrides`   | Jolokia    | MBean object name                  |

```yaml
clusters:
  - id: my-cluster
    prometheus:
      url: http://prom:9090
      metric_names:
        BytesInPerSec: acme_broker_bytesin_total
    jolokia:
      endpoints: [ ... ]
      mbean_overrides:
        BytesInPerSec: "acme.kafka:type=BrokerTopicMetrics,name=BytesInPerSec"
```

## Design decisions

- **Overrides key on the logical label, not the default series name** — stable,
  backend-agnostic, and identical to the `label` already written to the state
  file, so the same key works for both backends.
- **Prometheus is a base-series-name rename, not a full-PromQL rewrite** — kcp
  keeps its existing wrapping (`sum(rate(…))`, `sum(…)`, the GiB conversion) and
  the overridden name is threaded through `PrometheusMetric`, so `filter.labels`
  injection keeps working. `GlobalPartitionCount` preserves its
  `{name="GlobalPartitionCount"}` discriminator on top of the renamed series.
- **Unknown keys are a loud load-time error, not a silent no-op** — a single
  canonical label set in `internal/types` backs the validator; drift tests in
  the Prometheus and JMX packages assert their definitions cover exactly that
  set, so a validated key can never silently fail to apply. Only the (non-secret)
  override keys are echoed in the error; the override values are not.
- **An overridden-but-still-empty metric is elevated from DEBUG to WARN** — the
  override exists precisely to fix an empty result, so a still-empty result is
  actionable rather than routine noise.

No `types.State` shape change, so no schema-version bump (the credentials structs
are not part of persisted state).

## Validation

- `make test-go` — full suite green (0 failures, 74 packages). New tests cover
  override construction, byte-identical no-override regression, label/validator
  drift guards, the WARN-elevation for empty overridden metrics on both backends,
  and load-time rejection of unknown keys.
- `golangci-lint run ./...` — 0 issues. `go.mod`/`go.sum` unchanged.
- CLI exercised end-to-end: a credentials file with a misspelled override key
  fails fast with
  `metric_names: unknown metric label(s) BytesInPersec, NotARealMetric; valid labels are: …`
  (exit 1); a file with valid keys passes credential validation and proceeds to
  the scan.

> **Note:** this was a `strike` run — no pipeline review preceded it, so this PR
> review is the first review.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
