### PR TITLE
feat(migration): support non-SASL/PLAIN destination auth for init|execute

### DIFF
--- a/cmd/migration/execute/cmd_migration_execute.go
+++ b/cmd/migration/execute/cmd_migration_execute.go
@@ -394,11 +394,30 @@ func buildExecutorOpts(g *manifest.GatewayMigration, config *migration.Migration
 	if len(errs) > 0 {
 		return MigrationExecutorOpts{}, manifest.JoinProblems("spec.target.kafka.credentials", errs)
 	}
-	// The sasl_plain-only rule is enforced in two validators upstream; assert it
-	// here rather than dereferencing on an invariant that lives elsewhere,
-	// because the alternative failure is a nil panic mid-cutover.
-	if dstCreds.SASLPlain == nil {
-		return MigrationExecutorOpts{}, fmt.Errorf("spec.target.kafka.credentials: only sasl_plain is supported for the destination in this release")
+
+	// A nil bootstrap is fine here: MigrateConn folds it straight into
+	// KafkaSourceConn.BootstrapServers, which auth-type mapping never reads
+	// (see TestMigrateConn_NilBootstrapServers_AuthMappingUnaffected).
+	destConn := types.MigrateConn(nil, dstCreds)
+	destAuthType, err := destConn.GetSelectedAuthType()
+	if err != nil {
+		// The validators upstream already enforce exactly one method (and
+		// reject iam), so this is an invariant, not an expected user error —
+		// but failing loudly here beats a nil dereference mid-cutover.
+		return MigrationExecutorOpts{}, fmt.Errorf("resolving destination auth method: %w", err)
+	}
+	destAuthMethod := destConn.AuthMethod
+
+	// Backward-compat trap: the old destination client always dialled SASL/PLAIN
+	// over TLS against the public trust store (WithSASLPlainAuth with an empty
+	// ca_cert). AdminOptionForAuthMethod maps sasl_plain with NEITHER ca_cert nor
+	// tls set to cleartext SASL_PLAINTEXT — a silent downgrade for a Confluent
+	// Cloud destination. Default UseTLS=true in that case: the destination is a
+	// managed/production cluster, always TLS, unlike a source which may
+	// legitimately be on-prem plaintext. Every existing manifest (which never
+	// set tls: nor ca_cert:) keeps dialling exactly as before.
+	if sp := destAuthMethod.SASLPlain; sp != nil && sp.CACert == "" && !sp.UseTLS {
+		sp.UseTLS = true
 	}
 
 	// Policy is re-read fresh from the manifest on every run and overwrites
@@ -438,19 +457,20 @@ func buildExecutorOpts(g *manifest.GatewayMigration, config *migration.Migration
 		// The destination Kafka leg authenticates with the KAFKA block. When
 		// restCredentials is spelled out it may name a different, broader
 		// principal, and sending that to the broker would invert least privilege.
-		ClusterApiKey:    dstCreds.SASLPlain.Username,
-		ClusterApiSecret: dstCreds.SASLPlain.Password,
+		DestAuthType:   destAuthType,
+		DestAuthMethod: destAuthMethod,
 
-		RestApiKey:        restCreds.APIKey,
-		RestApiSecret:     restCreds.APISecret,
-		ClusterRestCACert: restCreds.CACert,
+		// The full resolved REST credential — basic, bearer, mtls, or the
+		// api_key form — carried through rather than flattened to a scalar
+		// key/secret pair, so bearer/basic/mTLS headers and client certs reach
+		// the REST leg.
+		RestCreds: restCreds,
 
 		// Each leg carries only what its own block asked for. Collapsing these
 		// would mean relaxing TLS for a self-signed source also stops verifying
 		// the destination connections that carry the destination API key.
 		SourceInsecureSkipTLSVerify:    srcCreds.InsecureSkipTLSVerify,
 		DestKafkaInsecureSkipTLSVerify: dstCreds.InsecureSkipTLSVerify,
-		RestInsecureSkipTLSVerify:      restCreds.InsecureSkipVerify,
 	}
 	applySourceAuth(&opts, srcCreds)
 	return opts, nil

--- a/cmd/migration/execute/cmd_migration_execute_test.go
+++ b/cmd/migration/execute/cmd_migration_execute_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confluentinc/kcp/internal/manifest"
 	"github.com/confluentinc/kcp/internal/services/gateway"
 	"github.com/confluentinc/kcp/internal/services/migration"
+	"github.com/confluentinc/kcp/internal/types"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -751,7 +752,7 @@ func TestExecute_InsecureSkipReachesAllThreeLegs(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, opts.SourceInsecureSkipTLSVerify)
 	assert.True(t, opts.DestKafkaInsecureSkipTLSVerify)
-	assert.True(t, opts.RestInsecureSkipTLSVerify)
+	assert.True(t, opts.RestCreds.InsecureSkipVerify)
 
 	rest, err := g.RestCredentials()
 	require.NoError(t, err)
@@ -764,8 +765,49 @@ func TestExecute_DestinationKeyAndSecretFeedBothLegs(t *testing.T) {
 	g := loadGateway(t, f.manifestPath)
 	opts, err := buildExecutorOpts(g, persistedConfig(t, f), *migration.NewMigrationState(), f.stateFile)
 	require.NoError(t, err)
-	assert.Equal(t, "CC_KEY", opts.ClusterApiKey)
-	assert.Equal(t, "CC_SECRET", opts.ClusterApiSecret)
+	assert.Equal(t, types.AuthTypeSASLPlain, opts.DestAuthType)
+	require.NotNil(t, opts.DestAuthMethod.SASLPlain)
+	assert.Equal(t, "CC_KEY", opts.DestAuthMethod.SASLPlain.Username)
+	assert.Equal(t, "CC_SECRET", opts.DestAuthMethod.SASLPlain.Password)
+}
+
+// TestExecute_DestSASLPlainDefaultsToTLS is the ⚠️ backward-compat fix (A.3):
+// the old destination client always dialled SASL_SSL over the public trust
+// store. AdminOptionForAuthMethod maps sasl_plain with no ca_cert/tls to
+// cleartext SASL_PLAINTEXT, so buildExecutorOpts must default UseTLS=true when
+// neither is set — the single most important regression to prove, since every
+// existing manifest never sets tls: nor ca_cert: on the destination.
+func TestExecute_DestSASLPlainDefaultsToTLS(t *testing.T) {
+	f := newFixture(t, func(doc string) string {
+		return strings.Replace(doc,
+			"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
+			"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET", 1)
+	})
+	g := loadGateway(t, f.manifestPath)
+	opts, err := buildExecutorOpts(g, persistedConfig(t, f), *migration.NewMigrationState(), f.stateFile)
+	require.NoError(t, err)
+	require.NotNil(t, opts.DestAuthMethod.SASLPlain)
+	assert.True(t, opts.DestAuthMethod.SASLPlain.UseTLS, "no ca_cert/tls set must still default to SASL_SSL, not a silent downgrade to SASL_PLAINTEXT")
+}
+
+// TestExecute_DestSASLPlainCACertIsNotOverridden — the compat default must not
+// clobber an explicit ca_cert (already selects SASL_SSL) nor flip UseTLS when
+// one is already set.
+func TestExecute_DestSASLPlainCACertIsNotOverridden(t *testing.T) {
+	ca := filepath.Join(t.TempDir(), "dest-ca.pem")
+	require.NoError(t, os.WriteFile(ca, []byte("pem"), 0600))
+
+	f := newFixture(t, func(doc string) string {
+		return strings.Replace(doc,
+			"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
+			"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          ca_cert: "+ca, 1)
+	})
+	g := loadGateway(t, f.manifestPath)
+	opts, err := buildExecutorOpts(g, persistedConfig(t, f), *migration.NewMigrationState(), f.stateFile)
+	require.NoError(t, err)
+	require.NotNil(t, opts.DestAuthMethod.SASLPlain)
+	assert.Equal(t, ca, opts.DestAuthMethod.SASLPlain.CACert)
+	assert.False(t, opts.DestAuthMethod.SASLPlain.UseTLS, "ca_cert already selects SASL_SSL; the compat default must not also flip UseTLS")
 }
 
 // --- ported preRunE errors (§6) ---
@@ -841,7 +883,7 @@ func TestExecute_SourceInsecureSkipDoesNotReachTheDestination(t *testing.T) {
 
 	assert.True(t, opts.SourceInsecureSkipTLSVerify, "the source asked for it")
 	assert.False(t, opts.DestKafkaInsecureSkipTLSVerify, "the destination Kafka leg did not")
-	assert.False(t, opts.RestInsecureSkipTLSVerify, "nor the destination REST leg")
+	assert.False(t, opts.RestCreds.InsecureSkipVerify, "nor the destination REST leg")
 }
 
 // TestExecute_DestinationInsecureSkipDoesNotReachTheSource — the same in reverse.
@@ -855,7 +897,7 @@ func TestExecute_DestinationInsecureSkipDoesNotReachTheSource(t *testing.T) {
 
 	assert.False(t, opts.SourceInsecureSkipTLSVerify)
 	assert.True(t, opts.DestKafkaInsecureSkipTLSVerify)
-	assert.True(t, opts.RestInsecureSkipTLSVerify, "a DERIVED REST leg inherits from the Kafka block")
+	assert.True(t, opts.RestCreds.InsecureSkipVerify, "a DERIVED REST leg inherits from the Kafka block")
 }
 
 // TestExecute_ExplicitRestCredentialsGovernTheRestLeg — with restCredentials
@@ -875,7 +917,7 @@ func TestExecute_ExplicitRestCredentialsGovernTheRestLeg(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, opts.SourceInsecureSkipTLSVerify)
-	assert.False(t, opts.RestInsecureSkipTLSVerify,
+	assert.False(t, opts.RestCreds.InsecureSkipVerify,
 		"an explicit REST block that did not ask for it must keep verifying")
 }
 
@@ -895,10 +937,11 @@ func TestExecute_DestinationKafkaUsesTheKafkaCredentialNotTheRestOne(t *testing.
 	opts, err := buildExecutorOpts(loadGateway(t, f.manifestPath), persistedConfig(t, f), *migration.NewMigrationState(), f.stateFile)
 	require.NoError(t, err)
 
-	assert.Equal(t, "CC_KEY", opts.ClusterApiKey, "the Kafka leg uses spec.target.kafka.credentials")
-	assert.Equal(t, "CC_SECRET", opts.ClusterApiSecret)
-	assert.Equal(t, "REST_ONLY_KEY", opts.RestApiKey, "the REST leg uses restCredentials")
-	assert.Equal(t, "REST_ONLY_SECRET", opts.RestApiSecret)
+	require.NotNil(t, opts.DestAuthMethod.SASLPlain, "the Kafka leg uses spec.target.kafka.credentials")
+	assert.Equal(t, "CC_KEY", opts.DestAuthMethod.SASLPlain.Username)
+	assert.Equal(t, "CC_SECRET", opts.DestAuthMethod.SASLPlain.Password)
+	assert.Equal(t, "REST_ONLY_KEY", opts.RestCreds.APIKey, "the REST leg uses restCredentials")
+	assert.Equal(t, "REST_ONLY_SECRET", opts.RestCreds.APISecret)
 }
 
 // TestExecute_DerivedRestCredentialsStillMatchTheKafkaLeg — the common case is
@@ -907,6 +950,7 @@ func TestExecute_DerivedRestCredentialsStillMatchTheKafkaLeg(t *testing.T) {
 	f := newFixture(t, nil)
 	opts, err := buildExecutorOpts(loadGateway(t, f.manifestPath), persistedConfig(t, f), *migration.NewMigrationState(), f.stateFile)
 	require.NoError(t, err)
-	assert.Equal(t, "CC_KEY", opts.ClusterApiKey)
-	assert.Equal(t, "CC_KEY", opts.RestApiKey)
+	require.NotNil(t, opts.DestAuthMethod.SASLPlain)
+	assert.Equal(t, "CC_KEY", opts.DestAuthMethod.SASLPlain.Username)
+	assert.Equal(t, "CC_KEY", opts.RestCreds.APIKey)
 }

--- a/cmd/migration/execute/migration_executor.go
+++ b/cmd/migration/execute/migration_executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confluentinc/kcp/internal/services/gateway"
 	"github.com/confluentinc/kcp/internal/services/migration"
 	"github.com/confluentinc/kcp/internal/services/offset"
+	"github.com/confluentinc/kcp/internal/targets"
 	"github.com/confluentinc/kcp/internal/types"
 )
 
@@ -20,8 +21,6 @@ type MigrationExecutorOpts struct {
 	MigrationState     migration.MigrationState
 	MigrationConfig    migration.MigrationConfig
 	LagThreshold       int64
-	ClusterApiKey      string
-	ClusterApiSecret   string
 	ClusterBootstrap   string
 	SourceBootstrap    string
 	AWSRegion          string
@@ -34,23 +33,29 @@ type MigrationExecutorOpts struct {
 	// SaslPlainUseTLS selects SASL_SSL over the system trust store when no
 	// ca_cert is supplied. Without it a `tls: true` source block would be
 	// silently downgraded to cleartext SASL_PLAINTEXT.
-	SaslPlainUseTLS   bool
-	TlsCaCert         string
-	TlsClientCert     string
-	TlsClientKey      string
-	ClusterRestCACert string
-	// RestApiKey / RestApiSecret authenticate the destination REST surface.
-	// They are separate from ClusterApiKey/ClusterApiSecret because an explicit
-	// spec.target.kafka.restCredentials may name a different principal, and the
-	// Kafka leg must not silently authenticate as the REST one.
-	RestApiKey    string
-	RestApiSecret string
+	SaslPlainUseTLS bool
+	TlsCaCert       string
+	TlsClientCert   string
+	TlsClientKey    string
+	// DestAuthType / DestAuthMethod select and configure the destination Kafka
+	// leg's auth, mapped via client.AdminOptionForAuthMethod — the same mapper
+	// the source leg uses. Carrying the full per-method config (rather than a
+	// scalar key/secret pair) is what makes SASL/SCRAM, mTLS and unauthenticated
+	// destinations possible, not just SASL/PLAIN.
+	DestAuthType   types.AuthType
+	DestAuthMethod types.AuthMethodConfig
+	// RestCreds authenticates the destination cluster-link REST surface. It is
+	// the full resolved credential (basic, bearer, mtls, or the api_key form),
+	// not just an api_key/api_secret pair, and is kept separate from the Kafka
+	// leg's DestAuthMethod because an explicit spec.target.kafka.restCredentials
+	// may name a different principal — the Kafka leg must not silently
+	// authenticate as the REST one.
+	RestCreds *targets.Credentials
 	// TLS trust is per leg. One shared boolean meant relaxing verification for a
 	// self-signed source also stopped verifying the destination connections,
 	// which carry the destination API key as SASL/PLAIN and as HTTP Basic.
 	SourceInsecureSkipTLSVerify    bool
 	DestKafkaInsecureSkipTLSVerify bool
-	RestInsecureSkipTLSVerify      bool
 	// RolloutTimeout bounds the gateway-readiness wait during fence and
 	// switch. A value of 0 means no deadline — the wait runs until the
 	// operator reports ready or the user cancels.
@@ -101,9 +106,9 @@ func (m *MigrationExecutor) Run() error {
 	}
 	defer func() { _ = destinationOffset.Close() }()
 
-	// REST client for the destination cluster-link API: trusts a private CA
-	// (--cluster-rest-ca-cert) and/or skips verification, else system roots (CC public CA).
-	httpClient, err := migration.NewRESTHTTPClient(m.opts.ClusterRestCACert, m.opts.RestInsecureSkipTLSVerify)
+	// REST client for the destination cluster-link API: presents whichever TLS
+	// trust (and, for mTLS, client cert) the resolved REST credentials carry.
+	httpClient, err := m.opts.RestCreds.HTTPClient()
 	if err != nil {
 		return fmt.Errorf("building destination REST client: %w", err)
 	}
@@ -175,13 +180,14 @@ func (m *MigrationExecutor) Run() error {
 	// The cluster-link REST API authenticates with the REST credentials, which
 	// may name a broader principal than the destination KAFKA credentials — the
 	// two are kept separate so neither leg silently authenticates as the other.
-	clusterLinkConfig := migration.BuildClusterLinkConfig(&config, m.opts.RestApiKey, m.opts.RestApiSecret)
+	restAuth := m.opts.RestCreds.Authenticator()
+	clusterLinkConfig := migration.BuildClusterLinkConfig(&config, restAuth)
 
 	// The consumer-offset-sync pause runs INSIDE the FSM (the
 	// pause_offset_sync stage, right after fencing) so destination offsets
 	// stay fresh through the lag and fence phases instead of going stale for
 	// the whole run. Only the restore below remains a bookend.
-	if execErr = orchestrator.Execute(ctx, m.opts.LagThreshold, m.opts.RestApiKey, m.opts.RestApiSecret); execErr != nil {
+	if execErr = orchestrator.Execute(ctx, m.opts.LagThreshold, restAuth); execErr != nil {
 		migration.WarnIfPausedOnExecuteFailure(&config, execErr)
 		return fmt.Errorf("failed to execute migration: %w", execErr)
 	}
@@ -268,14 +274,19 @@ func (m *MigrationExecutor) createSourceOffset(_ context.Context) (*offset.Servi
 
 func (m *MigrationExecutor) createDestinationOffset() (*offset.Service, error) {
 	ccBrokers := strings.Split(m.opts.ClusterBootstrap, ",")
-	slog.Debug("connecting to destination cluster (Confluent Cloud)",
+	slog.Debug("connecting to destination cluster",
 		"brokers", len(ccBrokers),
+		"auth_type", m.opts.DestAuthType,
 		"insecure_skip_tls_verify", m.opts.DestKafkaInsecureSkipTLSVerify,
 	)
-	// SASL/PLAIN over TLS (SASL_SSL), public CA (no ca_cert). The credential is
-	// the destination KAFKA one, not the REST one — they may differ.
-	destOpts := []client.AdminOption{client.WithSASLPlainAuth(m.opts.ClusterApiKey, m.opts.ClusterApiSecret, "", m.opts.DestKafkaInsecureSkipTLSVerify)}
-	destClient, err := client.NewKafkaClient(ccBrokers, "", destOpts...)
+	// The credential is the destination KAFKA one, not the REST one — they may
+	// differ. skipTLSVerify is threaded through the mapper into every TLS path,
+	// mirroring createSourceOffset.
+	authOpt, err := client.AdminOptionForAuthMethod(m.opts.DestAuthType, m.opts.DestAuthMethod, m.opts.DestKafkaInsecureSkipTLSVerify)
+	if err != nil {
+		return nil, fmt.Errorf("resolving destination auth option: %w", err)
+	}
+	destClient, err := client.NewKafkaClient(ccBrokers, "", authOpt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to destination cluster: %w", err)
 	}

--- a/cmd/migration/init/cmd_migration_init.go
+++ b/cmd/migration/init/cmd_migration_init.go
@@ -164,13 +164,10 @@ func runMigrationInit(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := MigrationInitializerOpts{
-		MigrationStateFile:    migrationStateFile,
-		MigrationState:        *migrationState,
-		MigrationConfig:       config,
-		RestApiKey:            restCreds.APIKey,
-		RestApiSecret:         restCreds.APISecret,
-		ClusterRestCACert:     restCreds.CACert,
-		InsecureSkipTLSVerify: restCreds.InsecureSkipVerify,
+		MigrationStateFile: migrationStateFile,
+		MigrationState:     *migrationState,
+		MigrationConfig:    config,
+		RestCreds:          restCreds,
 	}
 	if err := NewMigrationInitializer(opts).Run(); err != nil {
 		return err

--- a/cmd/migration/init/migration_initializer.go
+++ b/cmd/migration/init/migration_initializer.go
@@ -7,21 +7,18 @@ import (
 	"github.com/confluentinc/kcp/internal/services/clusterlink"
 	"github.com/confluentinc/kcp/internal/services/gateway"
 	"github.com/confluentinc/kcp/internal/services/migration"
+	"github.com/confluentinc/kcp/internal/targets"
 )
 
 type MigrationInitializerOpts struct {
 	MigrationStateFile string
 	MigrationState     migration.MigrationState
 	MigrationConfig    migration.MigrationConfig
-	// RestApiKey / RestApiSecret authenticate the destination REST surface —
-	// the only client this initializer builds. Named for the leg rather than
-	// the cluster because the sibling execute package uses ClusterApiKey for
-	// the KAFKA leg, and one name meaning two things a directory apart is what
-	// produced the credential-crossing bug in execute.
-	RestApiKey            string
-	RestApiSecret         string
-	ClusterRestCACert     string
-	InsecureSkipTLSVerify bool
+	// RestCreds authenticates the destination REST surface — the only client
+	// this initializer builds. Carrying the full resolved credential (rather
+	// than a scalar api_key/api_secret pair) is what lets a basic, bearer or
+	// mTLS destination REST leg reach a Confluent Platform cluster.
+	RestCreds *targets.Credentials
 }
 
 type MigrationInitializer struct {
@@ -37,9 +34,9 @@ func NewMigrationInitializer(opts MigrationInitializerOpts) *MigrationInitialize
 func (m *MigrationInitializer) Run() error {
 	config := m.opts.MigrationConfig
 
-	// REST client for the destination cluster-link API: trusts a private CA
-	// (--cluster-rest-ca-cert) and/or skips verification, else system roots (CC public CA).
-	httpClient, err := migration.NewRESTHTTPClient(m.opts.ClusterRestCACert, m.opts.InsecureSkipTLSVerify)
+	// REST client for the destination cluster-link API: presents whichever TLS
+	// trust (and, for mTLS, client cert) the resolved REST credentials carry.
+	httpClient, err := m.opts.RestCreds.HTTPClient()
 	if err != nil {
 		return fmt.Errorf("building destination REST client: %w", err)
 	}
@@ -56,7 +53,7 @@ func (m *MigrationInitializer) Run() error {
 	)
 
 	ctx := context.Background()
-	if err := orchestrator.Initialize(ctx, m.opts.RestApiKey, m.opts.RestApiSecret); err != nil {
+	if err := orchestrator.Initialize(ctx, m.opts.RestCreds.Authenticator()); err != nil {
 		return fmt.Errorf("failed to initialize migration: %w", err)
 	}
 

--- a/docs/assets/gateway-examples/gateway-migration.yaml
+++ b/docs/assets/gateway-examples/gateway-migration.yaml
@@ -57,30 +57,68 @@ spec:
       bootstrapServers:
         - pkc-xxxxx.us-east-1.aws.confluent.cloud:9092
       restEndpoint: https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443
-      # The destination KAFKA leg. Only sasl_plain is supported in this release
-      # — the destination client is hardcoded to SASL/PLAIN over TLS, so any
-      # other block would be accepted and then silently ignored.
+      # The destination KAFKA leg, dialled directly to read destination-side
+      # offsets. Accepts sasl_plain, sasl_scram, mtls, unauthenticated_tls, or
+      # unauthenticated_plaintext — iam is rejected (the destination is
+      # Confluent Cloud/Platform, never MSK).
       credentials:
         sasl_plain:
           username: ${CC_API_KEY}
           password: ${CC_API_SECRET}
           tls: true
+          # ca_cert: /etc/kcp/dest-ca.pem  # honoured here — trusts a private CA
         # insecure_skip_tls_verify is a SIBLING of the auth block, not a key
         # inside it, and it reaches all three connection legs:
         # insecure_skip_tls_verify: true
+        #
+        # A Confluent Platform destination behind SASL/SCRAM instead of
+        # SASL/PLAIN:
+        # sasl_scram:
+        #   username: ${CP_USERNAME}
+        #   password: ${CP_PASSWORD}
+        #   mechanism: SHA256 # SHA256 | SHA512
+        #   ca_cert: /etc/kcp/dest-ca.pem
+        #
+        # Or mutual TLS (the client authenticates via its certificate):
+        # mtls:
+        #   client_cert: /etc/kcp/dest-client.pem
+        #   client_key: /etc/kcp/dest-client-key.pem
+        #   ca_cert: /etc/kcp/dest-ca.pem
+        #
+        # Or one-way TLS / plaintext, for a lab/test destination:
+        # unauthenticated_tls:
+        #   ca_cert: /etc/kcp/dest-ca.pem
+        # unauthenticated_plaintext: {}
       #
-      # restCredentials is OPTIONAL and DERIVED in full from credentials when
-      # omitted: api_key/api_secret from sasl_plain.username/password, and
-      # insecure_skip_verify from insecure_skip_tls_verify above.
+      # restCredentials is OPTIONAL and DERIVED in full from credentials ONLY
+      # when that block is sasl_plain (above): api_key/api_secret from
+      # sasl_plain.username/password, and ca_cert/insecure_skip_verify from
+      # their sasl_plain siblings.
       #
-      # Spell it out only for a REST endpoint behind a private CA. A block that
-      # is present is used exactly as written — never partially derived — so it
-      # must restate the key and secret.
+      # For every other credentials method (sasl_scram, mtls, unauthenticated_*)
+      # there is no principal to derive a REST credential from, so
+      # restCredentials is REQUIRED. A block that is present is always used
+      # exactly as written — never partially derived — so a sasl_plain
+      # destination that spells it out anyway must restate the key and secret.
       #
       # restCredentials:
       #   api_key: ${CC_API_KEY}
       #   api_secret: ${CC_API_SECRET}
       #   ca_cert: /etc/kcp/dest-ca.pem
+      #
+      # Or, alongside a sasl_scram/mtls/unauthenticated_* destination above,
+      # any of the REST-specific forms:
+      # restCredentials:
+      #   basic:
+      #     username: ${CP_REST_USERNAME}
+      #     password: ${CP_REST_PASSWORD}
+      # restCredentials:
+      #   bearer:
+      #     token: ${CP_REST_TOKEN}
+      # restCredentials:
+      #   mtls:
+      #     client_cert: /etc/kcp/dest-rest-client.pem
+      #     client_key: /etc/kcp/dest-rest-client-key.pem
 
   clusterLink:
     name: msk-to-cc # the link must ALREADY EXIST on the destination

--- a/docs/assets/gateway-examples/gateway-migration.yaml
+++ b/docs/assets/gateway-examples/gateway-migration.yaml
@@ -57,6 +57,28 @@ spec:
       bootstrapServers:
         - pkc-xxxxx.us-east-1.aws.confluent.cloud:9092
       restEndpoint: https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443
+      # credentials and restCredentials authenticate two DIFFERENT servers:
+      # credentials dials bootstrapServers directly over the Kafka wire
+      # protocol (reads/writes destination-side offsets); restCredentials
+      # calls restEndpoint's Admin REST API, which is what actually manages
+      # the cluster link (status, list/promote mirror topics, alter
+      # configs) — the link itself must ALREADY EXIST; kcp never creates
+      # one. On self-managed Confluent Platform these are
+      # backed by two INDEPENDENT credential stores configured separately on
+      # the cluster itself — the Kafka SASL/SCRAM (or mTLS) listener has its
+      # own store; the REST API's auth (kafka.rest.authentication.method: a
+      # Basic realm file, MDS for bearer, or its own mTLS trust store) has
+      # another. A valid Kafka credential is NOT automatically a valid REST
+      # credential, even against the same broker process — the two stores
+      # only match if you provisioned the same principal into both yourself.
+      #
+      # The one case where reuse is automatic is Confluent Cloud's sasl_plain
+      # key below: Confluent Cloud issues it as a single artifact valid as
+      # both the Kafka SASL/PLAIN credential and the REST Basic-auth
+      # credential, so kcp can safely derive restCredentials from it. No such
+      # platform guarantee exists for sasl_scram/mtls/unauthenticated_*,
+      # which is why restCredentials must be spelled out explicitly there.
+      #
       # The destination KAFKA leg, dialled directly to read destination-side
       # offsets. Accepts sasl_plain, sasl_scram, mtls, unauthenticated_tls, or
       # unauthenticated_plaintext — iam is rejected (the destination is

--- a/docs/assets/gateway-manifest-reference/README.md
+++ b/docs/assets/gateway-manifest-reference/README.md
@@ -113,6 +113,15 @@ honoured here too: it names a private CA the destination client trusts
 directly, on top of (or instead of) the public trust store `tls: true`
 selects.
 
+Unlike the shared table above, a destination `sasl_plain` with **neither**
+`ca_cert` nor `tls` set does not fall back to `SASL_PLAINTEXT`: it defaults to
+`tls: true` against the public trust store, matching the destination client's
+pre-existing behavior — the destination is always a managed/production
+cluster, never on-prem plaintext like a source may legitimately be. There is
+no `sasl_plain` field that opts back into `SASL_PLAINTEXT` against the
+destination; use `unauthenticated_plaintext` for a genuinely plaintext
+destination (test/lab only).
+
 `kafka.restCredentials` is **optional and derived in full** from `credentials`
 **only when that block is `sasl_plain`**: `api_key`/`api_secret` come from
 `sasl_plain.username`/`password`, and `ca_cert`/`insecure_skip_verify` are

--- a/docs/assets/gateway-manifest-reference/README.md
+++ b/docs/assets/gateway-manifest-reference/README.md
@@ -102,26 +102,27 @@ The cluster being migrated to.
 | `clusterId` | string | yes | Required for **both** destination types — this kind never discovers it live. |
 | `kafka.bootstrapServers` | `[]string` | yes | Destination Kafka bootstrap. |
 | `kafka.restEndpoint` | string | yes | Destination Admin REST endpoint (cluster link + topic operations). |
-| `kafka.credentials` | path or inline | yes | Destination Kafka leg, used as SASL/PLAIN against the bootstrap. **Only `sasl_plain` is accepted** — see below. |
-| `kafka.restCredentials` | path or inline | no | Destination REST leg. Optional — derived from `credentials` when omitted. See below. |
+| `kafka.credentials` | path or inline | yes | Destination Kafka leg, dialled directly to read destination-side offsets. Accepts `sasl_plain`, `sasl_scram`, `mtls`, `unauthenticated_tls`, or `unauthenticated_plaintext` — see below. |
+| `kafka.restCredentials` | path or inline | no (except when `credentials` isn't `sasl_plain` — see below) | Destination REST leg. |
 
-`kafka.credentials` is checked against the destination client, which is
-hardcoded to SASL/PLAIN over TLS: any other auth block is rejected outright
-rather than silently accepted and ignored. A `ca_cert` inside `sasl_plain` is
-also rejected for the destination in this release — the client always dials
-the public trust store, so a private CA here would read as configured while
-actually connecting on system roots. Set `tls: true` (no `ca_cert`) for a
-public-CA destination.
+`kafka.credentials` accepts any Kafka auth method **except** `iam` — the
+destination is Confluent Cloud or Confluent Platform, never MSK, so `iam` is
+rejected outright rather than silently accepted and then failing opaquely at
+connection time. Unlike the source leg, a `ca_cert` inside `sasl_plain` is
+honoured here too: it names a private CA the destination client trusts
+directly, on top of (or instead of) the public trust store `tls: true`
+selects.
 
 `kafka.restCredentials` is **optional and derived in full** from `credentials`
-when omitted: `api_key`/`api_secret` come from `sasl_plain.username`/`password`,
-and `insecure_skip_verify` from the sibling `insecure_skip_tls_verify`. Spell it
-out only when the REST endpoint sits behind a different, private CA than the
-Kafka listener — and when you do, only the flat `api_key`/`api_secret` form is
-accepted (`basic`, `bearer`, `mtls` are all rejected, for the same reason as
-above: a form the client can't act on is worse silently dropped than refused).
-A block that is present is used exactly as written, never partially derived, so
-it must restate the key and secret even if they match `credentials`.
+**only when that block is `sasl_plain`**: `api_key`/`api_secret` come from
+`sasl_plain.username`/`password`, and `ca_cert`/`insecure_skip_verify` are
+inherited from their `sasl_plain` siblings. For every other `credentials`
+method there is no principal to derive a REST credential from, so
+`restCredentials` becomes **required** — spell out any of `api_key`/`api_secret`,
+`basic`, `bearer`, or `mtls` (see the REST credentials table below). A block
+that is present is always used exactly as written, never partially derived, so
+a `sasl_plain` destination that spells it out anyway must restate the key and
+secret even if they match `credentials`.
 
 ## `spec.clusterLink`
 
@@ -234,15 +235,12 @@ Specify **exactly one** block (or the `api_key`/`api_secret` pair).
 (e.g. self-managed CP/MDS). Public-CA endpoints (Confluent Cloud via `api_key`)
 need neither.
 
-Two restrictions are specific to **this** manifest, narrower than the two
+One restriction is specific to **this** manifest, narrower than the two
 tables above:
 
 - `spec.source.credentials.iam` is valid only when `spec.source.type: msk`.
-- `spec.target.kafka.credentials` accepts **only `sasl_plain`**, and
-  `spec.target.kafka.restCredentials`, if spelled out, accepts **only the flat
-  `api_key`/`api_secret` form** — every other block in the tables above is
-  rejected on these two slots specifically, because the destination clients
-  this manifest drives can't act on it.
+  `spec.target.kafka.credentials.iam` is rejected outright, on both source and
+  destination legs — the destination is Confluent Cloud/Platform, never MSK.
 
 ## How the commands read this file
 
@@ -315,8 +313,8 @@ Key rules, beyond required/optional per field above:
 | `spec.target.clusterId` | string | yes | — | required for both target types |
 | `spec.target.kafka.bootstrapServers` | `[]string` | yes | — | `host:port` |
 | `spec.target.kafka.restEndpoint` | string | yes | — | URL |
-| `spec.target.kafka.credentials` | path or inline | yes | — | `sasl_plain` only |
-| `spec.target.kafka.restCredentials` | path or inline | no | derived from `credentials` | `api_key`/`api_secret` form only |
+| `spec.target.kafka.credentials` | path or inline | yes | — | Kafka family except `iam` |
+| `spec.target.kafka.restCredentials` | path or inline | no if `credentials` is `sasl_plain`; **yes** otherwise | derived from `credentials` when `sasl_plain` | `api_key`/`api_secret`, `basic`, `bearer`, or `mtls` |
 | `spec.clusterLink.name` | string | yes | — | must reference an existing link |
 | `spec.clusterLink.pauseConsumerOffsetSync` | bool | no | `false` | — |
 | `spec.gateway.namespace` | string | yes | — | — |

--- a/docs/assets/gateway-manifest-reference/README.md
+++ b/docs/assets/gateway-manifest-reference/README.md
@@ -39,18 +39,18 @@ CLI flag can override for a single run, without editing the file.
 ## At a glance
 
 ```yaml
-apiVersion: kcp.confluent.io/v1alpha1   # required, exact literal
-kind: GatewayMigration                   # required, exact literal
+apiVersion: kcp.confluent.io/v1alpha1 # required, exact literal
+kind: GatewayMigration # required, exact literal
 metadata:
-  name: my-migration                     # required, non-blank — the migration identity
-interpolate: true                        # optional; opt this file in to ${ENV_VAR} resolution
+  name: my-migration # required, non-blank — the migration identity
+interpolate: true # optional; opt this file in to ${ENV_VAR} resolution
 spec:
-  source:          { ... }               # required — cluster being migrated from
-  target:          { ... }               # required — cluster being migrated to
-  clusterLink:     { ... }               # required — an ALREADY-EXISTING cluster link
-  gateway:          { ... }              # required — namespace, kubeconfig, gateway CRs
-  topics:          [ ... ]               # optional — literal topic names; omit = every active mirror
-  defaultPolicies: { ... }               # optional — execute-time policy defaults
+  source: { ... } # required — cluster being migrated from
+  target: { ... } # required — cluster being migrated to
+  clusterLink: { ... } # required — an ALREADY-EXISTING cluster link
+  gateway: { ... } # required — namespace, kubeconfig, gateway CRs
+  topics: [...] # optional — literal topic names; omit = every active mirror
+  defaultPolicies: { ... } # optional — execute-time policy defaults
 ```
 
 `apiVersion` must equal `kcp.confluent.io/v1alpha1` and `kind` must equal
@@ -82,11 +82,11 @@ true` to opt in independently.
 
 The cluster being migrated from. `kcp` only ever reads from it.
 
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `type` | enum | yes | `msk` or `apache-kafka`. Gates auth: `iam` is valid only for `msk`. |
-| `bootstrapServers` | `[]string` | yes | Non-empty; each entry `host:port`. |
-| `credentials` | path or inline | yes | Kafka-family credentials — see [Credentials](#credentials) below. |
+| Field              | Type           | Required | Notes                                                               |
+| ------------------ | -------------- | -------- | ------------------------------------------------------------------- |
+| `type`             | enum           | yes      | `msk` or `apache-kafka`. Gates auth: `iam` is valid only for `msk`. |
+| `bootstrapServers` | `[]string`     | yes      | Non-empty; each entry `host:port`.                                  |
+| `credentials`      | path or inline | yes      | Kafka-family credentials — see [Credentials](#credentials) below.   |
 
 `confluent-platform` is not a valid value here — this manifest only ever
 points at a link that already exists, so it never needs to act as a
@@ -96,14 +96,14 @@ source-side link initiator.
 
 The cluster being migrated to.
 
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `type` | enum | yes | `confluent-cloud` or `confluent-platform`. |
-| `clusterId` | string | yes | Required for **both** destination types — this kind never discovers it live. |
-| `kafka.bootstrapServers` | `[]string` | yes | Destination Kafka bootstrap. |
-| `kafka.restEndpoint` | string | yes | Destination Admin REST endpoint (cluster link + topic operations). |
-| `kafka.credentials` | path or inline | yes | Destination Kafka leg, dialled directly to read destination-side offsets. Accepts `sasl_plain`, `sasl_scram`, `mtls`, `unauthenticated_tls`, or `unauthenticated_plaintext` — see below. |
-| `kafka.restCredentials` | path or inline | no (except when `credentials` isn't `sasl_plain` — see below) | Destination REST leg. |
+| Field                    | Type           | Required                                                      | Notes                                                                                                                                                                                    |
+| ------------------------ | -------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                   | enum           | yes                                                           | `confluent-cloud` or `confluent-platform`.                                                                                                                                               |
+| `clusterId`              | string         | yes                                                           | Required for **both** destination types — this kind never discovers it live.                                                                                                             |
+| `kafka.bootstrapServers` | `[]string`     | yes                                                           | Destination Kafka bootstrap.                                                                                                                                                             |
+| `kafka.restEndpoint`     | string         | yes                                                           | Destination Admin REST endpoint (cluster link + topic operations).                                                                                                                       |
+| `kafka.credentials`      | path or inline | yes                                                           | Destination Kafka leg, dialled directly to read destination-side offsets. Accepts `sasl_plain`, `sasl_scram`, `mtls`, `unauthenticated_tls`, or `unauthenticated_plaintext` — see below. |
+| `kafka.restCredentials`  | path or inline | no (except when `credentials` isn't `sasl_plain` — see below) | Destination REST leg.                                                                                                                                                                    |
 
 `kafka.credentials` accepts any Kafka auth method **except** `iam` — the
 destination is Confluent Cloud or Confluent Platform, never MSK, so `iam` is
@@ -133,12 +133,29 @@ that is present is always used exactly as written, never partially derived, so
 a `sasl_plain` destination that spells it out anyway must restate the key and
 secret even if they match `credentials`.
 
+**Why two credentials at all?** `kafka.credentials` authenticates a direct
+Kafka-protocol connection to `bootstrapServers`; `kafka.restCredentials`
+authenticates HTTP calls to `restEndpoint`'s Admin REST API, which is what
+actually manages the cluster link (status, list/promote mirror topics,
+alter configs). These are two different servers speaking two
+different protocols. On self-managed Confluent Platform they are backed by two
+independent credential stores the operator configures separately on the
+cluster: the Kafka SASL/SCRAM (or mTLS) listener has its own store, while the
+REST API's auth (`kafka.rest.authentication.method` — a Basic realm file, MDS
+for bearer, or its own mTLS trust store) has another. A valid Kafka SASL/SCRAM
+credential is **not** automatically a valid REST credential, even against the
+same broker process — the two stores only match if the operator has explicitly
+provisioned the same principal into both. Confluent Cloud's `sasl_plain` API
+key is the one exception: Confluent Cloud issues it as a single artifact valid
+in both places by platform design, which is exactly why it's the only method
+kcp can safely derive from.
+
 ## `spec.clusterLink`
 
-| Field | Type | Required | Default | Notes |
-|---|---|---|---|---|
-| `name` | string | yes | — | Name of a cluster link that **already exists** on the destination. This kind never creates one. |
-| `pauseConsumerOffsetSync` | bool | no | `false` | Disable the link's `consumer.offset.sync.enable` during execute and restore it after switchover. Requires the link to currently have it enabled. |
+| Field                     | Type   | Required | Default | Notes                                                                                                                                            |
+| ------------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                    | string | yes      | —       | Name of a cluster link that **already exists** on the destination. This kind never creates one.                                                  |
+| `pauseConsumerOffsetSync` | bool   | no       | `false` | Disable the link's `consumer.offset.sync.enable` during execute and restore it after switchover. Requires the link to currently have it enabled. |
 
 ## `spec.gateway`
 
@@ -149,14 +166,14 @@ its declared switchover target. Setting `crs.switchover` is a validation
 error, not a silent no-op — it stays detectable on the manifest struct
 specifically so a stale manifest fails loudly instead of being read as valid.
 
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `namespace` | string | yes | Kubernetes namespace where the gateway is deployed. |
-| `kubeconfig` | string | no | Path to the kubeconfig to use. The **one** field in this manifest where a leading `~/` is expanded. |
-| `crs.initial` | string | yes | The **name** of the initial gateway custom resource — read live from the cluster at `init`, not a file path. |
-| `routes[].name` | string | yes | A `spec.routes[].name` in the initial CR to fence at cutover. Must be non-blank and unique within the list. |
-| `routes[].streamingDomain.name` | string | yes | The streaming domain this route switches to once unfenced. Must already be declared in the initial CR's `spec.streamingDomains`. |
-| `routes[].streamingDomain.bootstrapServerId` | string | yes | A bootstrap server id declared on that streaming domain. |
+| Field                                        | Type   | Required | Notes                                                                                                                            |
+| -------------------------------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `namespace`                                  | string | yes      | Kubernetes namespace where the gateway is deployed.                                                                              |
+| `kubeconfig`                                 | string | no       | Path to the kubeconfig to use. The **one** field in this manifest where a leading `~/` is expanded.                              |
+| `crs.initial`                                | string | yes      | The **name** of the initial gateway custom resource — read live from the cluster at `init`, not a file path.                     |
+| `routes[].name`                              | string | yes      | A `spec.routes[].name` in the initial CR to fence at cutover. Must be non-blank and unique within the list.                      |
+| `routes[].streamingDomain.name`              | string | yes      | The streaming domain this route switches to once unfenced. Must already be declared in the initial CR's `spec.streamingDomains`. |
+| `routes[].streamingDomain.bootstrapServerId` | string | yes      | A bootstrap server id declared on that streaming domain.                                                                         |
 
 ## `spec.topics`
 
@@ -173,15 +190,15 @@ Optional. Every field is a default that a matching `kcp migration execute` flag
 can override for a single run; the section is re-read fresh from the manifest
 on every `execute`, never frozen at `init`.
 
-| Field | Type | Default | Override flag | Notes |
-|---|---|---|---|---|
-| `lagThreshold` | int | `0` | `--lag-threshold` | Total replication lag (sum of all partition lags) tolerated before proceeding. `0` is the strictest. |
-| `promoteBatchSize` | int | `0` | `--promote-batch-size` | Max mirror topics promoted per batch. `0` promotes all at once; when set, each batch is promoted and confirmed stopped before the next is submitted. |
-| `rolloutTimeout` | duration | `0` | `--rollout-timeout` | Max wait for the operator to report the gateway `Ready` during fence and switchover (e.g. `10m`). `0` means no deadline — waits until convergence or cancellation. |
-| `detectUnroutedProducersDuration` | duration | `0` | `--detect-unrouted-producers-duration` | Window to monitor source offsets after fencing for producers still bypassing the gateway; a detected increase aborts before switchover. `0` **skips the check entirely**; minimum `10s` when set — shorter can't span a producer's metadata refresh. |
-| `consumerOffsetSyncDrainDuration` | duration | `0` | `--consumer-offset-sync-drain-duration` | Wait after fencing, before disabling the link's consumer offset sync, letting final offsets propagate. Has no effect unless `pauseConsumerOffsetSync` is set. `0` means no wait. |
-| `hotReloadTimeout` | duration | `0` | `--hot-reload-timeout` | Max wait for every gateway pod to report the new config revision when the gateway supports hot-reload (e.g. `90s`). Unlike `rolloutTimeout` this is never unbounded: a hot-reload moves no Kubernetes signal, so `0` uses the built-in 90s budget rather than waiting forever. |
-| `gatewayConfigPort` | int | `0` | `--gateway-config-port` | Port serving the gateway's `/config` endpoint, polled per pod to confirm a config revision was applied. `0` uses the persisted value, falling back to the gateway default (`9180`). |
+| Field                             | Type     | Default | Override flag                           | Notes                                                                                                                                                                                                                                                                          |
+| --------------------------------- | -------- | ------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `lagThreshold`                    | int      | `0`     | `--lag-threshold`                       | Total replication lag (sum of all partition lags) tolerated before proceeding. `0` is the strictest.                                                                                                                                                                           |
+| `promoteBatchSize`                | int      | `0`     | `--promote-batch-size`                  | Max mirror topics promoted per batch. `0` promotes all at once; when set, each batch is promoted and confirmed stopped before the next is submitted.                                                                                                                           |
+| `rolloutTimeout`                  | duration | `0`     | `--rollout-timeout`                     | Max wait for the operator to report the gateway `Ready` during fence and switchover (e.g. `10m`). `0` means no deadline — waits until convergence or cancellation.                                                                                                             |
+| `detectUnroutedProducersDuration` | duration | `0`     | `--detect-unrouted-producers-duration`  | Window to monitor source offsets after fencing for producers still bypassing the gateway; a detected increase aborts before switchover. `0` **skips the check entirely**; minimum `10s` when set — shorter can't span a producer's metadata refresh.                           |
+| `consumerOffsetSyncDrainDuration` | duration | `0`     | `--consumer-offset-sync-drain-duration` | Wait after fencing, before disabling the link's consumer offset sync, letting final offsets propagate. Has no effect unless `pauseConsumerOffsetSync` is set. `0` means no wait.                                                                                               |
+| `hotReloadTimeout`                | duration | `0`     | `--hot-reload-timeout`                  | Max wait for every gateway pod to report the new config revision when the gateway supports hot-reload (e.g. `90s`). Unlike `rolloutTimeout` this is never unbounded: a hot-reload moves no Kubernetes signal, so `0` uses the built-in 90s budget rather than waiting forever. |
+| `gatewayConfigPort`               | int      | `0`     | `--gateway-config-port`                 | Port serving the gateway's `/config` endpoint, polled per pod to confirm a config revision was applied. `0` uses the persisted value, falling back to the gateway default (`9180`).                                                                                            |
 
 ## Credentials
 
@@ -214,14 +231,14 @@ Specify **exactly one** method block — its **presence** selects it (no
 `auth_method:` wrapper, no `use:` flag). An optional top-level
 `insecure_skip_tls_verify: false` sibling applies to test environments only.
 
-| Method | Required fields | Notes |
-|---|---|---|
-| `iam` | `region` | MSK source only; Confluent Cloud can't present IAM (a link to MSK uses SCRAM instead). |
-| `sasl_scram` | `username`, `password` | Optional `mechanism` (`SHA256`/`SHA512`; MSK requires `SHA512`), `ca_cert`. Always TLS (SASL_SSL). |
-| `sasl_plain` | `username`, `password` | Optional `ca_cert`, `tls`. `ca_cert` present ⇒ SASL_SSL against that CA; `tls: true` ⇒ SASL_SSL over the system/public trust store; neither ⇒ SASL_PLAINTEXT. |
-| `mtls` | `client_cert`, `client_key` | Optional `ca_cert`. Client is authenticated via its certificate. |
-| `unauthenticated_tls` | — | Optional `ca_cert`. One-way TLS; client is not authenticated. |
-| `unauthenticated_plaintext` | — | No auth, no TLS. Test/lab only. |
+| Method                      | Required fields             | Notes                                                                                                                                                         |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `iam`                       | `region`                    | MSK source only; Confluent Cloud can't present IAM (a link to MSK uses SCRAM instead).                                                                        |
+| `sasl_scram`                | `username`, `password`      | Optional `mechanism` (`SHA256`/`SHA512`; MSK requires `SHA512`), `ca_cert`. Always TLS (SASL_SSL).                                                            |
+| `sasl_plain`                | `username`, `password`      | Optional `ca_cert`, `tls`. `ca_cert` present ⇒ SASL_SSL against that CA; `tls: true` ⇒ SASL_SSL over the system/public trust store; neither ⇒ SASL_PLAINTEXT. |
+| `mtls`                      | `client_cert`, `client_key` | Optional `ca_cert`. Client is authenticated via its certificate.                                                                                              |
+| `unauthenticated_tls`       | —                           | Optional `ca_cert`. One-way TLS; client is not authenticated.                                                                                                 |
+| `unauthenticated_plaintext` | —                           | No auth, no TLS. Test/lab only.                                                                                                                               |
 
 `ca_cert` (on `sasl_scram`, `sasl_plain`, `mtls`, `unauthenticated_tls`) is a
 PEM file path used to verify the broker's TLS certificate. Supply it only for a
@@ -232,12 +249,12 @@ against the system trust store and need no `ca_cert`.
 
 Specify **exactly one** block (or the `api_key`/`api_secret` pair).
 
-| Method | Required fields | Notes |
-|---|---|---|
-| `api_key` + `api_secret` | `api_key`, `api_secret` | Confluent Cloud; flat top-level pair; public CA. |
-| `basic` | `username`, `password` | e.g. Confluent Platform MDS. |
-| `bearer` | `token` | e.g. MDS/OAuth. |
-| `mtls` | `client_cert`, `client_key` | Auth at the TLS layer. |
+| Method                   | Required fields             | Notes                                            |
+| ------------------------ | --------------------------- | ------------------------------------------------ |
+| `api_key` + `api_secret` | `api_key`, `api_secret`     | Confluent Cloud; flat top-level pair; public CA. |
+| `basic`                  | `username`, `password`      | e.g. Confluent Platform MDS.                     |
+| `bearer`                 | `token`                     | e.g. MDS/OAuth.                                  |
+| `mtls`                   | `client_cert`, `client_key` | Auth at the TLS layer.                           |
 
 `basic`, `bearer`, and `mtls` each accept an optional `ca_cert` and
 `insecure_skip_verify` to reach a TLS endpoint fronted by a private/internal CA
@@ -253,17 +270,17 @@ tables above:
 
 ## How the commands read this file
 
-| Command | Flag | Required | Notes |
-|---|---|---|---|
-| `kcp migration init` | `--migration-yaml` | yes | Path to this manifest. |
-| | `--migration-state-file` | no (default `migration-state.json`) | Created if absent; the new migration is appended if it exists. |
-| | `--skip-validate` | no | Skip infrastructure validation and credential resolution — creates migration metadata only. |
-| `kcp migration execute` | `--migration-yaml` | yes | Path to this manifest. |
-| | `--migration-state-file` | yes | Produced by `init`. |
-| | `--migration-id` | no | Address a migration by id instead of `metadata.name` — needed only for migrations registered before `metadata.name` became the identity. |
-| | `--lag-threshold`, `--promote-batch-size`, `--rollout-timeout`, `--detect-unrouted-producers-duration`, `--consumer-offset-sync-drain-duration`, `--hot-reload-timeout`, `--gateway-config-port` | no | Per-run overrides of the matching `spec.defaultPolicies` field for this run only. |
-| `kcp migration lag-check` | `--migration-yaml` | yes | Path to this manifest. |
-| | `--poll-interval` | no (default `1`) | Poll interval in seconds, `1`-`60`. |
+| Command                   | Flag                                                                                                                                                                                             | Required                            | Notes                                                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `kcp migration init`      | `--migration-yaml`                                                                                                                                                                               | yes                                 | Path to this manifest.                                                                                                                   |
+|                           | `--migration-state-file`                                                                                                                                                                         | no (default `migration-state.json`) | Created if absent; the new migration is appended if it exists.                                                                           |
+|                           | `--skip-validate`                                                                                                                                                                                | no                                  | Skip infrastructure validation and credential resolution — creates migration metadata only.                                              |
+| `kcp migration execute`   | `--migration-yaml`                                                                                                                                                                               | yes                                 | Path to this manifest.                                                                                                                   |
+|                           | `--migration-state-file`                                                                                                                                                                         | yes                                 | Produced by `init`.                                                                                                                      |
+|                           | `--migration-id`                                                                                                                                                                                 | no                                  | Address a migration by id instead of `metadata.name` — needed only for migrations registered before `metadata.name` became the identity. |
+|                           | `--lag-threshold`, `--promote-batch-size`, `--rollout-timeout`, `--detect-unrouted-producers-duration`, `--consumer-offset-sync-drain-duration`, `--hot-reload-timeout`, `--gateway-config-port` | no                                  | Per-run overrides of the matching `spec.defaultPolicies` field for this run only.                                                        |
+| `kcp migration lag-check` | `--migration-yaml`                                                                                                                                                                               | yes                                 | Path to this manifest.                                                                                                                   |
+|                           | `--poll-interval`                                                                                                                                                                                | no (default `1`)                    | Poll interval in seconds, `1`-`60`.                                                                                                      |
 
 Every path in the manifest resolves relative to the **process working
 directory**, not the manifest's own location — the one exception is
@@ -309,37 +326,37 @@ Key rules, beyond required/optional per field above:
 
 ## Field reference
 
-| Path | Type | Required | Default | Allowed values |
-|---|---|---|---|---|
-| `apiVersion` | string | yes | — | `kcp.confluent.io/v1alpha1` |
-| `kind` | string | yes | — | `GatewayMigration` |
-| `metadata.name` | string | yes | — | non-blank |
-| `interpolate` | bool | no | `false` | — |
-| `spec.source.type` | enum | yes | — | `msk`, `apache-kafka` |
-| `spec.source.bootstrapServers` | `[]string` | yes | — | `host:port` |
-| `spec.source.credentials` | path or inline | yes | — | Kafka family; `iam` only if `type: msk` |
-| `spec.target.type` | enum | yes | — | `confluent-cloud`, `confluent-platform` |
-| `spec.target.clusterId` | string | yes | — | required for both target types |
-| `spec.target.kafka.bootstrapServers` | `[]string` | yes | — | `host:port` |
-| `spec.target.kafka.restEndpoint` | string | yes | — | URL |
-| `spec.target.kafka.credentials` | path or inline | yes | — | Kafka family except `iam` |
-| `spec.target.kafka.restCredentials` | path or inline | no if `credentials` is `sasl_plain`; **yes** otherwise | derived from `credentials` when `sasl_plain` | `api_key`/`api_secret`, `basic`, `bearer`, or `mtls` |
-| `spec.clusterLink.name` | string | yes | — | must reference an existing link |
-| `spec.clusterLink.pauseConsumerOffsetSync` | bool | no | `false` | — |
-| `spec.gateway.namespace` | string | yes | — | — |
-| `spec.gateway.kubeconfig` | string | no | — | `~/` expanded |
-| `spec.gateway.crs.initial` | string | yes | — | K8s object name |
-| `spec.gateway.routes[].name` | string | yes | — | must exist in the initial CR, unique |
-| `spec.gateway.routes[].streamingDomain.name` | string | yes | — | must be declared in the initial CR's `spec.streamingDomains` |
-| `spec.gateway.routes[].streamingDomain.bootstrapServerId` | string | yes | — | must be declared on that streaming domain |
-| `spec.topics` | `[]string` | no | omitted = every active mirror topic | non-empty if present, literal names |
-| `spec.defaultPolicies.lagThreshold` | int | no | `0` | `>= 0` |
-| `spec.defaultPolicies.promoteBatchSize` | int | no | `0` | `>= 0` |
-| `spec.defaultPolicies.rolloutTimeout` | duration | no | `0` | `>= 0` |
-| `spec.defaultPolicies.detectUnroutedProducersDuration` | duration | no | `0` | `0`, or `>= 10s` |
-| `spec.defaultPolicies.consumerOffsetSyncDrainDuration` | duration | no | `0` | `>= 0` |
-| `spec.defaultPolicies.hotReloadTimeout` | duration | no | `0` | `>= 0` |
-| `spec.defaultPolicies.gatewayConfigPort` | int | no | `0` | `>= 0` |
+| Path                                                      | Type           | Required                                               | Default                                      | Allowed values                                               |
+| --------------------------------------------------------- | -------------- | ------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------------------ |
+| `apiVersion`                                              | string         | yes                                                    | —                                            | `kcp.confluent.io/v1alpha1`                                  |
+| `kind`                                                    | string         | yes                                                    | —                                            | `GatewayMigration`                                           |
+| `metadata.name`                                           | string         | yes                                                    | —                                            | non-blank                                                    |
+| `interpolate`                                             | bool           | no                                                     | `false`                                      | —                                                            |
+| `spec.source.type`                                        | enum           | yes                                                    | —                                            | `msk`, `apache-kafka`                                        |
+| `spec.source.bootstrapServers`                            | `[]string`     | yes                                                    | —                                            | `host:port`                                                  |
+| `spec.source.credentials`                                 | path or inline | yes                                                    | —                                            | Kafka family; `iam` only if `type: msk`                      |
+| `spec.target.type`                                        | enum           | yes                                                    | —                                            | `confluent-cloud`, `confluent-platform`                      |
+| `spec.target.clusterId`                                   | string         | yes                                                    | —                                            | required for both target types                               |
+| `spec.target.kafka.bootstrapServers`                      | `[]string`     | yes                                                    | —                                            | `host:port`                                                  |
+| `spec.target.kafka.restEndpoint`                          | string         | yes                                                    | —                                            | URL                                                          |
+| `spec.target.kafka.credentials`                           | path or inline | yes                                                    | —                                            | Kafka family except `iam`                                    |
+| `spec.target.kafka.restCredentials`                       | path or inline | no if `credentials` is `sasl_plain`; **yes** otherwise | derived from `credentials` when `sasl_plain` | `api_key`/`api_secret`, `basic`, `bearer`, or `mtls`         |
+| `spec.clusterLink.name`                                   | string         | yes                                                    | —                                            | must reference an existing link                              |
+| `spec.clusterLink.pauseConsumerOffsetSync`                | bool           | no                                                     | `false`                                      | —                                                            |
+| `spec.gateway.namespace`                                  | string         | yes                                                    | —                                            | —                                                            |
+| `spec.gateway.kubeconfig`                                 | string         | no                                                     | —                                            | `~/` expanded                                                |
+| `spec.gateway.crs.initial`                                | string         | yes                                                    | —                                            | K8s object name                                              |
+| `spec.gateway.routes[].name`                              | string         | yes                                                    | —                                            | must exist in the initial CR, unique                         |
+| `spec.gateway.routes[].streamingDomain.name`              | string         | yes                                                    | —                                            | must be declared in the initial CR's `spec.streamingDomains` |
+| `spec.gateway.routes[].streamingDomain.bootstrapServerId` | string         | yes                                                    | —                                            | must be declared on that streaming domain                    |
+| `spec.topics`                                             | `[]string`     | no                                                     | omitted = every active mirror topic          | non-empty if present, literal names                          |
+| `spec.defaultPolicies.lagThreshold`                       | int            | no                                                     | `0`                                          | `>= 0`                                                       |
+| `spec.defaultPolicies.promoteBatchSize`                   | int            | no                                                     | `0`                                          | `>= 0`                                                       |
+| `spec.defaultPolicies.rolloutTimeout`                     | duration       | no                                                     | `0`                                          | `>= 0`                                                       |
+| `spec.defaultPolicies.detectUnroutedProducersDuration`    | duration       | no                                                     | `0`                                          | `0`, or `>= 10s`                                             |
+| `spec.defaultPolicies.consumerOffsetSyncDrainDuration`    | duration       | no                                                     | `0`                                          | `>= 0`                                                       |
+| `spec.defaultPolicies.hotReloadTimeout`                   | duration       | no                                                     | `0`                                          | `>= 0`                                                       |
+| `spec.defaultPolicies.gatewayConfigPort`                  | int            | no                                                     | `0`                                          | `>= 0`                                                       |
 
 ## Editor support
 

--- a/integration-tests/migrate/migration_dest_auth_test.go
+++ b/integration-tests/migrate/migration_dest_auth_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+// This file is the LIVE proof for `kcp migration init | execute`'s new
+// destination auth methods. Unlike migrate_clusterlink_*_test.go (which shell
+// out to `kcp migrate apply`), the `kcp migration` init/execute commands cannot
+// run against docker-compose alone — both require a live Kubernetes gateway CR
+// (GetGatewayYAML / ResolveGatewayCapability), which only the Minikube e2e tier
+// (integration-tests/migration/) provides. But the destination-auth code those
+// commands run is NOT gated by the gateway: createDestinationOffset dials the
+// destination broker BEFORE the gateway is ever touched, and the REST leg's auth
+// wiring is the same clusterlink.ConfluentCloudService the FSM uses. So this
+// file proves those exact production paths directly, in-process, against the
+// same cp-server brokers `make test-migrate` brings up — no CLI, no k8s.
+//
+//   - Kafka leg: MigrateConn → AdminOptionForAuthMethod → NewKafkaClient, the
+//     chain buildExecutorOpts + createDestinationOffset run. Reuses the source
+//     broker's listeners (which already expose the full SASL_SSL/SSL/plaintext
+//     matrix); the destination Kafka client is broker-agnostic, so pointing it
+//     at those listeners exercises identical code.
+//   - REST leg: targets.Credentials.HTTPClient()/Authenticator() driving a real
+//     clusterlink call against dest-basic/dest-mtls/dest-bearer, the wiring
+//     migration init (ListMirrorTopics) and execute (PromoteTopics) use.
+
+package migrate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/confluentinc/kcp/internal/client"
+	"github.com/confluentinc/kcp/internal/services/clusterlink"
+	"github.com/confluentinc/kcp/internal/services/offset"
+	"github.com/confluentinc/kcp/internal/targets"
+	"github.com/confluentinc/kcp/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// destKafkaCase is one destination Kafka-leg auth permutation: the migration
+// destination credentials block (spec.target.kafka.credentials) and the source
+// HOST listener it dials.
+type destKafkaCase struct {
+	name      string
+	credsYAML string
+	bootstrap string
+}
+
+// resolveDestKafkaAuth mirrors buildExecutorOpts
+// (cmd/migration/execute/cmd_migration_execute.go:401-421): it resolves the
+// destination Kafka auth from the migration destination credentials via
+// MigrateConn and applies the SASL_SSL backward-compat default. Kept in lockstep
+// with that function so this live test proves the same resolution the CLI runs.
+func resolveDestKafkaAuth(t *testing.T, credsYAML string) (types.AuthType, types.AuthMethodConfig, bool) {
+	t.Helper()
+	creds, errs := types.ParseMigrateClusterCredentials([]byte(credsYAML))
+	require.Empty(t, errs, "destination credentials must parse + validate")
+
+	destConn := types.MigrateConn(nil, creds)
+	authType, err := destConn.GetSelectedAuthType()
+	require.NoError(t, err)
+	method := destConn.AuthMethod
+
+	// SASL_SSL compat default: a sasl_plain destination with neither ca_cert nor
+	// tls dials SASL_SSL (a managed/CC destination is always TLS), never cleartext
+	// SASL_PLAINTEXT. buildExecutorOpts applies this and
+	// TestExecute_DestSASLPlainDefaultsToTLS asserts it at the unit level — here we
+	// prove the defaulted method actually connects to a SASL_SSL listener.
+	if sp := method.SASLPlain; sp != nil && sp.CACert == "" && !sp.UseTLS {
+		sp.UseTLS = true
+	}
+	return authType, method, creds.InsecureSkipTLSVerify
+}
+
+// TestMigrationDestAuth_KafkaLeg proves every new destination Kafka auth method
+// completes a real SASL/TLS handshake and an authenticated metadata read via the
+// exact mapper createDestinationOffset uses. Listeners (source HOST): SASL_SSL
+// 19093 (accepts SCRAM-256/512 + PLAIN), SSL 19094 (client-auth "requested", so
+// both mtls and unauthenticated_tls), SASL_PLAINTEXT 19095, PLAINTEXT 19092.
+func TestMigrationDestAuth_KafkaLeg(t *testing.T) {
+	// Self-signed certs (source.keystore CN) → skip verification, exactly as the
+	// migrate-apply matrix does for the same listeners.
+	const skip = "\ninsecure_skip_tls_verify: true\n"
+	cases := []destKafkaCase{
+		{"sasl_scram_256", "sasl_scram: { username: kcp, password: kcp-secret, mechanism: SHA256, ca_cert: ./certs/ca.crt }" + skip, "localhost:19093"},
+		{"sasl_scram_512", "sasl_scram: { username: kcp, password: kcp-secret, mechanism: SHA512, ca_cert: ./certs/ca.crt }" + skip, "localhost:19093"},
+		{"mtls", "mtls: { ca_cert: ./certs/ca.crt, client_cert: ./certs/client.crt, client_key: ./certs/client.key }" + skip, "localhost:19094"},
+		{"unauthenticated_tls", "unauthenticated_tls: { ca_cert: ./certs/ca.crt }" + skip, "localhost:19094"},
+		{"unauthenticated_plaintext", "unauthenticated_plaintext: {}\n", "localhost:19092"},
+		// sasl_plain over SASL_SSL — the managed/Confluent Cloud destination shape.
+		{"sasl_plain_tls", "sasl_plain: { username: kcp, password: kcp-secret, tls: true }" + skip, "localhost:19093"},
+		// THE compat regression (plan §A.3): a sasl_plain destination with neither
+		// ca_cert nor tls. resolveDestKafkaAuth applies the SASL_SSL default, so it
+		// MUST dial the SASL_SSL listener (19093) — without the default it would try
+		// cleartext SASL_PLAINTEXT and the TLS listener would reject the handshake.
+		{"sasl_plain_compat_default", "sasl_plain: { username: kcp, password: kcp-secret }" + skip, "localhost:19093"},
+	}
+
+	// Source HOST REST reachable => the source broker and all its listeners are up.
+	newRestClient(t, restSource).waitForClusterID(t)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			authType, method, skipVerify := resolveDestKafkaAuth(t, c.credsYAML)
+
+			authOpt, err := client.AdminOptionForAuthMethod(authType, method, skipVerify)
+			require.NoError(t, err)
+
+			kc, err := client.NewKafkaClient([]string{c.bootstrap}, "", authOpt)
+			require.NoError(t, err, "destination auth handshake to %s (%s) must succeed", c.bootstrap, c.name)
+			svc := offset.NewOffsetService(kc)
+			defer func() { _ = svc.Close() }()
+
+			// An authenticated metadata read (RefreshMetadata + list topics): proves
+			// createDestinationOffset's client can actually talk to the broker, not
+			// merely complete the SASL/TLS handshake.
+			_, err = svc.Exists("__consumer_offsets")
+			require.NoError(t, err, "authenticated metadata read against %s must succeed", c.bootstrap)
+		})
+	}
+}
+
+// TestMigrationDestAuth_RESTLeg proves every new destination REST auth method
+// authenticates a real clusterlink.ConfluentCloudService call. GetKafkaClusterID
+// (GET /kafka/v3/clusters) is an authenticated request that returns 200 with the
+// cluster id — the exact HTTPClient() + Config.Auth wiring migration init
+// (ListMirrorTopics) and execute (PromoteTopics) drive, without needing a
+// pre-existing cluster link.
+func TestMigrationDestAuth_RESTLeg(t *testing.T) {
+	ctx := context.Background()
+	// Each dest* service varies only its REST auth surface (Kafka is plaintext);
+	// restDest (no-auth) is covered by the existing api_key/basic path, so this
+	// sweeps only the newly-unlocked kinds.
+	for _, e := range []restEndpoint{restDestBasic, restDestMTLS, restDestBearer} {
+		t.Run(e.kind.String(), func(t *testing.T) {
+			newRestClient(t, e).waitForClusterID(t) // dest REST reachable
+
+			dir := t.TempDir()
+			credsPath := writeRestCreds(t, dir, "target-creds.yaml", e)
+			creds, err := targets.LoadCredentials(credsPath)
+			require.NoError(t, err)
+
+			httpClient, err := creds.HTTPClient()
+			require.NoError(t, err)
+
+			svc := clusterlink.NewConfluentCloudService(httpClient)
+			cfg := clusterlink.Config{
+				RestEndpoint: e.baseURL,
+				ClusterID:    e.clusterID,
+				Auth:         creds.Authenticator(),
+			}
+			id, err := svc.GetKafkaClusterID(ctx, cfg)
+			require.NoError(t, err, "authenticated REST call to %s (%s) must succeed", e.baseURL, e.kind)
+			require.Equal(t, e.clusterID, id)
+		})
+	}
+}

--- a/internal/manifest/gateway.go
+++ b/internal/manifest/gateway.go
@@ -309,16 +309,12 @@ func (g *GatewayMigration) Validate() []error {
 			add("spec.target.kafka.credentials: must not be empty")
 		} else if k.Credentials.IsInline() {
 			if mc, ok := peekMigrateCreds(k.Credentials); ok {
-				errs = append(errs, checkDestinationIsSASLPlain(mc)...)
+				errs = append(errs, checkDestinationKafkaAuth(mc)...)
 			}
 		}
 		if k.RestCredentials != nil {
 			if blankRef(*k.RestCredentials) {
 				add("spec.target.kafka.restCredentials: present but empty — omit it to derive from credentials, or fill it in")
-			} else if k.RestCredentials.IsInline() {
-				if tc, ok := peekTargetCreds(*k.RestCredentials); ok {
-					errs = append(errs, checkRestIsAPIKeyForm(tc)...)
-				}
 			}
 		}
 	}
@@ -437,62 +433,19 @@ func checkSourceAuthAgainstType(mc types.MigrateClusterCredentials, sourceType s
 	return nil
 }
 
-// checkDestinationIsSASLPlain rejects every destination block other than
-// sasl_plain. The destination Kafka client is hardcoded to SASL/PLAIN over TLS,
-// so any other block would be accepted and then silently ignored — worse than
-// the flag surface this replaces.
-func checkDestinationIsSASLPlain(mc types.MigrateClusterCredentials) []error {
-	if mc.SASLPlain != nil {
-		// The destination Kafka client dials SASL/PLAIN over the public trust
-		// store — createDestinationOffset hardcodes an empty ca_cert — and a
-		// derived REST leg drops ca_cert too. A ca_cert here would therefore be
-		// accepted and then silently ignored, so a private-CA destination would
-		// read as configured while actually connecting on the system roots.
-		// Refuse it, the same call as the sasl_plain-only and api_key-only rules.
-		// (tls stays permitted: it names the exact transport the destination
-		// already uses, so it is honoured rather than dropped.)
-		if strings.TrimSpace(mc.SASLPlain.CACert) != "" {
-			return []error{fmt.Errorf(
-				"spec.target.kafka.credentials.sasl_plain.ca_cert: a custom CA is not supported for the destination in this release (it dials the public trust store); remove ca_cert")}
-		}
-		return nil
-	}
-	if mc.IAM == nil && mc.SASLScram == nil && mc.MTLS == nil &&
-		mc.UnauthenticatedTLS == nil && mc.UnauthenticatedPlaintext == nil {
-		return nil // no block at all — the shared validator reports that
-	}
-	return []error{fmt.Errorf(
-		"spec.target.kafka.credentials: only sasl_plain is supported for the destination in this release")}
-}
-
-// peekTargetCreds decodes an inline REST credentials block for validation
-// without I/O.
-func peekTargetCreds(ref CredentialsRef) (targets.Credentials, bool) {
-	var tc targets.Credentials
-	if err := yaml.Unmarshal(ref.Inline, &tc); err != nil {
-		return tc, false
-	}
-	return tc, true
-}
-
-// checkRestIsAPIKeyForm rejects every REST credentials form other than the flat
-// api_key pair.
-//
-// targets.Credentials can express basic, bearer and mtls, and its own
-// HTTPClient/Authenticator handle all of them — but every kcp migration command
-// reads only APIKey/APISecret/CACert/InsecureSkipVerify. A bearer block would
-// therefore be accepted, then dropped, and the request would go out as
-// anonymous Basic auth with the declared ca_cert ignored. Refusing is the same
-// call as the sasl_plain-only rule on the destination Kafka leg: a credential
-// that is silently not used is worse than one that is rejected.
-func checkRestIsAPIKeyForm(tc targets.Credentials) []error {
-	switch {
-	case tc.Bearer != nil:
-		return []error{fmt.Errorf("spec.target.kafka.restCredentials: only the api_key/api_secret form is supported in this release (got bearer)")}
-	case tc.MTLS != nil:
-		return []error{fmt.Errorf("spec.target.kafka.restCredentials: only the api_key/api_secret form is supported in this release (got mtls)")}
-	case tc.Basic != nil:
-		return []error{fmt.Errorf("spec.target.kafka.restCredentials: only the api_key/api_secret form is supported in this release (got basic)")}
+// checkDestinationKafkaAuth rejects iam on the destination Kafka leg. iam is
+// MSK-only (SigV4 token signing against AWS), and the destination is Confluent
+// Cloud or Confluent Platform — never MSK — so it would be accepted here and
+// then fail opaquely at connection time. Every other method (sasl_plain,
+// sasl_scram, mtls, unauthenticated_tls, unauthenticated_plaintext) is honoured
+// end-to-end via AdminOptionForAuthMethod, the same mapper the source leg
+// already uses — including a custom ca_cert on sasl_plain, now that
+// createDestinationOffset routes through the mapper instead of a hardcoded
+// empty-CA client.
+func checkDestinationKafkaAuth(mc types.MigrateClusterCredentials) []error {
+	if mc.IAM != nil {
+		return []error{fmt.Errorf(
+			"spec.target.kafka.credentials.iam: not supported for the destination (the destination is Confluent Cloud/Platform, never MSK)")}
 	}
 	return nil
 }
@@ -520,7 +473,7 @@ func (g *GatewayMigration) DestinationKafkaCredentials() (types.MigrateClusterCr
 	if len(errs) > 0 {
 		return mc, errs
 	}
-	if errs := checkDestinationIsSASLPlain(mc); len(errs) > 0 {
+	if errs := checkDestinationKafkaAuth(mc); len(errs) > 0 {
 		return mc, errs
 	}
 	return mc, nil
@@ -528,25 +481,21 @@ func (g *GatewayMigration) DestinationKafkaCredentials() (types.MigrateClusterCr
 
 // RestCredentials resolves the destination REST leg.
 //
-// When spec.target.kafka.restCredentials is omitted it is DERIVED, in full,
-// from the Kafka leg: one flag pair feeds both legs today, so requiring both
-// blocks would make the operator type the same secret twice for the
-// overwhelmingly common case. Derivation is full-or-nothing — a block that is
-// present is used exactly as written, because a block that reads as complete
-// while silently acquiring fields from elsewhere is worse than either.
+// When spec.target.kafka.restCredentials is omitted AND the Kafka leg is
+// sasl_plain, it is DERIVED, in full, from that leg: one flag pair feeds both
+// destination legs today, so requiring both blocks would make the operator
+// type the same secret twice for the overwhelmingly common case. Derivation
+// is full-or-nothing — a block that is present is used exactly as written,
+// because a block that reads as complete while silently acquiring fields from
+// elsewhere is worse than either. For every other Kafka auth method there is
+// no principal to derive a REST credential from, so restCredentials becomes
+// required.
 func (g *GatewayMigration) RestCredentials() (*targets.Credentials, error) {
 	if g.Spec.Target.Kafka == nil {
 		return nil, fmt.Errorf("spec.target.kafka: required")
 	}
 	if ref := g.Spec.Target.Kafka.RestCredentials; ref != nil {
-		tc, err := ref.ResolveTarget(g.Interpolate)
-		if err != nil {
-			return nil, err
-		}
-		if errs := checkRestIsAPIKeyForm(*tc); len(errs) > 0 {
-			return nil, errs[0]
-		}
-		return tc, nil
+		return ref.ResolveTarget(g.Interpolate)
 	}
 
 	mc, errs := g.DestinationKafkaCredentials()
@@ -554,14 +503,16 @@ func (g *GatewayMigration) RestCredentials() (*targets.Credentials, error) {
 		return nil, fmt.Errorf("deriving spec.target.kafka.restCredentials from credentials: %w", errs[0])
 	}
 	if mc.SASLPlain == nil {
-		return nil, fmt.Errorf("spec.target.kafka.credentials: only sasl_plain is supported for the destination in this release")
+		return nil, fmt.Errorf("spec.target.kafka.restCredentials: required — it can only be derived from spec.target.kafka.credentials when that block is sasl_plain")
 	}
 	derived := &targets.Credentials{
 		APIKey:    mc.SASLPlain.Username,
 		APISecret: mc.SASLPlain.Password,
-		// Inherited so the single fan-out --insecure-skip-tls-verify had today
-		// is preserved: a derived REST leg must not silently verify while the
-		// Kafka leg does not.
+		// Inherited so the single fan-out --insecure-skip-tls-verify (and, now,
+		// a private destination CA) has today is preserved: a derived REST leg
+		// must not silently verify — or trust a different CA — while the Kafka
+		// leg does not.
+		CACert:             mc.SASLPlain.CACert,
 		InsecureSkipVerify: mc.InsecureSkipTLSVerify,
 	}
 	if err := targets.ValidateCredentials(derived); err != nil {

--- a/internal/manifest/gateway.go
+++ b/internal/manifest/gateway.go
@@ -254,7 +254,7 @@ func ParseGatewayMigration(data []byte) (*GatewayMigration, error) {
 //
 // It does no I/O, so a credentials slot spelled as a path is checked for
 // presence only; the rules that need the block's contents (source auth gating,
-// the sasl_plain-only destination rule) run here for an inline block and again
+// the destination iam rejection) run here for an inline block and again
 // in SourceCredentials / DestinationKafkaCredentials for both spellings.
 func (g *GatewayMigration) Validate() []error {
 	var errs []error
@@ -310,11 +310,14 @@ func (g *GatewayMigration) Validate() []error {
 		} else if k.Credentials.IsInline() {
 			if mc, ok := peekMigrateCreds(k.Credentials); ok {
 				errs = append(errs, checkDestinationKafkaAuth(mc)...)
+				if k.RestCredentials == nil && mc.SASLPlain == nil {
+					add("spec.target.kafka.restCredentials: required — it can only be derived from spec.target.kafka.credentials when that block is sasl_plain")
+				}
 			}
 		}
 		if k.RestCredentials != nil {
 			if blankRef(*k.RestCredentials) {
-				add("spec.target.kafka.restCredentials: present but empty — omit it to derive from credentials, or fill it in")
+				add("spec.target.kafka.restCredentials: present but empty — fill it in, or omit it entirely to derive from credentials (only possible when that block is sasl_plain)")
 			}
 		}
 	}
@@ -462,9 +465,9 @@ func (g *GatewayMigration) SourceCredentials() (types.MigrateClusterCredentials,
 	return mc, nil
 }
 
-// DestinationKafkaCredentials resolves the destination Kafka leg — the API
-// key/secret used as SASL/PLAIN against the destination bootstrap, not only as
-// HTTP basic over REST.
+// DestinationKafkaCredentials resolves the destination Kafka leg. Any auth
+// method is accepted except iam — the destination is Confluent Cloud/Platform,
+// never MSK.
 func (g *GatewayMigration) DestinationKafkaCredentials() (types.MigrateClusterCredentials, []error) {
 	if g.Spec.Target.Kafka == nil {
 		return types.MigrateClusterCredentials{}, []error{fmt.Errorf("spec.target.kafka: required")}

--- a/internal/manifest/gateway_test.go
+++ b/internal/manifest/gateway_test.go
@@ -220,44 +220,66 @@ func TestGateway_RequiresTargetKafkaBootstrapServers(t *testing.T) {
 // migration_executor.go dials the destination as SASL/PLAIN unconditionally, so
 // any other block would be silently ignored — worse than the flag surface it
 // replaces.
-func TestGateway_RejectsNonSASLPlainDestination(t *testing.T) {
-	for _, block := range []string{
-		"        sasl_scram:\n          username: u\n          password: p\n          mechanism: SHA512",
-		"        mtls:\n          client_cert: /c.pem\n          client_key: /k.pem",
-		"        unauthenticated_plaintext: {}",
-		"        unauthenticated_tls: {}",
-		"        iam:\n          region: us-east-1",
+// TestGateway_AcceptsEveryDestinationMethodExceptIAM. All the auth/TLS
+// machinery on the destination Kafka leg already exists and is now routed
+// through AdminOptionForAuthMethod, the same mapper the source leg uses — so
+// sasl_scram, mtls, and both unauthenticated forms validate like any other
+// leg. Non-sasl_plain destinations can no longer derive restCredentials (there
+// is no principal to derive from), so each case supplies an explicit block.
+func TestGateway_AcceptsEveryDestinationMethodExceptIAM(t *testing.T) {
+	certDir := t.TempDir()
+	cert := filepath.Join(certDir, "client.pem")
+	key := filepath.Join(certDir, "client-key.pem")
+	require.NoError(t, os.WriteFile(cert, []byte("cert"), 0600))
+	require.NoError(t, os.WriteFile(key, []byte("key"), 0600))
+
+	for name, block := range map[string]string{
+		"sasl_scram":                "        sasl_scram:\n          username: u\n          password: p\n          mechanism: SHA512",
+		"mtls":                      "        mtls:\n          client_cert: " + cert + "\n          client_key: " + key,
+		"unauthenticated_plaintext": "        unauthenticated_plaintext: {}",
+		"unauthenticated_tls":       "        unauthenticated_tls: {}",
 	} {
-		t.Run(strings.TrimSpace(strings.SplitN(block, ":", 2)[0]), func(t *testing.T) {
-			doc := strings.Replace(validGatewayDoc,
+		t.Run(name, func(t *testing.T) {
+			doc := withRestCredentials(t, "      restCredentials:\n        api_key: K\n        api_secret: S\n")
+			doc = strings.Replace(doc,
 				"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
 				block, 1)
 			g := parseGateway(t, doc)
-			requireErrContains(t, g.Validate(), "sasl_plain")
+			assert.Empty(t, g.Validate())
 		})
 	}
 }
 
-// TestGateway_RejectsDestinationSASLPlainCACert. The destination Kafka client
-// dials the public trust store unconditionally (createDestinationOffset passes an
-// empty ca_cert) and a derived REST leg drops ca_cert, so a ca_cert on the
-// destination sasl_plain block would be accepted and then silently ignored — a
-// private-CA destination would read as configured while connecting on the system
-// roots. Refuse it, mirroring the sasl_plain-only and api_key-only rules.
-func TestGateway_RejectsDestinationSASLPlainCACert(t *testing.T) {
+// TestGateway_RejectsIAMDestination. iam is MSK-only (SigV4 signing against
+// AWS), and the destination is Confluent Cloud or Confluent Platform — never
+// MSK — so it would otherwise fail opaquely at connection time.
+func TestGateway_RejectsIAMDestination(t *testing.T) {
 	doc := strings.Replace(validGatewayDoc,
 		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
-		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          ca_cert: /dest-ca.pem",
+		"        iam:\n          region: us-east-1",
 		1)
 	g := parseGateway(t, doc)
-	requireErrContains(t, g.Validate(), "ca_cert")
+	requireErrContains(t, g.Validate(), "iam")
+}
 
-	// Resolution must refuse it too, not only Validate — including via the
-	// derived REST leg, which routes through DestinationKafkaCredentials.
-	_, errs := g.DestinationKafkaCredentials()
-	require.NotEmpty(t, errs)
-	_, err := g.RestCredentials()
-	require.Error(t, err)
+// TestGateway_AllowsDestinationSASLPlainCACert — the validator relaxation in
+// A.1 unlocks a private-CA sasl_plain destination now that
+// createDestinationOffset routes through AdminOptionForAuthMethod instead of
+// a hardcoded empty-CA client.
+func TestGateway_AllowsDestinationSASLPlainCACert(t *testing.T) {
+	ca := filepath.Join(t.TempDir(), "dest-ca.pem")
+	require.NoError(t, os.WriteFile(ca, []byte("pem"), 0600))
+
+	doc := strings.Replace(validGatewayDoc,
+		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
+		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          ca_cert: "+ca,
+		1)
+	g := parseGateway(t, doc)
+	require.Empty(t, g.Validate())
+
+	mc, errs := g.DestinationKafkaCredentials()
+	require.Empty(t, errs)
+	assert.Equal(t, ca, mc.SASLPlain.CACert)
 }
 
 // TestGateway_AllowsDestinationSASLPlainTLS keeps the counterpart honest: tls
@@ -296,6 +318,42 @@ func TestGateway_DerivedRestCredentialsInheritInsecureSkip(t *testing.T) {
 	rest, err := g.RestCredentials()
 	require.NoError(t, err)
 	assert.True(t, rest.InsecureSkipVerify)
+}
+
+// TestGateway_DerivedRestCredentialsInheritCACert closes the gap A.5 fixes:
+// derivation copied insecure_skip_tls_verify but not ca_cert, so a private-CA
+// sasl_plain destination would derive a Kafka leg that trusts the CA and a
+// REST leg that does not — a TLS failure against the very same cluster.
+func TestGateway_DerivedRestCredentialsInheritCACert(t *testing.T) {
+	ca := filepath.Join(t.TempDir(), "dest-ca.pem")
+	require.NoError(t, os.WriteFile(ca, []byte("pem"), 0600))
+
+	doc := strings.Replace(validGatewayDoc,
+		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
+		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          ca_cert: "+ca,
+		1)
+	g := parseGateway(t, doc)
+	require.Empty(t, g.Validate())
+
+	rest, err := g.RestCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, ca, rest.CACert)
+}
+
+// TestGateway_RestCredentialsRequiredWhenNotSASLPlain — there is no principal
+// to derive a REST credential from when the Kafka leg isn't sasl_plain, so
+// omitting restCredentials must fail with a clear, field-naming error rather
+// than silently deriving nothing.
+func TestGateway_RestCredentialsRequiredWhenNotSASLPlain(t *testing.T) {
+	doc := strings.Replace(validGatewayDoc,
+		"        sasl_plain:\n          username: CC_KEY\n          password: CC_SECRET\n          tls: true",
+		"        sasl_scram:\n          username: u\n          password: p\n          mechanism: SHA512",
+		1)
+	g := parseGateway(t, doc)
+
+	_, err := g.RestCredentials()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restCredentials")
 }
 
 // TestGateway_DerivedEqualsHandWritten is the §7.1 parity test: a derived block
@@ -803,18 +861,27 @@ func TestGateway_ManifestParseErrorDoesNotEchoInlineSecrets(t *testing.T) {
 // the request goes out as anonymous Basic auth, with the declared ca_cert
 // ignored. Refuse rather than silently degrade, mirroring the sasl_plain-only
 // rule on the destination Kafka leg.
-func TestGateway_RejectsNonAPIKeyRestCredentials(t *testing.T) {
+// TestGateway_AcceptsEveryRestCredentialsForm. targets.Credentials already
+// implements Authenticator/HTTPClient for basic, bearer and mtls — B.4 stops
+// refusing them so a CP destination behind RBAC or mTLS can be reached.
+func TestGateway_AcceptsEveryRestCredentialsForm(t *testing.T) {
+	certDir := t.TempDir()
+	cert := filepath.Join(certDir, "client.pem")
+	key := filepath.Join(certDir, "client-key.pem")
+	require.NoError(t, os.WriteFile(cert, []byte("cert"), 0600))
+	require.NoError(t, os.WriteFile(key, []byte("key"), 0600))
+
 	for name, block := range map[string]string{
 		"bearer": "      restCredentials:\n        bearer:\n          token: TOK\n",
 		"basic":  "      restCredentials:\n        basic:\n          username: u\n          password: p\n",
-		"mtls":   "      restCredentials:\n        mtls:\n          client_cert: /c.pem\n          client_key: /k.pem\n",
+		"mtls":   "      restCredentials:\n        mtls:\n          client_cert: " + cert + "\n          client_key: " + key + "\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := parseGateway(t, withRestCredentials(t, block))
-			requireErrContains(t, g.Validate(), "restCredentials")
+			assert.Empty(t, g.Validate())
 
 			_, err := g.RestCredentials()
-			require.Error(t, err, "resolution must refuse it too, not only Validate")
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/manifest/gateway_test.go
+++ b/internal/manifest/gateway_test.go
@@ -216,10 +216,6 @@ func TestGateway_RequiresTargetKafkaBootstrapServers(t *testing.T) {
 	requireErrContains(t, g.Validate(), "spec.target.kafka.bootstrapServers")
 }
 
-// TestGateway_RejectsNonSASLPlainDestination is the rule decision 29 forces:
-// migration_executor.go dials the destination as SASL/PLAIN unconditionally, so
-// any other block would be silently ignored — worse than the flag surface it
-// replaces.
 // TestGateway_AcceptsEveryDestinationMethodExceptIAM. All the auth/TLS
 // machinery on the destination Kafka leg already exists and is now routed
 // through AdminOptionForAuthMethod, the same mapper the source leg uses — so
@@ -350,6 +346,8 @@ func TestGateway_RestCredentialsRequiredWhenNotSASLPlain(t *testing.T) {
 		"        sasl_scram:\n          username: u\n          password: p\n          mechanism: SHA512",
 		1)
 	g := parseGateway(t, doc)
+
+	requireErrContains(t, g.Validate(), "spec.target.kafka.restCredentials")
 
 	_, err := g.RestCredentials()
 	require.Error(t, err)
@@ -855,12 +853,6 @@ func TestGateway_ManifestParseErrorDoesNotEchoInlineSecrets(t *testing.T) {
 
 // --- security review F3: a restCredentials form kcp cannot honour must be refused ---
 
-// TestGateway_RejectsNonAPIKeyRestCredentials. targets.ValidateCredentials
-// accepts basic/bearer/mtls and the generated schema advertises them, but every
-// command reads only the flat api_key form — so a bearer token is dropped and
-// the request goes out as anonymous Basic auth, with the declared ca_cert
-// ignored. Refuse rather than silently degrade, mirroring the sasl_plain-only
-// rule on the destination Kafka leg.
 // TestGateway_AcceptsEveryRestCredentialsForm. targets.Credentials already
 // implements Authenticator/HTTPClient for basic, bearer and mtls — B.4 stops
 // refusing them so a CP destination behind RBAC or mTLS can be reached.

--- a/internal/manifest/gatewaymigration.schema.json
+++ b/internal/manifest/gatewaymigration.schema.json
@@ -98,7 +98,7 @@
                   "description": "Destination Kafka bootstrap endpoint (e.g. pkc-abc123.us-east-1.aws.confluent.cloud:9092)."
                 },
                 "credentials": {
-                  "description": "Destination Kafka credentials, used as SASL/PLAIN against the destination bootstrap. Only sasl_plain is supported in this release.",
+                  "description": "Destination Kafka credentials, dialled directly to read destination-side offsets. Accepts sasl_plain, sasl_scram, mtls, unauthenticated_tls, or unauthenticated_plaintext — iam is rejected (the destination is Confluent Cloud/Platform, never MSK).",
                   "oneOf": [
                     {
                       "type": "string"
@@ -109,7 +109,7 @@
                   ]
                 },
                 "restCredentials": {
-                  "description": "Destination REST credentials. OPTIONAL: when omitted these are derived in full from credentials (api_key/api_secret from sasl_plain.username/password, insecure_skip_verify from insecure_skip_tls_verify). Spell it out only for a REST endpoint behind a private CA — a block that is present is used exactly as written, never partially derived.",
+                  "description": "Destination REST (cluster-link) credentials: api_key/api_secret, basic, bearer, or mtls. OPTIONAL only when credentials is sasl_plain — then derived in full (api_key/api_secret from sasl_plain.username/password, ca_cert and insecure_skip_verify inherited). Required for every other credentials method, since there is no principal to derive one from. A present block is used exactly as written, never partially derived.",
                   "oneOf": [
                     {
                       "type": "string"

--- a/internal/manifest/migration.go
+++ b/internal/manifest/migration.go
@@ -102,8 +102,9 @@ type TargetKafka struct {
 	// BootstrapServers is the destination bootstrap, dialled directly (not only
 	// via REST) to read destination-side offsets.
 	BootstrapServers []string `yaml:"bootstrapServers,omitempty" json:"bootstrapServers,omitempty"`
-	// Credentials is the destination KAFKA leg. Only sasl_plain is supported in
-	// this release — the destination client is hardcoded to SASL/PLAIN over TLS.
+	// Credentials is the destination KAFKA leg: sasl_plain, sasl_scram, mtls,
+	// unauthenticated_tls, or unauthenticated_plaintext (iam is rejected — the
+	// destination is Confluent Cloud/Platform, never MSK).
 	Credentials CredentialsRef `yaml:"credentials,omitempty" json:"credentials,omitempty"`
 	// RestCredentials is the destination REST leg. A POINTER so that omitted
 	// (⇒ derived from Credentials) stays distinguishable from present-but-empty

--- a/internal/manifest/schemagen/schemagen.go
+++ b/internal/manifest/schemagen/schemagen.go
@@ -160,8 +160,8 @@ func GenerateGateway() ([]byte, error) {
 
 		kafka.Properties["bootstrapServers"]: "Destination Kafka bootstrap endpoint (e.g. pkc-abc123.us-east-1.aws.confluent.cloud:9092).",
 		kafka.Properties["restEndpoint"]:     "REST endpoint of the destination cluster.",
-		kafka.Properties["credentials"]:      "Destination Kafka credentials, used as SASL/PLAIN against the destination bootstrap. Only sasl_plain is supported in this release.",
-		kafka.Properties["restCredentials"]:  "Destination REST credentials. OPTIONAL: when omitted these are derived in full from credentials (api_key/api_secret from sasl_plain.username/password, insecure_skip_verify from insecure_skip_tls_verify). Spell it out only for a REST endpoint behind a private CA — a block that is present is used exactly as written, never partially derived.",
+		kafka.Properties["credentials"]:      "Destination Kafka credentials, dialled directly to read destination-side offsets. Accepts sasl_plain, sasl_scram, mtls, unauthenticated_tls, or unauthenticated_plaintext — iam is rejected (the destination is Confluent Cloud/Platform, never MSK).",
+		kafka.Properties["restCredentials"]:  "Destination REST (cluster-link) credentials: api_key/api_secret, basic, bearer, or mtls. OPTIONAL only when credentials is sasl_plain — then derived in full (api_key/api_secret from sasl_plain.username/password, ca_cert and insecure_skip_verify inherited). Required for every other credentials method, since there is no principal to derive one from. A present block is used exactly as written, never partially derived.",
 
 		clusterLink.Properties["name"]:                    "Name of the cluster link on the destination cluster. The link must ALREADY EXIST.",
 		clusterLink.Properties["pauseConsumerOffsetSync"]: "Disable the cluster link's consumer.offset.sync.enable during execute and restore it after switchover. Requires the cluster link to currently have consumer.offset.sync.enable=true.",

--- a/internal/services/migration/offset_sync_bookend.go
+++ b/internal/services/migration/offset_sync_bookend.go
@@ -271,15 +271,16 @@ func WarnIfPausedOnExecuteFailure(config *MigrationConfig, execErr error) {
 }
 
 // BuildClusterLinkConfig assembles a clusterlink.Config from a migration
-// config plus runtime API credentials. Centralized here so the bookend
-// callers in cmd/migration/execute don't duplicate the field layout.
-func BuildClusterLinkConfig(config *MigrationConfig, apiKey, apiSecret string) clusterlink.Config {
+// config plus a runtime REST Authenticator. Centralized here so the bookend
+// callers in cmd/migration/execute don't duplicate the field layout. auth
+// carries whichever REST auth form the manifest resolved — basic, bearer or
+// mtls — not only the api_key/api_secret pair BasicAuth wraps.
+func BuildClusterLinkConfig(config *MigrationConfig, auth clusterlink.Authenticator) clusterlink.Config {
 	return clusterlink.Config{
 		RestEndpoint: config.ClusterRestEndpoint,
 		ClusterID:    config.ClusterId,
 		LinkName:     config.ClusterLinkName,
-		APIKey:       apiKey,
-		APISecret:    apiSecret,
 		Topics:       config.Topics,
+		Auth:         auth,
 	}
 }

--- a/internal/services/migration/offset_sync_bookend_test.go
+++ b/internal/services/migration/offset_sync_bookend_test.go
@@ -67,7 +67,7 @@ func TestPauseOffsetSync_FlagOff_PassesThrough(t *testing.T) {
 	mock, rec := newRecordingMock(t, "true", nil, nil)
 	cfg := &MigrationConfig{ClusterLinkName: "link-1", PauseConsumerOffsetSync: false}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.NoError(t, err)
 	assert.Equal(t, 0, rec.listConfigs, "must not contact the cluster link when flag is off")
 	assert.Len(t, rec.alterConfigs, 0, "must not flip when flag is off")
@@ -86,7 +86,7 @@ func TestPauseOffsetSync_AlreadyFlipped_SkipsIdempotently(t *testing.T) {
 		CurrentState:                   StateFenced,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.NoError(t, err)
 	assert.Equal(t, 0, rec.listConfigs, "resume must skip drift detection")
 	assert.Len(t, rec.alterConfigs, 0, "resume must skip the re-flip")
@@ -108,7 +108,7 @@ func TestPauseOffsetSync_HappyPath_FlipsAndPersistsInline(t *testing.T) {
 		return nil
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", persist)
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, persist)
 	require.NoError(t, err)
 	assert.Equal(t, 1, rec.listConfigs, "drift detection must query the live state")
 	require.Len(t, rec.alterConfigs, 1)
@@ -132,7 +132,7 @@ func TestPauseOffsetSync_DriftDetected_RefusesNamingBothCauses(t *testing.T) {
 		PauseConsumerOffsetSync: true,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "link-drifty")
 	assert.Contains(t, err.Error(), "consumer.offset.sync.enable")
@@ -152,7 +152,7 @@ func TestPauseOffsetSync_DriftDetected_RefusesOnAbsentKey(t *testing.T) {
 		PauseConsumerOffsetSync: true,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no consumer.offset.sync.enable key")
 	assert.Len(t, rec.alterConfigs, 0)
@@ -166,7 +166,7 @@ func TestPauseOffsetSync_AlterFails_NoMutation(t *testing.T) {
 		PauseConsumerOffsetSync: true,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to disable")
 	assert.False(t, cfg.PauseConsumerOffsetSyncFlipped, "marker must NOT be set on AlterConfigs failure")
@@ -181,7 +181,7 @@ func TestPauseOffsetSync_AlterSucceeds_PersistFails_Surfaces(t *testing.T) {
 		PauseConsumerOffsetSync: true,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, fmt.Errorf("disk full")))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, fmt.Errorf("disk full")))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to persist marker")
 	assert.Contains(t, err.Error(), "recovery", "error must include recovery hint")
@@ -197,7 +197,7 @@ func TestPauseOffsetSync_ListConfigsFails_Surfaces(t *testing.T) {
 		PauseConsumerOffsetSync: true,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "drift detection")
 	assert.Contains(t, err.Error(), "link-1")
@@ -725,12 +725,12 @@ func TestBuildClusterLinkConfig_CarriesAllFields(t *testing.T) {
 		Topics:              []string{"orders", "users"},
 	}
 
-	cl := BuildClusterLinkConfig(cfg, "key", "secret")
+	auth := clusterlink.BasicAuth{Username: "key", Password: "secret"}
+	cl := BuildClusterLinkConfig(cfg, auth)
 	assert.Equal(t, "https://pkc.us-east-1.aws.confluent.cloud:443", cl.RestEndpoint)
 	assert.Equal(t, "lkc-abc", cl.ClusterID)
 	assert.Equal(t, "link-xyz", cl.LinkName)
-	assert.Equal(t, "key", cl.APIKey)
-	assert.Equal(t, "secret", cl.APISecret)
+	assert.Equal(t, auth, cl.Auth, "carries the resolved Authenticator, not just a scalar key/secret pair")
 	assert.Equal(t, []string{"orders", "users"}, cl.Topics)
 }
 
@@ -752,7 +752,7 @@ func TestPauseOffsetSync_Drain_WaitsBeforeDisabling(t *testing.T) {
 	}
 
 	start := time.Now()
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -775,7 +775,7 @@ func TestPauseOffsetSync_Drain_ContextCancelledLeavesSyncEnabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before the drain begins
 
-	err := pauseActions(mock).PauseOffsetSync(ctx, cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(ctx, cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, rec.listConfigs, "drift check runs before the drain")
@@ -793,7 +793,7 @@ func TestPauseOffsetSync_Drain_ZeroDisablesImmediately(t *testing.T) {
 		CurrentState:                    StateFenced,
 	}
 
-	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, "k", "s", makePersist(rec, nil))
+	err := pauseActions(mock).PauseOffsetSync(context.Background(), cfg, clusterlink.BasicAuth{Username: "k", Password: "s"}, makePersist(rec, nil))
 
 	require.NoError(t, err)
 	require.Len(t, rec.alterConfigs, 1, "sync disabled without any drain")

--- a/internal/services/migration/orchestrator.go
+++ b/internal/services/migration/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/confluentinc/kcp/internal/services/clusterlink"
 	"github.com/confluentinc/kcp/internal/services/gateway"
 	"github.com/looplab/fsm"
 )
@@ -77,9 +78,11 @@ var stepHeaders = map[string]string{
 // execParamsFromEvent, rather than stashed on the orchestrator, so the values
 // flow with the event instead of living as mutable orchestrator state.
 type ExecutionParams struct {
-	LagThreshold     int64
-	ClusterApiKey    string
-	ClusterApiSecret string
+	LagThreshold int64
+	// RestAuth authenticates the destination cluster-link REST surface — the
+	// full resolved Authenticator (basic, bearer, or mtls), not only an
+	// api_key/api_secret pair.
+	RestAuth clusterlink.Authenticator
 }
 
 // execParamsFromEvent returns the ExecutionParams passed to fsm.Event. Forward
@@ -219,8 +222,8 @@ func (o *MigrationOrchestrator) SetRunReportRecorder(r *RunReportRecorder) {
 }
 
 // Initialize triggers the initialization event
-func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, clusterApiSecret string) error {
-	params := ExecutionParams{ClusterApiKey: clusterApiKey, ClusterApiSecret: clusterApiSecret}
+func (o *MigrationOrchestrator) Initialize(ctx context.Context, restAuth clusterlink.Authenticator) error {
+	params := ExecutionParams{RestAuth: restAuth}
 	if err := o.fsm.Event(ctx, EventInitialize, params); err != nil {
 		return err
 	}
@@ -228,7 +231,7 @@ func (o *MigrationOrchestrator) Initialize(ctx context.Context, clusterApiKey, c
 }
 
 // Execute runs the full migration workflow from the current state
-func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64, clusterApiKey, clusterApiSecret string) error {
+func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64, restAuth clusterlink.Authenticator) error {
 	// An unknown persisted state (corrupted file, or one written by a newer
 	// kcp) makes every canTransition check below return false, so the loop
 	// would skip every step and falsely report the migration complete. Refuse
@@ -238,9 +241,8 @@ func (o *MigrationOrchestrator) Execute(ctx context.Context, lagThreshold int64,
 	}
 
 	params := ExecutionParams{
-		LagThreshold:     lagThreshold,
-		ClusterApiKey:    clusterApiKey,
-		ClusterApiSecret: clusterApiSecret,
+		LagThreshold: lagThreshold,
+		RestAuth:     restAuth,
 	}
 
 	// Drive execution from canonical workflow - single source of truth
@@ -335,7 +337,7 @@ func (o *MigrationOrchestrator) handleStepFailure(ctx context.Context, step Work
 	// Restore the paused sync config even when the persist failed: cluster
 	// reality outranks state-file tidiness, and the restore's own persist (via
 	// the same path) keeps the marker honest when it can.
-	o.actions.restoreOffsetSyncAfterRollback(o.config, params.ClusterApiKey, params.ClusterApiSecret, o.PersistState)
+	o.actions.restoreOffsetSyncAfterRollback(o.config, params.RestAuth, o.PersistState)
 
 	if persistErr != nil {
 		return fmt.Errorf("%w; additionally, the rollback completed — the gateway was unfenced — but persisting the rolled-back state failed: %w; the state file may still show the pre-rollback state, and re-running execute will re-assert the fence and resume from it", stepFailure, persistErr)
@@ -438,7 +440,7 @@ func (o *MigrationOrchestrator) leaveStateCallback(ctx context.Context, e *fsm.E
 // onInitialize runs the initialize transition: delegates to workflow Initialize.
 func (o *MigrationOrchestrator) onInitialize(ctx context.Context, e *fsm.Event) {
 	p := execParamsFromEvent(e)
-	if err := o.actions.Initialize(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
+	if err := o.actions.Initialize(ctx, o.config, p.RestAuth); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -446,7 +448,7 @@ func (o *MigrationOrchestrator) onInitialize(ctx context.Context, e *fsm.Event) 
 // onWaitForLags runs the wait_for_lags transition: delegates to workflow CheckLags.
 func (o *MigrationOrchestrator) onWaitForLags(ctx context.Context, e *fsm.Event) {
 	p := execParamsFromEvent(e)
-	if err := o.actions.CheckLags(ctx, o.config, p.LagThreshold, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
+	if err := o.actions.CheckLags(ctx, o.config, p.LagThreshold, p.RestAuth); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -464,7 +466,7 @@ func (o *MigrationOrchestrator) onFence(ctx context.Context, e *fsm.Event) {
 // way — promotion's path runs through offset_sync_paused unconditionally.
 func (o *MigrationOrchestrator) onPauseOffsetSync(ctx context.Context, e *fsm.Event) {
 	p := execParamsFromEvent(e)
-	if err := o.actions.PauseOffsetSync(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret, o.PersistState); err != nil {
+	if err := o.actions.PauseOffsetSync(ctx, o.config, p.RestAuth, o.PersistState); err != nil {
 		e.Cancel(err)
 	}
 }
@@ -483,7 +485,7 @@ func (o *MigrationOrchestrator) onVerifyFence(ctx context.Context, e *fsm.Event)
 // onPromote runs the forward promote transition: delegates to PromoteTopics.
 func (o *MigrationOrchestrator) onPromote(ctx context.Context, e *fsm.Event) {
 	p := execParamsFromEvent(e)
-	if err := o.actions.PromoteTopics(ctx, o.config, p.ClusterApiKey, p.ClusterApiSecret); err != nil {
+	if err := o.actions.PromoteTopics(ctx, o.config, p.RestAuth); err != nil {
 		e.Cancel(err)
 	}
 }

--- a/internal/services/migration/orchestrator_test.go
+++ b/internal/services/migration/orchestrator_test.go
@@ -199,7 +199,7 @@ func loadPersistedMigration(t *testing.T, stateFilePath, migrationID string) *Mi
 func TestOrchestrator_Initialize_FromUninitialized(t *testing.T) {
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateUninitialized, nil)
 
-	err := orch.Initialize(context.Background(), "api-key", "api-secret")
+	err := orch.Initialize(context.Background(), clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, StateInitialized, config.CurrentState)
@@ -211,7 +211,7 @@ func TestOrchestrator_Initialize_FromUninitialized(t *testing.T) {
 func TestOrchestrator_Execute_FullWorkflow(t *testing.T) {
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateUninitialized, nil)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, StateSwitched, config.CurrentState)
@@ -233,7 +233,7 @@ func TestOrchestrator_Execute_ResumesFromState(t *testing.T) {
 
 			orch, config, stateFilePath := newHappyPathOrchestrator(t, startState, nil, overrides)
 
-			err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+			err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 			require.NoError(t, err)
 
 			assert.Equal(t, StateSwitched, config.CurrentState)
@@ -284,7 +284,7 @@ func TestHasPendingWork(t *testing.T) {
 		orch, _, _ := newHappyPathOrchestrator(t, "some-future-state", nil)
 		require.True(t, orch.HasPendingWork())
 
-		err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+		err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unrecognized migration state")
 	})
@@ -301,7 +301,7 @@ func TestOrchestrator_Initialize_WorkflowError(t *testing.T) {
 
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateUninitialized, nil, overrides)
 
-	err := orch.Initialize(context.Background(), "api-key", "api-secret")
+	err := orch.Initialize(context.Background(), clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 
 	// Config state should NOT have advanced
@@ -333,7 +333,7 @@ func TestOrchestrator_Execute_FenceError(t *testing.T) {
 
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateUninitialized, nil, overrides)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 
 	// The orchestrator should have persisted state after each successful step.
@@ -386,7 +386,7 @@ func TestOrchestrator_Execute_UnroutedProducers_AbortsFenceAndRollsBack(t *testi
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnroutedProducers)
 
@@ -446,7 +446,7 @@ func TestOrchestrator_Execute_UnroutedProducers_UnfenceFails_StaysAtOffsetSyncPa
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	// Unrouted producers were detected, so the surfaced error still wraps
 	// ErrUnroutedProducers; the unfence happens on the abort_fence rollback and
@@ -494,7 +494,7 @@ func TestOrchestrator_Execute_UnroutedProducers_UnfenceReadinessFails_StaysAtOff
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnroutedProducers)
 
@@ -522,7 +522,7 @@ func TestOrchestrator_Execute_VerifyFencePersistedBeforePromote(t *testing.T) {
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenced, nil, overrides)
 	config.DetectUnroutedProducersDuration = time.Millisecond
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 
 	// The verify step succeeded (stable offsets) and was persisted; the promote
@@ -616,7 +616,7 @@ func TestOrchestrator_Execute_ResumeFromOffsetSyncPaused_RerunsDetection(t *test
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, atomic.LoadInt64(&getCalls), int64(2),
@@ -648,7 +648,7 @@ func TestOrchestrator_Execute_ResumeFromFencedFamily_ReassertsFence(t *testing.T
 
 			orch, config, stateFilePath := newHappyPathOrchestrator(t, state, nil, overrides)
 
-			err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+			err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 			require.NoError(t, err)
 
 			mu.Lock()
@@ -701,7 +701,7 @@ func TestOrchestrator_Execute_RollbackPersistFails_SurfacesBothErrors(t *testing
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnroutedProducers,
 		"the step error must keep its classification through the persist-failure wrap")
@@ -761,7 +761,7 @@ func TestOrchestrator_Execute_PauseOffsetSync_FiresAfterFenceBeforeDetection(t *
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -826,7 +826,7 @@ func TestOrchestrator_Execute_PauseError_RollsBackToInitialized(t *testing.T) {
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "503 pause boom", "the original pause error must surface")
 
@@ -874,7 +874,7 @@ func TestOrchestrator_Execute_UnconfirmedFence_RestoresInitialCR(t *testing.T) {
 
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateLagsOk, nil, overrides)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrFenceUnconfirmed)
 	assert.Contains(t, err.Error(), "gateway pods did not converge",
@@ -918,7 +918,7 @@ func TestOrchestrator_Execute_UnconfirmedFence_RestoreFails_ReportsBoth(t *testi
 
 	orch, _, stateFilePath := newHappyPathOrchestrator(t, StateLagsOk, nil, overrides)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrFenceUnconfirmed)
 	assert.Contains(t, err.Error(), "gateway pods did not converge", "the fence failure")
@@ -945,7 +945,7 @@ func TestOrchestrator_Execute_FenceApplyFails_DoesNotRestore(t *testing.T) {
 
 	orch, _, _ := newHappyPathOrchestrator(t, StateLagsOk, nil, overrides)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrFenceUnconfirmed)
 	assert.Equal(t, int64(1), atomic.LoadInt64(&applyCalls),
@@ -992,7 +992,7 @@ func TestOrchestrator_Execute_RejectedFence_RestoresWithRejectionMessage(t *test
 	stderr := captureStderr(t, func() {
 		stdout = captureStdout(t, func() {
 			orch, _, _ := newHappyPathOrchestrator(t, StateLagsOk, nil, overrides)
-			err = orch.Execute(context.Background(), 0, "api-key", "api-secret")
+			err = orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 		})
 	})
 	out := stdout + stderr
@@ -1052,7 +1052,7 @@ func TestOrchestrator_Execute_PauseError_UnfenceFails_StaysAtFenced(t *testing.T
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "503 pause boom")
 
@@ -1065,7 +1065,7 @@ func TestOrchestrator_Execute_PauseError_UnfenceFails_StaysAtFenced(t *testing.T
 	// Re-run recovery: the transient pause failure is gone; execute resumes
 	// from fenced, pauses, and completes — no pending-rollback bookkeeping.
 	atomic.StoreInt32(&alterFail, 0)
-	err = orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err = orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err, "a re-run after a failed rollback must retry the pause and proceed")
 	persisted = loadPersistedMigration(t, stateFilePath, config.MigrationId)
 	assert.Equal(t, StateSwitched, persisted.CurrentState)
@@ -1103,7 +1103,7 @@ func TestOrchestrator_Execute_PauseError_CtxCancelledMidUnfence_NoRestore(t *tes
 		},
 	}
 
-	err := orch.Execute(ctx, 0, "api-key", "api-secret")
+	err := orch.Execute(ctx, 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "503 pause boom", "the original pause error must surface")
 
@@ -1171,7 +1171,7 @@ func TestOrchestrator_Execute_RogueAfterPause_RestoresSyncConfig(t *testing.T) {
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnroutedProducers)
 
@@ -1229,7 +1229,7 @@ func TestOrchestrator_Execute_RollbackRestoreFails_StillLandsInitialized(t *test
 	}
 
 	stderr := captureStderr(t, func() {
-		err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+		err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrUnroutedProducers)
 	})
@@ -1289,7 +1289,7 @@ func TestOrchestrator_Execute_RollbackRestoreAlterFails_StillLandsInitialized(t 
 	}
 
 	stderr := captureStderr(t, func() {
-		err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+		err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrUnroutedProducers)
 	})
@@ -1437,7 +1437,7 @@ func TestOrchestrator_ExecuteFailure_EmitsStateMatchedGuidance(t *testing.T) {
 			orch, config, stateFilePath := newHappyPathOrchestrator(t, StateLagsOk, nil, tc.overrides)
 			tc.configure(orch, config)
 
-			err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+			err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 			require.Error(t, err)
 
 			// The FSM rests in the expected urgent state, in memory (the value
@@ -1486,7 +1486,7 @@ func TestOrchestrator_Execute_NoOptIn_NeverTouchesClusterLinkConfig(t *testing.T
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(0), atomic.LoadInt64(&alterCalls),
@@ -1522,7 +1522,7 @@ func TestOrchestrator_Execute_LegacyFlippedAtFenced_SkipsPauseAndProceeds(t *tes
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(0), atomic.LoadInt64(&alterCalls), "no second pause")
@@ -1590,7 +1590,7 @@ func TestOrchestrator_RollbackOutput_NamesKeysNotValues(t *testing.T) {
 	var stdout string
 	stderrOut := captureStderr(t, func() {
 		stdout = captureStdout(t, func() {
-			err := orch.Execute(context.Background(), 0, "api-key", "super-secret-value")
+			err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "super-secret-value"})
 			require.Error(t, err)
 		})
 	})
@@ -1610,7 +1610,7 @@ func TestOrchestrator_Execute_UnknownState_Fails(t *testing.T) {
 	// and printing "Migration complete!" is the failure mode this guards.
 	orch, config, _ := newHappyPathOrchestrator(t, "bogus_state", nil)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err, "an unrecognized persisted state must not execute as a silent no-op")
 	assert.Contains(t, err.Error(), "bogus_state")
 	assert.Equal(t, "bogus_state", config.CurrentState,
@@ -1641,7 +1641,7 @@ func TestOrchestrator_Execute_ResumeFromFenceVerified_RerunsDetection(t *testing
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := orch.Execute(ctx, 0, "api-key", "api-secret")
+	err := orch.Execute(ctx, 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err,
 		"resume from fence_verified must re-run detection and catch the rogue producer")
 	assert.ErrorIs(t, err, ErrUnroutedProducers)
@@ -1678,7 +1678,7 @@ func TestOrchestrator_Execute_VerifyFetchError_NoRollback(t *testing.T) {
 		},
 	}
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrUnroutedProducers,
 		"a fetch failure must not be classified as a detection")
@@ -1701,7 +1701,7 @@ func TestOrchestrator_Execute_PromoteError(t *testing.T) {
 
 	orch, config, stateFilePath := newHappyPathOrchestrator(t, StateFenced, nil, overrides)
 
-	err := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, err)
 
 	// The verify_fence transition succeeded first (detection disabled → no-op),

--- a/internal/services/migration/run_report_test.go
+++ b/internal/services/migration/run_report_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/confluentinc/kcp/internal/services/clusterlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +64,7 @@ func TestRunReport_FullWorkflow(t *testing.T) {
 	require.NotNil(t, recorder)
 	orch.SetRunReportRecorder(recorder)
 
-	err := orch.Execute(context.Background(), 42, "api-key", "api-secret")
+	err := orch.Execute(context.Background(), 42, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.NoError(t, err)
 	recorder.Finish(config.CurrentState, nil)
 
@@ -117,7 +118,7 @@ func TestRunReport_ResumeRecordsSkippedStages(t *testing.T) {
 	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
 	orch.SetRunReportRecorder(recorder)
 
-	require.NoError(t, orch.Execute(context.Background(), 0, "api-key", "api-secret"))
+	require.NoError(t, orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"}))
 	recorder.Finish(config.CurrentState, nil)
 
 	report := readRunReport(t, reportPath)
@@ -145,7 +146,7 @@ func TestRunReport_FailedRunIsRecorded(t *testing.T) {
 	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
 	orch.SetRunReportRecorder(recorder)
 
-	execErr := orch.Execute(context.Background(), 0, "api-key", "api-secret")
+	execErr := orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"})
 	require.Error(t, execErr)
 	recorder.Finish(config.CurrentState, execErr)
 
@@ -254,7 +255,7 @@ func TestRunReport_NoCredentialsOrTopicNames(t *testing.T) {
 	recorder := NewRunReportRecorder(reportPath, config.MigrationId, len(config.Topics), 0, config.CurrentState)
 	orch.SetRunReportRecorder(recorder)
 
-	require.NoError(t, orch.Execute(context.Background(), 0, "api-key", "api-secret"))
+	require.NoError(t, orch.Execute(context.Background(), 0, clusterlink.BasicAuth{Username: "api-key", Password: "api-secret"}))
 	recorder.Finish(config.CurrentState, nil)
 
 	raw, err := os.ReadFile(reportPath)

--- a/internal/services/migration/workflow.go
+++ b/internal/services/migration/workflow.go
@@ -407,7 +407,7 @@ func (s *MigrationActions) SetPromoteBatchSize(n int) {
 func (s *MigrationActions) Initialize(
 	ctx context.Context,
 	config *MigrationConfig,
-	clusterApiKey, clusterApiSecret string,
+	restAuth clusterlink.Authenticator,
 ) error {
 	slog.Debug("initializing migration", "migrationId", config.MigrationId)
 
@@ -461,8 +461,7 @@ func (s *MigrationActions) Initialize(
 		RestEndpoint: config.ClusterRestEndpoint,
 		ClusterID:    config.ClusterId,
 		LinkName:     config.ClusterLinkName,
-		APIKey:       clusterApiKey,
-		APISecret:    clusterApiSecret,
+		Auth:         restAuth,
 		Topics:       config.Topics,
 	}
 
@@ -541,7 +540,7 @@ func (s *MigrationActions) CheckLags(
 	ctx context.Context,
 	config *MigrationConfig,
 	lagThreshold int64,
-	clusterApiKey, clusterApiSecret string,
+	restAuth clusterlink.Authenticator,
 ) error {
 	if s.sourceOffset == nil || s.destinationOffset == nil {
 		return fmt.Errorf("source and destination offset services are required")
@@ -1004,7 +1003,7 @@ func (s *MigrationActions) detectUnroutedProducers(ctx context.Context, topics [
 func (s *MigrationActions) PauseOffsetSync(
 	ctx context.Context,
 	config *MigrationConfig,
-	clusterApiKey, clusterApiSecret string,
+	restAuth clusterlink.Authenticator,
 	persist func() error,
 ) error {
 	if !config.PauseConsumerOffsetSync {
@@ -1018,7 +1017,7 @@ func (s *MigrationActions) PauseOffsetSync(
 		return nil
 	}
 
-	clCfg := BuildClusterLinkConfig(config, clusterApiKey, clusterApiSecret)
+	clCfg := BuildClusterLinkConfig(config, restAuth)
 
 	s.reporter.section("⏸  Pausing consumer.offset.sync on cluster link...")
 
@@ -1087,10 +1086,10 @@ func (s *MigrationActions) PauseOffsetSync(
 // refusal), which also keeps externally-set config untouched.
 func (s *MigrationActions) restoreOffsetSyncAfterRollback(
 	config *MigrationConfig,
-	clusterApiKey, clusterApiSecret string,
+	restAuth clusterlink.Authenticator,
 	persist func() error,
 ) {
-	clCfg := BuildClusterLinkConfig(config, clusterApiKey, clusterApiSecret)
+	clCfg := BuildClusterLinkConfig(config, restAuth)
 	restoreOffsetSync(s.clusterLinkService, clCfg, config, persist, "Gateway unfenced but")
 }
 
@@ -1123,7 +1122,7 @@ func (s *MigrationActions) VerifyFence(ctx context.Context, config *MigrationCon
 }
 
 // PromoteTopics polls offsets and promotes mirror topics that reach zero lag
-func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationConfig, clusterApiKey, clusterApiSecret string) error {
+func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationConfig, restAuth clusterlink.Authenticator) error {
 	if s.sourceOffset == nil || s.destinationOffset == nil {
 		return fmt.Errorf("source and destination offset services are required")
 	}
@@ -1136,8 +1135,7 @@ func (s *MigrationActions) PromoteTopics(ctx context.Context, config *MigrationC
 		RestEndpoint: config.ClusterRestEndpoint,
 		ClusterID:    config.ClusterId,
 		LinkName:     config.ClusterLinkName,
-		APIKey:       clusterApiKey,
-		APISecret:    clusterApiSecret,
+		Auth:         restAuth,
 		Topics:       config.Topics,
 	}
 

--- a/internal/services/migration/workflow_test.go
+++ b/internal/services/migration/workflow_test.go
@@ -75,7 +75,7 @@ func TestWorkflow_Initialize_Success(t *testing.T) {
 		SwitchoverTargets:   testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, testInitialCR, string(config.InitialCrYAML))
@@ -126,7 +126,7 @@ func initializeWithValidation(t *testing.T, result gateway.CRValidationResult, v
 		ClusterLinkName:     "link-1",
 		FenceRoutes:         []string{"migration-route"},
 		SwitchoverTargets:   testSwitchoverTargets,
-	}, "key", "secret")
+	}, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 
 	return out.String() + errOut.String(), err
 }
@@ -227,7 +227,7 @@ func TestWorkflow_Initialize_PassesNamespaceAndTargetsToValidator(t *testing.T) 
 		ClusterLinkName:     "link-1",
 		FenceRoutes:         []string{"migration-route"},
 		SwitchoverTargets:   testSwitchoverTargets,
-	}, "key", "secret")
+	}, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 
 	require.NoError(t, err)
 	assert.Equal(t, "kcp", gotNamespace)
@@ -249,7 +249,7 @@ func TestWorkflow_Initialize_GatewayFetchError(t *testing.T) {
 		InitialCrName: "my-gw",
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "failed to get initial CR YAML: k8s unreachable", err.Error())
 }
@@ -281,7 +281,7 @@ func TestWorkflow_Initialize_InactiveMirrorTopics(t *testing.T) {
 		SwitchoverTargets:   testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "1 mirror topics are not active: topic-b (status: PAUSED)", err.Error())
 }
@@ -316,7 +316,7 @@ func TestWorkflow_Initialize_TopicValidationError(t *testing.T) {
 		SwitchoverTargets:   testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "failed to validate topics in cluster link: topic topic-x not found in cluster link", err.Error())
 }
@@ -353,7 +353,7 @@ func TestWorkflow_Initialize_NoTopicsDiscoverAll(t *testing.T) {
 		SwitchoverTargets:   testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 
 	require.Len(t, config.Topics, 3)
@@ -397,7 +397,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_Pass(t *testing.T) {
 		SwitchoverTargets:       testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 	assert.True(t, config.PauseConsumerOffsetSync, "intent should be retained on config")
 	assert.False(t, config.PauseConsumerOffsetSyncFlipped, "flipped marker must remain false at init time")
@@ -414,7 +414,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_RefusesOnFalse(t *testing.T) {
 		SwitchoverTargets:       testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "link-falsey")
 	assert.Contains(t, err.Error(), "consumer.offset.sync.enable")
@@ -432,7 +432,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_RefusesOnAbsentKey(t *testing.T) {
 		SwitchoverTargets:       testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "link-absent")
 	assert.Contains(t, err.Error(), "no consumer.offset.sync.enable config key", "error must distinguish absent key from false value")
@@ -451,7 +451,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_FlagOff_IgnoresConfigValue(t *testi
 		SwitchoverTargets:       testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "flag off must not assert offset-sync state")
 }
 
@@ -476,7 +476,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_AlreadyFlipped_SkipsPrecondition(t 
 		SwitchoverTargets:              testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "Initialize must not refuse when kcp already flipped the config (Flipped=true)")
 }
 
@@ -508,7 +508,7 @@ func TestWorkflow_Initialize_PauseOffsetSync_AlreadyFlipped_PreservesSnapshot(t 
 		SwitchoverTargets:              testSwitchoverTargets,
 	}
 
-	err := wf.Initialize(context.Background(), config, "key", "secret")
+	err := wf.Initialize(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "true", config.ClusterLinkConfigs["consumer.offset.sync.enable"],
@@ -541,7 +541,7 @@ func TestWorkflow_CheckLags_ImmediatelyBelowThreshold(t *testing.T) {
 		Topics: []string{"topic-1", "topic-2"},
 	}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 }
 
@@ -565,7 +565,7 @@ func TestWorkflow_CheckLags_NoTopics(t *testing.T) {
 		Topics: []string{},
 	}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 }
 
@@ -578,7 +578,7 @@ func TestWorkflow_CheckLags_NilOffsetServices(t *testing.T) {
 		Topics: []string{"topic-1"},
 	}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "source and destination offset services are required", err.Error())
 }
@@ -607,7 +607,7 @@ func TestWorkflow_CheckLags_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
-	err := wf.CheckLags(ctx, config, 10, "key", "secret")
+	err := wf.CheckLags(ctx, config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -632,7 +632,7 @@ func TestWorkflow_CheckLags_DestinationAhead(t *testing.T) {
 		Topics: []string{"topic-1"},
 	}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "negative lag (destination ahead) should be treated as 0 and pass threshold")
 }
 
@@ -685,7 +685,7 @@ func TestWorkflow_PromoteTopics_AllAtZeroLag(t *testing.T) {
 		ClusterLinkName:     "link-1",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 	assert.True(t, promoted["topic-1"], "topic-1 should have been promoted")
 	assert.True(t, promoted["topic-2"], "topic-2 should have been promoted")
@@ -741,7 +741,7 @@ func TestWorkflow_PromoteTopics_PartialPromotionError(t *testing.T) {
 		ClusterLinkName:     "link-1",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "retry should succeed")
 
 	finalCallCount := atomic.LoadInt64(&callCount)
@@ -797,7 +797,7 @@ func TestWorkflow_PromoteTopics_StuckPendingStoppedDoesNotSucceed(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	err := wf.PromoteTopics(ctx, config, "key", "secret")
+	err := wf.PromoteTopics(ctx, config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err, "must not report success while topic is stuck in PENDING_STOPPED")
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -850,7 +850,7 @@ func TestWorkflow_PromoteTopics_WaitsForStoppedStatus(t *testing.T) {
 		ClusterLinkName:     "link-1",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, atomic.LoadInt64(&listCalls), int64(3),
 		"expected PromoteTopics to poll mirror status until STOPPED was observed")
@@ -937,7 +937,7 @@ func TestWorkflow_PromoteTopics_BatchSizeProcessesSequentially(t *testing.T) {
 		ClusterLinkName:     "link-1",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -982,7 +982,7 @@ func TestWorkflow_PromoteTopics_MaxRetriesExceeded(t *testing.T) {
 		ClusterLinkName:     "link-1",
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "topic topic-1 failed promotion after 3 attempts: persistent error", err.Error())
 }
@@ -996,7 +996,7 @@ func TestWorkflow_PromoteTopics_NilOffsetServices(t *testing.T) {
 		Topics: []string{"topic-1"},
 	}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Equal(t, "source and destination offset services are required", err.Error())
 }
@@ -1670,7 +1670,7 @@ func TestWorkflow_PromoteTopics_IgnoresDetectionConfig(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err := wf.PromoteTopics(ctx, config, "key", "secret")
+	err := wf.PromoteTopics(ctx, config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "PromoteTopics should not run unrouted-producer detection")
 	assert.True(t, promoted["topic-1"])
 }
@@ -1865,7 +1865,7 @@ func TestWorkflow_CheckLags_ToleratesTransientSweepFailures(t *testing.T) {
 	wf.lagPollInterval = time.Millisecond
 	config := &MigrationConfig{Topics: []string{"topic-1"}}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "two transient sweep failures must be ridden out")
 	assert.GreaterOrEqual(t, calls.Load(), int32(3), "expected the sweep to be retried on later ticks")
 }
@@ -1891,7 +1891,7 @@ func TestWorkflow_CheckLags_AbortsAfterMaxConsecutiveSweepFailures(t *testing.T)
 	wf.lagPollInterval = time.Millisecond
 	config := &MigrationConfig{Topics: []string{"topic-1"}}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("%d consecutive", maxConsecutiveSweepFailures))
 	assert.Contains(t, err.Error(), "broker unreachable", "the underlying cause must be preserved")
@@ -1929,7 +1929,7 @@ func TestWorkflow_CheckLags_SweepFailureCounterResetsOnSuccess(t *testing.T) {
 	wf.lagPollInterval = time.Millisecond
 	config := &MigrationConfig{Topics: []string{"topic-1"}}
 
-	err := wf.CheckLags(context.Background(), config, 10, "key", "secret")
+	err := wf.CheckLags(context.Background(), config, 10, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "four non-consecutive failures must not abort")
 	assert.Equal(t, int32(6), calls.Load())
 }
@@ -1981,7 +1981,7 @@ func TestWorkflow_PromoteTopics_ToleratesTransientSweepFailures(t *testing.T) {
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{Topics: []string{"topic-1"}}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.NoError(t, err, "two transient sweep failures must be ridden out")
 	assert.True(t, promoted["topic-1"], "topic must still be promoted after tolerated failures")
 }
@@ -2007,7 +2007,7 @@ func TestWorkflow_PromoteTopics_AbortsAfterMaxConsecutiveSweepFailures(t *testin
 	wf.promotePollInterval = time.Millisecond
 	config := &MigrationConfig{Topics: []string{"topic-1"}}
 
-	err := wf.PromoteTopics(context.Background(), config, "key", "secret")
+	err := wf.PromoteTopics(context.Background(), config, clusterlink.BasicAuth{Username: "key", Password: "secret"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("%d consecutive", maxConsecutiveSweepFailures))
 	assert.Contains(t, err.Error(), "broker unreachable", "the underlying cause must be preserved")

--- a/internal/types/credentials_migrate_test.go
+++ b/internal/types/credentials_migrate_test.go
@@ -251,6 +251,25 @@ func TestMigrateConn(t *testing.T) {
 	require.True(t, got.AuthMethod.SASLScram.Use)
 }
 
+// TestMigrateConn_NilBootstrapServers_AuthMappingUnaffected. Every existing
+// MigrateConn call site passes real bootstrap addresses; buildExecutorOpts
+// resolving the migration destination auth via MigrateConn(nil, dstCreds) is a
+// new usage shape. Bootstrap servers must not affect the auth-type mapping —
+// proven here rather than assumed from precedent.
+func TestMigrateConn_NilBootstrapServers_AuthMappingUnaffected(t *testing.T) {
+	creds := MigrateClusterCredentials{SASLPlain: &MigrateSASLPlain{Username: "u", Password: "p", UseTLS: true}}
+
+	got := MigrateConn(nil, creds)
+	require.Nil(t, got.BootstrapServers)
+	require.NotNil(t, got.AuthMethod.SASLPlain)
+	require.True(t, got.AuthMethod.SASLPlain.Use)
+	require.True(t, got.AuthMethod.SASLPlain.UseTLS)
+
+	authType, err := got.GetSelectedAuthType()
+	require.NoError(t, err)
+	require.Equal(t, AuthTypeSASLPlain, authType)
+}
+
 // writeMigrateCreds writes a migrate credentials file and returns its path.
 func writeMigrateCreds(t *testing.T, content string) string {
 	t.Helper()


### PR DESCRIPTION
## What & why

Today a `kcp migration init | execute` destination is locked to **SASL/PLAIN** on both credential legs, which effectively limits the target to Confluent Cloud (or a CP cluster configured for SASL/PLAIN). This expands destination auth so a broader set of Confluent Platform clusters can be migration targets.

The destination has two independent auth gates, both moved here:
- **Kafka broker leg** (offset/lag reads via `createDestinationOffset`)
- **REST / cluster-link leg** (mirror list/validate at init, promote at execute)

Schema + docs regenerated; the example manifest gains SCRAM/mTLS/unauth and basic/bearer/mTLS destination examples.

## Stacked

Base is `feat/gateway-redundant-auth-switchover` (this PR is exactly one commit on top). Still waiting on #405 (first) and #418 (second) to be merged.

## Out of scope (documented)

`kcp migration lagcheck` still reads `restCredentials.APIKey/APISecret` and would silently send empty Basic auth for a non-api-key REST credential. Will follow-up after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
