### PR TITLE
fix(connect-scan): stop the integration test flaking randomly in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -122,6 +122,13 @@ blocks:
   - name: 'integration: kafka connect scan'
     dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
     task:
+      agent:
+        machine:
+          # This job runs a broker + four Connect JVMs concurrently. The pipeline
+          # default (amd64-1) is memory-tight for five JVMs and was contributing to
+          # runs being hard-killed mid-startup; use the larger machine already used by
+          # the migration e2e block. (Per-JVM heaps are also capped in docker-compose.yml.)
+          type: s1-prod-ubuntu24-04-amd64-2
       prologue:
         commands:
           # keytool (from JDK) is required for TLS certificate generation

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,18 @@ test-osk-scan: build ## Run OSK scan tests (all auth methods, JMX, Prometheus)
 	  status=$$? ; cd ../.. ; bash integration-tests/osk-scan/teardown.sh ; exit $$status
 
 test-kafka-connect: build ## Run Kafka Connect self-managed connector scan tests
-	@bash integration-tests/connect-scan/setup.sh
-	cd integration-tests/connect-scan && go test -tags integration -v ./... ; \
-	  status=$$? ; cd ../.. ; bash integration-tests/connect-scan/teardown.sh ; exit $$status
+	@cd integration-tests/connect-scan && \
+	  if bash setup.sh; then \
+	    go test -tags integration -timeout 8m -v ./... ; status=$$? ; \
+	  else \
+	    echo "ERROR: connect-scan setup.sh failed" ; status=1 ; \
+	  fi ; \
+	  if [ $$status -ne 0 ]; then \
+	    echo "=== docker compose logs (connect-scan, on failure) ===" ; \
+	    docker compose logs --no-color --tail=400 || true ; \
+	  fi ; \
+	  bash teardown.sh || true ; \
+	  exit $$status
 
 test-schema-registry: build ## Run Schema Registry scan tests (unauthenticated, basic auth)
 	@bash integration-tests/schema-registry/setup.sh

--- a/integration-tests/connect-scan/docker-compose.yml
+++ b/integration-tests/connect-scan/docker-compose.yml
@@ -18,6 +18,11 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      # Cap the JVM heap. This suite runs the broker + four Connect workers (five
+      # JVMs) concurrently on one CI agent; with the images' unbounded defaults the
+      # agent was running out of memory and the job was being hard-killed mid-startup
+      # (~23 min, no test output). Explicit small heaps make total memory predictable.
+      KAFKA_HEAP_OPTS: '-Xmx512M -Xms512M'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
@@ -39,6 +44,9 @@ services:
       CONNECT_BOOTSTRAP_SERVERS: 'connect-kafka:29092'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'localhost'
       CONNECT_REST_PORT: 8083
+      # Small, explicit heap — see the broker note above; keeps five concurrent JVMs
+      # inside the agent's memory budget.
+      KAFKA_HEAP_OPTS: '-Xmx512M -Xms256M'
       CONNECT_GROUP_ID: 'connect-cluster'
       CONNECT_CONFIG_STORAGE_TOPIC: 'connect-configs'
       CONNECT_OFFSET_STORAGE_TOPIC: 'connect-offsets'
@@ -57,7 +65,20 @@ services:
         cub kafka-ready -b connect-kafka:29092 1 120
 
         echo "Downloading Jolokia agent..."
-        curl -sSL https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.7.2/jolokia-jvm-1.7.2.jar -o /tmp/jolokia-agent.jar
+        # Bounded + retried: the old unbounded `curl -sSL` had no timeout, so a slow
+        # or unreachable Maven Central would hang this worker's startup indefinitely
+        # (Connect never started, and the readiness wait then stalled). Fail each
+        # attempt fast and retry a few times instead.
+        for attempt in 1 2 3 4 5; do
+          if curl -fsSL --connect-timeout 5 --max-time 60 \
+               https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.7.2/jolokia-jvm-1.7.2.jar \
+               -o /tmp/jolokia-agent.jar && [ -s /tmp/jolokia-agent.jar ]; then
+            break
+          fi
+          echo "Jolokia download attempt $$attempt failed; retrying..."
+          rm -f /tmp/jolokia-agent.jar
+          sleep 3
+        done
 
         echo "Starting Kafka Connect with Jolokia..."
         export KAFKA_OPTS="-javaagent:/tmp/jolokia-agent.jar=port=8781,host=0.0.0.0"
@@ -108,6 +129,7 @@ services:
       CONNECT_PLUGIN_PATH: '/usr/share/java,/usr/share/confluent-hub-components'
       CONNECT_REST_EXTENSION_CLASSES: 'org.apache.kafka.connect.rest.basic.auth.extension.BasicAuthSecurityRestExtension'
       KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/connect/connect-jaas.conf'
+      KAFKA_HEAP_OPTS: '-Xmx512M -Xms256M'
     command:
       - bash
       - -c
@@ -134,6 +156,7 @@ services:
       CONNECT_LISTENERS: 'https://0.0.0.0:8083'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'localhost'
       CONNECT_REST_ADVERTISED_LISTENER: 'https'
+      KAFKA_HEAP_OPTS: '-Xmx512M -Xms256M'
       CONNECT_GROUP_ID: 'connect-cluster-mtls'
       CONNECT_CONFIG_STORAGE_TOPIC: 'connect-configs-mtls'
       CONNECT_OFFSET_STORAGE_TOPIC: 'connect-offsets-mtls'
@@ -179,6 +202,7 @@ services:
       CONNECT_LISTENERS: 'https://0.0.0.0:8083'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'localhost'
       CONNECT_REST_ADVERTISED_LISTENER: 'https'
+      KAFKA_HEAP_OPTS: '-Xmx512M -Xms256M'
       CONNECT_GROUP_ID: 'connect-cluster-basic-tls'
       CONNECT_CONFIG_STORAGE_TOPIC: 'connect-configs-basic-tls'
       CONNECT_OFFSET_STORAGE_TOPIC: 'connect-offsets-basic-tls'

--- a/integration-tests/connect-scan/setup.sh
+++ b/integration-tests/connect-scan/setup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Stand up the Connect env: 1 plaintext broker + three single-node Connect workers
-# (unauthenticated + HTTP-Basic + mTLS), and create a test connector on each so the
-# scanner has something to find. The Go test (connect_scan_test.go) assumes this ran.
+# Stand up the Connect env: 1 plaintext broker + four single-node Connect workers
+# (unauthenticated, HTTP-Basic, mTLS, and HTTPS+Basic), and create a test connector
+# on each so the scanner has something to find. Each worker is its own Connect group
+# (distinct group.id + internal topics), so they don't rebalance against each other.
+# The Go test (connect_scan_test.go) assumes this ran.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,46 +21,68 @@ CONNECTOR_JSON='{
   }
 }'
 
-# wait_rest <label> <base-url> [curl-auth-args...] — poll the Connect REST root.
-# --connect-timeout/--max-time bound each attempt so a listener that accepts the
-# TCP connection but never completes the TLS handshake (or never responds) fails
-# that attempt in seconds instead of hanging the whole retry loop indefinitely.
+# wait_rest <label> <base-url> [curl-auth-args...] — block until the Connect REST
+# API is genuinely serving requests, not merely accepting a TCP connection.
+#
+# We poll GET /connectors and require a 2xx (curl -sf). Connect's listener accepts
+# connections — and answers "/" — while the herder is still starting up and joining
+# the group, a window in which /connectors 404s and a freshly-POSTed connector would
+# too. Gating on /connectors is the real "herder is ready" signal, which removes the
+# transient 404-on-create races seen in CI.
+#
+# --connect-timeout/--max-time bound each attempt so a half-open or mid-handshake
+# listener fails that attempt in seconds; the `if` is what keeps `set -e` from
+# aborting the whole script on an expected not-ready-yet failure. 90 attempts (~a
+# few minutes) is generous headroom for a slow agent without ever hanging.
 wait_rest() {
   local label="$1" url="$2"; shift 2
   echo "Waiting for Kafka Connect REST — $label ($url)..."
-  for i in $(seq 1 60); do
-    if curl -s --connect-timeout 3 --max-time 5 "$@" "$url/" > /dev/null 2>&1; then
+  for i in $(seq 1 90); do
+    if curl -sf --connect-timeout 3 --max-time 5 "$@" "$url/connectors" > /dev/null 2>&1; then
       echo "  $label ready!"
       return 0
     fi
-    [ "$i" = "60" ] && { echo "ERROR: $label REST did not become ready in time"; return 1; }
+    [ "$i" = "90" ] && { echo "ERROR: $label REST did not become ready in time"; return 1; }
     sleep 2
   done
 }
 
-# create_connector <label> <base-url> [curl-auth-args...] — POST the test connector, with retry.
+# create_connector <label> <base-url> [curl-auth-args...] — POST the test connector,
+# retrying until it sticks.
+#
+# Uses `if curl -sf …; then`, never `code=$(curl …)`: under `set -euo pipefail` a
+# command substitution that captures a non-zero curl exit (e.g. a --max-time timeout,
+# exit 28) makes the assignment fail and aborts the whole script — which is exactly
+# the `make ... Error 28` failure observed in CI, where a single slow POST killed the
+# run instead of being retried. -sf turns any non-2xx (a herder still rebalancing can
+# briefly 404/409) or transport error into a retry.
+#
+# The POST is also treated idempotently: if an attempt's response was lost to a
+# timeout but the connector was in fact created, the follow-up GET catches it so we
+# don't loop forever re-POSTing an existing connector.
 create_connector() {
   local label="$1" url="$2"; shift 2
   echo "Creating test connector — $label..."
   for i in $(seq 1 30); do
-    local code
-    code=$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w "%{http_code}" "$@" -X POST "$url/connectors" \
-      -H "Content-Type: application/json" -d "$CONNECTOR_JSON" 2>/dev/null)
-    if [ "$code" = "201" ] || [ "$code" = "200" ]; then
-      echo "  connector created on $label (HTTP $code)"
+    if curl -sf --connect-timeout 3 --max-time 10 "$@" -X POST "$url/connectors" \
+         -H "Content-Type: application/json" -d "$CONNECTOR_JSON" > /dev/null 2>&1; then
+      echo "  connector created on $label"
       return 0
     fi
-    echo "  $label connector create returned HTTP $code, retrying ($i/30)..."
+    if curl -sf --connect-timeout 3 --max-time 5 "$@" "$url/connectors/test-heartbeat" > /dev/null 2>&1; then
+      echo "  connector already present on $label"
+      return 0
+    fi
+    [ "$i" = "30" ] && { echo "ERROR: failed to create connector on $label"; return 1; }
+    echo "  $label not ready for connector create, retrying ($i/30)..."
     sleep 2
   done
-  echo "ERROR: failed to create connector on $label"
-  return 1
 }
 
 echo "Generating mTLS certificates..."
 bash generate-certs.sh
 
-echo "Starting Connect env (broker + 3 Connect workers)..."
+echo "Starting Connect env (broker + 4 Connect workers)..."
 docker compose up -d
 
 # ── Unauthenticated worker (:18083) ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

The `kafka connect scan` Semaphore job fails ~25–30% of runs across **unrelated PRs and on `main` itself** — an environmental flake, not the code under test. Runtimes are bimodal: pass ≈ 9 min, fail ≈ 23 min. PR #413's curl timeout only addressed a sliver, so the failure kept relocating (it recurred e.g. on the docs-only PR #416, job `e1940f44`).

Evidence from 22 recent runs + job logs (`sem logs`/Semaphore API): failures split into two root causes.

## Root causes & fixes (keeps the real containerised test)

**1. Memory contention.** One agent runs a broker + four Connect JVMs with unbounded heaps → out of memory → job hard-killed mid-startup (died ~23 min with no test output and no epilogue flushed).
- Cap every JVM heap via `KAFKA_HEAP_OPTS` in `docker-compose.yml`.
- Move the block to the larger `s1-prod-ubuntu24-04-amd64-2` agent already used by the migration e2e block.

**2. Readiness races.**
- `wait_rest` polled `/`, which answers *before* the herder joins the group, so `POST /connectors` raced into 404s. It now gates on `GET /connectors` → 2xx (real herder-ready).
- `create_connector` captured `code=$(curl --max-time 5)` under `set -euo pipefail`, so a timed-out POST (curl exit 28) aborted the whole script instead of retrying — the observed `make … Error 28`. It now uses the `set -e`-safe `if curl -sf` idiom with an idempotent GET fallback.

**Also hardened**
- Bound + retry the in-container Jolokia download (was an unbounded `curl` that could hang a worker's startup).
- `Makefile` target now **always tears down**, **dumps `docker compose logs` on failure**, and runs `go test -timeout 8m` — so a failure is clean and diagnosable instead of a silent 23-minute stall.

## Verification

Local `make test-kafka-connect` passes with the changes — all auth subtests plus the Jolokia metrics subtest (`ok … 34.4s`), clean teardown, no leaked containers. Elimination of the flake is by construction (bounded memory can't OOM; the readiness gate reflects reality; failures are now logged); it'll be confirmed by CI over several runs, and any recurrence will now surface the container-level cause via the new logs dump.

## Note for reviewers

The agent bump to `amd64-2` is for headroom; the heap caps bound memory on their own, so if the default `amd64-1` is already large that one line can be dropped. The identical fragile Makefile pattern in `test-osk-scan` / `test-schema-registry` likely flakes the same way and could get the same treatment separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
