### PR TITLE
fix(deps): patch mkdocs-material and fast-uri dependabot alerts

### DIFF
--- a/cmd/ui/frontend/package.json
+++ b/cmd/ui/frontend/package.json
@@ -51,7 +51,7 @@
   "resolutions": {
     "lodash": "^4.18.0",
     "lodash-es": "^4.18.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "@rjsf/core/nanoid": "^6.0.0",
     "@rjsf/utils/nanoid": "^6.0.0",
     "**/postcss/nanoid": "^6.0.0"

--- a/cmd/ui/frontend/yarn.lock
+++ b/cmd/ui/frontend/yarn.lock
@@ -2853,10 +2853,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1, fast-uri@^3.0.6, fast-uri@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@^3.0.1, fast-uri@^3.0.6, fast-uri@^3.1.6:
+  version "3.1.7"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastq@^1.6.0:
   version "1.19.1"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.6.1
-mkdocs-material==9.7.6
+mkdocs-material==9.7.7
 mike==2.1.3
 mkdocs-callouts==1.16.0
 mkdocs-awesome-pages-plugin==2.10.1


### PR DESCRIPTION
## What

Patches the two Dependabot alerts that touch a real execution path:

- **`mkdocs-material` 9.7.6 → 9.7.7** (`requirements-docs.txt`) — clears GHSA-xvg9-69gf-fjrf (DOM XSS in docs-site search suggestions via query parameter). The docs site is the only user-facing surface here.
- **`fast-uri` resolution `^3.1.5` → `^3.1.6`** (`cmd/ui/frontend`) — lockfile now resolves `fast-uri` to `3.1.7`, clearing GHSA-jqff-g426-hqxp, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8. `fast-uri` reaches the client bundle via `ajv` ← `@rjsf/validator-ajv8`; the CVEs aren't reachable in kcp (ajv only parses schema URIs, never fetches), but the bump is a one-liner and clears the noise.

## Not fixed (dismissed separately)

The remaining open npm alerts — `browserslist`, `@humanfs/node`, `postcss-selector-parser`, `@hono/node-server`, `js-yaml`, `hono`, `ip-address`, `postcss` — are all transitive dependencies of the `shadcn` and `eslint` **devDependencies**. None are bundled into the Vite `dist/` that ships embedded in the Go binary and is served by Echo, so their code never executes in kcp's runtime. Dismissed on the dashboard as *vulnerable code not in execution path*.

## Test

Frontend `yarn install` regenerates the lockfile cleanly; `fast-uri` collapses to a single `3.1.7` entry across all consumers. No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
