### PR TITLE
ci: run static analysis as a non-blocking pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -230,34 +230,6 @@ blocks:
           commands:
             - cache store minikube-cache ~/.minikube/cache/
 
-  - name: 'static analysis'
-    dependencies: ['resolve frontend dependencies', 'resolve go dependencies']
-    task:
-      env_vars:
-        - name: TRIVY_DB_REPOSITORIES
-          value: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
-      prologue:
-        commands:
-          - sem-version go 1.26.7
-          - export "GOPATH=$(go env GOPATH)"
-          - export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"
-          - export "PATH=${GOPATH}/bin:${PATH}"
-          - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
-          - cache restore frontend-dependencies
-          - cache restore go-mod-cache
-          - cache restore go-build-cache
-          - cd cmd/ui/frontend && yarn install && yarn build && cd -
-      jobs:
-        - name: 'golangci-lint'
-          commands:
-            - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.3/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
-            - git fetch origin main
-            - golangci-lint run --config .golangci.yml ./...
-
-        - name: 'trivy scan'
-          commands:
-            - trivy fs --scanners vuln --show-suppressed --db-repository=$TRIVY_DB_REPOSITORIES --severity HIGH,CRITICAL --exit-code 1 .
-
   - name: 'docs build'
     dependencies: ['resolve go dependencies']
     task:
@@ -353,3 +325,13 @@ blocks:
         on_pass:
           commands:
             - cache store minikube-cache ~/.minikube/cache/
+
+# Static analysis (lint + vuln scan) runs as its own auto-promoted pipeline so it
+# reports a separate `static-analysis` status check. It still triggers on every
+# workflow, but a golangci-lint or trivy failure no longer fails `build-test` and
+# therefore does not gate PR merges.
+promotions:
+  - name: static-analysis
+    pipeline_file: static-analysis.yml
+    auto_promote:
+      when: "true"

--- a/.semaphore/static-analysis.yml
+++ b/.semaphore/static-analysis.yml
@@ -1,0 +1,47 @@
+version: v1.0
+name: static-analysis
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+# Auto-promoted from build-test (see semaphore.yml). Runs on every workflow but
+# reports its own `static-analysis` status check, so a lint or vuln-scan failure
+# is visible without gating the merge of the build-test pipeline.
+global_job_config:
+  prologue:
+    commands:
+      - sem-version node 24.6.0
+      - npm install -g yarn@1.22.22
+      - sem-version go 1.26.7
+      - export "GOPATH=$(go env GOPATH)"
+      - export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"
+      - export "PATH=${GOPATH}/bin:${PATH}"
+      - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
+      - checkout
+
+blocks:
+  - name: 'static analysis'
+    dependencies: []
+    task:
+      env_vars:
+        - name: TRIVY_DB_REPOSITORIES
+          value: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
+      prologue:
+        commands:
+          - cache restore frontend-dependencies
+          - cache restore go-mod-cache
+          - cache restore go-build-cache
+          - cd cmd/ui/frontend && yarn install && yarn build && cd -
+      jobs:
+        - name: 'golangci-lint'
+          commands:
+            - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.3/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
+            - git fetch origin main
+            - golangci-lint run --config .golangci.yml ./...
+
+        - name: 'trivy scan'
+          commands:
+            - trivy fs --scanners vuln --show-suppressed --db-repository=$TRIVY_DB_REPOSITORIES --severity HIGH,CRITICAL --exit-code 1 .


### PR DESCRIPTION
## What

Move the `static analysis` block (golangci-lint + trivy vuln scan) out of the `build-test` pipeline into its own **auto-promoted `static-analysis` pipeline** (`.semaphore/static-analysis.yml`) which will run after `build-test` either passes or fails.

## Why

Static analysis should keep running on every workflow, but a lint issue or a HIGH/CRITICAL CVE should **not gate PR merges**, these can be addressed in follow-up PRs to avoid a commit+push restarting the 30m CI runs.

As a separate auto-promoted pipeline it reports its own `static-analysis` status check. Since branch protection requires `build-test` (not `static-analysis`), **the jobs still trigger and stay visible, but no longer block merging**.

## Changes

- `.semaphore/semaphore.yml` — remove the `static analysis` block; add a `promotions:` entry auto-promoting (`when: "true"`) to `static-analysis.yml`.
- `.semaphore/static-analysis.yml` (new) — self-contained pipeline with the same `golangci-lint` + `trivy scan` jobs and its own `global_job_config` prologue (node/go setup + `checkout`, previously inherited from `build-test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
